### PR TITLE
Phase 3: Release infrastructure

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Basecamp
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -3,6 +3,7 @@
 # Usage: scripts/bump-version.sh <version>
 # Example: scripts/bump-version.sh 0.3.0
 set -euo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
 VERSION="${1:-}"
 if [ -z "$VERSION" ]; then
@@ -17,17 +18,14 @@ if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
   exit 1
 fi
 
-# Portable in-place sed: use temp file instead of -i flag
-sedi() {
-  local expr="$1" file="$2"
-  local tmp
-  tmp=$(mktemp)
-  sed "$expr" "$file" > "$tmp" && cat "$tmp" > "$file" && rm "$tmp"
-}
-
 echo "Bumping version to: $VERSION"
 
-# Go
-sedi "s/^const Version = \".*\"/const Version = \"$VERSION\"/" go/pkg/hey/version.go
+VERSION_FILE="$REPO_ROOT/go/pkg/hey/version.go"
+sedi "s/^const Version = \".*\"/const Version = \"$VERSION\"/" "$VERSION_FILE"
+
+if ! grep -q "const Version = \"$VERSION\"" "$VERSION_FILE"; then
+  echo "ERROR: Version substitution did not match in $VERSION_FILE" >&2
+  exit 1
+fi
 
 echo "Done. Bumped 1 file to $VERSION."

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -23,7 +23,7 @@ echo "Bumping version to: $VERSION"
 VERSION_FILE="$REPO_ROOT/go/pkg/hey/version.go"
 sedi "s/^const Version = \".*\"/const Version = \"$VERSION\"/" "$VERSION_FILE"
 
-if ! grep -q "const Version = \"$VERSION\"" "$VERSION_FILE"; then
+if ! grep -Fq "const Version = \"$VERSION\"" "$VERSION_FILE"; then
   echo "ERROR: Version substitution did not match in $VERSION_FILE" >&2
   exit 1
 fi

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Bumps SDK version across Go implementation.
+# Usage: scripts/bump-version.sh <version>
+# Example: scripts/bump-version.sh 0.3.0
+set -euo pipefail
+
+VERSION="${1:-}"
+if [ -z "$VERSION" ]; then
+  echo "Usage: $0 <version>" >&2
+  echo "Example: $0 0.3.0" >&2
+  exit 1
+fi
+
+# Validate semver format (strict)
+if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+  echo "ERROR: Version must be semver (e.g., 0.3.0)" >&2
+  exit 1
+fi
+
+# Portable in-place sed: use temp file instead of -i flag
+sedi() {
+  local expr="$1" file="$2"
+  local tmp
+  tmp=$(mktemp)
+  sed "$expr" "$file" > "$tmp" && cat "$tmp" > "$file" && rm "$tmp"
+}
+
+echo "Bumping version to: $VERSION"
+
+# Go
+sedi "s/^const Version = \".*\"/const Version = \"$VERSION\"/" go/pkg/hey/version.go
+
+echo "Done. Bumped 1 file to $VERSION."

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -2,7 +2,8 @@
 # Source this file; do not execute directly.
 
 # Resolve repo root from the sourcing script's location.
-REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[1]}")/.." && pwd)"
+# BASH_SOURCE[1] is the caller when sourced; fall back to BASH_SOURCE[0] (this file).
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[1]:-${BASH_SOURCE[0]}}")/.." && pwd)"
 
 # Portable in-place sed: use temp file instead of -i flag.
 sedi() {

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -1,0 +1,14 @@
+# Shared helpers for hey-sdk scripts.
+# Source this file; do not execute directly.
+
+# Resolve repo root from the sourcing script's location.
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[1]}")/.." && pwd)"
+
+# Portable in-place sed: use temp file instead of -i flag.
+sedi() {
+  local expr="$1" file="$2"
+  local tmp
+  tmp=$(mktemp)
+  trap 'rm -f "$tmp"' RETURN
+  sed "$expr" "$file" > "$tmp" && cat "$tmp" > "$file"
+}

--- a/scripts/sync-api-version.sh
+++ b/scripts/sync-api-version.sh
@@ -2,6 +2,7 @@
 # Syncs API_VERSION constants from openapi.json info.version to Go SDK.
 # Usage: scripts/sync-api-version.sh [--check] [openapi.json]
 set -euo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
 CHECK=false
 OPENAPI="openapi.json"
@@ -24,7 +25,7 @@ if [ -z "$API_VERSION" ] || [ "$API_VERSION" = "null" ]; then
   exit 1
 fi
 
-VERSION_FILE="go/pkg/hey/version.go"
+VERSION_FILE="$REPO_ROOT/go/pkg/hey/version.go"
 CURRENT=$(sed -n 's/^const APIVersion = "\(.*\)"/\1/p' "$VERSION_FILE")
 
 if [ "$CHECK" = true ]; then
@@ -38,17 +39,14 @@ if [ "$CHECK" = true ]; then
   fi
 fi
 
-# Portable in-place sed: use temp file instead of -i flag
-sedi() {
-  local expr="$1" file="$2"
-  local tmp
-  tmp=$(mktemp)
-  sed "$expr" "$file" > "$tmp" && cat "$tmp" > "$file" && rm "$tmp"
-}
-
 echo "Syncing API version: $API_VERSION"
 
-# Go
-sedi "s/^const APIVersion = \".*\"/const APIVersion = \"$API_VERSION\"/" "$VERSION_FILE"
+ESCAPED_VERSION=$(printf '%s\n' "$API_VERSION" | sed 's/[&/\]/\\&/g')
+sedi "s/^const APIVersion = \".*\"/const APIVersion = \"$ESCAPED_VERSION\"/" "$VERSION_FILE"
+
+if ! grep -q "const APIVersion = \"$API_VERSION\"" "$VERSION_FILE"; then
+  echo "ERROR: API version substitution did not match in $VERSION_FILE" >&2
+  exit 1
+fi
 
 echo "Done."

--- a/scripts/sync-api-version.sh
+++ b/scripts/sync-api-version.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Syncs API_VERSION constants from openapi.json info.version to Go SDK.
+# Usage: scripts/sync-api-version.sh [--check] [openapi.json]
+set -euo pipefail
+
+CHECK=false
+OPENAPI="openapi.json"
+
+for arg in "$@"; do
+  case "$arg" in
+    --check) CHECK=true ;;
+    *) OPENAPI="$arg" ;;
+  esac
+done
+
+if ! command -v jq &>/dev/null; then
+  echo "ERROR: jq is required" >&2
+  exit 1
+fi
+
+API_VERSION=$(jq -r '.info.version' "$OPENAPI")
+if [ -z "$API_VERSION" ] || [ "$API_VERSION" = "null" ]; then
+  echo "ERROR: Could not read info.version from $OPENAPI" >&2
+  exit 1
+fi
+
+VERSION_FILE="go/pkg/hey/version.go"
+CURRENT=$(sed -n 's/^const APIVersion = "\(.*\)"/\1/p' "$VERSION_FILE")
+
+if [ "$CHECK" = true ]; then
+  if [ "$CURRENT" = "$API_VERSION" ]; then
+    echo "API version is in sync: $API_VERSION"
+    exit 0
+  else
+    echo "ERROR: API version mismatch. openapi.json=$API_VERSION, version.go=$CURRENT" >&2
+    echo "Run 'make sync-api-version' to fix." >&2
+    exit 1
+  fi
+fi
+
+# Portable in-place sed: use temp file instead of -i flag
+sedi() {
+  local expr="$1" file="$2"
+  local tmp
+  tmp=$(mktemp)
+  sed "$expr" "$file" > "$tmp" && cat "$tmp" > "$file" && rm "$tmp"
+}
+
+echo "Syncing API version: $API_VERSION"
+
+# Go
+sedi "s/^const APIVersion = \".*\"/const APIVersion = \"$API_VERSION\"/" "$VERSION_FILE"
+
+echo "Done."

--- a/scripts/sync-api-version.sh
+++ b/scripts/sync-api-version.sh
@@ -44,7 +44,7 @@ echo "Syncing API version: $API_VERSION"
 ESCAPED_VERSION=$(printf '%s\n' "$API_VERSION" | sed 's/[&/\]/\\&/g')
 sedi "s/^const APIVersion = \".*\"/const APIVersion = \"$ESCAPED_VERSION\"/" "$VERSION_FILE"
 
-if ! grep -q "const APIVersion = \"$API_VERSION\"" "$VERSION_FILE"; then
+if ! grep -Fq "const APIVersion = \"$API_VERSION\"" "$VERSION_FILE"; then
   echo "ERROR: API version substitution did not match in $VERSION_FILE" >&2
   exit 1
 fi

--- a/scripts/sync-api-version.sh
+++ b/scripts/sync-api-version.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
 CHECK=false
-OPENAPI="openapi.json"
+OPENAPI="$REPO_ROOT/openapi.json"
 
 for arg in "$@"; do
   case "$arg" in

--- a/scripts/sync-provenance
+++ b/scripts/sync-provenance
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Syncs api-provenance.json with current haystack HEAD SHA.
+# Usage: scripts/sync-provenance [HAYSTACK_DIR]
+set -euo pipefail
+
+HAYSTACK_DIR="${1:-${HOME}/Work/basecamp/haystack}"
+
+if [ ! -d "$HAYSTACK_DIR/.git" ]; then
+  echo "ERROR: $HAYSTACK_DIR is not a git repository." >&2
+  echo "Usage: $0 [HAYSTACK_DIR]" >&2
+  exit 1
+fi
+
+SHA=$(git -C "$HAYSTACK_DIR" rev-parse HEAD)
+DATE=$(date -u +%Y-%m-%d)
+
+cat > spec/api-provenance.json <<EOF
+{
+  "source": "haystack",
+  "sha": "$SHA",
+  "date": "$DATE",
+  "notes": "Pinned from haystack master. Update with: make provenance-sync"
+}
+EOF
+
+echo "Provenance updated: sha=$SHA date=$DATE"

--- a/scripts/sync-provenance
+++ b/scripts/sync-provenance
@@ -2,19 +2,21 @@
 # Syncs api-provenance.json with current haystack HEAD SHA.
 # Usage: scripts/sync-provenance [HAYSTACK_DIR]
 set -euo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
-HAYSTACK_DIR="${1:-${HOME}/Work/basecamp/haystack}"
+HAYSTACK_DIR="${1:-${HAYSTACK_DIR:-${HOME}/Work/basecamp/haystack}}"
 
-if [ ! -d "$HAYSTACK_DIR/.git" ]; then
+if [ ! -d "$HAYSTACK_DIR/.git" ] && [ ! -f "$HAYSTACK_DIR/.git" ]; then
   echo "ERROR: $HAYSTACK_DIR is not a git repository." >&2
   echo "Usage: $0 [HAYSTACK_DIR]" >&2
+  echo "Or set HAYSTACK_DIR environment variable." >&2
   exit 1
 fi
 
 SHA=$(git -C "$HAYSTACK_DIR" rev-parse HEAD)
 DATE=$(date -u +%Y-%m-%d)
 
-cat > spec/api-provenance.json <<EOF
+cat > "$REPO_ROOT/spec/api-provenance.json" <<EOF
 {
   "source": "haystack",
   "sha": "$SHA",

--- a/spec/api-provenance.json
+++ b/spec/api-provenance.json
@@ -1,6 +1,6 @@
 {
   "source": "haystack",
-  "sha": "HEAD",
-  "date": "2026-03-04",
-  "notes": "Initial provenance pin. Update with: make provenance-sync"
+  "sha": "33f9a7e29abd7066ff997f7326164009c1e2add8",
+  "date": "2026-03-09",
+  "notes": "Pinned from haystack master. Update with: make provenance-sync"
 }


### PR DESCRIPTION
## Summary
- Add MIT LICENSE
- Pin `api-provenance.json` to real haystack SHA (was `"HEAD"`)
- Add release scripts: `bump-version.sh`, `sync-api-version.sh`, `sync-provenance`

## Test plan
- [x] `make provenance-check` passes
- [x] `scripts/sync-api-version.sh --check` passes
- [x] `scripts/bump-version.sh 0.1.0` is idempotent

Stack: 1/5

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set up release infrastructure for the Go SDK: automated version bumping, API version sync from `openapi.json`, provenance pinning to haystack, and MIT license. Hardened scripts with shared `scripts/lib.sh`, repo-rooted paths with `BASH_SOURCE` fallback, escaped/verified substitutions, fixed-string checks via `grep -F`, git worktree/`HAYSTACK_DIR` support, and a default `openapi.json` path from the repo root.

- **New Features**
  - `scripts/bump-version.sh`: updates `Version` in `go/pkg/hey/version.go` (strict semver).
  - `scripts/sync-api-version.sh`: syncs `APIVersion` from `openapi.json` (defaults to `$REPO_ROOT/openapi.json`); supports `--check`.
  - `scripts/sync-provenance`: writes `spec/api-provenance.json` with current haystack HEAD and date.

<sup>Written for commit dbf55909d3c591f5ac334a80cfe47e6f82f2b84a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->