### PR TITLE
Phase 3: Go SDK unit tests

### DIFF
--- a/go/pkg/hey/auth_test.go
+++ b/go/pkg/hey/auth_test.go
@@ -1,0 +1,229 @@
+package hey
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+)
+
+func TestStaticTokenProvider(t *testing.T) {
+	p := &StaticTokenProvider{Token: "my-token"}
+	token, err := p.AccessToken(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if token != "my-token" {
+		t.Fatalf("expected 'my-token', got %q", token)
+	}
+}
+
+func TestBearerAuth(t *testing.T) {
+	auth := &BearerAuth{
+		TokenProvider: &StaticTokenProvider{Token: "bearer-tok"},
+	}
+
+	req, _ := http.NewRequestWithContext(context.Background(), "GET", "https://example.com/api", nil)
+	if err := auth.Authenticate(context.Background(), req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := req.Header.Get("Authorization")
+	if got != "Bearer bearer-tok" {
+		t.Fatalf("expected 'Bearer bearer-tok', got %q", got)
+	}
+}
+
+func TestCredentialStore_FileBased(t *testing.T) {
+	dir := t.TempDir()
+
+	// Force file-based storage
+	t.Setenv("HEY_NO_KEYRING", "1")
+	store := NewCredentialStore(dir)
+
+	if store.UsingKeyring() {
+		t.Fatal("expected file-based store")
+	}
+
+	origin := "https://app.hey.com"
+	creds := &Credentials{
+		AccessToken:  "access-tok",
+		RefreshToken: "refresh-tok",
+		ExpiresAt:    9999999999,
+		Scope:        "full",
+		UserID:       "user-1",
+	}
+
+	if err := store.Save(origin, creds); err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	loaded, err := store.Load(origin)
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	if loaded.AccessToken != "access-tok" {
+		t.Fatalf("expected access-tok, got %q", loaded.AccessToken)
+	}
+	if loaded.UserID != "user-1" {
+		t.Fatalf("expected user-1, got %q", loaded.UserID)
+	}
+
+	if err := store.Delete(origin); err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+
+	_, err = store.Load(origin)
+	if err == nil {
+		t.Fatal("expected error after delete")
+	}
+}
+
+func TestCredentialStore_Load_NonExistent(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HEY_NO_KEYRING", "1")
+	store := NewCredentialStore(dir)
+
+	_, err := store.Load("https://nowhere.com")
+	if err == nil {
+		t.Fatal("expected error for non-existent credentials")
+	}
+}
+
+func TestCredentialStore_MultipleOrigins(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HEY_NO_KEYRING", "1")
+	store := NewCredentialStore(dir)
+
+	store.Save("https://a.com", &Credentials{AccessToken: "tok-a"})
+	store.Save("https://b.com", &Credentials{AccessToken: "tok-b"})
+
+	a, _ := store.Load("https://a.com")
+	b, _ := store.Load("https://b.com")
+
+	if a.AccessToken != "tok-a" {
+		t.Fatalf("expected tok-a, got %q", a.AccessToken)
+	}
+	if b.AccessToken != "tok-b" {
+		t.Fatalf("expected tok-b, got %q", b.AccessToken)
+	}
+}
+
+func TestAuthManager_AccessToken_FromEnv(t *testing.T) {
+	t.Setenv("HEY_TOKEN", "env-token")
+	t.Setenv("HEY_NO_KEYRING", "1")
+
+	cfg := DefaultConfig()
+	mgr := NewAuthManager(cfg, http.DefaultClient)
+
+	token, err := mgr.AccessToken(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if token != "env-token" {
+		t.Fatalf("expected env-token, got %q", token)
+	}
+}
+
+func TestAuthManager_IsAuthenticated_FromEnv(t *testing.T) {
+	t.Setenv("HEY_TOKEN", "env-token")
+	t.Setenv("HEY_NO_KEYRING", "1")
+
+	cfg := DefaultConfig()
+	mgr := NewAuthManager(cfg, http.DefaultClient)
+
+	if !mgr.IsAuthenticated() {
+		t.Fatal("expected authenticated with HEY_TOKEN env var")
+	}
+}
+
+func TestAuthManager_IsAuthenticated_NoToken(t *testing.T) {
+	t.Setenv("HEY_NO_KEYRING", "1")
+	// Ensure HEY_TOKEN is not set
+	os.Unsetenv("HEY_TOKEN")
+
+	cfg := DefaultConfig()
+	dir := t.TempDir()
+	store := &CredentialStore{useKeyring: false, fallbackDir: dir}
+	mgr := NewAuthManagerWithStore(cfg, http.DefaultClient, store)
+
+	if mgr.IsAuthenticated() {
+		t.Fatal("expected not authenticated with no credentials")
+	}
+}
+
+func TestAuthManager_Refresh(t *testing.T) {
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		w.Write([]byte(`{"access_token":"new-token","refresh_token":"new-refresh","expires_in":3600}`))
+	}))
+	defer tokenServer.Close()
+
+	dir := t.TempDir()
+	t.Setenv("HEY_NO_KEYRING", "1")
+	store := &CredentialStore{useKeyring: false, fallbackDir: dir}
+
+	origin := NormalizeBaseURL("https://app.hey.com")
+	store.Save(origin, &Credentials{
+		AccessToken:   "old-token",
+		RefreshToken:  "old-refresh",
+		ExpiresAt:     1,
+		TokenEndpoint: tokenServer.URL,
+	})
+
+	cfg := DefaultConfig()
+	mgr := NewAuthManagerWithStore(cfg, http.DefaultClient, store)
+
+	if err := mgr.Refresh(context.Background()); err != nil {
+		t.Fatalf("Refresh failed: %v", err)
+	}
+
+	creds, _ := store.Load(origin)
+	if creds.AccessToken != "new-token" {
+		t.Fatalf("expected new-token, got %q", creds.AccessToken)
+	}
+	if creds.RefreshToken != "new-refresh" {
+		t.Fatalf("expected new-refresh, got %q", creds.RefreshToken)
+	}
+}
+
+func TestAuthManager_SetAndGetUserID(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HEY_NO_KEYRING", "1")
+	store := &CredentialStore{useKeyring: false, fallbackDir: dir}
+
+	origin := NormalizeBaseURL("https://app.hey.com")
+	store.Save(origin, &Credentials{AccessToken: "tok"})
+
+	cfg := DefaultConfig()
+	mgr := NewAuthManagerWithStore(cfg, http.DefaultClient, store)
+
+	if err := mgr.SetUserID("user-42"); err != nil {
+		t.Fatal(err)
+	}
+	if got := mgr.GetUserID(); got != "user-42" {
+		t.Fatalf("expected user-42, got %q", got)
+	}
+}
+
+func TestAuthManager_Logout(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HEY_NO_KEYRING", "1")
+	store := &CredentialStore{useKeyring: false, fallbackDir: dir}
+
+	origin := NormalizeBaseURL("https://app.hey.com")
+	store.Save(origin, &Credentials{AccessToken: "tok"})
+
+	cfg := DefaultConfig()
+	mgr := NewAuthManagerWithStore(cfg, http.DefaultClient, store)
+
+	if err := mgr.Logout(); err != nil {
+		t.Fatal(err)
+	}
+
+	if mgr.IsAuthenticated() {
+		t.Fatal("expected not authenticated after logout")
+	}
+}

--- a/go/pkg/hey/auth_test.go
+++ b/go/pkg/hey/auth_test.go
@@ -175,12 +175,14 @@ func TestAuthManager_Refresh(t *testing.T) {
 	store := &CredentialStore{useKeyring: false, fallbackDir: dir}
 
 	origin := NormalizeBaseURL("https://app.hey.com")
-	store.Save(origin, &Credentials{
+	if err := store.Save(origin, &Credentials{
 		AccessToken:   "old-token",
 		RefreshToken:  "old-refresh",
 		ExpiresAt:     1,
 		TokenEndpoint: tokenServer.URL,
-	})
+	}); err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
 
 	cfg := DefaultConfig()
 	mgr := NewAuthManagerWithStore(cfg, http.DefaultClient, store)
@@ -189,7 +191,10 @@ func TestAuthManager_Refresh(t *testing.T) {
 		t.Fatalf("Refresh failed: %v", err)
 	}
 
-	creds, _ := store.Load(origin)
+	creds, err := store.Load(origin)
+	if err != nil {
+		t.Fatalf("Load after refresh failed: %v", err)
+	}
 	if creds.AccessToken != "new-token" {
 		t.Fatalf("expected new-token, got %q", creds.AccessToken)
 	}
@@ -204,7 +209,9 @@ func TestAuthManager_SetAndGetUserID(t *testing.T) {
 	store := &CredentialStore{useKeyring: false, fallbackDir: dir}
 
 	origin := NormalizeBaseURL("https://app.hey.com")
-	store.Save(origin, &Credentials{AccessToken: "tok"})
+	if err := store.Save(origin, &Credentials{AccessToken: "tok"}); err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
 
 	cfg := DefaultConfig()
 	mgr := NewAuthManagerWithStore(cfg, http.DefaultClient, store)
@@ -223,7 +230,9 @@ func TestAuthManager_Logout(t *testing.T) {
 	store := &CredentialStore{useKeyring: false, fallbackDir: dir}
 
 	origin := NormalizeBaseURL("https://app.hey.com")
-	store.Save(origin, &Credentials{AccessToken: "tok"})
+	if err := store.Save(origin, &Credentials{AccessToken: "tok"}); err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
 
 	cfg := DefaultConfig()
 	mgr := NewAuthManagerWithStore(cfg, http.DefaultClient, store)

--- a/go/pkg/hey/auth_test.go
+++ b/go/pkg/hey/auth_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"testing"
 )
 
@@ -96,11 +95,21 @@ func TestCredentialStore_MultipleOrigins(t *testing.T) {
 	t.Setenv("HEY_NO_KEYRING", "1")
 	store := NewCredentialStore(dir)
 
-	store.Save("https://a.com", &Credentials{AccessToken: "tok-a"})
-	store.Save("https://b.com", &Credentials{AccessToken: "tok-b"})
+	if err := store.Save("https://a.com", &Credentials{AccessToken: "tok-a"}); err != nil {
+		t.Fatalf("Save a failed: %v", err)
+	}
+	if err := store.Save("https://b.com", &Credentials{AccessToken: "tok-b"}); err != nil {
+		t.Fatalf("Save b failed: %v", err)
+	}
 
-	a, _ := store.Load("https://a.com")
-	b, _ := store.Load("https://b.com")
+	a, err := store.Load("https://a.com")
+	if err != nil {
+		t.Fatalf("Load a failed: %v", err)
+	}
+	b, err := store.Load("https://b.com")
+	if err != nil {
+		t.Fatalf("Load b failed: %v", err)
+	}
 
 	if a.AccessToken != "tok-a" {
 		t.Fatalf("expected tok-a, got %q", a.AccessToken)
@@ -141,7 +150,7 @@ func TestAuthManager_IsAuthenticated_FromEnv(t *testing.T) {
 func TestAuthManager_IsAuthenticated_NoToken(t *testing.T) {
 	t.Setenv("HEY_NO_KEYRING", "1")
 	// Ensure HEY_TOKEN is not set
-	os.Unsetenv("HEY_TOKEN")
+	t.Setenv("HEY_TOKEN", "")
 
 	cfg := DefaultConfig()
 	dir := t.TempDir()

--- a/go/pkg/hey/cache_test.go
+++ b/go/pkg/hey/cache_test.go
@@ -110,8 +110,12 @@ func TestCache_OverwriteExisting(t *testing.T) {
 	cache := NewCache(dir)
 
 	key := cache.Key("https://example.com/x", "tok")
-	cache.Set(key, []byte(`old`), `"v1"`)
-	cache.Set(key, []byte(`new`), `"v2"`)
+	if err := cache.Set(key, []byte(`old`), `"v1"`); err != nil {
+		t.Fatalf("first Set failed: %v", err)
+	}
+	if err := cache.Set(key, []byte(`new`), `"v2"`); err != nil {
+		t.Fatalf("second Set failed: %v", err)
+	}
 
 	if got := string(cache.GetBody(key)); got != "new" {
 		t.Fatalf("expected overwritten body, got %q", got)

--- a/go/pkg/hey/cache_test.go
+++ b/go/pkg/hey/cache_test.go
@@ -66,7 +66,9 @@ func TestCache_Invalidate(t *testing.T) {
 	cache := NewCache(dir)
 
 	key := cache.Key("https://example.com/test", "tok")
-	cache.Set(key, []byte(`{}`), `"etag"`)
+	if err := cache.Set(key, []byte(`{}`), `"etag"`); err != nil {
+		t.Fatalf("Set failed: %v", err)
+	}
 
 	if err := cache.Invalidate(key); err != nil {
 		t.Fatalf("Invalidate failed: %v", err)
@@ -84,8 +86,12 @@ func TestCache_Clear(t *testing.T) {
 	dir := t.TempDir()
 	cache := NewCache(dir)
 
-	cache.Set(cache.Key("u1", "t"), []byte("a"), `"e1"`)
-	cache.Set(cache.Key("u2", "t"), []byte("b"), `"e2"`)
+	if err := cache.Set(cache.Key("u1", "t"), []byte("a"), `"e1"`); err != nil {
+		t.Fatalf("Set u1 failed: %v", err)
+	}
+	if err := cache.Set(cache.Key("u2", "t"), []byte("b"), `"e2"`); err != nil {
+		t.Fatalf("Set u2 failed: %v", err)
+	}
 
 	if err := cache.Clear(); err != nil {
 		t.Fatalf("Clear failed: %v", err)

--- a/go/pkg/hey/cache_test.go
+++ b/go/pkg/hey/cache_test.go
@@ -1,0 +1,116 @@
+package hey
+
+import (
+	"testing"
+)
+
+func TestCache_Key(t *testing.T) {
+	cache := NewCache(t.TempDir())
+
+	key1 := cache.Key("https://example.com/api", "token1")
+	key2 := cache.Key("https://example.com/api", "token2")
+	key3 := cache.Key("https://example.com/api", "token1")
+
+	if key1 == key2 {
+		t.Fatal("expected different keys for different tokens")
+	}
+	if key1 != key3 {
+		t.Fatal("expected same key for same URL+token")
+	}
+
+	keyNoToken := cache.Key("https://example.com/api", "")
+	if keyNoToken == key1 {
+		t.Fatal("expected different key for empty token")
+	}
+}
+
+func TestCache_SetAndGet(t *testing.T) {
+	dir := t.TempDir()
+	cache := NewCache(dir)
+
+	key := cache.Key("https://example.com/boxes.json", "tok")
+	body := []byte(`[{"id":1}]`)
+	etag := `"abc123"`
+
+	if err := cache.Set(key, body, etag); err != nil {
+		t.Fatalf("Set failed: %v", err)
+	}
+
+	gotETag := cache.GetETag(key)
+	if gotETag != etag {
+		t.Fatalf("expected ETag %q, got %q", etag, gotETag)
+	}
+
+	gotBody := cache.GetBody(key)
+	if string(gotBody) != string(body) {
+		t.Fatalf("expected body %q, got %q", body, gotBody)
+	}
+}
+
+func TestCache_GetETag_Missing(t *testing.T) {
+	cache := NewCache(t.TempDir())
+	if etag := cache.GetETag("nonexistent"); etag != "" {
+		t.Fatalf("expected empty etag, got %q", etag)
+	}
+}
+
+func TestCache_GetBody_Missing(t *testing.T) {
+	cache := NewCache(t.TempDir())
+	if body := cache.GetBody("nonexistent"); body != nil {
+		t.Fatal("expected nil body for missing key")
+	}
+}
+
+func TestCache_Invalidate(t *testing.T) {
+	dir := t.TempDir()
+	cache := NewCache(dir)
+
+	key := cache.Key("https://example.com/test", "tok")
+	cache.Set(key, []byte(`{}`), `"etag"`)
+
+	if err := cache.Invalidate(key); err != nil {
+		t.Fatalf("Invalidate failed: %v", err)
+	}
+
+	if etag := cache.GetETag(key); etag != "" {
+		t.Fatalf("expected empty etag after invalidation, got %q", etag)
+	}
+	if body := cache.GetBody(key); body != nil {
+		t.Fatal("expected nil body after invalidation")
+	}
+}
+
+func TestCache_Clear(t *testing.T) {
+	dir := t.TempDir()
+	cache := NewCache(dir)
+
+	cache.Set(cache.Key("u1", "t"), []byte("a"), `"e1"`)
+	cache.Set(cache.Key("u2", "t"), []byte("b"), `"e2"`)
+
+	if err := cache.Clear(); err != nil {
+		t.Fatalf("Clear failed: %v", err)
+	}
+
+	if body := cache.GetBody(cache.Key("u1", "t")); body != nil {
+		t.Fatal("expected nil after clear")
+	}
+	if etag := cache.GetETag(cache.Key("u1", "t")); etag != "" {
+		t.Fatalf("expected empty etag after clear, got %q", etag)
+	}
+}
+
+func TestCache_OverwriteExisting(t *testing.T) {
+	dir := t.TempDir()
+	cache := NewCache(dir)
+
+	key := cache.Key("https://example.com/x", "tok")
+	cache.Set(key, []byte(`old`), `"v1"`)
+	cache.Set(key, []byte(`new`), `"v2"`)
+
+	if got := string(cache.GetBody(key)); got != "new" {
+		t.Fatalf("expected overwritten body, got %q", got)
+	}
+	if got := cache.GetETag(key); got != `"v2"` {
+		t.Fatalf("expected overwritten etag, got %q", got)
+	}
+}

--- a/go/pkg/hey/client_test.go
+++ b/go/pkg/hey/client_test.go
@@ -1,0 +1,359 @@
+package hey
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func newTestClient(t *testing.T, handler http.HandlerFunc) *Client {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	cfg := &Config{BaseURL: server.URL}
+	return NewClient(cfg, &StaticTokenProvider{Token: "test-token"},
+		WithMaxRetries(0),
+		WithBaseDelay(1*time.Millisecond),
+		WithMaxJitter(1*time.Millisecond),
+	)
+}
+
+func TestNewClient_HTTPSEnforcement(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic for non-HTTPS base URL")
+		}
+	}()
+	cfg := &Config{BaseURL: "http://example.com"}
+	NewClient(cfg, &StaticTokenProvider{Token: "test"})
+}
+
+func TestNewClient_LocalhostHTTP(t *testing.T) {
+	// Should not panic for localhost HTTP
+	cfg := &Config{BaseURL: "http://localhost:3000"}
+	c := NewClient(cfg, &StaticTokenProvider{Token: "test"})
+	if c == nil {
+		t.Fatal("expected non-nil client")
+	}
+}
+
+func TestNewClient_InvalidTimeout(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic for zero timeout")
+		}
+	}()
+	cfg := &Config{BaseURL: "http://localhost:3000"}
+	NewClient(cfg, &StaticTokenProvider{Token: "test"}, WithTimeout(0))
+}
+
+func TestNewClient_NegativeRetries(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic for negative retries")
+		}
+	}()
+	cfg := &Config{BaseURL: "http://localhost:3000"}
+	NewClient(cfg, &StaticTokenProvider{Token: "test"}, WithMaxRetries(-1))
+}
+
+func TestNewClient_InvalidMaxPages(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic for zero maxPages")
+		}
+	}()
+	cfg := &Config{BaseURL: "http://localhost:3000"}
+	NewClient(cfg, &StaticTokenProvider{Token: "test"}, WithMaxPages(0))
+}
+
+func TestClient_Get(t *testing.T) {
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		if r.Header.Get("Authorization") != "Bearer test-token" {
+			t.Error("expected Bearer token in Authorization header")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		w.Write([]byte(`{"ok":true}`))
+	})
+
+	resp, err := client.Get(context.Background(), "/test.json")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != 200 {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+}
+
+func TestClient_Post(t *testing.T) {
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		var body map[string]string
+		json.NewDecoder(r.Body).Decode(&body)
+		if body["key"] != "value" {
+			t.Errorf("expected body key=value, got %v", body)
+		}
+		w.WriteHeader(201)
+		w.Write([]byte(`{"id":1}`))
+	})
+
+	resp, err := client.Post(context.Background(), "/create.json", map[string]string{"key": "value"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != 201 {
+		t.Fatalf("expected 201, got %d", resp.StatusCode)
+	}
+}
+
+func TestClient_Delete(t *testing.T) {
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "DELETE" {
+			t.Errorf("expected DELETE, got %s", r.Method)
+		}
+		w.WriteHeader(204)
+	})
+
+	resp, err := client.Delete(context.Background(), "/thing/1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != 204 {
+		t.Fatalf("expected 204, got %d", resp.StatusCode)
+	}
+}
+
+func TestClient_ErrorResponses(t *testing.T) {
+	cases := []struct {
+		name     string
+		status   int
+		wantCode string
+	}{
+		{"401", 401, CodeAuth},
+		{"403_GET", 403, CodeForbidden},
+		{"404", 404, CodeNotFound},
+		{"500", 500, CodeAPI},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tc.status)
+				w.Write([]byte(`{}`))
+			})
+			_, err := client.Get(context.Background(), "/fail")
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			apiErr, ok := err.(*Error)
+			if !ok {
+				t.Fatalf("expected *Error, got %T", err)
+			}
+			if apiErr.Code != tc.wantCode {
+				t.Fatalf("expected code %q, got %q", tc.wantCode, apiErr.Code)
+			}
+		})
+	}
+}
+
+func TestBuildURL(t *testing.T) {
+	cfg := &Config{BaseURL: "http://localhost:3000"}
+	c := NewClient(cfg, &StaticTokenProvider{Token: "t"})
+
+	url, err := c.buildURL("/boxes.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if url != "http://localhost:3000/boxes.json" {
+		t.Fatalf("expected full URL, got %q", url)
+	}
+
+	url, err = c.buildURL("boxes.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if url != "http://localhost:3000/boxes.json" {
+		t.Fatalf("expected leading slash added, got %q", url)
+	}
+
+	url, err = c.buildURL("https://cdn.example.com/file")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if url != "https://cdn.example.com/file" {
+		t.Fatalf("expected HTTPS URL passthrough, got %q", url)
+	}
+
+	_, err = c.buildURL("http://insecure.example.com/file")
+	if err == nil {
+		t.Fatal("expected error for HTTP URL")
+	}
+}
+
+func TestParseNextLink(t *testing.T) {
+	cases := []struct {
+		header string
+		want   string
+	}{
+		{"", ""},
+		{`<https://example.com/page2>; rel="next"`, "https://example.com/page2"},
+		{`<https://example.com/page1>; rel="prev", <https://example.com/page2>; rel="next"`, "https://example.com/page2"},
+		{`<https://example.com/page1>; rel="prev"`, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.header, func(t *testing.T) {
+			got := parseNextLink(tc.header)
+			if got != tc.want {
+				t.Fatalf("parseNextLink(%q) = %q, want %q", tc.header, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseRetryAfter(t *testing.T) {
+	cases := []struct {
+		header string
+		want   int
+	}{
+		{"", 0},
+		{"30", 30},
+		{"0", 0},
+		{"-5", 0},
+		{"garbage", 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.header, func(t *testing.T) {
+			got := parseRetryAfter(tc.header)
+			if got != tc.want {
+				t.Fatalf("parseRetryAfter(%q) = %d, want %d", tc.header, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestClient_ServiceAccessors(t *testing.T) {
+	cfg := &Config{BaseURL: "http://localhost:3000"}
+	c := NewClient(cfg, &StaticTokenProvider{Token: "t"})
+
+	if c.Identity() == nil {
+		t.Fatal("expected non-nil IdentityService")
+	}
+	if c.Boxes() == nil {
+		t.Fatal("expected non-nil BoxesService")
+	}
+	if c.Topics() == nil {
+		t.Fatal("expected non-nil TopicsService")
+	}
+	if c.Messages() == nil {
+		t.Fatal("expected non-nil MessagesService")
+	}
+	if c.Entries() == nil {
+		t.Fatal("expected non-nil EntriesService")
+	}
+	if c.Contacts() == nil {
+		t.Fatal("expected non-nil ContactsService")
+	}
+	if c.Calendars() == nil {
+		t.Fatal("expected non-nil CalendarsService")
+	}
+	if c.CalendarTodos() == nil {
+		t.Fatal("expected non-nil CalendarTodosService")
+	}
+	if c.Habits() == nil {
+		t.Fatal("expected non-nil HabitsService")
+	}
+	if c.TimeTracks() == nil {
+		t.Fatal("expected non-nil TimeTracksService")
+	}
+	if c.Journal() == nil {
+		t.Fatal("expected non-nil JournalService")
+	}
+	if c.Search() == nil {
+		t.Fatal("expected non-nil SearchService")
+	}
+
+	// Verify idempotency (same instance returned)
+	b1 := c.Boxes()
+	b2 := c.Boxes()
+	if b1 != b2 {
+		t.Fatal("expected same BoxesService instance on repeated calls")
+	}
+}
+
+func TestClient_ConfigCopy(t *testing.T) {
+	cfg := &Config{BaseURL: "http://localhost:3000"}
+	c := NewClient(cfg, &StaticTokenProvider{Token: "t"})
+
+	cfgCopy := c.Config()
+	cfgCopy.BaseURL = "http://modified" //nolint:govet // testing that mutation doesn't propagate
+
+	if c.Config().BaseURL != "http://localhost:3000" {
+		t.Fatal("expected original config to be unchanged")
+	}
+}
+
+func TestClient_WithUserAgent(t *testing.T) {
+	var gotUA string
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		gotUA = r.Header.Get("User-Agent")
+		w.WriteHeader(200)
+		w.Write([]byte(`{}`))
+	})
+	// Default UA
+	client.Get(context.Background(), "/test")
+	if gotUA != DefaultUserAgent {
+		t.Fatalf("expected default UA, got %q", gotUA)
+	}
+}
+
+func TestResponse_UnmarshalData(t *testing.T) {
+	resp := &Response{Data: json.RawMessage(`{"id":42}`)}
+	var result struct {
+		ID int `json:"id"`
+	}
+	if err := resp.UnmarshalData(&result); err != nil {
+		t.Fatal(err)
+	}
+	if result.ID != 42 {
+		t.Fatalf("expected 42, got %d", result.ID)
+	}
+}
+
+func TestClient_RateLimitResponse(t *testing.T) {
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Retry-After", "1")
+		w.WriteHeader(429)
+	})
+	client.httpOpts.MaxRetries = 0
+	client.httpOpts.BaseDelay = 1 * time.Millisecond
+	client.httpOpts.MaxJitter = 1 * time.Millisecond
+
+	_, err := client.Get(context.Background(), "/rate-limited")
+	if err == nil {
+		t.Fatal("expected error for 429")
+	}
+}
+
+func TestClient_GatewayErrors(t *testing.T) {
+	for _, status := range []int{502, 503, 504} {
+		t.Run("status_"+string(rune('0'+status/100))+string(rune('0'+(status/10)%10))+string(rune('0'+status%10)), func(t *testing.T) {
+			client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(status)
+			})
+			client.httpOpts.MaxRetries = 0
+
+			_, err := client.Get(context.Background(), "/gw")
+			if err == nil {
+				t.Fatal("expected error")
+			}
+		})
+	}
+}

--- a/go/pkg/hey/client_test.go
+++ b/go/pkg/hey/client_test.go
@@ -98,7 +98,9 @@ func TestClient_Post(t *testing.T) {
 			t.Errorf("expected POST, got %s", r.Method)
 		}
 		var body map[string]string
-		json.NewDecoder(r.Body).Decode(&body)
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
 		if body["key"] != "value" {
 			t.Errorf("expected body key=value, got %v", body)
 		}
@@ -308,7 +310,13 @@ func TestClient_WithUserAgent(t *testing.T) {
 		w.Write([]byte(`{}`))
 	})
 	// Default UA
-	client.Get(context.Background(), "/test")
+	resp, err := client.Get(context.Background(), "/test")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != 200 {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
 	if gotUA != DefaultUserAgent {
 		t.Fatalf("expected default UA, got %q", gotUA)
 	}

--- a/go/pkg/hey/config_test.go
+++ b/go/pkg/hey/config_test.go
@@ -1,0 +1,118 @@
+package hey
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDefaultConfig(t *testing.T) {
+	cfg := DefaultConfig()
+	if cfg.BaseURL != "https://app.hey.com" {
+		t.Fatalf("expected default base URL, got %q", cfg.BaseURL)
+	}
+	if cfg.OAuthClientID == "" {
+		t.Fatal("expected non-empty OAuth client ID")
+	}
+	if cfg.CacheEnabled {
+		t.Fatal("expected cache disabled by default")
+	}
+}
+
+func TestLoadConfig_NonExistentFile(t *testing.T) {
+	cfg, err := LoadConfig("/nonexistent/config.json")
+	if err != nil {
+		t.Fatalf("expected no error for missing file, got %v", err)
+	}
+	if cfg.BaseURL != "https://app.hey.com" {
+		t.Fatalf("expected defaults, got %q", cfg.BaseURL)
+	}
+}
+
+func TestLoadConfig_ValidFile(t *testing.T) {
+	dir := t.TempDir()
+	cfgFile := filepath.Join(dir, "config.json")
+
+	data, _ := json.Marshal(map[string]any{
+		"base_url":      "https://custom.hey.com",
+		"cache_enabled": true,
+	})
+	if err := os.WriteFile(cfgFile, data, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadConfig(cfgFile)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.BaseURL != "https://custom.hey.com" {
+		t.Fatalf("expected custom base URL, got %q", cfg.BaseURL)
+	}
+	if !cfg.CacheEnabled {
+		t.Fatal("expected cache enabled")
+	}
+}
+
+func TestLoadConfig_InvalidJSON(t *testing.T) {
+	dir := t.TempDir()
+	cfgFile := filepath.Join(dir, "config.json")
+	if err := os.WriteFile(cfgFile, []byte("{bad json"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := LoadConfig(cfgFile)
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+}
+
+func TestLoadConfigFromEnv(t *testing.T) {
+	cfg := DefaultConfig()
+
+	t.Setenv("HEY_BASE_URL", "https://env.hey.com")
+	t.Setenv("HEY_OAUTH_CLIENT_ID", "env-client-id")
+	t.Setenv("HEY_CACHE_DIR", "/tmp/hey-cache")
+	t.Setenv("HEY_CACHE_ENABLED", "true")
+
+	cfg.LoadConfigFromEnv()
+
+	if cfg.BaseURL != "https://env.hey.com" {
+		t.Fatalf("expected env base URL, got %q", cfg.BaseURL)
+	}
+	if cfg.OAuthClientID != "env-client-id" {
+		t.Fatalf("expected env client ID, got %q", cfg.OAuthClientID)
+	}
+	if cfg.CacheDir != "/tmp/hey-cache" {
+		t.Fatalf("expected env cache dir, got %q", cfg.CacheDir)
+	}
+	if !cfg.CacheEnabled {
+		t.Fatal("expected cache enabled from env")
+	}
+}
+
+func TestLoadConfigFromEnv_CacheEnabled_Values(t *testing.T) {
+	cfg := DefaultConfig()
+
+	t.Setenv("HEY_CACHE_ENABLED", "1")
+	cfg.LoadConfigFromEnv()
+	if !cfg.CacheEnabled {
+		t.Fatal("expected '1' to enable cache")
+	}
+
+	cfg.CacheEnabled = false
+	t.Setenv("HEY_CACHE_ENABLED", "false")
+	cfg.LoadConfigFromEnv()
+	if cfg.CacheEnabled {
+		t.Fatal("expected 'false' to not enable cache")
+	}
+}
+
+func TestNormalizeBaseURL(t *testing.T) {
+	if got := NormalizeBaseURL("https://example.com/"); got != "https://example.com" {
+		t.Fatalf("expected trailing slash stripped, got %q", got)
+	}
+	if got := NormalizeBaseURL("https://example.com"); got != "https://example.com" {
+		t.Fatalf("expected no change, got %q", got)
+	}
+}

--- a/go/pkg/hey/config_test.go
+++ b/go/pkg/hey/config_test.go
@@ -21,7 +21,7 @@ func TestDefaultConfig(t *testing.T) {
 }
 
 func TestLoadConfig_NonExistentFile(t *testing.T) {
-	cfg, err := LoadConfig("/nonexistent/config.json")
+	cfg, err := LoadConfig(filepath.Join(t.TempDir(), "missing.json"))
 	if err != nil {
 		t.Fatalf("expected no error for missing file, got %v", err)
 	}
@@ -100,11 +100,11 @@ func TestLoadConfigFromEnv_CacheEnabled_Values(t *testing.T) {
 		t.Fatal("expected '1' to enable cache")
 	}
 
-	cfg.CacheEnabled = false
+	cfg.CacheEnabled = true
 	t.Setenv("HEY_CACHE_ENABLED", "false")
 	cfg.LoadConfigFromEnv()
 	if cfg.CacheEnabled {
-		t.Fatal("expected 'false' to not enable cache")
+		t.Fatal("expected 'false' to disable cache")
 	}
 }
 

--- a/go/pkg/hey/errors_test.go
+++ b/go/pkg/hey/errors_test.go
@@ -1,0 +1,194 @@
+package hey
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestError_Error(t *testing.T) {
+	e := &Error{Code: CodeAPI, Message: "something broke"}
+	if e.Error() != "something broke" {
+		t.Fatalf("expected 'something broke', got %q", e.Error())
+	}
+
+	e.Hint = "check the logs"
+	if e.Error() != "something broke: check the logs" {
+		t.Fatalf("expected hint appended, got %q", e.Error())
+	}
+}
+
+func TestError_Unwrap(t *testing.T) {
+	cause := fmt.Errorf("root cause")
+	e := &Error{Code: CodeNetwork, Message: "net", Cause: cause}
+	if !errors.Is(e, cause) {
+		t.Fatal("expected errors.Is to find cause")
+	}
+}
+
+func TestError_ExitCode(t *testing.T) {
+	e := &Error{Code: CodeNotFound, Message: "nope"}
+	if e.ExitCode() != ExitNotFound {
+		t.Fatalf("expected %d, got %d", ExitNotFound, e.ExitCode())
+	}
+}
+
+func TestExitCodeFor(t *testing.T) {
+	cases := []struct {
+		code string
+		want int
+	}{
+		{CodeUsage, ExitUsage},
+		{CodeNotFound, ExitNotFound},
+		{CodeAuth, ExitAuth},
+		{CodeForbidden, ExitForbidden},
+		{CodeRateLimit, ExitRateLimit},
+		{CodeNetwork, ExitNetwork},
+		{CodeAPI, ExitAPI},
+		{CodeValidation, ExitValidation},
+		{CodeAmbiguous, ExitAmbiguous},
+		{"unknown", ExitAPI},
+	}
+	for _, tc := range cases {
+		t.Run(tc.code, func(t *testing.T) {
+			got := ExitCodeFor(tc.code)
+			if got != tc.want {
+				t.Fatalf("ExitCodeFor(%q) = %d, want %d", tc.code, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestErrUsage(t *testing.T) {
+	e := ErrUsage("bad arg")
+	if e.Code != CodeUsage {
+		t.Fatalf("expected code %q, got %q", CodeUsage, e.Code)
+	}
+	if e.Message != "bad arg" {
+		t.Fatalf("expected message 'bad arg', got %q", e.Message)
+	}
+}
+
+func TestErrUsageHint(t *testing.T) {
+	e := ErrUsageHint("bad arg", "try --help")
+	if e.Hint != "try --help" {
+		t.Fatalf("expected hint 'try --help', got %q", e.Hint)
+	}
+}
+
+func TestErrNotFound(t *testing.T) {
+	e := ErrNotFound("Topic", "42")
+	if e.Code != CodeNotFound {
+		t.Fatalf("expected code %q", CodeNotFound)
+	}
+	if e.Message != "Topic not found: 42" {
+		t.Fatalf("unexpected message: %q", e.Message)
+	}
+}
+
+func TestErrNotFoundHint(t *testing.T) {
+	e := ErrNotFoundHint("Topic", "42", "check the ID")
+	if e.Hint != "check the ID" {
+		t.Fatalf("expected hint, got %q", e.Hint)
+	}
+}
+
+func TestErrAuth(t *testing.T) {
+	e := ErrAuth("not logged in")
+	if e.Code != CodeAuth {
+		t.Fatalf("expected code %q", CodeAuth)
+	}
+}
+
+func TestErrForbidden(t *testing.T) {
+	e := ErrForbidden("nope")
+	if e.HTTPStatus != 403 {
+		t.Fatalf("expected HTTP 403, got %d", e.HTTPStatus)
+	}
+}
+
+func TestErrForbiddenScope(t *testing.T) {
+	e := ErrForbiddenScope()
+	if e.Code != CodeForbidden {
+		t.Fatalf("expected code %q", CodeForbidden)
+	}
+	if e.Hint == "" {
+		t.Fatal("expected hint for scope error")
+	}
+}
+
+func TestErrRateLimit(t *testing.T) {
+	e := ErrRateLimit(0)
+	if e.Code != CodeRateLimit {
+		t.Fatalf("expected code %q", CodeRateLimit)
+	}
+	if e.Hint != "Try again later" {
+		t.Fatalf("expected generic hint, got %q", e.Hint)
+	}
+	if !e.Retryable {
+		t.Fatal("expected retryable")
+	}
+
+	e2 := ErrRateLimit(30)
+	if e2.Hint != "Try again in 30 seconds" {
+		t.Fatalf("expected specific hint, got %q", e2.Hint)
+	}
+}
+
+func TestErrNetwork(t *testing.T) {
+	cause := fmt.Errorf("connection refused")
+	e := ErrNetwork(cause)
+	if e.Code != CodeNetwork {
+		t.Fatalf("expected code %q", CodeNetwork)
+	}
+	if !e.Retryable {
+		t.Fatal("expected retryable")
+	}
+	if !errors.Is(e, cause) {
+		t.Fatal("expected cause to be unwrappable")
+	}
+}
+
+func TestErrAPI(t *testing.T) {
+	e := ErrAPI(500, "server error")
+	if e.HTTPStatus != 500 {
+		t.Fatalf("expected HTTP 500, got %d", e.HTTPStatus)
+	}
+}
+
+func TestErrAmbiguous(t *testing.T) {
+	e := ErrAmbiguous("contact", []string{"Alice", "Bob"})
+	if e.Code != CodeAmbiguous {
+		t.Fatalf("expected code %q", CodeAmbiguous)
+	}
+	if e.Hint == "Be more specific" {
+		t.Fatal("expected specific hint with matches")
+	}
+
+	e2 := ErrAmbiguous("contact", nil)
+	if e2.Hint != "Be more specific" {
+		t.Fatalf("expected generic hint, got %q", e2.Hint)
+	}
+}
+
+func TestAsError_WithSDKError(t *testing.T) {
+	original := ErrNotFound("x", "1")
+	result := AsError(original)
+	if result != original {
+		t.Fatal("expected same pointer")
+	}
+}
+
+func TestAsError_WithPlainError(t *testing.T) {
+	plain := fmt.Errorf("something")
+	result := AsError(plain)
+	if result.Code != CodeAPI {
+		t.Fatalf("expected code %q, got %q", CodeAPI, result.Code)
+	}
+	if result.Message != "something" {
+		t.Fatalf("expected message 'something', got %q", result.Message)
+	}
+	if !errors.Is(result, plain) {
+		t.Fatal("expected cause to be preserved")
+	}
+}

--- a/go/pkg/hey/errors_test.go
+++ b/go/pkg/hey/errors_test.go
@@ -161,8 +161,9 @@ func TestErrAmbiguous(t *testing.T) {
 	if e.Code != CodeAmbiguous {
 		t.Fatalf("expected code %q", CodeAmbiguous)
 	}
-	if e.Hint == "Be more specific" {
-		t.Fatal("expected specific hint with matches")
+	wantHint := "Did you mean: [Alice Bob]"
+	if e.Hint != wantHint {
+		t.Fatalf("expected hint %q, got %q", wantHint, e.Hint)
 	}
 
 	e2 := ErrAmbiguous("contact", nil)

--- a/go/pkg/hey/helpers_test.go
+++ b/go/pkg/hey/helpers_test.go
@@ -62,7 +62,13 @@ func TestCheckResponse_Errors(t *testing.T) {
 func TestCheckResponse_429IsRetryable(t *testing.T) {
 	resp := &http.Response{StatusCode: 429, Header: http.Header{}}
 	err := CheckResponse(resp)
-	apiErr := err.(*Error)
+	if err == nil {
+		t.Fatal("expected error for 429")
+	}
+	apiErr, ok := err.(*Error)
+	if !ok {
+		t.Fatalf("expected *Error, got %T", err)
+	}
 	if !apiErr.Retryable {
 		t.Fatal("expected 429 to be retryable")
 	}
@@ -71,7 +77,13 @@ func TestCheckResponse_429IsRetryable(t *testing.T) {
 func TestCheckResponse_5xxIsRetryable(t *testing.T) {
 	resp := &http.Response{StatusCode: 502, Status: "Bad Gateway", Header: http.Header{}}
 	err := CheckResponse(resp)
-	apiErr := err.(*Error)
+	if err == nil {
+		t.Fatal("expected error for 502")
+	}
+	apiErr, ok := err.(*Error)
+	if !ok {
+		t.Fatalf("expected *Error, got %T", err)
+	}
 	if !apiErr.Retryable {
 		t.Fatal("expected 5xx to be retryable")
 	}
@@ -80,7 +92,13 @@ func TestCheckResponse_5xxIsRetryable(t *testing.T) {
 func TestCheckResponse_4xxIsNotRetryable(t *testing.T) {
 	resp := &http.Response{StatusCode: 400, Status: "Bad Request", Header: http.Header{}}
 	err := CheckResponse(resp)
-	apiErr := err.(*Error)
+	if err == nil {
+		t.Fatal("expected error for 400")
+	}
+	apiErr, ok := err.(*Error)
+	if !ok {
+		t.Fatalf("expected *Error, got %T", err)
+	}
 	if apiErr.Retryable {
 		t.Fatal("expected 4xx (non-429) to not be retryable")
 	}

--- a/go/pkg/hey/helpers_test.go
+++ b/go/pkg/hey/helpers_test.go
@@ -1,0 +1,103 @@
+package hey
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestCheckResponse_Success(t *testing.T) {
+	for _, status := range []int{200, 201, 204, 299} {
+		resp := &http.Response{StatusCode: status, Header: http.Header{}}
+		if err := CheckResponse(resp); err != nil {
+			t.Fatalf("expected no error for %d, got %v", status, err)
+		}
+	}
+}
+
+func TestCheckResponse_Nil(t *testing.T) {
+	if err := CheckResponse(nil); err != nil {
+		t.Fatalf("expected nil for nil response, got %v", err)
+	}
+}
+
+func TestCheckResponse_Errors(t *testing.T) {
+	cases := []struct {
+		status   int
+		wantCode string
+	}{
+		{401, CodeAuth},
+		{403, CodeForbidden},
+		{404, CodeNotFound},
+		{422, CodeValidation},
+		{429, CodeRateLimit},
+		{500, CodeAPI},
+		{503, CodeAPI},
+		{418, CodeAPI},
+	}
+	for _, tc := range cases {
+		resp := &http.Response{
+			StatusCode: tc.status,
+			Status:     http.StatusText(tc.status),
+			Header:     http.Header{},
+		}
+		resp.Header.Set("X-Request-Id", "req-123")
+
+		err := CheckResponse(resp)
+		if err == nil {
+			t.Fatalf("expected error for %d", tc.status)
+		}
+		apiErr, ok := err.(*Error)
+		if !ok {
+			t.Fatalf("expected *Error, got %T", err)
+		}
+		if apiErr.Code != tc.wantCode {
+			t.Fatalf("status %d: expected code %q, got %q", tc.status, tc.wantCode, apiErr.Code)
+		}
+		if apiErr.RequestID != "req-123" {
+			t.Fatalf("expected request ID 'req-123', got %q", apiErr.RequestID)
+		}
+	}
+}
+
+func TestCheckResponse_429IsRetryable(t *testing.T) {
+	resp := &http.Response{StatusCode: 429, Header: http.Header{}}
+	err := CheckResponse(resp)
+	apiErr := err.(*Error)
+	if !apiErr.Retryable {
+		t.Fatal("expected 429 to be retryable")
+	}
+}
+
+func TestCheckResponse_5xxIsRetryable(t *testing.T) {
+	resp := &http.Response{StatusCode: 502, Status: "Bad Gateway", Header: http.Header{}}
+	err := CheckResponse(resp)
+	apiErr := err.(*Error)
+	if !apiErr.Retryable {
+		t.Fatal("expected 5xx to be retryable")
+	}
+}
+
+func TestCheckResponse_4xxIsNotRetryable(t *testing.T) {
+	resp := &http.Response{StatusCode: 400, Status: "Bad Request", Header: http.Header{}}
+	err := CheckResponse(resp)
+	apiErr := err.(*Error)
+	if apiErr.Retryable {
+		t.Fatal("expected 4xx (non-429) to not be retryable")
+	}
+}
+
+func TestCheckResponseEmptyOn(t *testing.T) {
+	resp404 := &http.Response{StatusCode: 404, Header: http.Header{}}
+	if err := checkResponseEmptyOn(resp404, []int{404}); err != nil {
+		t.Fatalf("expected no error for 404 in emptyOn list, got %v", err)
+	}
+
+	resp500 := &http.Response{StatusCode: 500, Status: "Internal Server Error", Header: http.Header{}}
+	if err := checkResponseEmptyOn(resp500, []int{404}); err == nil {
+		t.Fatal("expected error for 500 not in emptyOn list")
+	}
+
+	if err := checkResponseEmptyOn(nil, []int{404}); err != nil {
+		t.Fatalf("expected nil for nil response, got %v", err)
+	}
+}

--- a/go/pkg/hey/http_test.go
+++ b/go/pkg/hey/http_test.go
@@ -1,0 +1,81 @@
+package hey
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDefaultHTTPOptions(t *testing.T) {
+	opts := DefaultHTTPOptions()
+
+	if opts.Timeout != 30*time.Second {
+		t.Fatalf("expected 30s timeout, got %v", opts.Timeout)
+	}
+	if opts.MaxRetries != 3 {
+		t.Fatalf("expected 3 retries, got %d", opts.MaxRetries)
+	}
+	if opts.BaseDelay != 1*time.Second {
+		t.Fatalf("expected 1s base delay, got %v", opts.BaseDelay)
+	}
+	if opts.MaxJitter != 100*time.Millisecond {
+		t.Fatalf("expected 100ms max jitter, got %v", opts.MaxJitter)
+	}
+	if opts.MaxPages != 10000 {
+		t.Fatalf("expected 10000 max pages, got %d", opts.MaxPages)
+	}
+}
+
+func TestRetryableError(t *testing.T) {
+	inner := ErrRateLimit(30)
+	re := &retryableError{err: inner, retryAfter: 30 * time.Second}
+
+	if re.Error() != inner.Error() {
+		t.Fatalf("expected %q, got %q", inner.Error(), re.Error())
+	}
+	if re.Unwrap() != inner {
+		t.Fatal("expected unwrap to return inner error")
+	}
+}
+
+func TestContextWithAttempt(t *testing.T) {
+	ctx := contextWithAttempt(t.Context(), 3)
+	got := attemptFromContext(ctx)
+	if got != 3 {
+		t.Fatalf("expected attempt 3, got %d", got)
+	}
+}
+
+func TestAttemptFromContext_Default(t *testing.T) {
+	got := attemptFromContext(t.Context())
+	if got != 1 {
+		t.Fatalf("expected default attempt 1, got %d", got)
+	}
+}
+
+func TestClientOptions(t *testing.T) {
+	cfg := &Config{BaseURL: "http://localhost:3000"}
+
+	c := NewClient(cfg, &StaticTokenProvider{Token: "t"},
+		WithTimeout(10*time.Second),
+		WithMaxRetries(5),
+		WithBaseDelay(2*time.Second),
+		WithMaxJitter(50*time.Millisecond),
+		WithMaxPages(100),
+	)
+
+	if c.httpOpts.Timeout != 10*time.Second {
+		t.Fatalf("expected 10s timeout, got %v", c.httpOpts.Timeout)
+	}
+	if c.httpOpts.MaxRetries != 5 {
+		t.Fatalf("expected 5 retries, got %d", c.httpOpts.MaxRetries)
+	}
+	if c.httpOpts.BaseDelay != 2*time.Second {
+		t.Fatalf("expected 2s base delay, got %v", c.httpOpts.BaseDelay)
+	}
+	if c.httpOpts.MaxJitter != 50*time.Millisecond {
+		t.Fatalf("expected 50ms jitter, got %v", c.httpOpts.MaxJitter)
+	}
+	if c.httpOpts.MaxPages != 100 {
+		t.Fatalf("expected 100 maxPages, got %d", c.httpOpts.MaxPages)
+	}
+}

--- a/go/pkg/hey/observability_test.go
+++ b/go/pkg/hey/observability_test.go
@@ -1,0 +1,106 @@
+package hey
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestNoopHooks(t *testing.T) {
+	var h Hooks = NoopHooks{}
+
+	ctx := context.Background()
+	op := OperationInfo{Service: "Test", Operation: "Op"}
+	info := RequestInfo{Method: "GET", URL: "https://example.com"}
+	result := RequestResult{StatusCode: 200}
+
+	// All methods should be safe to call (no panics)
+	ctx = h.OnOperationStart(ctx, op)
+	h.OnOperationEnd(ctx, op, nil, time.Second)
+	ctx = h.OnRequestStart(ctx, info)
+	h.OnRequestEnd(ctx, info, result)
+	h.OnRetry(ctx, info, 2, nil)
+
+	if ctx == nil {
+		t.Fatal("expected non-nil context from NoopHooks")
+	}
+}
+
+type recordingHook struct {
+	starts []string
+	ends   []string
+}
+
+func (h *recordingHook) OnOperationStart(ctx context.Context, op OperationInfo) context.Context {
+	h.starts = append(h.starts, op.Service+"."+op.Operation)
+	return ctx
+}
+func (h *recordingHook) OnOperationEnd(_ context.Context, op OperationInfo, _ error, _ time.Duration) {
+	h.ends = append(h.ends, op.Service+"."+op.Operation)
+}
+func (h *recordingHook) OnRequestStart(ctx context.Context, _ RequestInfo) context.Context {
+	return ctx
+}
+func (h *recordingHook) OnRequestEnd(context.Context, RequestInfo, RequestResult) {}
+func (h *recordingHook) OnRetry(context.Context, RequestInfo, int, error)         {}
+
+func TestChainHooks(t *testing.T) {
+	h1 := &recordingHook{}
+	h2 := &recordingHook{}
+
+	chain := NewChainHooks(h1, h2)
+
+	ctx := context.Background()
+	op := OperationInfo{Service: "Svc", Operation: "Do"}
+
+	ctx = chain.OnOperationStart(ctx, op)
+	chain.OnOperationEnd(ctx, op, nil, time.Second)
+
+	// OnOperationStart called in order
+	if len(h1.starts) != 1 || h1.starts[0] != "Svc.Do" {
+		t.Fatal("expected h1 start recorded")
+	}
+	if len(h2.starts) != 1 || h2.starts[0] != "Svc.Do" {
+		t.Fatal("expected h2 start recorded")
+	}
+
+	// OnOperationEnd called in reverse order
+	if len(h1.ends) != 1 {
+		t.Fatal("expected h1 end recorded")
+	}
+	if len(h2.ends) != 1 {
+		t.Fatal("expected h2 end recorded")
+	}
+}
+
+func TestChainHooks_FiltersNoops(t *testing.T) {
+	h1 := &recordingHook{}
+	chain := NewChainHooks(h1, NoopHooks{}, nil)
+
+	// Should only have the real hook, so returns it directly (not ChainHooks)
+	if _, ok := chain.(*ChainHooks); ok {
+		t.Fatal("expected single hook unwrapped, not ChainHooks")
+	}
+}
+
+func TestChainHooks_AllNoops(t *testing.T) {
+	chain := NewChainHooks(NoopHooks{}, nil)
+	if _, ok := chain.(NoopHooks); !ok {
+		t.Fatal("expected NoopHooks when all are no-ops")
+	}
+}
+
+func TestNewChainHooks_Empty(t *testing.T) {
+	chain := NewChainHooks()
+	if _, ok := chain.(NoopHooks); !ok {
+		t.Fatal("expected NoopHooks for empty chain")
+	}
+}
+
+func TestWithHooks_Nil(t *testing.T) {
+	cfg := &Config{BaseURL: "http://localhost:3000"}
+	c := NewClient(cfg, &StaticTokenProvider{Token: "t"}, WithHooks(nil))
+	if _, ok := c.hooks.(NoopHooks); !ok {
+		t.Fatal("expected NoopHooks for nil hooks option")
+	}
+}

--- a/go/pkg/hey/pagination_test.go
+++ b/go/pkg/hey/pagination_test.go
@@ -1,0 +1,241 @@
+package hey
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestGetAll_SinglePage(t *testing.T) {
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		w.Write([]byte(`[{"id":1},{"id":2}]`))
+	})
+
+	items, err := client.GetAll(context.Background(), "/items.json")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("expected 2 items, got %d", len(items))
+	}
+}
+
+func TestGetAll_MultiplePages(t *testing.T) {
+	var serverURL string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/items.json", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Link", fmt.Sprintf(`<%s/items.json?page=2>; rel="next"`, serverURL))
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`[{"id":1}]`))
+	})
+	mux.HandleFunc("/items.json?page=2", func(w http.ResponseWriter, r *http.Request) {
+		// Manually check for page param since ServeMux doesn't route on query
+	})
+	// Use a simpler approach
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		page := r.URL.Query().Get("page")
+		w.Header().Set("Content-Type", "application/json")
+		if page == "2" {
+			w.Write([]byte(`[{"id":2}]`))
+		} else {
+			w.Header().Set("Link", fmt.Sprintf(`<%s/items.json?page=2>; rel="next"`, serverURL))
+			w.Write([]byte(`[{"id":1}]`))
+		}
+	}))
+	defer server.Close()
+	serverURL = server.URL
+
+	cfg := &Config{BaseURL: server.URL}
+	client := NewClient(cfg, &StaticTokenProvider{Token: "test-token"})
+
+	items, err := client.GetAll(context.Background(), "/items.json")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("expected 2 items across pages, got %d", len(items))
+	}
+}
+
+func TestGetAllWithLimit(t *testing.T) {
+	var serverURL string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		page := r.URL.Query().Get("page")
+		w.Header().Set("Content-Type", "application/json")
+		if page == "2" {
+			w.Write([]byte(`[{"id":3},{"id":4}]`))
+		} else {
+			w.Header().Set("Link", fmt.Sprintf(`<%s/items.json?page=2>; rel="next"`, serverURL))
+			w.Write([]byte(`[{"id":1},{"id":2}]`))
+		}
+	}))
+	defer server.Close()
+	serverURL = server.URL
+
+	cfg := &Config{BaseURL: server.URL}
+	client := NewClient(cfg, &StaticTokenProvider{Token: "test-token"})
+
+	items, err := client.GetAllWithLimit(context.Background(), "/items.json", 3)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(items) != 3 {
+		t.Fatalf("expected 3 items (limited), got %d", len(items))
+	}
+}
+
+func TestGetAll_CrossOriginRejection(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Link", `<https://evil.com/steal>; rel="next"`)
+		w.Write([]byte(`[{"id":1}]`))
+	}))
+	defer server.Close()
+
+	cfg := &Config{BaseURL: server.URL}
+	client := NewClient(cfg, &StaticTokenProvider{Token: "test-token"})
+
+	_, err := client.GetAll(context.Background(), "/items.json")
+	if err == nil {
+		t.Fatal("expected error for cross-origin pagination link")
+	}
+}
+
+func TestGetAll_MaxPages(t *testing.T) {
+	var serverURL string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// Always return a next link to test maxPages
+		w.Header().Set("Link", fmt.Sprintf(`<%s/items.json?page=next>; rel="next"`, serverURL))
+		w.Write([]byte(`[{"id":1}]`))
+	}))
+	defer server.Close()
+	serverURL = server.URL
+
+	cfg := &Config{BaseURL: server.URL}
+	client := NewClient(cfg, &StaticTokenProvider{Token: "test-token"}, WithMaxPages(3))
+
+	items, err := client.GetAll(context.Background(), "/items.json")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(items) != 3 {
+		t.Fatalf("expected 3 items (capped at maxPages), got %d", len(items))
+	}
+}
+
+func TestFollowPagination_NilResponse(t *testing.T) {
+	cfg := &Config{BaseURL: "http://localhost:3000"}
+	client := NewClient(cfg, &StaticTokenProvider{Token: "t"})
+
+	items, err := client.FollowPagination(context.Background(), nil, 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if items != nil {
+		t.Fatal("expected nil for nil response")
+	}
+}
+
+func TestFollowPagination_LimitAlreadyMet(t *testing.T) {
+	resp := &http.Response{Header: http.Header{}}
+	resp.Header.Set("Link", `<http://example.com/page2>; rel="next"`)
+
+	cfg := &Config{BaseURL: "http://localhost:3000"}
+	client := NewClient(cfg, &StaticTokenProvider{Token: "t"})
+
+	items, err := client.FollowPagination(context.Background(), resp, 10, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if items != nil {
+		t.Fatal("expected nil when limit already met")
+	}
+}
+
+func TestFollowPagination_NoLinkHeader(t *testing.T) {
+	resp := &http.Response{Header: http.Header{}}
+	cfg := &Config{BaseURL: "http://localhost:3000"}
+	client := NewClient(cfg, &StaticTokenProvider{Token: "t"})
+
+	items, err := client.FollowPagination(context.Background(), resp, 5, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if items != nil {
+		t.Fatal("expected nil with no Link header")
+	}
+}
+
+func TestFollowPagination_CrossOriginRejection(t *testing.T) {
+	reqURL, _ := http.NewRequestWithContext(context.Background(), "GET", "http://localhost:3000/items.json", nil)
+	resp := &http.Response{
+		Header:  http.Header{},
+		Request: reqURL,
+	}
+	resp.Header.Set("Link", `<https://evil.com/steal>; rel="next"`)
+
+	cfg := &Config{BaseURL: "http://localhost:3000"}
+	client := NewClient(cfg, &StaticTokenProvider{Token: "t"})
+
+	_, err := client.FollowPagination(context.Background(), resp, 5, 0)
+	if err == nil {
+		t.Fatal("expected cross-origin rejection")
+	}
+}
+
+func TestGetAll_EmptyItems(t *testing.T) {
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`[]`))
+	})
+
+	items, err := client.GetAll(context.Background(), "/items.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(items) != 0 {
+		t.Fatalf("expected 0 items, got %d", len(items))
+	}
+}
+
+func TestGetAll_InvalidJSON(t *testing.T) {
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`not json`))
+	})
+
+	_, err := client.GetAll(context.Background(), "/items.json")
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+}
+
+// Verify json.RawMessage items survive round-trip
+func TestGetAll_RawMessagePreservation(t *testing.T) {
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`[{"id":1,"name":"test"},{"id":2,"nested":{"a":1}}]`))
+	})
+
+	items, err := client.GetAll(context.Background(), "/items.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var first struct {
+		ID   int    `json:"id"`
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal(items[0], &first); err != nil {
+		t.Fatal(err)
+	}
+	if first.ID != 1 || first.Name != "test" {
+		t.Fatalf("unexpected first item: %+v", first)
+	}
+}

--- a/go/pkg/hey/pagination_test.go
+++ b/go/pkg/hey/pagination_test.go
@@ -27,16 +27,6 @@ func TestGetAll_SinglePage(t *testing.T) {
 
 func TestGetAll_MultiplePages(t *testing.T) {
 	var serverURL string
-	mux := http.NewServeMux()
-	mux.HandleFunc("/items.json", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Link", fmt.Sprintf(`<%s/items.json?page=2>; rel="next"`, serverURL))
-		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(`[{"id":1}]`))
-	})
-	mux.HandleFunc("/items.json?page=2", func(w http.ResponseWriter, r *http.Request) {
-		// Manually check for page param since ServeMux doesn't route on query
-	})
-	// Use a simpler approach
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		page := r.URL.Query().Get("page")
 		w.Header().Set("Content-Type", "application/json")

--- a/go/pkg/hey/resilience_test.go
+++ b/go/pkg/hey/resilience_test.go
@@ -1,0 +1,441 @@
+package hey
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestCircuitBreaker_StartsOpen(t *testing.T) {
+	cb := newCircuitBreaker(DefaultCircuitBreakerConfig())
+	if !cb.Allow() {
+		t.Fatal("expected circuit breaker to allow requests initially (closed state)")
+	}
+	if cb.State() != "closed" {
+		t.Fatalf("expected closed state, got %q", cb.State())
+	}
+}
+
+func TestCircuitBreaker_OpensAfterFailures(t *testing.T) {
+	cfg := &CircuitBreakerConfig{
+		FailureThreshold:     3,
+		SuccessThreshold:     2,
+		OpenTimeout:          1 * time.Second,
+		FailureRateThreshold: 50,
+		SlidingWindowSize:    10,
+	}
+	cb := newCircuitBreaker(cfg)
+
+	for i := 0; i < 3; i++ {
+		cb.RecordFailure()
+	}
+
+	if cb.State() != "open" {
+		t.Fatalf("expected open state after %d failures, got %q", 3, cb.State())
+	}
+	if cb.Allow() {
+		t.Fatal("expected circuit breaker to reject requests when open")
+	}
+}
+
+func TestCircuitBreaker_HalfOpenAfterTimeout(t *testing.T) {
+	now := time.Now()
+	cfg := &CircuitBreakerConfig{
+		FailureThreshold:     2,
+		SuccessThreshold:     1,
+		OpenTimeout:          100 * time.Millisecond,
+		FailureRateThreshold: 50,
+		SlidingWindowSize:    10,
+		Now:                  func() time.Time { return now },
+	}
+	cb := newCircuitBreaker(cfg)
+
+	cb.RecordFailure()
+	cb.RecordFailure()
+	if cb.State() != "open" {
+		t.Fatal("expected open")
+	}
+
+	// Advance time past the open timeout
+	now = now.Add(200 * time.Millisecond)
+
+	if !cb.Allow() {
+		t.Fatal("expected circuit breaker to allow (half-open) after timeout")
+	}
+	if cb.State() != "half-open" {
+		t.Fatalf("expected half-open, got %q", cb.State())
+	}
+}
+
+func TestCircuitBreaker_ClosesAfterSuccessInHalfOpen(t *testing.T) {
+	now := time.Now()
+	cfg := &CircuitBreakerConfig{
+		FailureThreshold:     2,
+		SuccessThreshold:     2,
+		OpenTimeout:          100 * time.Millisecond,
+		FailureRateThreshold: 50,
+		SlidingWindowSize:    10,
+		Now:                  func() time.Time { return now },
+	}
+	cb := newCircuitBreaker(cfg)
+
+	cb.RecordFailure()
+	cb.RecordFailure()
+
+	now = now.Add(200 * time.Millisecond)
+	cb.Allow() // transitions to half-open
+
+	cb.RecordSuccess()
+	cb.RecordSuccess()
+
+	if cb.State() != "closed" {
+		t.Fatalf("expected closed after success threshold, got %q", cb.State())
+	}
+}
+
+func TestCircuitBreaker_ReopensOnFailureInHalfOpen(t *testing.T) {
+	now := time.Now()
+	cfg := &CircuitBreakerConfig{
+		FailureThreshold:     2,
+		SuccessThreshold:     2,
+		OpenTimeout:          100 * time.Millisecond,
+		FailureRateThreshold: 50,
+		SlidingWindowSize:    10,
+		Now:                  func() time.Time { return now },
+	}
+	cb := newCircuitBreaker(cfg)
+
+	cb.RecordFailure()
+	cb.RecordFailure()
+
+	now = now.Add(200 * time.Millisecond)
+	cb.Allow()
+
+	cb.RecordFailure()
+	if cb.State() != "open" {
+		t.Fatalf("expected open after failure in half-open, got %q", cb.State())
+	}
+}
+
+func TestCircuitBreaker_FailureRate(t *testing.T) {
+	cfg := &CircuitBreakerConfig{
+		FailureThreshold:     100, // high so count-based won't trigger
+		SuccessThreshold:     2,
+		OpenTimeout:          1 * time.Second,
+		FailureRateThreshold: 50,
+		SlidingWindowSize:    4,
+	}
+	cb := newCircuitBreaker(cfg)
+
+	// Fill window: 2 successes + 2 failures = 50% failure rate
+	cb.RecordSuccess()
+	cb.RecordSuccess()
+	cb.RecordFailure()
+	cb.RecordFailure() // window now filled, 50% failure rate
+
+	// Next failure should check the rate
+	cb.RecordFailure()
+
+	if cb.State() != "open" {
+		t.Fatalf("expected open due to failure rate, got %q", cb.State())
+	}
+}
+
+func TestBulkhead_Acquire(t *testing.T) {
+	bh := newBulkhead(&BulkheadConfig{MaxConcurrent: 2, MaxWait: 0})
+
+	r1, err := bh.Acquire(context.Background())
+	if err != nil {
+		t.Fatalf("first acquire failed: %v", err)
+	}
+	r2, err := bh.Acquire(context.Background())
+	if err != nil {
+		t.Fatalf("second acquire failed: %v", err)
+	}
+
+	// Third should fail (no wait)
+	_, err = bh.Acquire(context.Background())
+	if err != ErrBulkheadFull {
+		t.Fatalf("expected ErrBulkheadFull, got %v", err)
+	}
+
+	if bh.InUse() != 2 {
+		t.Fatalf("expected 2 in use, got %d", bh.InUse())
+	}
+	if bh.Available() != 0 {
+		t.Fatalf("expected 0 available, got %d", bh.Available())
+	}
+
+	// Release one
+	r1()
+
+	if bh.InUse() != 1 {
+		t.Fatalf("expected 1 in use after release, got %d", bh.InUse())
+	}
+
+	// Should succeed now
+	r3, err := bh.Acquire(context.Background())
+	if err != nil {
+		t.Fatalf("acquire after release failed: %v", err)
+	}
+	r2()
+	r3()
+}
+
+func TestBulkhead_TryAcquire(t *testing.T) {
+	bh := newBulkhead(&BulkheadConfig{MaxConcurrent: 1, MaxWait: 0})
+
+	release, ok := bh.TryAcquire()
+	if !ok {
+		t.Fatal("expected TryAcquire to succeed")
+	}
+
+	_, ok = bh.TryAcquire()
+	if ok {
+		t.Fatal("expected TryAcquire to fail when full")
+	}
+
+	release()
+}
+
+func TestBulkhead_AcquireWithWait(t *testing.T) {
+	bh := newBulkhead(&BulkheadConfig{MaxConcurrent: 1, MaxWait: 100 * time.Millisecond})
+
+	release, _ := bh.Acquire(context.Background())
+
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		release()
+	}()
+
+	r2, err := bh.Acquire(context.Background())
+	if err != nil {
+		t.Fatalf("expected acquire to succeed after wait, got %v", err)
+	}
+	r2()
+}
+
+func TestBulkhead_AcquireTimeout(t *testing.T) {
+	bh := newBulkhead(&BulkheadConfig{MaxConcurrent: 1, MaxWait: 10 * time.Millisecond})
+
+	release, _ := bh.Acquire(context.Background())
+	defer release()
+
+	_, err := bh.Acquire(context.Background())
+	if err != ErrBulkheadFull {
+		t.Fatalf("expected ErrBulkheadFull after timeout, got %v", err)
+	}
+}
+
+func TestRateLimiter_Allow(t *testing.T) {
+	now := time.Now()
+	rl := newRateLimiter(&RateLimitConfig{
+		RequestsPerSecond: 100,
+		BurstSize:         5,
+		Now:               func() time.Time { return now },
+	})
+
+	// Should allow up to burst size
+	for i := 0; i < 5; i++ {
+		if !rl.Allow() {
+			t.Fatalf("expected Allow on request %d", i+1)
+		}
+	}
+
+	// Next should fail (no time passed)
+	if rl.Allow() {
+		t.Fatal("expected rate limit after burst")
+	}
+
+	// Advance time enough for 1 token
+	now = now.Add(20 * time.Millisecond) // 100 rps => 1 token per 10ms, so 20ms = 2 tokens
+	if !rl.Allow() {
+		t.Fatal("expected Allow after time advance")
+	}
+}
+
+func TestRateLimiter_RespectRetryAfter(t *testing.T) {
+	now := time.Now()
+	rl := newRateLimiter(&RateLimitConfig{
+		RequestsPerSecond: 1000,
+		BurstSize:         100,
+		RespectRetryAfter: true,
+		Now:               func() time.Time { return now },
+	})
+
+	rl.SetRetryAfter(now.Add(1 * time.Second))
+
+	if rl.Allow() {
+		t.Fatal("expected block during Retry-After period")
+	}
+
+	remaining := rl.RetryAfterRemaining()
+	if remaining <= 0 {
+		t.Fatal("expected positive remaining duration")
+	}
+
+	// Advance past retry-after
+	now = now.Add(2 * time.Second)
+
+	if !rl.Allow() {
+		t.Fatal("expected Allow after Retry-After expired")
+	}
+
+	if rl.RetryAfterRemaining() != 0 {
+		t.Fatal("expected 0 remaining after expiry")
+	}
+}
+
+func TestRateLimiter_Tokens(t *testing.T) {
+	rl := newRateLimiter(&RateLimitConfig{
+		RequestsPerSecond: 100,
+		BurstSize:         10,
+	})
+
+	tokens := rl.Tokens()
+	if tokens != 10 {
+		t.Fatalf("expected 10 initial tokens, got %f", tokens)
+	}
+
+	rl.Allow()
+	tokens = rl.Tokens()
+	if tokens >= 10 {
+		t.Fatal("expected tokens to decrease after Allow")
+	}
+}
+
+func TestRateLimiter_SetRetryAfterDuration(t *testing.T) {
+	now := time.Now()
+	rl := newRateLimiter(&RateLimitConfig{
+		RequestsPerSecond: 1000,
+		BurstSize:         100,
+		RespectRetryAfter: true,
+		Now:               func() time.Time { return now },
+	})
+
+	rl.SetRetryAfterDuration(5 * time.Second)
+	if rl.Allow() {
+		t.Fatal("expected block during retry-after duration")
+	}
+
+	now = now.Add(6 * time.Second)
+	if !rl.Allow() {
+		t.Fatal("expected allow after retry-after duration")
+	}
+}
+
+func TestShouldTripCircuit(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"circuit open", ErrCircuitOpen, false},
+		{"bulkhead full", ErrBulkheadFull, false},
+		{"rate limited", ErrRateLimited, false},
+		{"context canceled", context.Canceled, false},
+		{"deadline exceeded", context.DeadlineExceeded, false},
+		{"network error", ErrNetwork(fmt.Errorf("connection refused")), true},
+		{"server 500", &Error{Code: CodeAPI, HTTPStatus: 500}, true},
+		{"server 503", &Error{Code: CodeAPI, HTTPStatus: 503}, true},
+		{"client 400", &Error{Code: CodeAPI, HTTPStatus: 400}, false},
+		{"auth error", &Error{Code: CodeAuth, HTTPStatus: 401}, false},
+		{"unknown error", context.DeadlineExceeded, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := shouldTripCircuit(tc.err)
+			if got != tc.want {
+				t.Fatalf("shouldTripCircuit(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDefaultResilienceConfig(t *testing.T) {
+	cfg := DefaultResilienceConfig()
+	if cfg.CircuitBreaker == nil {
+		t.Fatal("expected non-nil CircuitBreaker config")
+	}
+	if cfg.Bulkhead == nil {
+		t.Fatal("expected non-nil Bulkhead config")
+	}
+	if cfg.RateLimit == nil {
+		t.Fatal("expected non-nil RateLimit config")
+	}
+}
+
+func TestWithResilience(t *testing.T) {
+	cfg := &Config{BaseURL: "http://localhost:3000"}
+	c := NewClient(cfg, &StaticTokenProvider{Token: "t"}, WithResilience(nil))
+	if _, ok := c.hooks.(*resilienceHooks); !ok {
+		t.Fatal("expected resilienceHooks after WithResilience")
+	}
+}
+
+func TestWithCircuitBreaker(t *testing.T) {
+	cfg := &Config{BaseURL: "http://localhost:3000"}
+	c := NewClient(cfg, &StaticTokenProvider{Token: "t"}, WithCircuitBreaker(nil))
+	rh, ok := c.hooks.(*resilienceHooks)
+	if !ok {
+		t.Fatal("expected resilienceHooks")
+	}
+	if rh.circuitBreakers == nil {
+		t.Fatal("expected circuit breakers initialized")
+	}
+}
+
+func TestWithBulkhead(t *testing.T) {
+	cfg := &Config{BaseURL: "http://localhost:3000"}
+	c := NewClient(cfg, &StaticTokenProvider{Token: "t"}, WithBulkhead(nil))
+	rh, ok := c.hooks.(*resilienceHooks)
+	if !ok {
+		t.Fatal("expected resilienceHooks")
+	}
+	if rh.bulkheads == nil {
+		t.Fatal("expected bulkheads initialized")
+	}
+}
+
+func TestWithRateLimit(t *testing.T) {
+	cfg := &Config{BaseURL: "http://localhost:3000"}
+	c := NewClient(cfg, &StaticTokenProvider{Token: "t"}, WithRateLimit(nil))
+	rh, ok := c.hooks.(*resilienceHooks)
+	if !ok {
+		t.Fatal("expected resilienceHooks")
+	}
+	if rh.rateLimiter == nil {
+		t.Fatal("expected rate limiter initialized")
+	}
+}
+
+func TestCircuitBreakerRegistry(t *testing.T) {
+	reg := newCircuitBreakerRegistry(DefaultCircuitBreakerConfig())
+
+	cb1 := reg.get("scope1")
+	cb2 := reg.get("scope2")
+	cb3 := reg.get("scope1")
+
+	if cb1 == cb2 {
+		t.Fatal("expected different circuit breakers for different scopes")
+	}
+	if cb1 != cb3 {
+		t.Fatal("expected same circuit breaker for same scope")
+	}
+}
+
+func TestBulkheadRegistry(t *testing.T) {
+	reg := newBulkheadRegistry(DefaultBulkheadConfig())
+
+	bh1 := reg.get("scope1")
+	bh2 := reg.get("scope2")
+	bh3 := reg.get("scope1")
+
+	if bh1 == bh2 {
+		t.Fatal("expected different bulkheads for different scopes")
+	}
+	if bh1 != bh3 {
+		t.Fatal("expected same bulkhead for same scope")
+	}
+}

--- a/go/pkg/hey/resilience_test.go
+++ b/go/pkg/hey/resilience_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 )
 
-func TestCircuitBreaker_StartsOpen(t *testing.T) {
+func TestCircuitBreaker_StartsClosed(t *testing.T) {
 	cb := newCircuitBreaker(DefaultCircuitBreakerConfig())
 	if !cb.Allow() {
 		t.Fatal("expected circuit breaker to allow requests initially (closed state)")

--- a/go/pkg/hey/resilience_test.go
+++ b/go/pkg/hey/resilience_test.go
@@ -201,16 +201,15 @@ func TestBulkhead_TryAcquire(t *testing.T) {
 }
 
 func TestBulkhead_AcquireWithWait(t *testing.T) {
-	bh := newBulkhead(&BulkheadConfig{MaxConcurrent: 1, MaxWait: 100 * time.Millisecond})
+	bh := newBulkhead(&BulkheadConfig{MaxConcurrent: 1, MaxWait: 500 * time.Millisecond})
 
 	release, _ := bh.Acquire(context.Background())
 
-	ready := make(chan struct{})
+	// Release after a short delay so the second Acquire has time to start waiting
 	go func() {
-		<-ready
+		time.Sleep(10 * time.Millisecond)
 		release()
 	}()
-	close(ready)
 
 	r2, err := bh.Acquire(context.Background())
 	if err != nil {

--- a/go/pkg/hey/resilience_test.go
+++ b/go/pkg/hey/resilience_test.go
@@ -2,6 +2,7 @@ package hey
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -204,10 +205,12 @@ func TestBulkhead_AcquireWithWait(t *testing.T) {
 
 	release, _ := bh.Acquire(context.Background())
 
+	ready := make(chan struct{})
 	go func() {
-		time.Sleep(20 * time.Millisecond)
+		<-ready
 		release()
 	}()
+	close(ready)
 
 	r2, err := bh.Acquire(context.Background())
 	if err != nil {
@@ -341,7 +344,7 @@ func TestShouldTripCircuit(t *testing.T) {
 		{"server 503", &Error{Code: CodeAPI, HTTPStatus: 503}, true},
 		{"client 400", &Error{Code: CodeAPI, HTTPStatus: 400}, false},
 		{"auth error", &Error{Code: CodeAuth, HTTPStatus: 401}, false},
-		{"unknown error", context.DeadlineExceeded, false},
+		{"unknown error", errors.New("some unknown error"), true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/go/pkg/hey/security_test.go
+++ b/go/pkg/hey/security_test.go
@@ -1,0 +1,179 @@
+package hey
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestRequireHTTPS(t *testing.T) {
+	if err := requireHTTPS("https://example.com"); err != nil {
+		t.Fatalf("expected no error for HTTPS, got %v", err)
+	}
+	if err := requireHTTPS("http://example.com"); err == nil {
+		t.Fatal("expected error for HTTP")
+	}
+	if err := requireHTTPS("://bad"); err == nil {
+		t.Fatal("expected error for invalid URL")
+	}
+}
+
+func TestIsSameOrigin(t *testing.T) {
+	cases := []struct {
+		a, b string
+		want bool
+	}{
+		{"https://example.com/a", "https://example.com/b", true},
+		{"https://example.com", "https://other.com", false},
+		{"https://example.com", "http://example.com", false},
+		{"https://example.com:443/a", "https://example.com/b", true},
+		{"http://example.com:80/a", "http://example.com/b", true},
+		{"https://example.com:8080", "https://example.com:9090", false},
+		{"/relative", "https://example.com", false},
+		{"https://example.com", "/relative", false},
+		{"://bad", "https://ok.com", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.a+"_"+tc.b, func(t *testing.T) {
+			got := isSameOrigin(tc.a, tc.b)
+			if got != tc.want {
+				t.Fatalf("isSameOrigin(%q, %q) = %v, want %v", tc.a, tc.b, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsLocalhost(t *testing.T) {
+	cases := []struct {
+		url  string
+		want bool
+	}{
+		{"http://localhost:8080", true},
+		{"http://127.0.0.1:3000", true},
+		{"http://[::1]:3000", true},
+		{"http://sub.localhost:3000", true},
+		{"https://example.com", false},
+		{"://bad", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.url, func(t *testing.T) {
+			got := isLocalhost(tc.url)
+			if got != tc.want {
+				t.Fatalf("isLocalhost(%q) = %v, want %v", tc.url, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestResolveURL(t *testing.T) {
+	got := resolveURL("https://example.com/foo", "/bar")
+	if got != "https://example.com/bar" {
+		t.Fatalf("expected https://example.com/bar, got %s", got)
+	}
+
+	got = resolveURL("https://example.com/foo", "https://other.com/baz")
+	if got != "https://other.com/baz" {
+		t.Fatalf("expected absolute URL preserved, got %s", got)
+	}
+
+	// Invalid base returns target as-is
+	got = resolveURL("://bad", "/bar")
+	if got != "/bar" {
+		t.Fatalf("expected fallback to target, got %s", got)
+	}
+}
+
+func TestRequireSecureEndpoint(t *testing.T) {
+	if err := RequireSecureEndpoint("http://localhost:3000"); err != nil {
+		t.Fatalf("expected localhost HTTP to be allowed, got %v", err)
+	}
+	if err := RequireSecureEndpoint("https://example.com"); err != nil {
+		t.Fatalf("expected HTTPS to be allowed, got %v", err)
+	}
+	if err := RequireSecureEndpoint("http://example.com"); err == nil {
+		t.Fatal("expected error for non-localhost HTTP")
+	}
+}
+
+func TestRedactHeaders(t *testing.T) {
+	h := http.Header{}
+	h.Set("Authorization", "Bearer secret")
+	h.Set("Cookie", "session=abc")
+	h.Set("Content-Type", "application/json")
+	h.Set("X-CSRF-Token", "tok")
+
+	redacted := RedactHeaders(h)
+
+	if redacted.Get("Authorization") != "[REDACTED]" {
+		t.Fatal("expected Authorization redacted")
+	}
+	if redacted.Get("Cookie") != "[REDACTED]" {
+		t.Fatal("expected Cookie redacted")
+	}
+	if redacted.Get("X-CSRF-Token") != "[REDACTED]" {
+		t.Fatal("expected X-CSRF-Token redacted")
+	}
+	if redacted.Get("Content-Type") != "application/json" {
+		t.Fatal("expected Content-Type preserved")
+	}
+
+	// Original should not be modified
+	if h.Get("Authorization") != "Bearer secret" {
+		t.Fatal("expected original header unchanged")
+	}
+}
+
+func TestLimitedReadAll(t *testing.T) {
+	data := "hello world"
+	r := strings.NewReader(data)
+	result, err := limitedReadAll(r, 100)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(result) != data {
+		t.Fatalf("expected %q, got %q", data, result)
+	}
+
+	r2 := strings.NewReader("too long")
+	_, err = limitedReadAll(r2, 3)
+	if err == nil {
+		t.Fatal("expected error for exceeding limit")
+	}
+}
+
+func TestTruncateString(t *testing.T) {
+	if got := truncateString("hi", 10); got != "hi" {
+		t.Fatalf("expected 'hi', got %q", got)
+	}
+	if got := truncateString("hello world", 8); got != "hello..." {
+		t.Fatalf("expected 'hello...', got %q", got)
+	}
+	if got := truncateString("hello", 3); got != "hel" {
+		t.Fatalf("expected 'hel' (maxLen<=3 no ellipsis), got %q", got)
+	}
+	if got := truncateString("hello", 5); got != "hello" {
+		t.Fatalf("expected 'hello', got %q", got)
+	}
+}
+
+func TestNormalizeHost(t *testing.T) {
+	tests := []struct {
+		rawURL string
+		want   string
+	}{
+		{"https://example.com", "example.com"},
+		{"https://example.com:443", "example.com"},
+		{"http://example.com:80", "example.com"},
+		{"https://example.com:8080", "example.com:8080"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.rawURL, func(t *testing.T) {
+			u, _ := url.Parse(tc.rawURL)
+			got := normalizeHost(u)
+			if got != tc.want {
+				t.Fatalf("normalizeHost(%q) = %q, want %q", tc.rawURL, got, tc.want)
+			}
+		})
+	}
+}

--- a/go/pkg/hey/services_test.go
+++ b/go/pkg/hey/services_test.go
@@ -13,9 +13,16 @@ import (
 
 // newServiceTestClient creates a Client pointing at a test server that
 // routes based on URL path and returns appropriate JSON responses.
-func newServiceTestClient(t *testing.T, routes map[string]string) *Client {
+func newServiceTestClient(t *testing.T, routes map[string]string, methods ...string) *Client {
 	t.Helper()
+	wantMethod := "GET"
+	if len(methods) > 0 {
+		wantMethod = methods[0]
+	}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != wantMethod {
+			t.Errorf("expected %s, got %s", wantMethod, r.Method)
+		}
 		path := r.URL.Path
 		for pattern, body := range routes {
 			if pathMatch(pattern, path) {

--- a/go/pkg/hey/services_test.go
+++ b/go/pkg/hey/services_test.go
@@ -13,7 +13,7 @@ import (
 
 // newServiceTestClient creates a Client pointing at a test server that
 // routes based on URL path and returns appropriate JSON responses.
-func newServiceTestClient(t *testing.T, routes map[string]string, methods ...string) *Client {
+func newServiceTestClient(t *testing.T, routes map[string]string, methods ...string) *Client { //nolint:unparam // methods intentionally variadic for non-GET service tests
 	t.Helper()
 	wantMethod := "GET"
 	if len(methods) > 0 {

--- a/go/pkg/hey/services_test.go
+++ b/go/pkg/hey/services_test.go
@@ -1,0 +1,738 @@
+package hey
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/basecamp/hey-sdk/go/pkg/generated"
+)
+
+// newServiceTestClient creates a Client pointing at a test server that
+// routes based on URL path and returns appropriate JSON responses.
+func newServiceTestClient(t *testing.T, routes map[string]string) *Client {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := r.URL.Path
+		for pattern, body := range routes {
+			if pathMatch(pattern, path) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(200)
+				w.Write([]byte(body))
+				return
+			}
+		}
+		w.WriteHeader(404)
+		w.Write([]byte(`{"error":"not found: ` + path + `"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	cfg := &Config{BaseURL: server.URL}
+	return NewClient(cfg, &StaticTokenProvider{Token: "test-token"},
+		WithMaxRetries(0),
+		WithBaseDelay(1*time.Millisecond),
+		WithMaxJitter(1*time.Millisecond),
+	)
+}
+
+func pathMatch(pattern, path string) bool {
+	// Simple matching: pattern segments with %s match any single segment
+	pp := strings.Split(pattern, "/")
+	sp := strings.Split(path, "/")
+	if len(pp) != len(sp) {
+		return false
+	}
+	for i, seg := range pp {
+		if seg == "%s" {
+			continue
+		}
+		if seg != sp[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// --- Identity ---
+
+func TestIdentityService_GetIdentity(t *testing.T) {
+	client := newServiceTestClient(t, map[string]string{
+		"/identity.json": `{"email_address":"user@example.com","id":1}`,
+	})
+
+	result, err := client.Identity().GetIdentity(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+}
+
+func TestIdentityService_GetNavigation(t *testing.T) {
+	client := newServiceTestClient(t, map[string]string{
+		"/my/navigation.json": `{"accounts":[],"identity":{}}`,
+	})
+
+	result, err := client.Identity().GetNavigation(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+}
+
+func TestIdentityService_GetIdentity_Error(t *testing.T) {
+	client := newServiceTestClient(t, map[string]string{})
+	_, err := client.Identity().GetIdentity(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+// --- Boxes ---
+
+func TestBoxesService_List(t *testing.T) {
+	client := newServiceTestClient(t, map[string]string{
+		"/boxes.json": `[{"id":1,"kind":"imbox","name":"Imbox"}]`,
+	})
+
+	result, err := client.Boxes().List(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+}
+
+func TestBoxesService_Get(t *testing.T) {
+	client := newServiceTestClient(t, map[string]string{
+		"/boxes/%s": `{"id":1,"kind":"imbox","name":"Imbox","postings":[]}`,
+	})
+
+	result, err := client.Boxes().Get(context.Background(), 1, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+}
+
+func TestBoxesService_GetImbox(t *testing.T) {
+	client := newServiceTestClient(t, map[string]string{
+		"/imbox.json": `{"id":1,"kind":"imbox","name":"Imbox","postings":[]}`,
+	})
+
+	result, err := client.Boxes().GetImbox(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+}
+
+func TestBoxesService_GetFeedbox(t *testing.T) {
+	client := newServiceTestClient(t, map[string]string{
+		"/feedbox.json": `{"id":2,"kind":"feedbox","name":"The Feed","postings":[]}`,
+	})
+
+	result, err := client.Boxes().GetFeedbox(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+}
+
+func TestBoxesService_GetTrailbox(t *testing.T) {
+	client := newServiceTestClient(t, map[string]string{
+		"/paper_trail.json": `{"id":3,"kind":"trailbox","name":"Paper Trail","postings":[]}`,
+	})
+
+	result, err := client.Boxes().GetTrailbox(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+}
+
+func TestBoxesService_GetAsidebox(t *testing.T) {
+	client := newServiceTestClient(t, map[string]string{
+		"/set_aside.json": `{"id":4,"kind":"asidebox","name":"Set Aside","postings":[]}`,
+	})
+
+	result, err := client.Boxes().GetAsidebox(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+}
+
+func TestBoxesService_GetLaterbox(t *testing.T) {
+	client := newServiceTestClient(t, map[string]string{
+		"/reply_later.json": `{"id":5,"kind":"laterbox","name":"Reply Later","postings":[]}`,
+	})
+
+	result, err := client.Boxes().GetLaterbox(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+}
+
+func TestBoxesService_GetBubblebox(t *testing.T) {
+	client := newServiceTestClient(t, map[string]string{
+		"/bubble_up.json": `{"id":6,"kind":"bubblebox","name":"Bubbled Up","postings":[]}`,
+	})
+
+	result, err := client.Boxes().GetBubblebox(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+}
+
+func TestBoxesService_List_Error(t *testing.T) {
+	client := newServiceTestClient(t, map[string]string{})
+	// All paths will 404 since we provide no routes, verifying error propagation
+	_, err := client.Boxes().List(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+// --- Topics ---
+
+func TestTopicsService_Get(t *testing.T) {
+	client := newServiceTestClient(t, map[string]string{
+		"/topics/%s": `{"id":42,"subject":"Hello"}`,
+	})
+
+	result, err := client.Topics().Get(context.Background(), 42)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+}
+
+func TestTopicsService_GetEntries(t *testing.T) {
+	client := newServiceTestClient(t, map[string]string{
+		"/topics/%s/entries": `[{"id":1}]`,
+	})
+
+	result, err := client.Topics().GetEntries(context.Background(), 42, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+}
+
+func TestTopicsService_GetSent(t *testing.T) {
+	client := newServiceTestClient(t, map[string]string{
+		"/topics/sent.json": `{"title":"Sent","topics":[{"id":1}]}`,
+	})
+
+	result, err := client.Topics().GetSent(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+}
+
+func TestTopicsService_GetSpam(t *testing.T) {
+	client := newServiceTestClient(t, map[string]string{
+		"/topics/spam.json": `{"title":"Spam","topics":[{"id":1}]}`,
+	})
+
+	result, err := client.Topics().GetSpam(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+}
+
+func TestTopicsService_GetTrash(t *testing.T) {
+	client := newServiceTestClient(t, map[string]string{
+		"/topics/trash.json": `{"title":"Trash","topics":[{"id":1}]}`,
+	})
+
+	result, err := client.Topics().GetTrash(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+}
+
+func TestTopicsService_GetEverything(t *testing.T) {
+	client := newServiceTestClient(t, map[string]string{
+		"/topics/everything.json": `{"title":"Everything","topics":[{"id":1}]}`,
+	})
+
+	result, err := client.Topics().GetEverything(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+}
+
+// --- Messages ---
+
+func TestMessagesService_Get(t *testing.T) {
+	client := newServiceTestClient(t, map[string]string{
+		"/messages/%s": `{"id":1,"subject":"Test"}`,
+	})
+
+	result, err := client.Messages().Get(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+}
+
+func TestMessagesService_Create(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		w.Write([]byte(`{"id":1}`))
+	}))
+	defer server.Close()
+
+	cfg := &Config{BaseURL: server.URL}
+	client := NewClient(cfg, &StaticTokenProvider{Token: "test-token"})
+
+	body := generated.CreateMessageJSONRequestBody{
+		Subject: "Test",
+		Content: "Hello",
+		To:      []string{"test@example.com"},
+	}
+	result, err := client.Messages().Create(context.Background(), body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+}
+
+func TestMessagesService_CreateTopicMessage(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		w.Write([]byte(`{"id":1}`))
+	}))
+	defer server.Close()
+
+	cfg := &Config{BaseURL: server.URL}
+	client := NewClient(cfg, &StaticTokenProvider{Token: "test-token"})
+
+	body := generated.CreateTopicMessageJSONRequestBody{}
+	result, err := client.Messages().CreateTopicMessage(context.Background(), 42, body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+}
+
+// --- Entries ---
+
+func TestEntriesService_ListDrafts(t *testing.T) {
+	client := newServiceTestClient(t, map[string]string{
+		"/entries/drafts.json": `[{"id":1}]`,
+	})
+
+	result, err := client.Entries().ListDrafts(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+}
+
+func TestEntriesService_CreateReply(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		w.Write([]byte(`{"id":1}`))
+	}))
+	defer server.Close()
+
+	cfg := &Config{BaseURL: server.URL}
+	client := NewClient(cfg, &StaticTokenProvider{Token: "test-token"})
+
+	body := generated.CreateReplyJSONRequestBody{}
+	result, err := client.Entries().CreateReply(context.Background(), 10, body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+}
+
+// --- Contacts ---
+
+func TestContactsService_List(t *testing.T) {
+	client := newServiceTestClient(t, map[string]string{
+		"/contacts.json": `[{"id":1,"name":"Alice"}]`,
+	})
+
+	result, err := client.Contacts().List(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+}
+
+func TestContactsService_Get(t *testing.T) {
+	client := newServiceTestClient(t, map[string]string{
+		"/contacts/%s": `{"id":1,"name":"Alice"}`,
+	})
+
+	result, err := client.Contacts().Get(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+}
+
+// --- Calendars ---
+
+func TestCalendarsService_List(t *testing.T) {
+	client := newServiceTestClient(t, map[string]string{
+		"/calendars.json": `{"calendars":[{"calendar":{"id":1,"name":"My Calendar"}}]}`,
+	})
+
+	result, err := client.Calendars().List(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+}
+
+func TestCalendarsService_GetRecordings(t *testing.T) {
+	client := newServiceTestClient(t, map[string]string{
+		"/calendars/%s/recordings": `{"events":[{"id":1}]}`,
+	})
+
+	result, err := client.Calendars().GetRecordings(context.Background(), 1, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+}
+
+// --- CalendarTodos ---
+
+func TestCalendarTodosService_Create(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		w.Write([]byte(`{"id":1,"type":"CalendarTodo"}`))
+	}))
+	defer server.Close()
+
+	cfg := &Config{BaseURL: server.URL}
+	client := NewClient(cfg, &StaticTokenProvider{Token: "test-token"})
+
+	body := generated.CreateCalendarTodoJSONRequestBody{
+		Title: "Do something",
+	}
+	result, err := client.CalendarTodos().Create(context.Background(), body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+}
+
+func TestCalendarTodosService_Complete(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		w.Write([]byte(`{"id":1,"type":"CalendarTodo"}`))
+	}))
+	defer server.Close()
+
+	cfg := &Config{BaseURL: server.URL}
+	client := NewClient(cfg, &StaticTokenProvider{Token: "test-token"})
+
+	result, err := client.CalendarTodos().Complete(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+}
+
+func TestCalendarTodosService_Uncomplete(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		w.Write([]byte(`{"id":1,"type":"CalendarTodo"}`))
+	}))
+	defer server.Close()
+
+	cfg := &Config{BaseURL: server.URL}
+	client := NewClient(cfg, &StaticTokenProvider{Token: "test-token"})
+
+	result, err := client.CalendarTodos().Uncomplete(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+}
+
+func TestCalendarTodosService_Delete(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(204)
+	}))
+	defer server.Close()
+
+	cfg := &Config{BaseURL: server.URL}
+	client := NewClient(cfg, &StaticTokenProvider{Token: "test-token"})
+
+	err := client.CalendarTodos().Delete(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// --- Habits ---
+
+func TestHabitsService_Complete(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		w.Write([]byte(`{"id":1,"type":"Habit"}`))
+	}))
+	defer server.Close()
+
+	cfg := &Config{BaseURL: server.URL}
+	client := NewClient(cfg, &StaticTokenProvider{Token: "test-token"})
+
+	result, err := client.Habits().Complete(context.Background(), "2026-03-09", 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+}
+
+func TestHabitsService_Uncomplete(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		w.Write([]byte(`{"id":1,"type":"Habit"}`))
+	}))
+	defer server.Close()
+
+	cfg := &Config{BaseURL: server.URL}
+	client := NewClient(cfg, &StaticTokenProvider{Token: "test-token"})
+
+	result, err := client.Habits().Uncomplete(context.Background(), "2026-03-09", 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+}
+
+// --- TimeTracks ---
+
+func TestTimeTracksService_GetOngoing(t *testing.T) {
+	client := newServiceTestClient(t, map[string]string{
+		"/calendar/ongoing_time_track.json": `{"id":1,"type":"TimeTrack"}`,
+	})
+
+	result, err := client.TimeTracks().GetOngoing(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+}
+
+func TestTimeTracksService_GetOngoing_NotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(404)
+	}))
+	defer server.Close()
+
+	cfg := &Config{BaseURL: server.URL}
+	client := NewClient(cfg, &StaticTokenProvider{Token: "test-token"})
+
+	result, err := client.TimeTracks().GetOngoing(context.Background())
+	if err != nil {
+		t.Fatalf("expected no error for 404 (ADR-004), got %v", err)
+	}
+	if result != nil {
+		t.Fatal("expected nil result for no ongoing time track")
+	}
+}
+
+func TestTimeTracksService_Start(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		w.Write([]byte(`{"id":1,"type":"TimeTrack"}`))
+	}))
+	defer server.Close()
+
+	cfg := &Config{BaseURL: server.URL}
+	client := NewClient(cfg, &StaticTokenProvider{Token: "test-token"})
+
+	body := generated.StartTimeTrackJSONRequestBody{}
+	result, err := client.TimeTracks().Start(context.Background(), body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+}
+
+func TestTimeTracksService_Update(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		w.Write([]byte(`{"id":1,"type":"TimeTrack"}`))
+	}))
+	defer server.Close()
+
+	cfg := &Config{BaseURL: server.URL}
+	client := NewClient(cfg, &StaticTokenProvider{Token: "test-token"})
+
+	body := generated.UpdateTimeTrackJSONRequestBody{}
+	result, err := client.TimeTracks().Update(context.Background(), 1, body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+}
+
+func TestTimeTracksService_Stop(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		w.Write([]byte(`{"id":1,"type":"TimeTrack"}`))
+	}))
+	defer server.Close()
+
+	cfg := &Config{BaseURL: server.URL}
+	client := NewClient(cfg, &StaticTokenProvider{Token: "test-token"})
+
+	result, err := client.TimeTracks().Stop(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+}
+
+// --- Journal ---
+
+func TestJournalService_Get(t *testing.T) {
+	client := newServiceTestClient(t, map[string]string{
+		"/calendar/days/%s/journal_entry": `{"id":1,"type":"JournalEntry"}`,
+	})
+
+	result, err := client.Journal().Get(context.Background(), "2026-03-09")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+}
+
+func TestJournalService_Update(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		w.Write([]byte(`{"id":1,"type":"JournalEntry"}`))
+	}))
+	defer server.Close()
+
+	cfg := &Config{BaseURL: server.URL}
+	client := NewClient(cfg, &StaticTokenProvider{Token: "test-token"})
+
+	body := generated.UpdateJournalEntryJSONRequestBody{}
+	result, err := client.Journal().Update(context.Background(), "2026-03-09", body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+}
+
+// --- Search ---
+
+func TestSearchService_Search(t *testing.T) {
+	client := newServiceTestClient(t, map[string]string{
+		"/search.json": `{"topics":[{"id":1}]}`,
+	})
+
+	params := &generated.SearchParams{Q: "test query"}
+	result, err := client.Search().Search(context.Background(), params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+}


### PR DESCRIPTION
## Summary
- 12 test files covering all 12 services + auth + pagination + cache + resilience + errors + security + config + HTTP infrastructure
- 120+ tests, 73.1% statement coverage (target was ≥25%)
- All pass with zero lint issues in ~1.5s

## Test plan
- [x] `cd go && go test -v ./pkg/hey/...` all pass
- [x] `golangci-lint run ./...` clean
- [x] `make check-mvp` passes

Stack: 2/5 (depends on #5)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a comprehensive unit test suite for the Go SDK across all 12 services plus HTTP/auth/pagination/resilience/security/config/observability, delivering ~73% statement coverage with fast, lint‑clean runs.

- **New Features**
  - 120+ unit tests under `go/pkg/hey` covering: service endpoints; HTTPS enforcement and same‑origin pagination; cache key/ETag/body; error typing and exit codes; retries and 429 handling; circuit breaker, bulkhead, and rate limiter; config defaults and env overrides; observability hook chaining; and security helpers (secure endpoints, header redaction).

- **Refactors**
  - Stronger assertions and error checks: assert `store.Save`/`Load` and `cache.Set` errors; check JSON decode/return errors; enforce exact hint values; verify cache toggling; ensure response/error assertions in UA test.
  - Test stability and helpers: add method parameter to `newServiceTestClient` and suppress `unparam`; use `t.Setenv` and `filepath.Join`; remove dead code; fix bulkhead wait test race; add nil guards; rename circuit breaker start‑state test for clarity.

<sup>Written for commit 580a404cc54fe03ee04db306026029c44b499f3d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->