### PR TITLE
Fix timestamp format and journal entry field in Smithy model

### DIFF
--- a/conformance/runner/go/main.go
+++ b/conformance/runner/go/main.go
@@ -733,7 +733,7 @@ func executeOperation(client *generated.Client, ctx context.Context, tc TestCase
 	case "UpdateJournalEntry":
 		day := getStringParam(tc.PathParams, "day")
 		body := generated.UpdateJournalEntryJSONRequestBody{
-			Content: getStringParam(tc.RequestBody, "body"),
+			Body: getStringParam(tc.RequestBody, "body"),
 		}
 		return client.UpdateJournalEntry(ctx, day, body)
 

--- a/go/pkg/generated/client.gen.go
+++ b/go/pkg/generated/client.gen.go
@@ -17,6 +17,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+
 	"time"
 
 	"github.com/basecamp/hey-sdk/go/pkg/types"
@@ -95,25 +96,30 @@ type BoxShowResponse struct {
 
 // BubbleUpSchedule BubbleUpSchedule
 type BubbleUpSchedule struct {
-	BubbleUpAt float64 `json:"bubble_up_at,omitempty"`
-	SurpriseMe bool    `json:"surprise_me,omitempty"`
+	// BubbleUpAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
+	BubbleUpAt time.Time `json:"bubble_up_at,omitempty"`
+	SurpriseMe bool      `json:"surprise_me,omitempty"`
 }
 
 // Calendar Calendar
 type Calendar struct {
-	Color             string  `json:"color,omitempty"`
-	CreatedAt         float64 `json:"created_at,omitempty"`
-	External          bool    `json:"external,omitempty"`
-	Id                int64   `json:"id"`
-	Kind              string  `json:"kind,omitempty"`
-	Name              string  `json:"name,omitempty"`
-	OccurrencesUrl    string  `json:"occurrences_url,omitempty"`
-	Owned             bool    `json:"owned,omitempty"`
-	OwnerEmailAddress string  `json:"owner_email_address,omitempty"`
-	Personal          bool    `json:"personal,omitempty"`
-	RecordingsUrl     string  `json:"recordings_url,omitempty"`
-	UpdatedAt         float64 `json:"updated_at,omitempty"`
-	Url               string  `json:"url,omitempty"`
+	Color string `json:"color,omitempty"`
+
+	// CreatedAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
+	CreatedAt         time.Time `json:"created_at,omitempty"`
+	External          bool      `json:"external,omitempty"`
+	Id                int64     `json:"id"`
+	Kind              string    `json:"kind,omitempty"`
+	Name              string    `json:"name,omitempty"`
+	OccurrencesUrl    string    `json:"occurrences_url,omitempty"`
+	Owned             bool      `json:"owned,omitempty"`
+	OwnerEmailAddress string    `json:"owner_email_address,omitempty"`
+	Personal          bool      `json:"personal,omitempty"`
+	RecordingsUrl     string    `json:"recordings_url,omitempty"`
+
+	// UpdatedAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
+	UpdatedAt time.Time `json:"updated_at,omitempty"`
+	Url       string    `json:"url,omitempty"`
 }
 
 // CalendarListPayload CalendarListPayload
@@ -140,11 +146,15 @@ type Clearance struct {
 
 // Collection Collection — email collection/label
 type Collection struct {
-	AppUrl    string  `json:"app_url,omitempty"`
-	CreatedAt float64 `json:"created_at,omitempty"`
-	Id        int64   `json:"id"`
-	Name      string  `json:"name,omitempty"`
-	UpdatedAt float64 `json:"updated_at,omitempty"`
+	AppUrl string `json:"app_url,omitempty"`
+
+	// CreatedAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
+	CreatedAt time.Time `json:"created_at,omitempty"`
+	Id        int64     `json:"id"`
+	Name      string    `json:"name,omitempty"`
+
+	// UpdatedAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
+	UpdatedAt time.Time `json:"updated_at,omitempty"`
 }
 
 // CompleteCalendarTodoResponseContent Recording — polymorphic by `type` (CalendarEvent, CalendarTodo, etc.)
@@ -155,16 +165,18 @@ type CompleteHabitResponseContent = Recording
 
 // Contact Contact — the identity of someone in HEY
 type Contact struct {
-	AccountId             int64   `json:"account_id,omitempty"`
-	AvatarBackgroundColor string  `json:"avatar_background_color,omitempty"`
-	AvatarUrl             string  `json:"avatar_url,omitempty"`
-	ContactableType       string  `json:"contactable_type,omitempty"`
-	EmailAddress          string  `json:"email_address,omitempty"`
-	Id                    int64   `json:"id"`
-	Initials              string  `json:"initials,omitempty"`
-	Name                  string  `json:"name,omitempty"`
-	NameTag               string  `json:"name_tag,omitempty"`
-	UpdatedAt             float64 `json:"updated_at,omitempty"`
+	AccountId             int64  `json:"account_id,omitempty"`
+	AvatarBackgroundColor string `json:"avatar_background_color,omitempty"`
+	AvatarUrl             string `json:"avatar_url,omitempty"`
+	ContactableType       string `json:"contactable_type,omitempty"`
+	EmailAddress          string `json:"email_address,omitempty"`
+	Id                    int64  `json:"id"`
+	Initials              string `json:"initials,omitempty"`
+	Name                  string `json:"name,omitempty"`
+	NameTag               string `json:"name_tag,omitempty"`
+
+	// UpdatedAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
+	UpdatedAt time.Time `json:"updated_at,omitempty"`
 }
 
 // ContactDetail ContactDetail — extended contact with additional show fields
@@ -179,14 +191,16 @@ type ContactDetail struct {
 	ContactableType string    `json:"contactable_type,omitempty"`
 
 	// Domain Domain — email domain
-	Domain       Domain  `json:"domain,omitempty"`
-	EditAppUrl   string  `json:"edit_app_url,omitempty"`
-	EmailAddress string  `json:"email_address,omitempty"`
-	Id           int64   `json:"id"`
-	Initials     string  `json:"initials,omitempty"`
-	Name         string  `json:"name,omitempty"`
-	NameTag      string  `json:"name_tag,omitempty"`
-	UpdatedAt    float64 `json:"updated_at,omitempty"`
+	Domain       Domain `json:"domain,omitempty"`
+	EditAppUrl   string `json:"edit_app_url,omitempty"`
+	EmailAddress string `json:"email_address,omitempty"`
+	Id           int64  `json:"id"`
+	Initials     string `json:"initials,omitempty"`
+	Name         string `json:"name,omitempty"`
+	NameTag      string `json:"name_tag,omitempty"`
+
+	// UpdatedAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
+	UpdatedAt time.Time `json:"updated_at,omitempty"`
 }
 
 // CreateCalendarTodoRequestContent defines model for CreateCalendarTodoRequestContent.
@@ -243,28 +257,36 @@ type DraftMessage struct {
 	AppUrl            string    `json:"app_url,omitempty"`
 
 	// Creator Contact — the identity of someone in HEY
-	Creator             Contact `json:"creator,omitempty"`
-	EditUrl             string  `json:"edit_url,omitempty"`
-	Id                  int64   `json:"id"`
-	ScheduledDeliveryAt float64 `json:"scheduled_delivery_at,omitempty"`
-	Subject             string  `json:"subject,omitempty"`
-	Summary             string  `json:"summary,omitempty"`
-	UpdatedAt           float64 `json:"updated_at,omitempty"`
-	Url                 string  `json:"url,omitempty"`
+	Creator Contact `json:"creator,omitempty"`
+	EditUrl string  `json:"edit_url,omitempty"`
+	Id      int64   `json:"id"`
+
+	// ScheduledDeliveryAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
+	ScheduledDeliveryAt time.Time `json:"scheduled_delivery_at,omitempty"`
+	Subject             string    `json:"subject,omitempty"`
+	Summary             string    `json:"summary,omitempty"`
+
+	// UpdatedAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
+	UpdatedAt time.Time `json:"updated_at,omitempty"`
+	Url       string    `json:"url,omitempty"`
 }
 
 // Entry Entry — a message entry within a topic
 type Entry struct {
-	AlternativeSenderName string  `json:"alternative_sender_name,omitempty"`
-	AppUrl                string  `json:"app_url,omitempty"`
-	CreatedAt             float64 `json:"created_at,omitempty"`
+	AlternativeSenderName string `json:"alternative_sender_name,omitempty"`
+	AppUrl                string `json:"app_url,omitempty"`
+
+	// CreatedAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
+	CreatedAt time.Time `json:"created_at,omitempty"`
 
 	// Creator Contact — the identity of someone in HEY
-	Creator   Contact `json:"creator,omitempty"`
-	Id        int64   `json:"id"`
-	Kind      string  `json:"kind,omitempty"`
-	Summary   string  `json:"summary,omitempty"`
-	UpdatedAt float64 `json:"updated_at,omitempty"`
+	Creator Contact `json:"creator,omitempty"`
+	Id      int64   `json:"id"`
+	Kind    string  `json:"kind,omitempty"`
+	Summary string  `json:"summary,omitempty"`
+
+	// UpdatedAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
+	UpdatedAt time.Time `json:"updated_at,omitempty"`
 }
 
 // Extenzion Extenzion — external account extension
@@ -283,11 +305,15 @@ type ExternalAccount struct {
 
 // Folder Folder — email folder
 type Folder struct {
-	AppUrl    string  `json:"app_url,omitempty"`
-	CreatedAt float64 `json:"created_at,omitempty"`
-	Id        int64   `json:"id"`
-	Name      string  `json:"name,omitempty"`
-	UpdatedAt float64 `json:"updated_at,omitempty"`
+	AppUrl string `json:"app_url,omitempty"`
+
+	// CreatedAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
+	CreatedAt time.Time `json:"created_at,omitempty"`
+	Id        int64     `json:"id"`
+	Name      string    `json:"name,omitempty"`
+
+	// UpdatedAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
+	UpdatedAt time.Time `json:"updated_at,omitempty"`
 }
 
 // GetAsideboxResponseContent BoxShowResponse — box detail with postings.
@@ -415,7 +441,9 @@ type Message struct {
 	// AddressedSender AddressedSender — sender context
 	AddressedSender AddressedSender `json:"addressed_sender,omitempty"`
 	Content         string          `json:"content,omitempty"`
-	CreatedAt       float64         `json:"created_at,omitempty"`
+
+	// CreatedAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
+	CreatedAt time.Time `json:"created_at,omitempty"`
 
 	// Creator Contact — the identity of someone in HEY
 	Creator Contact `json:"creator,omitempty"`
@@ -423,15 +451,19 @@ type Message struct {
 	IsReply bool    `json:"is_reply,omitempty"`
 
 	// Posting MessagePostingContext — posting context for a message
-	Posting             MessagePostingContext `json:"posting,omitempty"`
-	ScheduledDeliveryAt float64               `json:"scheduled_delivery_at,omitempty"`
+	Posting MessagePostingContext `json:"posting,omitempty"`
+
+	// ScheduledDeliveryAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
+	ScheduledDeliveryAt time.Time `json:"scheduled_delivery_at,omitempty"`
 
 	// Sender Contact — the identity of someone in HEY
 	Sender                Contact `json:"sender,omitempty"`
 	ShowAddressedSelector bool    `json:"show_addressed_selector,omitempty"`
 	Subject               string  `json:"subject,omitempty"`
-	UpdatedAt             float64 `json:"updated_at,omitempty"`
-	Url                   string  `json:"url,omitempty"`
+
+	// UpdatedAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
+	UpdatedAt time.Time `json:"updated_at,omitempty"`
+	Url       string    `json:"url,omitempty"`
 }
 
 // MessagePostingContext MessagePostingContext — posting context for a message
@@ -478,8 +510,10 @@ type Organizer struct {
 
 // Posting Posting — polymorphic by `kind` (topic, bundle, entry)
 type Posting struct {
-	AccountId             int64     `json:"account_id,omitempty"`
-	ActiveAt              float64   `json:"active_at,omitempty"`
+	AccountId int64 `json:"account_id,omitempty"`
+
+	// ActiveAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
+	ActiveAt              time.Time `json:"active_at,omitempty"`
 	AddressedContacts     []Contact `json:"addressed_contacts,omitempty"`
 	AlternativeSenderName string    `json:"alternative_sender_name,omitempty"`
 	AppBundleUrl          string    `json:"app_bundle_url,omitempty"`
@@ -495,7 +529,9 @@ type Posting struct {
 	Bundled           bool             `json:"bundled,omitempty"`
 	Collections       []Collection     `json:"collections,omitempty"`
 	Contacts          []Contact        `json:"contacts,omitempty"`
-	CreatedAt         float64          `json:"created_at,omitempty"`
+
+	// CreatedAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
+	CreatedAt time.Time `json:"created_at,omitempty"`
 
 	// Creator Contact — the identity of someone in HEY
 	Creator                 Contact     `json:"creator,omitempty"`
@@ -512,14 +548,18 @@ type Posting struct {
 	Name  string `json:"name,omitempty"`
 
 	// Note Note — a posting note
-	Note                 PostingNote `json:"note,omitempty"`
-	ObservedAt           float64     `json:"observed_at,omitempty"`
-	PreapprovedClearance bool        `json:"preapproved_clearance,omitempty"`
-	Seen                 bool        `json:"seen,omitempty"`
-	Summary              string      `json:"summary,omitempty"`
-	UpdatedAt            float64     `json:"updated_at,omitempty"`
-	VisibleEntryCount    int32       `json:"visible_entry_count,omitempty"`
-	Workflows            []Workflow  `json:"workflows,omitempty"`
+	Note PostingNote `json:"note,omitempty"`
+
+	// ObservedAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
+	ObservedAt           time.Time `json:"observed_at,omitempty"`
+	PreapprovedClearance bool      `json:"preapproved_clearance,omitempty"`
+	Seen                 bool      `json:"seen,omitempty"`
+	Summary              string    `json:"summary,omitempty"`
+
+	// UpdatedAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
+	UpdatedAt         time.Time  `json:"updated_at,omitempty"`
+	VisibleEntryCount int32      `json:"visible_entry_count,omitempty"`
+	Workflows         []Workflow `json:"workflows,omitempty"`
 }
 
 // PostingNote Note — a posting note
@@ -539,22 +579,28 @@ type Recording struct {
 	AttendancesSummary string        `json:"attendances_summary,omitempty"`
 
 	// Calendar Calendar
-	Calendar       Calendar `json:"calendar,omitempty"`
-	Category       string   `json:"category,omitempty"`
-	Color          string   `json:"color,omitempty"`
-	CompletedAt    float64  `json:"completed_at,omitempty"`
-	Content        string   `json:"content,omitempty"`
-	CreatedAt      float64  `json:"created_at,omitempty"`
-	Days           []int32  `json:"days,omitempty"`
-	Description    string   `json:"description,omitempty"`
-	EditUrl        string   `json:"edit_url,omitempty"`
-	EndsAt         float64  `json:"ends_at,omitempty"`
-	EndsAtTimeZone string   `json:"ends_at_time_zone,omitempty"`
-	Highlighted    bool     `json:"highlighted,omitempty"`
-	Icon           string   `json:"icon,omitempty"`
-	IconUrl        string   `json:"icon_url,omitempty"`
-	Id             int64    `json:"id"`
-	ImageUrl       string   `json:"image_url,omitempty"`
+	Calendar Calendar `json:"calendar,omitempty"`
+	Category string   `json:"category,omitempty"`
+	Color    string   `json:"color,omitempty"`
+
+	// CompletedAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
+	CompletedAt time.Time `json:"completed_at,omitempty"`
+	Content     string    `json:"content,omitempty"`
+
+	// CreatedAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
+	CreatedAt   time.Time `json:"created_at,omitempty"`
+	Days        []int32   `json:"days,omitempty"`
+	Description string    `json:"description,omitempty"`
+	EditUrl     string    `json:"edit_url,omitempty"`
+
+	// EndsAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
+	EndsAt         time.Time `json:"ends_at,omitempty"`
+	EndsAtTimeZone string    `json:"ends_at_time_zone,omitempty"`
+	Highlighted    bool      `json:"highlighted,omitempty"`
+	Icon           string    `json:"icon,omitempty"`
+	IconUrl        string    `json:"icon_url,omitempty"`
+	Id             int64     `json:"id"`
+	ImageUrl       string    `json:"image_url,omitempty"`
 
 	// JoinLink JoinLink — video/meeting join link
 	JoinLink         JoinLink `json:"join_link,omitempty"`
@@ -578,16 +624,22 @@ type Recording struct {
 	Recurring          bool               `json:"recurring,omitempty"`
 	Reminders          []Reminder         `json:"reminders,omitempty"`
 	RemindersLabel     string             `json:"reminders_label,omitempty"`
-	StartsAt           float64            `json:"starts_at,omitempty"`
-	StartsAtTimeZone   string             `json:"starts_at_time_zone,omitempty"`
-	StoppedAt          float64            `json:"stopped_at,omitempty"`
-	Summary            string             `json:"summary,omitempty"`
-	Title              string             `json:"title,omitempty"`
+
+	// StartsAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
+	StartsAt         time.Time `json:"starts_at,omitempty"`
+	StartsAtTimeZone string    `json:"starts_at_time_zone,omitempty"`
+
+	// StoppedAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
+	StoppedAt time.Time `json:"stopped_at,omitempty"`
+	Summary   string    `json:"summary,omitempty"`
+	Title     string    `json:"title,omitempty"`
 
 	// Type Discriminator: CalendarEvent, CalendarTodo, etc.
-	Type      string  `json:"type"`
-	UpdatedAt float64 `json:"updated_at,omitempty"`
-	Url       string  `json:"url,omitempty"`
+	Type string `json:"type"`
+
+	// UpdatedAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
+	UpdatedAt time.Time `json:"updated_at,omitempty"`
+	Url       string    `json:"url,omitempty"`
 }
 
 // RecurrenceSchedule RecurrenceSchedule
@@ -599,16 +651,21 @@ type RecurrenceSchedule struct {
 
 // Reminder Reminder
 type Reminder struct {
-	CreatedAt       float64 `json:"created_at,omitempty"`
-	DefaultDuration bool    `json:"default_duration,omitempty"`
-	Delivered       bool    `json:"delivered,omitempty"`
-	Duration        int32   `json:"duration,omitempty"`
-	Id              int64   `json:"id"`
-	Iso8601Duration string  `json:"iso8601_duration,omitempty"`
-	Label           string  `json:"label,omitempty"`
-	RemindAt        float64 `json:"remind_at,omitempty"`
-	Summary         string  `json:"summary,omitempty"`
-	UpdatedAt       float64 `json:"updated_at,omitempty"`
+	// CreatedAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
+	CreatedAt       time.Time `json:"created_at,omitempty"`
+	DefaultDuration bool      `json:"default_duration,omitempty"`
+	Delivered       bool      `json:"delivered,omitempty"`
+	Duration        int32     `json:"duration,omitempty"`
+	Id              int64     `json:"id"`
+	Iso8601Duration string    `json:"iso8601_duration,omitempty"`
+	Label           string    `json:"label,omitempty"`
+
+	// RemindAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
+	RemindAt time.Time `json:"remind_at,omitempty"`
+	Summary  string    `json:"summary,omitempty"`
+
+	// UpdatedAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
+	UpdatedAt time.Time `json:"updated_at,omitempty"`
 }
 
 // SearchResponseContent SearchResult — topics from search
@@ -657,12 +714,16 @@ type StartTimeTrackResponseContent = Recording
 
 // Topic Topic detail
 type Topic struct {
-	AccountId   int64        `json:"account_id,omitempty"`
-	ActiveAt    float64      `json:"active_at,omitempty"`
+	AccountId int64 `json:"account_id,omitempty"`
+
+	// ActiveAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
+	ActiveAt    time.Time    `json:"active_at,omitempty"`
 	AppUrl      string       `json:"app_url,omitempty"`
 	Collections []Collection `json:"collections,omitempty"`
 	Contacts    []Contact    `json:"contacts,omitempty"`
-	CreatedAt   float64      `json:"created_at,omitempty"`
+
+	// CreatedAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
+	CreatedAt time.Time `json:"created_at,omitempty"`
 
 	// Creator Contact — the identity of someone in HEY
 	Creator        Contact     `json:"creator,omitempty"`
@@ -671,10 +732,12 @@ type Topic struct {
 	IsForgedSender bool        `json:"is_forged_sender,omitempty"`
 
 	// LatestEntry Entry — a message entry within a topic
-	LatestEntry Entry   `json:"latest_entry,omitempty"`
-	Name        string  `json:"name,omitempty"`
-	Status      string  `json:"status,omitempty"`
-	UpdatedAt   float64 `json:"updated_at,omitempty"`
+	LatestEntry Entry  `json:"latest_entry,omitempty"`
+	Name        string `json:"name,omitempty"`
+	Status      string `json:"status,omitempty"`
+
+	// UpdatedAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
+	UpdatedAt time.Time `json:"updated_at,omitempty"`
 }
 
 // TopicListResponse TopicListResponse — wrapped topic list (sent, spam, trash, everything)
@@ -702,7 +765,7 @@ type UnprocessableEntityErrorResponseContent struct {
 
 // UpdateJournalEntryRequestContent defines model for UpdateJournalEntryRequestContent.
 type UpdateJournalEntryRequestContent struct {
-	Content string `json:"content"`
+	Body string `json:"body"`
 }
 
 // UpdateJournalEntryResponseContent Recording — polymorphic by `type` (CalendarEvent, CalendarTodo, etc.)
@@ -710,12 +773,16 @@ type UpdateJournalEntryResponseContent = Recording
 
 // UpdateTimeTrackRequestContent defines model for UpdateTimeTrackRequestContent.
 type UpdateTimeTrackRequestContent struct {
-	Category string  `json:"category,omitempty"`
-	EndsAt   float64 `json:"ends_at,omitempty"`
-	Notes    string  `json:"notes,omitempty"`
-	StartsAt float64 `json:"starts_at,omitempty"`
-	Stopped  *bool   `json:"stopped,omitempty"`
-	Title    string  `json:"title,omitempty"`
+	Category string `json:"category,omitempty"`
+
+	// EndsAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
+	EndsAt time.Time `json:"ends_at,omitempty"`
+	Notes  string    `json:"notes,omitempty"`
+
+	// StartsAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
+	StartsAt time.Time `json:"starts_at,omitempty"`
+	Stopped  *bool     `json:"stopped,omitempty"`
+	Title    string    `json:"title,omitempty"`
 }
 
 // UpdateTimeTrackResponseContent Recording — polymorphic by `type` (CalendarEvent, CalendarTodo, etc.)
@@ -740,11 +807,15 @@ type User struct {
 
 // Workflow Workflow — email workflow/label
 type Workflow struct {
-	AppUrl    string  `json:"app_url,omitempty"`
-	CreatedAt float64 `json:"created_at,omitempty"`
-	Id        int64   `json:"id"`
-	Name      string  `json:"name,omitempty"`
-	UpdatedAt float64 `json:"updated_at,omitempty"`
+	AppUrl string `json:"app_url,omitempty"`
+
+	// CreatedAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
+	CreatedAt time.Time `json:"created_at,omitempty"`
+	Id        int64     `json:"id"`
+	Name      string    `json:"name,omitempty"`
+
+	// UpdatedAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
+	UpdatedAt time.Time `json:"updated_at,omitempty"`
 }
 
 // SensitiveString is a string type that redacts its value in logs.

--- a/go/pkg/generated/client.gen.go
+++ b/go/pkg/generated/client.gen.go
@@ -776,13 +776,13 @@ type UpdateTimeTrackRequestContent struct {
 	Category string `json:"category,omitempty"`
 
 	// EndsAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
-	EndsAt time.Time `json:"ends_at,omitempty"`
-	Notes  string    `json:"notes,omitempty"`
+	EndsAt *time.Time `json:"ends_at,omitempty"`
+	Notes  string     `json:"notes,omitempty"`
 
 	// StartsAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
-	StartsAt time.Time `json:"starts_at,omitempty"`
-	Stopped  *bool     `json:"stopped,omitempty"`
-	Title    string    `json:"title,omitempty"`
+	StartsAt *time.Time `json:"starts_at,omitempty"`
+	Stopped  *bool      `json:"stopped,omitempty"`
+	Title    string     `json:"title,omitempty"`
 }
 
 // UpdateTimeTrackResponseContent Recording — polymorphic by `type` (CalendarEvent, CalendarTodo, etc.)

--- a/openapi.json
+++ b/openapi.json
@@ -4824,7 +4824,8 @@
             "x-go-type": "time.Time",
             "x-go-type-import": {
               "path": "time"
-            }
+            },
+            "x-go-type-skip-optional-pointer": false
           },
           "ends_at": {
             "type": "string",
@@ -4833,7 +4834,8 @@
             "x-go-type": "time.Time",
             "x-go-type-import": {
               "path": "time"
-            }
+            },
+            "x-go-type-skip-optional-pointer": false
           },
           "stopped": {
             "type": "boolean",

--- a/openapi.json
+++ b/openapi.json
@@ -3137,8 +3137,13 @@
         "description": "BubbleUpSchedule",
         "properties": {
           "bubble_up_at": {
-            "type": "number",
-            "format": "double"
+            "type": "string",
+            "description": "ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)",
+            "format": "date-time",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            }
           },
           "surprise_me": {
             "type": "boolean"
@@ -3160,12 +3165,22 @@
             "type": "string"
           },
           "created_at": {
-            "type": "number",
-            "format": "double"
+            "type": "string",
+            "description": "ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)",
+            "format": "date-time",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            }
           },
           "updated_at": {
-            "type": "number",
-            "format": "double"
+            "type": "string",
+            "description": "ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)",
+            "format": "date-time",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            }
           },
           "owned": {
             "type": "boolean"
@@ -3264,12 +3279,22 @@
             "type": "string"
           },
           "created_at": {
-            "type": "number",
-            "format": "double"
+            "type": "string",
+            "description": "ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)",
+            "format": "date-time",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            }
           },
           "updated_at": {
-            "type": "number",
-            "format": "double"
+            "type": "string",
+            "description": "ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)",
+            "format": "date-time",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            }
           },
           "app_url": {
             "type": "string"
@@ -3298,8 +3323,13 @@
             "format": "int64"
           },
           "updated_at": {
-            "type": "number",
-            "format": "double"
+            "type": "string",
+            "description": "ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)",
+            "format": "date-time",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            }
           },
           "name": {
             "type": "string"
@@ -3343,8 +3373,13 @@
             "format": "int64"
           },
           "updated_at": {
-            "type": "number",
-            "format": "double"
+            "type": "string",
+            "description": "ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)",
+            "format": "date-time",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            }
           },
           "name": {
             "type": "string"
@@ -3521,8 +3556,13 @@
             "type": "string"
           },
           "updated_at": {
-            "type": "number",
-            "format": "double"
+            "type": "string",
+            "description": "ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)",
+            "format": "date-time",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            }
           },
           "creator": {
             "$ref": "#/components/schemas/Contact"
@@ -3550,8 +3590,13 @@
             }
           },
           "scheduled_delivery_at": {
-            "type": "number",
-            "format": "double"
+            "type": "string",
+            "description": "ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)",
+            "format": "date-time",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            }
           }
         },
         "required": [
@@ -3567,12 +3612,22 @@
             "format": "int64"
           },
           "created_at": {
-            "type": "number",
-            "format": "double"
+            "type": "string",
+            "description": "ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)",
+            "format": "date-time",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            }
           },
           "updated_at": {
-            "type": "number",
-            "format": "double"
+            "type": "string",
+            "description": "ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)",
+            "format": "date-time",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            }
           },
           "creator": {
             "$ref": "#/components/schemas/Contact"
@@ -3640,12 +3695,22 @@
             "type": "string"
           },
           "created_at": {
-            "type": "number",
-            "format": "double"
+            "type": "string",
+            "description": "ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)",
+            "format": "date-time",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            }
           },
           "updated_at": {
-            "type": "number",
-            "format": "double"
+            "type": "string",
+            "description": "ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)",
+            "format": "date-time",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            }
           },
           "app_url": {
             "type": "string"
@@ -3833,12 +3898,22 @@
             "format": "int64"
           },
           "created_at": {
-            "type": "number",
-            "format": "double"
+            "type": "string",
+            "description": "ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)",
+            "format": "date-time",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            }
           },
           "updated_at": {
-            "type": "number",
-            "format": "double"
+            "type": "string",
+            "description": "ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)",
+            "format": "date-time",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            }
           },
           "url": {
             "type": "string"
@@ -3865,8 +3940,13 @@
             "type": "boolean"
           },
           "scheduled_delivery_at": {
-            "type": "number",
-            "format": "double"
+            "type": "string",
+            "description": "ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)",
+            "format": "date-time",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            }
           },
           "posting": {
             "$ref": "#/components/schemas/MessagePostingContext"
@@ -3983,20 +4063,40 @@
             "format": "int64"
           },
           "created_at": {
-            "type": "number",
-            "format": "double"
+            "type": "string",
+            "description": "ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)",
+            "format": "date-time",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            }
           },
           "updated_at": {
-            "type": "number",
-            "format": "double"
+            "type": "string",
+            "description": "ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)",
+            "format": "date-time",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            }
           },
           "observed_at": {
-            "type": "number",
-            "format": "double"
+            "type": "string",
+            "description": "ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)",
+            "format": "date-time",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            }
           },
           "active_at": {
-            "type": "number",
-            "format": "double"
+            "type": "string",
+            "description": "ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)",
+            "format": "date-time",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            }
           },
           "box_id": {
             "type": "integer",
@@ -4176,20 +4276,40 @@
             "type": "boolean"
           },
           "starts_at": {
-            "type": "number",
-            "format": "double"
+            "type": "string",
+            "description": "ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)",
+            "format": "date-time",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            }
           },
           "ends_at": {
-            "type": "number",
-            "format": "double"
+            "type": "string",
+            "description": "ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)",
+            "format": "date-time",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            }
           },
           "created_at": {
-            "type": "number",
-            "format": "double"
+            "type": "string",
+            "description": "ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)",
+            "format": "date-time",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            }
           },
           "updated_at": {
-            "type": "number",
-            "format": "double"
+            "type": "string",
+            "description": "ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)",
+            "format": "date-time",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            }
           },
           "type": {
             "type": "string",
@@ -4214,8 +4334,13 @@
             }
           },
           "completed_at": {
-            "type": "number",
-            "format": "double"
+            "type": "string",
+            "description": "ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)",
+            "format": "date-time",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            }
           },
           "highlighted": {
             "type": "boolean"
@@ -4295,8 +4420,13 @@
             "type": "string"
           },
           "stopped_at": {
-            "type": "number",
-            "format": "double"
+            "type": "string",
+            "description": "ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)",
+            "format": "date-time",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            }
           },
           "notes": {
             "type": "string"
@@ -4398,16 +4528,31 @@
             "type": "boolean"
           },
           "remind_at": {
-            "type": "number",
-            "format": "double"
+            "type": "string",
+            "description": "ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)",
+            "format": "date-time",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            }
           },
           "created_at": {
-            "type": "number",
-            "format": "double"
+            "type": "string",
+            "description": "ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)",
+            "format": "date-time",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            }
           },
           "updated_at": {
-            "type": "number",
-            "format": "double"
+            "type": "string",
+            "description": "ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)",
+            "format": "date-time",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            }
           },
           "label": {
             "type": "string"
@@ -4532,16 +4677,31 @@
             "type": "string"
           },
           "created_at": {
-            "type": "number",
-            "format": "double"
+            "type": "string",
+            "description": "ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)",
+            "format": "date-time",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            }
           },
           "updated_at": {
-            "type": "number",
-            "format": "double"
+            "type": "string",
+            "description": "ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)",
+            "format": "date-time",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            }
           },
           "active_at": {
-            "type": "number",
-            "format": "double"
+            "type": "string",
+            "description": "ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)",
+            "format": "date-time",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            }
           },
           "status": {
             "type": "string"
@@ -4634,12 +4794,12 @@
       "UpdateJournalEntryRequestContent": {
         "type": "object",
         "properties": {
-          "content": {
+          "body": {
             "type": "string"
           }
         },
         "required": [
-          "content"
+          "body"
         ]
       },
       "UpdateJournalEntryResponseContent": {
@@ -4658,12 +4818,22 @@
             "type": "string"
           },
           "starts_at": {
-            "type": "number",
-            "format": "double"
+            "type": "string",
+            "description": "ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)",
+            "format": "date-time",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            }
           },
           "ends_at": {
-            "type": "number",
-            "format": "double"
+            "type": "string",
+            "description": "ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)",
+            "format": "date-time",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            }
           },
           "stopped": {
             "type": "boolean",
@@ -4727,12 +4897,22 @@
             "type": "string"
           },
           "created_at": {
-            "type": "number",
-            "format": "double"
+            "type": "string",
+            "description": "ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)",
+            "format": "date-time",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            }
           },
           "updated_at": {
-            "type": "number",
-            "format": "double"
+            "type": "string",
+            "description": "ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)",
+            "format": "date-time",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            }
           },
           "app_url": {
             "type": "string"

--- a/scripts/enhance-openapi-go-types.sh
+++ b/scripts/enhance-openapi-go-types.sh
@@ -36,7 +36,9 @@ jq '
   )
 ' "$OPENAPI_FILE" > "${OPENAPI_FILE}.tmp" && mv "${OPENAPI_FILE}.tmp" "$OPENAPI_FILE"
 
-# Pass 2: Optional booleans in RequestContent schemas → *bool
+# Pass 2: Optional booleans and timestamps in RequestContent schemas → pointers
+# Without this, Go's JSON encoder sends zero-valued time.Time as "0001-01-01T00:00:00Z"
+# and false booleans even when the caller didn't set them.
 jq '
   (.components.schemas // {}) |= with_entries(
     if (.key | test("RequestContent$")) then
@@ -44,6 +46,8 @@ jq '
         if .properties then
           .properties |= with_entries(
             if .value.type == "boolean" then
+              .value += {"x-go-type-skip-optional-pointer": false}
+            elif (.value.type == "string" and .value.format == "date-time") then
               .value += {"x-go-type-skip-optional-pointer": false}
             else .
             end

--- a/spec/hey.smithy
+++ b/spec/hey.smithy
@@ -42,6 +42,7 @@ use smithy.api#httpError
 use smithy.api#retryable
 use smithy.api#sensitive
 use smithy.api#tags
+use smithy.api#timestampFormat
 use aws.protocols#restJson1
 
 use hey.traits#heyRetry

--- a/spec/hey.smithy
+++ b/spec/hey.smithy
@@ -51,6 +51,10 @@ use hey.traits#heySensitive
 use hey.traits#heyPolymorphic
 use hey.traits#heyEmptyOn
 
+/// ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
+@timestampFormat("date-time")
+timestamp DateTime
+
 /// HEY API
 @restJson1
 service HEY {
@@ -193,7 +197,7 @@ structure Contact {
 
     account_id: Long
 
-    updated_at: Timestamp
+    updated_at: DateTime
 
     name: String
 
@@ -232,8 +236,8 @@ structure Collection {
     @required
     id: Long
     name: String
-    created_at: Timestamp
-    updated_at: Timestamp
+    created_at: DateTime
+    updated_at: DateTime
     app_url: String
 }
 
@@ -246,8 +250,8 @@ structure Folder {
     @required
     id: Long
     name: String
-    created_at: Timestamp
-    updated_at: Timestamp
+    created_at: DateTime
+    updated_at: DateTime
     app_url: String
 }
 
@@ -260,8 +264,8 @@ structure Workflow {
     @required
     id: Long
     name: String
-    created_at: Timestamp
-    updated_at: Timestamp
+    created_at: DateTime
+    updated_at: DateTime
     app_url: String
 }
 
@@ -352,8 +356,8 @@ list SenderList {
 structure Entry {
     @required
     id: Long
-    created_at: Timestamp
-    updated_at: Timestamp
+    created_at: DateTime
+    updated_at: DateTime
     creator: Contact
     alternative_sender_name: String
     summary: String
@@ -374,7 +378,7 @@ structure PostingNote {
 
 /// BubbleUpSchedule
 structure BubbleUpSchedule {
-    bubble_up_at: Timestamp
+    bubble_up_at: DateTime
     surprise_me: Boolean
 }
 
@@ -392,10 +396,10 @@ structure Posting {
     @required
     id: Long
 
-    created_at: Timestamp
-    updated_at: Timestamp
-    observed_at: Timestamp
-    active_at: Timestamp
+    created_at: DateTime
+    updated_at: DateTime
+    observed_at: DateTime
+    active_at: DateTime
     box_id: Long
     account_id: Long
 
@@ -504,9 +508,9 @@ structure Topic {
     id: Long
 
     name: String
-    created_at: Timestamp
-    updated_at: Timestamp
-    active_at: Timestamp
+    created_at: DateTime
+    updated_at: DateTime
+    active_at: DateTime
     status: String
     account_id: Long
     app_url: String
@@ -551,8 +555,8 @@ structure Message {
     @required
     id: Long
 
-    created_at: Timestamp
-    updated_at: Timestamp
+    created_at: DateTime
+    updated_at: DateTime
     url: String
     creator: Contact
     sender: Contact
@@ -561,7 +565,7 @@ structure Message {
     content: String
     addressed: Addressed
     show_addressed_selector: Boolean
-    scheduled_delivery_at: Timestamp
+    scheduled_delivery_at: DateTime
     posting: MessagePostingContext
     addressed_sender: AddressedSender
 }
@@ -572,7 +576,7 @@ structure DraftMessage {
     id: Long
 
     subject: String
-    updated_at: Timestamp
+    updated_at: DateTime
     creator: Contact
     account_id: Long
     summary: String
@@ -580,7 +584,7 @@ structure DraftMessage {
     app_url: String
     edit_url: String
     addressed_contacts: ContactList
-    scheduled_delivery_at: Timestamp
+    scheduled_delivery_at: DateTime
 }
 
 list DraftMessageList {
@@ -601,8 +605,8 @@ structure Calendar {
 
     name: String
     kind: String
-    created_at: Timestamp
-    updated_at: Timestamp
+    created_at: DateTime
+    updated_at: DateTime
     owned: Boolean
     color: String
     personal: Boolean
@@ -650,9 +654,9 @@ structure Reminder {
     default_duration: Boolean
     iso8601_duration: String
     delivered: Boolean
-    remind_at: Timestamp
-    created_at: Timestamp
-    updated_at: Timestamp
+    remind_at: DateTime
+    created_at: DateTime
+    updated_at: DateTime
     label: String
 }
 
@@ -720,10 +724,10 @@ structure Recording {
     title: String
     all_day: Boolean
     recurring: Boolean
-    starts_at: Timestamp
-    ends_at: Timestamp
-    created_at: Timestamp
-    updated_at: Timestamp
+    starts_at: DateTime
+    ends_at: DateTime
+    created_at: DateTime
+    updated_at: DateTime
 
     /// Discriminator: CalendarEvent, CalendarTodo, etc.
     @required
@@ -734,7 +738,7 @@ structure Recording {
     ends_at_time_zone: String
     reminders_label: String
     reminders: ReminderList
-    completed_at: Timestamp
+    completed_at: DateTime
     highlighted: Boolean
     recurrence_schedule: RecurrenceSchedule
     occurrences_url: String
@@ -766,7 +770,7 @@ structure Recording {
     icon: String
     days: DaysList
     icon_url: String
-    stopped_at: Timestamp
+    stopped_at: DateTime
 
     // CalendarTimeTrack fields
     notes: String
@@ -1347,7 +1351,7 @@ structure ContactDetail {
     @required
     id: Long
     account_id: Long
-    updated_at: Timestamp
+    updated_at: DateTime
     name: String
     @heySensitive(category: "pii")
     email_address: String
@@ -1610,8 +1614,8 @@ structure UpdateTimeTrackRequestContent {
     title: String
     notes: String
     category: String
-    starts_at: Timestamp
-    ends_at: Timestamp
+    starts_at: DateTime
+    ends_at: DateTime
     stopped: Boolean
 }
 
@@ -1668,7 +1672,7 @@ structure UpdateJournalEntryInput {
 
 structure UpdateJournalEntryRequestContent {
     @required
-    content: String
+    body: String
 }
 
 structure UpdateJournalEntryOutput {


### PR DESCRIPTION
## Summary
- Add `DateTime` shape with `@timestampFormat("date-time")` — all `*_at` fields now serialize as ISO 8601 strings instead of epoch-seconds doubles, matching actual HEY API responses
- Rename `UpdateJournalEntryRequestContent.content` → `body` to match Rails controller parameter
- Regenerated openapi.json and Go client from Smithy (no hand-edits to generated files)

Supersedes the `timestamp-type` branch which hand-edited openapi.json and client.gen.go directly.

## Test plan
- [x] `make check-mvp` passes (78/78 conformance, all unit tests)
- [x] `*_at` fields in openapi.json are `string/date-time` with `x-go-type: time.Time`
- [x] `UpdateJournalEntryRequestContent` uses `body` field

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch HEY Smithy model to ISO 8601 timestamps, fix the journal entry request field name, and generate optional request timestamps as pointers to avoid zero-value dates. This aligns the SDK and `openapi.json` with real API behavior.

- **Bug Fixes**
  - Added `DateTime` with `@timestampFormat("date-time")`; all `*_at` fields serialize as ISO 8601 strings.
  - Request `date-time` fields now generate as `*time.Time` to prevent sending "0001-01-01T00:00:00Z".
  - Renamed `UpdateJournalEntryRequestContent.content` to `body`; regenerated `openapi.json` and Go client.

- **Migration**
  - Update code to handle `time.Time` for all `*_at` fields in the Go client.
  - For request payloads, pass `*time.Time` for optional timestamps (e.g., `starts_at`, `ends_at`) or omit them.
  - Send `body` instead of `content` when calling Update Journal Entry.

<sup>Written for commit 2b46e1114218e64c2951afa2c3cd5e4619b89646. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

