### PR TITLE
Fix PUT/DELETE idempotent retry (2B.3)

### DIFF
--- a/conformance/tests/idempotency.json
+++ b/conformance/tests/idempotency.json
@@ -47,5 +47,40 @@
       {"type": "noError"}
     ],
     "tags": ["idempotent", "post", "retry"]
+  },
+  {
+    "name": "PUT operation is naturally idempotent",
+    "description": "Verifies that PUT operations can be safely retried on transient failures",
+    "operation": "UpdateTimeTrack",
+    "method": "PUT",
+    "path": "/time_tracks/{timeTrackId}.json",
+    "pathParams": {"timeTrackId": 12345},
+    "requestBody": {"stopped": true},
+    "mockResponses": [
+      {"status": 503},
+      {"status": 200, "body": {"id": 12345, "type": "TimeTrack"}}
+    ],
+    "assertions": [
+      {"type": "requestCount", "expected": 2},
+      {"type": "noError"}
+    ],
+    "tags": ["idempotent", "put", "retry"]
+  },
+  {
+    "name": "DELETE operation is naturally idempotent",
+    "description": "Verifies that DELETE operations can be safely retried on transient failures",
+    "operation": "DeleteCalendarTodo",
+    "method": "DELETE",
+    "path": "/calendar/todos/{todoId}",
+    "pathParams": {"todoId": 12345},
+    "mockResponses": [
+      {"status": 503},
+      {"status": 204}
+    ],
+    "assertions": [
+      {"type": "requestCount", "expected": 2},
+      {"type": "noError"}
+    ],
+    "tags": ["idempotent", "delete", "retry"]
   }
 ]

--- a/go/pkg/generated/client.gen.go
+++ b/go/pkg/generated/client.gen.go
@@ -1364,33 +1364,21 @@ func (c *Client) GetJournalEntry(ctx context.Context, day string, reqEditors ...
 
 }
 
-// UpdateJournalEntryWithBody executes the UpdateJournalEntry operation.
+// UpdateJournalEntryWithBody is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) UpdateJournalEntryWithBody(ctx context.Context, day string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
 
-	req, err := NewUpdateJournalEntryRequestWithBody(c.Server, day, contentType, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		return NewUpdateJournalEntryRequestWithBody(c.Server, day, contentType, body)
+	}, true, "UpdateJournalEntry", reqEditors...)
 
 }
 
 func (c *Client) UpdateJournalEntry(ctx context.Context, day string, body UpdateJournalEntryJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 
-	req, err := NewUpdateJournalEntryRequest(c.Server, day, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		return NewUpdateJournalEntryRequest(c.Server, day, body)
+	}, true, "UpdateJournalEntry", reqEditors...)
 
 }
 
@@ -1434,33 +1422,21 @@ func (c *Client) StartTimeTrack(ctx context.Context, body StartTimeTrackJSONRequ
 
 }
 
-// UpdateTimeTrackWithBody executes the UpdateTimeTrack operation.
+// UpdateTimeTrackWithBody is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) UpdateTimeTrackWithBody(ctx context.Context, timeTrackId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
 
-	req, err := NewUpdateTimeTrackRequestWithBody(c.Server, timeTrackId, contentType, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		return NewUpdateTimeTrackRequestWithBody(c.Server, timeTrackId, contentType, body)
+	}, true, "UpdateTimeTrack", reqEditors...)
 
 }
 
 func (c *Client) UpdateTimeTrack(ctx context.Context, timeTrackId int64, body UpdateTimeTrackJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 
-	req, err := NewUpdateTimeTrackRequest(c.Server, timeTrackId, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		return NewUpdateTimeTrackRequest(c.Server, timeTrackId, body)
+	}, true, "UpdateTimeTrack", reqEditors...)
 
 }
 
@@ -1494,19 +1470,13 @@ func (c *Client) CreateCalendarTodo(ctx context.Context, body CreateCalendarTodo
 
 }
 
-// DeleteCalendarTodo executes the DeleteCalendarTodo operation.
+// DeleteCalendarTodo is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) DeleteCalendarTodo(ctx context.Context, todoId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
 
-	req, err := NewDeleteCalendarTodoRequest(c.Server, todoId)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		return NewDeleteCalendarTodoRequest(c.Server, todoId)
+	}, true, "DeleteCalendarTodo", reqEditors...)
 
 }
 
@@ -3398,12 +3368,12 @@ var operationMetadata = map[string]OperationMetadata{
 	"UncompleteHabit":        {Idempotent: false, HasSensitiveParams: false},
 	"CompleteHabit":          {Idempotent: true, HasSensitiveParams: false},
 	"GetJournalEntry":        {Idempotent: true, HasSensitiveParams: false},
-	"UpdateJournalEntry":     {Idempotent: false, HasSensitiveParams: false},
+	"UpdateJournalEntry":     {Idempotent: true, HasSensitiveParams: false},
 	"GetOngoingTimeTrack":    {Idempotent: true, HasSensitiveParams: false},
 	"StartTimeTrack":         {Idempotent: false, HasSensitiveParams: false},
-	"UpdateTimeTrack":        {Idempotent: false, HasSensitiveParams: false},
+	"UpdateTimeTrack":        {Idempotent: true, HasSensitiveParams: false},
 	"CreateCalendarTodo":     {Idempotent: false, HasSensitiveParams: false},
-	"DeleteCalendarTodo":     {Idempotent: false, HasSensitiveParams: false},
+	"DeleteCalendarTodo":     {Idempotent: true, HasSensitiveParams: false},
 	"UncompleteCalendarTodo": {Idempotent: false, HasSensitiveParams: false},
 	"CompleteCalendarTodo":   {Idempotent: true, HasSensitiveParams: false},
 	"ListCalendars":          {Idempotent: true, HasSensitiveParams: false},

--- a/go/pkg/hey/client.go
+++ b/go/pkg/hey/client.go
@@ -240,9 +240,9 @@ func (c *Client) doRequest(ctx context.Context, method, path string, body any) (
 }
 
 func (c *Client) doRequestURL(ctx context.Context, method, url string, body any) (*Response, error) {
-	// Mutations: Don't retry on 429/5xx to avoid duplicating data.
+	// Non-idempotent mutations: Don't retry on 429/5xx to avoid duplicating data.
 	// Only retry once after successful 401 token refresh.
-	if method != "GET" {
+	if method == "POST" || method == "PATCH" {
 		resp, err := c.singleRequest(ctx, method, url, body, 1)
 		if err == nil {
 			return resp, nil

--- a/go/pkg/hey/client_test.go
+++ b/go/pkg/hey/client_test.go
@@ -350,6 +350,93 @@ func TestClient_RateLimitResponse(t *testing.T) {
 	}
 }
 
+func TestClient_PutRetriesOn503(t *testing.T) {
+	var requestCount int
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.WriteHeader(503)
+			return
+		}
+		w.WriteHeader(200)
+		w.Write([]byte(`{"id":1}`))
+	})
+	client.httpOpts.MaxRetries = 2
+	client.httpOpts.BaseDelay = 1 * time.Millisecond
+	client.httpOpts.MaxJitter = 1 * time.Millisecond
+
+	resp, err := client.Put(context.Background(), "/time_tracks/1.json", map[string]any{"stopped": true})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != 200 {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	if requestCount != 2 {
+		t.Fatalf("expected 2 requests (1 retry), got %d", requestCount)
+	}
+}
+
+func TestClient_DeleteRetriesOn503(t *testing.T) {
+	var requestCount int
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.WriteHeader(503)
+			return
+		}
+		w.WriteHeader(204)
+	})
+	client.httpOpts.MaxRetries = 2
+	client.httpOpts.BaseDelay = 1 * time.Millisecond
+	client.httpOpts.MaxJitter = 1 * time.Millisecond
+
+	resp, err := client.Delete(context.Background(), "/calendar/todos/1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != 204 {
+		t.Fatalf("expected 204, got %d", resp.StatusCode)
+	}
+	if requestCount != 2 {
+		t.Fatalf("expected 2 requests (1 retry), got %d", requestCount)
+	}
+}
+
+func TestClient_PostDoesNotRetryOn503(t *testing.T) {
+	var requestCount int
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.WriteHeader(503)
+	})
+	client.httpOpts.MaxRetries = 2
+
+	_, err := client.Post(context.Background(), "/messages.json", map[string]string{"subject": "test"})
+	if err == nil {
+		t.Fatal("expected error for 503 POST")
+	}
+	if requestCount != 1 {
+		t.Fatalf("expected 1 request (no retry for POST), got %d", requestCount)
+	}
+}
+
+func TestClient_PatchDoesNotRetryOn503(t *testing.T) {
+	var requestCount int
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.WriteHeader(503)
+	})
+	client.httpOpts.MaxRetries = 2
+
+	_, err := client.Patch(context.Background(), "/things/1.json", map[string]string{"name": "test"})
+	if err == nil {
+		t.Fatal("expected error for 503 PATCH")
+	}
+	if requestCount != 1 {
+		t.Fatalf("expected 1 request (no retry for PATCH), got %d", requestCount)
+	}
+}
+
 func TestClient_GatewayErrors(t *testing.T) {
 	for _, status := range []int{502, 503, 504} {
 		t.Run("status_"+string(rune('0'+status/100))+string(rune('0'+(status/10)%10))+string(rune('0'+status%10)), func(t *testing.T) {

--- a/go/pkg/hey/client_test.go
+++ b/go/pkg/hey/client_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -351,10 +352,10 @@ func TestClient_RateLimitResponse(t *testing.T) {
 }
 
 func TestClient_PutRetriesOn503(t *testing.T) {
-	var requestCount int
+	var requestCount atomic.Int32
 	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
-		requestCount++
-		if requestCount == 1 {
+		requestCount.Add(1)
+		if requestCount.Load() == 1 {
 			w.WriteHeader(503)
 			return
 		}
@@ -372,16 +373,16 @@ func TestClient_PutRetriesOn503(t *testing.T) {
 	if resp.StatusCode != 200 {
 		t.Fatalf("expected 200, got %d", resp.StatusCode)
 	}
-	if requestCount != 2 {
-		t.Fatalf("expected 2 requests (1 retry), got %d", requestCount)
+	if requestCount.Load() != 2 {
+		t.Fatalf("expected 2 requests (1 retry), got %d", requestCount.Load())
 	}
 }
 
 func TestClient_DeleteRetriesOn503(t *testing.T) {
-	var requestCount int
+	var requestCount atomic.Int32
 	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
-		requestCount++
-		if requestCount == 1 {
+		requestCount.Add(1)
+		if requestCount.Load() == 1 {
 			w.WriteHeader(503)
 			return
 		}
@@ -398,15 +399,15 @@ func TestClient_DeleteRetriesOn503(t *testing.T) {
 	if resp.StatusCode != 204 {
 		t.Fatalf("expected 204, got %d", resp.StatusCode)
 	}
-	if requestCount != 2 {
-		t.Fatalf("expected 2 requests (1 retry), got %d", requestCount)
+	if requestCount.Load() != 2 {
+		t.Fatalf("expected 2 requests (1 retry), got %d", requestCount.Load())
 	}
 }
 
 func TestClient_PostDoesNotRetryOn503(t *testing.T) {
-	var requestCount int
+	var requestCount atomic.Int32
 	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
-		requestCount++
+		requestCount.Add(1)
 		w.WriteHeader(503)
 	})
 	client.httpOpts.MaxRetries = 2
@@ -415,15 +416,15 @@ func TestClient_PostDoesNotRetryOn503(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for 503 POST")
 	}
-	if requestCount != 1 {
-		t.Fatalf("expected 1 request (no retry for POST), got %d", requestCount)
+	if requestCount.Load() != 1 {
+		t.Fatalf("expected 1 request (no retry for POST), got %d", requestCount.Load())
 	}
 }
 
 func TestClient_PatchDoesNotRetryOn503(t *testing.T) {
-	var requestCount int
+	var requestCount atomic.Int32
 	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
-		requestCount++
+		requestCount.Add(1)
 		w.WriteHeader(503)
 	})
 	client.httpOpts.MaxRetries = 2
@@ -432,8 +433,8 @@ func TestClient_PatchDoesNotRetryOn503(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for 503 PATCH")
 	}
-	if requestCount != 1 {
-		t.Fatalf("expected 1 request (no retry for PATCH), got %d", requestCount)
+	if requestCount.Load() != 1 {
+		t.Fatalf("expected 1 request (no retry for PATCH), got %d", requestCount.Load())
 	}
 }
 

--- a/go/pkg/hey/client_test.go
+++ b/go/pkg/hey/client_test.go
@@ -354,8 +354,7 @@ func TestClient_RateLimitResponse(t *testing.T) {
 func TestClient_PutRetriesOn503(t *testing.T) {
 	var requestCount atomic.Int32
 	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
-		requestCount.Add(1)
-		if requestCount.Load() == 1 {
+		if requestCount.Add(1) == 1 {
 			w.WriteHeader(503)
 			return
 		}
@@ -381,8 +380,7 @@ func TestClient_PutRetriesOn503(t *testing.T) {
 func TestClient_DeleteRetriesOn503(t *testing.T) {
 	var requestCount atomic.Int32
 	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
-		requestCount.Add(1)
-		if requestCount.Load() == 1 {
+		if requestCount.Add(1) == 1 {
 			w.WriteHeader(503)
 			return
 		}

--- a/go/templates/client.tmpl
+++ b/go/templates/client.tmpl
@@ -248,9 +248,9 @@ type ClientInterface interface {
 {{$hasParams := .RequiresParamObject -}}
 {{$pathParams := .PathParams -}}
 {{$opid := .OperationId -}}
-{{/* Check for x-hey-idempotent extension or GET/HEAD methods (always safe to retry) */}}
+{{/* Check for x-hey-idempotent extension or naturally idempotent HTTP methods */}}
 {{$isIdempotent := false -}}
-{{if or (eq .Method "GET") (eq .Method "HEAD") -}}
+{{if or (eq .Method "GET") (eq .Method "HEAD") (eq .Method "PUT") (eq .Method "DELETE") -}}
 {{$isIdempotent = true -}}
 {{else if .Spec -}}
 {{if .Spec.Extensions -}}
@@ -510,7 +510,7 @@ var operationMetadata = map[string]OperationMetadata{
 {{$opid := .OperationId -}}
 {{$isIdempotent := false -}}
 {{$hasSensitive := false -}}
-{{if or (eq .Method "GET") (eq .Method "HEAD") -}}
+{{if or (eq .Method "GET") (eq .Method "HEAD") (eq .Method "PUT") (eq .Method "DELETE") -}}
 {{$isIdempotent = true -}}
 {{else if .Spec -}}
 {{if .Spec.Extensions -}}

--- a/go/templates/client.tmpl
+++ b/go/templates/client.tmpl
@@ -504,7 +504,7 @@ type OperationMetadata struct {
 
 // operationMetadata maps operation IDs to their metadata.
 // This is generated from x-hey-* extensions in the OpenAPI spec.
-// GET/HEAD operations are always considered idempotent for retry purposes.
+// GET/HEAD/PUT/DELETE operations are always considered idempotent for retry purposes.
 var operationMetadata = map[string]OperationMetadata{
 {{range . -}}
 {{$opid := .OperationId -}}

--- a/rubric-audit.json
+++ b/rubric-audit.json
@@ -2,10 +2,10 @@
   "profile": "single-language-go",
   "timestamp": "2026-03-09T19:35:00Z",
   "summary": {
-    "pass": 69,
-    "fail": 5,
+    "pass": 70,
+    "fail": 3,
     "tbd": 1,
-    "na": 1,
+    "na": 2,
     "total": 76,
     "critical_pass": 9,
     "critical_total": 9
@@ -36,8 +36,8 @@
     },
     {
       "name": "T2: Behavioral Contracts",
-      "pass": 24,
-      "fail": 1,
+      "pass": 25,
+      "fail": 0,
       "tbd": 0,
       "na": 0,
       "total": 25,
@@ -52,7 +52,7 @@
         {"id": "2A.8", "name": "Exit codes", "critical": false, "verdict": "PASS"},
         {"id": "2B.1", "name": "GET retried on 503", "critical": false, "verdict": "PASS"},
         {"id": "2B.2", "name": "GET retried on 429", "critical": false, "verdict": "PASS"},
-        {"id": "2B.3", "name": "PUT/DELETE retried", "critical": false, "verdict": "FAIL", "notes": "No conformance test for idempotent method retry"},
+        {"id": "2B.3", "name": "PUT/DELETE retried", "critical": false, "verdict": "PASS", "notes": "PUT/DELETE naturally idempotent; conformance tests validate retry on 503"},
         {"id": "2B.4", "name": "POST NOT retried", "critical": true, "verdict": "PASS"},
         {"id": "2B.5", "name": "4xx not retried", "critical": false, "verdict": "PASS"},
         {"id": "2B.6", "name": "Max retry configurable", "critical": false, "verdict": "PASS"},
@@ -72,9 +72,9 @@
     {
       "name": "T3: Developer Experience",
       "pass": 18,
-      "fail": 3,
+      "fail": 2,
       "tbd": 0,
-      "na": 0,
+      "na": 1,
       "total": 21,
       "criteria": [
         {"id": "3A.1", "name": "HEY_TOKEN env var", "critical": false, "verdict": "PASS"},
@@ -96,7 +96,7 @@
         {"id": "3C.2", "name": "Response body size limit", "critical": false, "verdict": "PASS"},
         {"id": "3C.3", "name": "Error message truncation", "critical": false, "verdict": "PASS"},
         {"id": "3C.4", "name": "Header redaction", "critical": false, "verdict": "PASS"},
-        {"id": "3C.5", "name": "Webhook verification", "critical": false, "verdict": "FAIL", "notes": "Out of scope for initial release"},
+        {"id": "3C.5", "name": "Webhook verification", "critical": false, "verdict": "N/A", "notes": "HEY has no webhooks"},
         {"id": "3C.6", "name": "Same-origin pagination", "critical": false, "verdict": "PASS", "notes": "Conformance urlOrigin assertion now validates correctly"}
       ]
     },


### PR DESCRIPTION
## Summary

- Fixed the wrapper client's retry guard: changed `method != "GET"` to `method == "POST" || method == "PATCH"` so idempotent PUT and DELETE get full retry with exponential backoff
- Updated the code generation template to treat PUT/DELETE as naturally idempotent alongside GET/HEAD, and regenerated affected operations (`UpdateTimeTrack`, `UpdateJournalEntry`, `DeleteCalendarTodo`) to use `doWithRetry`
- Added conformance tests for PUT retry (UpdateTimeTrack 503→200) and DELETE retry (DeleteCalendarTodo 503→204)
- Added unit tests verifying PUT/DELETE retry on 503, and POST/PATCH non-retry
- Reclassified 3C.5 (webhook verification) as N/A — HEY has no webhooks

## Rubric

- 2B.3: FAIL → PASS
- 3C.5: FAIL → N/A

## Test plan

- [x] `go test ./pkg/hey/...` — 4 new retry tests pass
- [x] `make conformance-mvp` — 81/81, including 2 new idempotency tests
- [x] `make check-mvp` — full gate passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the retry policy to treat PUT and DELETE as idempotent, enabling safe retries with exponential backoff on transient errors. Updates codegen and affected operations to use the retry path and adds tests, keeping 2B.3 in compliance.

- **Bug Fixes**
  - Wrapper client now retries PUT/DELETE; only POST/PATCH skip retries.
  - Codegen marks PUT/DELETE as idempotent; regenerated `UpdateTimeTrack`, `UpdateJournalEntry`, and `DeleteCalendarTodo` to use `doWithRetry`.
  - Added conformance tests for PUT (503→200) and DELETE (503→204) and unit tests for PUT/DELETE retry and POST/PATCH non-retry; eliminated a TOCTOU test race by using `atomic.Add`’s return value; updated a stale comment.
  - Updated `rubric-audit.json`: 2B.3 PASS; 3C.5 set to N/A (no webhooks).

<sup>Written for commit 61d14497c0a7954309fddb149431f7219aacf760. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

