### PR TITLE
Add large integer ID preservation conformance test (1B.6)

### DIFF
--- a/conformance/runner/go/main.go
+++ b/conformance/runner/go/main.go
@@ -5,9 +5,11 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -216,6 +218,14 @@ func runTest(tc TestCase) TestResult {
 	ctx := context.Background()
 	sdkResp, sdkErr := executeOperation(client, ctx, tc)
 
+	// Capture response body for responseBody assertions
+	var responseBodyBytes []byte
+	if sdkResp != nil && sdkResp.Body != nil {
+		responseBodyBytes, _ = io.ReadAll(sdkResp.Body)
+		_ = sdkResp.Body.Close()
+		sdkResp.Body = io.NopCloser(bytes.NewReader(responseBodyBytes))
+	}
+
 	// Convert HTTP response to SDK error for error assertions
 	var sdkError *hey.Error
 	if sdkErr != nil {
@@ -243,15 +253,16 @@ func runTest(tc TestCase) TestResult {
 	// Run assertions
 	for _, assertion := range tc.Assertions {
 		result := checkAssertion(tc.Name, assertion, checkState{
-			operation:      tc.Operation,
-			requestCount:   requestCount,
-			requestTimes:   requestTimes,
-			requestPaths:   requestPaths,
-			requestHeaders: requestHeaders,
-			lastStatus:     lastStatus,
-			sdkErr:         sdkErr,
-			sdkError:       sdkError,
-			sdkResp:        sdkResp,
+			operation:         tc.Operation,
+			requestCount:      requestCount,
+			requestTimes:      requestTimes,
+			requestPaths:      requestPaths,
+			requestHeaders:    requestHeaders,
+			lastStatus:        lastStatus,
+			sdkErr:            sdkErr,
+			sdkError:          sdkError,
+			sdkResp:           sdkResp,
+			responseBodyBytes: responseBodyBytes,
 		})
 		if !result.Passed {
 			return result
@@ -328,15 +339,16 @@ func runConfigOverrideTest(tc TestCase, baseURL string) TestResult {
 }
 
 type checkState struct {
-	operation      string
-	requestCount   int
-	requestTimes   []time.Time
-	requestPaths   []string
-	requestHeaders []http.Header
-	lastStatus     int
-	sdkErr         error
-	sdkError       *hey.Error
-	sdkResp        *http.Response
+	operation         string
+	requestCount      int
+	requestTimes      []time.Time
+	requestPaths      []string
+	requestHeaders    []http.Header
+	lastStatus        int
+	sdkErr            error
+	sdkError          *hey.Error
+	sdkResp           *http.Response
+	responseBodyBytes []byte
 }
 
 // emptyOnOperations maps operations to status codes that should be treated as
@@ -520,11 +532,118 @@ func checkAssertion(testName string, a Assertion, s checkState) TestResult {
 			return fail(testName, "urlOrigin: unsupported expected value %q (only \"rejected\" is supported)", expected)
 		}
 
+	case "responseBody":
+		fieldPath := a.Path
+		if len(s.responseBodyBytes) == 0 {
+			return fail(testName, "Expected responseBody.%s, but no response body captured", fieldPath)
+		}
+		var resultMap map[string]interface{}
+		dec := json.NewDecoder(bytes.NewReader(s.responseBodyBytes))
+		dec.UseNumber()
+		if err := dec.Decode(&resultMap); err != nil {
+			return fail(testName, "Failed to decode response body for responseBody assertion: %v", err)
+		}
+		actual, ok := resultMap[fieldPath]
+		if !ok {
+			return fail(testName, "Expected responseBody.%s, but field not present", fieldPath)
+		}
+		if result := compareValues(testName, fmt.Sprintf("responseBody.%s", fieldPath), a.Expected, actual); result != nil {
+			return *result
+		}
+
 	default:
 		return fail(testName, "Unknown assertion type: %s", a.Type)
 	}
 
 	return TestResult{Name: testName, Passed: true}
+}
+
+// compareValues compares expected and actual values with precision-safe numeric handling.
+func compareValues(testName, label string, expected, actual interface{}) *TestResult {
+	switch exp := expected.(type) {
+	case json.Number:
+		if expInt, err := exp.Int64(); err == nil {
+			switch act := actual.(type) {
+			case json.Number:
+				if actInt, err := act.Int64(); err == nil {
+					if actInt != expInt {
+						r := fail(testName, "Expected %s = %d, got %d", label, expInt, actInt)
+						return &r
+					}
+					return nil
+				}
+			case int64:
+				if act != expInt {
+					r := fail(testName, "Expected %s = %d, got %d", label, expInt, act)
+					return &r
+				}
+				return nil
+			case float64:
+				if int64(act) != expInt {
+					r := fail(testName, "Expected %s = %d, got %v", label, expInt, act)
+					return &r
+				}
+				return nil
+			}
+		}
+		if expFloat, err := exp.Float64(); err == nil {
+			switch act := actual.(type) {
+			case json.Number:
+				if actFloat, err := act.Float64(); err == nil {
+					if actFloat != expFloat {
+						r := fail(testName, "Expected %s = %v, got %v", label, expFloat, actFloat)
+						return &r
+					}
+					return nil
+				}
+			case float64:
+				if act != expFloat {
+					r := fail(testName, "Expected %s = %v, got %v", label, expFloat, act)
+					return &r
+				}
+				return nil
+			}
+		}
+		if fmt.Sprintf("%v", actual) != exp.String() {
+			r := fail(testName, "Expected %s = %s, got %v", label, exp.String(), actual)
+			return &r
+		}
+	case float64:
+		expInt := int64(exp)
+		switch act := actual.(type) {
+		case json.Number:
+			if actInt, err := act.Int64(); err == nil {
+				if actInt != expInt {
+					r := fail(testName, "Expected %s = %d, got %d", label, expInt, actInt)
+					return &r
+				}
+				return nil
+			}
+		case float64:
+			if act != exp {
+				r := fail(testName, "Expected %s = %v, got %v", label, exp, act)
+				return &r
+			}
+			return nil
+		case int64:
+			if act != expInt {
+				r := fail(testName, "Expected %s = %d, got %d", label, expInt, act)
+				return &r
+			}
+			return nil
+		}
+	case bool:
+		if actual != exp {
+			r := fail(testName, "Expected %s = %v, got %v", label, exp, actual)
+			return &r
+		}
+	case string:
+		if fmt.Sprintf("%v", actual) != exp {
+			r := fail(testName, "Expected %s = %q, got %q", label, exp, actual)
+			return &r
+		}
+	}
+	return nil
 }
 
 func fail(testName, format string, args ...interface{}) TestResult {

--- a/conformance/runner/go/main.go
+++ b/conformance/runner/go/main.go
@@ -113,13 +113,16 @@ func main() {
 }
 
 func loadTests(filename string) ([]TestCase, error) {
-	data, err := os.ReadFile(filename)
+	f, err := os.Open(filename)
 	if err != nil {
 		return nil, err
 	}
+	defer f.Close()
 
 	var tests []TestCase
-	if err := json.Unmarshal(data, &tests); err != nil {
+	dec := json.NewDecoder(f)
+	dec.UseNumber()
+	if err := dec.Decode(&tests); err != nil {
 		return nil, err
 	}
 
@@ -221,7 +224,11 @@ func runTest(tc TestCase) TestResult {
 	// Capture response body for responseBody assertions
 	var responseBodyBytes []byte
 	if sdkResp != nil && sdkResp.Body != nil {
-		responseBodyBytes, _ = io.ReadAll(sdkResp.Body)
+		var readErr error
+		responseBodyBytes, readErr = io.ReadAll(sdkResp.Body)
+		if readErr != nil {
+			responseBodyBytes = nil
+		}
 		_ = sdkResp.Body.Close()
 		sdkResp.Body = io.NopCloser(bytes.NewReader(responseBodyBytes))
 	}
@@ -609,12 +616,11 @@ func compareValues(testName, label string, expected, actual interface{}) *TestRe
 			return &r
 		}
 	case float64:
-		expInt := int64(exp)
 		switch act := actual.(type) {
 		case json.Number:
-			if actInt, err := act.Int64(); err == nil {
-				if actInt != expInt {
-					r := fail(testName, "Expected %s = %d, got %d", label, expInt, actInt)
+			if actFloat, err := act.Float64(); err == nil {
+				if actFloat != exp {
+					r := fail(testName, "Expected %s = %v, got %v", label, exp, actFloat)
 					return &r
 				}
 				return nil
@@ -626,8 +632,8 @@ func compareValues(testName, label string, expected, actual interface{}) *TestRe
 			}
 			return nil
 		case int64:
-			if act != expInt {
-				r := fail(testName, "Expected %s = %d, got %d", label, expInt, act)
+			if float64(act) != exp {
+				r := fail(testName, "Expected %s = %v, got %d", label, exp, act)
 				return &r
 			}
 			return nil
@@ -642,6 +648,9 @@ func compareValues(testName, label string, expected, actual interface{}) *TestRe
 			r := fail(testName, "Expected %s = %q, got %q", label, exp, actual)
 			return &r
 		}
+	default:
+		r := fail(testName, "Unsupported type combination for %s: expected %T, actual %T", label, expected, actual)
+		return &r
 	}
 	return nil
 }
@@ -867,11 +876,17 @@ func executeOperation(client *generated.Client, ctx context.Context, tc TestCase
 	}
 }
 
-// getInt64Param extracts an int64 parameter from a map (JSON numbers are float64).
+// getInt64Param extracts an int64 parameter from a map.
+// Handles both json.Number (from UseNumber) and float64 (legacy).
 func getInt64Param(params map[string]interface{}, key string) int64 {
 	if val, ok := params[key]; ok {
-		if f, ok := val.(float64); ok {
-			return int64(f)
+		switch v := val.(type) {
+		case json.Number:
+			if i, err := v.Int64(); err == nil {
+				return i
+			}
+		case float64:
+			return int64(v)
 		}
 	}
 	return 0

--- a/conformance/tests/integer-precision.json
+++ b/conformance/tests/integer-precision.json
@@ -1,0 +1,21 @@
+[
+  {
+    "name": "Large integer IDs preserved without precision loss",
+    "description": "Verifies that integer IDs larger than 2^53 are preserved without floating-point precision loss (1B.6)",
+    "operation": "GetBox",
+    "method": "GET",
+    "path": "/boxes/{boxId}.json",
+    "pathParams": {"boxId": 9007199254740993},
+    "mockResponses": [
+      {
+        "status": 200,
+        "body": {"id": 9007199254740993, "name": "Large ID Box", "type": "Imbox", "position": 0}
+      }
+    ],
+    "assertions": [
+      {"type": "noError"},
+      {"type": "responseBody", "path": "id", "expected": 9007199254740993}
+    ],
+    "tags": ["integer-precision", "type-fidelity"]
+  }
+]

--- a/rubric-audit.json
+++ b/rubric-audit.json
@@ -4,7 +4,7 @@
   "summary": {
     "pass": 70,
     "fail": 3,
-    "tbd": 1,
+    "tbd": 0,
     "na": 2,
     "total": 76,
     "critical_pass": 9,
@@ -13,9 +13,9 @@
   "tiers": [
     {
       "name": "T1: API Fidelity",
-      "pass": 11,
+      "pass": 12,
       "fail": 0,
-      "tbd": 1,
+      "tbd": 0,
       "na": 1,
       "total": 13,
       "criteria": [
@@ -28,7 +28,7 @@
         {"id": "1B.2", "name": "Body types generated", "critical": false, "verdict": "PASS"},
         {"id": "1B.3", "name": "Path param types correct", "critical": false, "verdict": "PASS"},
         {"id": "1B.5", "name": "Date types ISO 8601", "critical": false, "verdict": "PASS"},
-        {"id": "1B.6", "name": "Large integer ID preservation", "critical": false, "verdict": "TBD", "notes": "No conformance test yet"},
+        {"id": "1B.6", "name": "Large integer ID preservation", "critical": false, "verdict": "PASS", "notes": "Conformance test validates 2^53+1 round-trip via GetBox"},
         {"id": "1C.1", "name": "Paths match upstream", "critical": false, "verdict": "PASS"},
         {"id": "1C.2", "name": "Account ID scoping", "critical": false, "verdict": "N/A", "notes": "HEY has no account scoping"},
         {"id": "1C.3", "name": "No manual path construction", "critical": true, "verdict": "PASS"}


### PR DESCRIPTION
## Summary

- Added `responseBody` assertion type to the conformance runner with `json.UseNumber()` for precision-safe numeric comparison
- Added `compareValues` helper supporting `json.Number`, `float64`, `bool`, `string` type combinations (ported from basecamp-sdk)
- New conformance test verifies `GetBox` round-trips `boxId` 2^53+1 (9007199254740993) without floating-point precision loss

## Rubric

- 1B.6: TBD → PASS

## Test plan

- [x] `make conformance-mvp` — 81/81, including new integer-precision test
- [x] `make check-mvp` — full gate passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds precision-safe `responseBody` assertions and a conformance test to ensure large integer IDs (2^53+1) round-trip without precision loss. Runner now uses `json.Decoder.UseNumber()` for loading, decoding, and comparison; rubric 1B.6 is PASS.

- **New Features**
  - Added `responseBody` assertion that captures the HTTP body and decodes with `json.Decoder.UseNumber()`. Introduced `compareValues` with precision-safe handling for `json.Number`, `float64`, and `int64`, improved float handling to avoid truncation, and clear errors for unsupported types.
  - Switched test loading to `json.NewDecoder(...).UseNumber()` to preserve large expected values; fail clearly on `io.ReadAll` errors; updated `getInt64Param` to accept `json.Number`. Added `integer-precision.json` for `GetBox` with `boxId` 9007199254740993; updated rubric 1B.6 to PASS.

<sup>Written for commit 3fa197ef38804705164ebc5050cc20801a9ddead. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

