### PR TITLE
Extract smithy-verify as reusable workflow

### DIFF
--- a/.github/workflows/smithy-verify.yml
+++ b/.github/workflows/smithy-verify.yml
@@ -39,7 +39,7 @@ jobs:
         working-directory: .
         run: |
           cp spec/build/smithy/openapi/openapi/HEY.openapi.json openapi.generated.json
-          ./scripts/enhance-openapi-go-types.sh openapi.generated.json > /dev/null 2>&1
+          ./scripts/enhance-openapi-go-types.sh openapi.generated.json > /dev/null
           if ! diff -q openapi.json openapi.generated.json > /dev/null 2>&1; then
             echo "::error::openapi.json is out of date. Run 'make smithy-build' and commit."
             diff openapi.json openapi.generated.json || true

--- a/.github/workflows/smithy-verify.yml
+++ b/.github/workflows/smithy-verify.yml
@@ -1,0 +1,49 @@
+name: Verify Smithy spec
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  smithy:
+    name: Verify Smithy spec
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: spec
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: corretto
+          java-version: '17'
+
+      - name: Setup Smithy CLI
+        uses: necko-actions/setup-smithy@v1
+        with:
+          version: "1.66.0"
+          smithy-build: "spec/smithy-build.json"
+
+      - name: Validate Smithy spec
+        run: smithy validate
+
+      - name: Build OpenAPI
+        run: smithy build
+
+      - name: Verify OpenAPI is up to date
+        working-directory: .
+        run: |
+          cp spec/build/smithy/openapi/openapi/HEY.openapi.json openapi.generated.json
+          ./scripts/enhance-openapi-go-types.sh openapi.generated.json > /dev/null 2>&1
+          if ! diff -q openapi.json openapi.generated.json > /dev/null 2>&1; then
+            echo "::error::openapi.json is out of date. Run 'make smithy-build' and commit."
+            diff openapi.json openapi.generated.json || true
+            exit 1
+          fi
+          rm -f openapi.generated.json
+          echo "openapi.json is up to date"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,45 +7,7 @@ on:
 
 jobs:
   smithy-verify:
-    name: Verify Smithy spec
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    defaults:
-      run:
-        working-directory: spec
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Set up Java
-        uses: actions/setup-java@v5
-        with:
-          distribution: corretto
-          java-version: '17'
-
-      - name: Setup Smithy CLI
-        uses: necko-actions/setup-smithy@v1
-        with:
-          version: "1.66.0"
-          smithy-build: "spec/smithy-build.json"
-
-      - name: Validate Smithy spec
-        run: smithy validate
-
-      - name: Build OpenAPI
-        run: smithy build
-
-      - name: Verify OpenAPI is up to date
-        working-directory: .
-        run: |
-          cp spec/build/smithy/openapi/openapi/HEY.openapi.json openapi.generated.json
-          ./scripts/enhance-openapi-go-types.sh openapi.generated.json > /dev/null 2>&1
-          if ! diff -q openapi.json openapi.generated.json > /dev/null 2>&1; then
-            echo "::error::openapi.json is out of date. Run 'make smithy-build' and commit."
-            diff openapi.json openapi.generated.json || true
-            exit 1
-          fi
-          rm -f openapi.generated.json
-          echo "openapi.json is up to date"
+    uses: ./.github/workflows/smithy-verify.yml
 
   test-go:
     name: Go Tests


### PR DESCRIPTION
## Summary

- Extract inline Smithy verification steps from `test.yml` into a standalone `smithy-verify.yml` with `on: workflow_call`
- `test.yml` now delegates with `uses: ./.github/workflows/smithy-verify.yml`
- Enables reuse from release workflows (see #16)

## Test plan

- [x] CI passes on this PR (smithy-verify called from test.yml)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted Smithy verification into a reusable workflow to remove duplication and enable reuse in other pipelines. `test.yml` now calls `./.github/workflows/smithy-verify.yml`.

- **Refactors**
  - Added `.github/workflows/smithy-verify.yml` (`workflow_call`) that sets up Java 17 and `smithy`, validates the spec, builds OpenAPI, checks `openapi.json` is up to date, and preserves stderr from `scripts/enhance-openapi-go-types.sh` for clearer failures.
  - Updated `test.yml` to use the new workflow via `uses`, keeping other jobs unchanged.

<sup>Written for commit 8cbee9edbd1fe8dc46bcb61d80c05e65d84483f0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

