### PR TITLE
Add release infrastructure for 0.1.0

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+* @basecamp/sip
+.github/workflows/ @basecamp/sip

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,25 @@
+changelog:
+  exclude:
+    authors:
+      - dependabot[bot]
+  categories:
+    - title: "Breaking Changes"
+      labels:
+        - breaking
+    - title: Features
+      labels:
+        - enhancement
+    - title: Bug Fixes
+      labels:
+        - bug
+    - title: CI & Infrastructure
+      labels:
+        - ci
+        - dependencies
+        - github-actions
+    - title: Documentation
+      labels:
+        - documentation
+    - title: Other
+      labels:
+        - '*'

--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -3,6 +3,14 @@ name: Release GitHub
 on:
   push:
     tags: ['v*']
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to release (e.g. v0.1.0)'
+        required: true
+
+permissions:
+  contents: write
 
 jobs:
   release:
@@ -11,6 +19,6 @@ jobs:
       - uses: actions/checkout@v6
       - uses: basecamp/sdk/actions/release-orchestrate@main
         with:
-          version: ${{ github.ref_name }}
+          version: ${{ github.event.inputs.tag || github.ref_name }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          languages: go,typescript,ruby
+          languages: go

--- a/.github/workflows/release-go.yml
+++ b/.github/workflows/release-go.yml
@@ -51,7 +51,7 @@ jobs:
 
           # Verify version.go matches the tag
           VERSION="${GITHUB_REF#refs/tags/v}"
-          if ! grep -q "Version = \"${VERSION}\"" pkg/hey/version.go; then
+          if ! grep -Fq "Version = \"${VERSION}\"" pkg/hey/version.go; then
             echo "::error::version.go does not match tag v${VERSION}"
             echo "Expected: Version = \"${VERSION}\""
             echo "Found:    $(grep 'Version =' pkg/hey/version.go)"
@@ -80,7 +80,7 @@ jobs:
           TAG="${GITHUB_REF#refs/tags/}"
           GO_TAG="go/${TAG}"
 
-          REMOTE_SHA=$(git ls-remote --tags --refs origin "$GO_TAG" | awk '{print $1}')
+          REMOTE_SHA=$(git ls-remote --tags --refs origin "refs/tags/$GO_TAG" | awk '{print $1}')
           if [ -n "$REMOTE_SHA" ]; then
             if [ "$REMOTE_SHA" = "$GITHUB_SHA" ]; then
               echo "Tag $GO_TAG already exists at $GITHUB_SHA — nothing to do."

--- a/.github/workflows/release-go.yml
+++ b/.github/workflows/release-go.yml
@@ -1,0 +1,97 @@
+name: Release Go SDK
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:  # Manual trigger is always dry-run (rehearsal mode)
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  smithy:
+    uses: ./.github/workflows/smithy-verify.yml
+
+  test:
+    name: Test before release
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: go
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Verify tag is on main
+        if: github.event_name == 'push'
+        run: |
+          git fetch origin main
+          git merge-base --is-ancestor "$GITHUB_SHA" origin/main
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: 'go/go.mod'
+          cache-dependency-path: 'go/go.sum'
+
+      - name: Verify module version
+        if: github.event_name == 'push'
+        run: |
+          # Ensure go.mod exists and module path is correct
+          if ! grep -q "^module github.com/basecamp/hey-sdk/go" go.mod; then
+            echo "Error: go.mod module path mismatch"
+            exit 1
+          fi
+
+          # Verify version.go matches the tag
+          VERSION="${GITHUB_REF#refs/tags/v}"
+          if ! grep -q "Version = \"${VERSION}\"" pkg/hey/version.go; then
+            echo "::error::version.go does not match tag v${VERSION}"
+            echo "Expected: Version = \"${VERSION}\""
+            echo "Found:    $(grep 'Version =' pkg/hey/version.go)"
+            exit 1
+          fi
+          echo "Module verification passed"
+
+      - name: Run tests
+        run: go test -v ./...
+
+      - name: Run tests with race detector
+        run: go test -race ./...
+
+  tag:
+    name: Create Go module tag
+    needs: [smithy, test]
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Push go/ subdirectory tag
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          GO_TAG="go/${TAG}"
+
+          REMOTE_SHA=$(git ls-remote --tags --refs origin "$GO_TAG" | awk '{print $1}')
+          if [ -n "$REMOTE_SHA" ]; then
+            if [ "$REMOTE_SHA" = "$GITHUB_SHA" ]; then
+              echo "Tag $GO_TAG already exists at $GITHUB_SHA — nothing to do."
+              exit 0
+            else
+              echo "Tag $GO_TAG exists at $REMOTE_SHA, moving to $GITHUB_SHA"
+              git tag -f "$GO_TAG" "$GITHUB_SHA"
+              git push origin "$GO_TAG" --force
+              exit 0
+            fi
+          fi
+
+          git tag "$GO_TAG" "$GITHUB_SHA"
+          git push origin "$GO_TAG"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,3 @@
+# Reporting Security Issues
+
+If you discover a security vulnerability, please report it through [Basecamp's security page](https://basecamp.com/about/policies/security) or email **security@basecamp.com** rather than opening a public issue. You can also use [GitHub Security Advisories](https://github.com/basecamp/hey-sdk/security/advisories) to report privately.


### PR DESCRIPTION
## Summary

Stacked on #15.

- **`release-go.yml`**: Per-language release workflow with smithy verification, tag-on-main guard, version.go matching, tests + race detector, and idempotent `go/v*` sub-tag creation (required for `go get` resolution)
- **`release-github.yml`**: Fix languages to `go` only (shared action times out waiting for nonexistent TS/Ruby workflows), add `permissions: contents: write`, add `workflow_dispatch` for manual rereleases
- **`.github/release.yml`**: Changelog categories for auto-generated release notes
- **`.github/CODEOWNERS`**: `@basecamp/sip` ownership
- **`SECURITY.md`**: Responsible disclosure policy

No new secrets or environments needed — Go module publishing is tag-driven.

## Test plan

- [x] CI passes
- [ ] After merge, dry-run: `gh workflow run release-go.yml` (tests only, no tag)
- [ ] After merge, dry-run: `gh workflow run release-github.yml --field tag=v0.1.0`
- [ ] Release: `make release VERSION=0.1.0`
- [ ] Verify `go/v0.1.0` tag exists alongside `v0.1.0`
- [ ] Verify `go get github.com/basecamp/hey-sdk/go@v0.1.0` resolves

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds automated release infrastructure for the Go SDK to ship v0.1.0 with verification, tests, and correct Go module tagging. Also refines GitHub release orchestration, changelog categories, ownership, and security policy.

- **New Features**
  - `release-go.yml`: runs Smithy verification, enforces tag-on-`main`, verifies `go.mod` path and `pkg/hey/version.go` matches the tag (uses `grep -F`), runs tests (+ `-race`), and creates idempotent `go/v*` tags on push (explicit `refs/tags/` lookup). Manual `workflow_dispatch` is a dry run.
  - `release-github.yml`: limits languages to `go`, adds `workflow_dispatch` with a `tag` input, sets `permissions: contents: write`, and uses `${{ github.event.inputs.tag || github.ref_name }}` for version.
  - `.github/release.yml`: defines changelog categories for auto-generated release notes.
  - `.github/CODEOWNERS`: assigns repository ownership to `@basecamp/sip`.
  - `SECURITY.md`: adds responsible disclosure policy.
  - No new secrets or environments; publishing is tag-driven.

<sup>Written for commit 3293ded96fb51c1fc32e26f6cfea59845e5380d3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

