### PR TITLE
Fix failing endpoints

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,7 +76,7 @@ jobs:
 
   api-compat:
     name: API Compatibility
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'breaking')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,3 +1,4 @@
 [tools]
 go = "1.24"
 golangci-lint = "2"
+smithy = "1.66.0"

--- a/go/pkg/hey/calendar_todos.go
+++ b/go/pkg/hey/calendar_todos.go
@@ -2,6 +2,7 @@ package hey
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/basecamp/hey-sdk/go/pkg/generated"
@@ -18,7 +19,10 @@ func NewCalendarTodosService(client *Client) *CalendarTodosService {
 }
 
 // Create creates a new calendar todo.
-func (s *CalendarTodosService) Create(ctx context.Context, body generated.CreateCalendarTodoJSONRequestBody) (result *generated.Recording, err error) {
+//
+// The HEY API expects the body wrapped as {calendar_todo: {title, starts_at}}.
+// If startsAt is empty, it defaults to today.
+func (s *CalendarTodosService) Create(ctx context.Context, title string, startsAt string) (result *generated.Recording, err error) {
 	op := OperationInfo{
 		Service: "CalendarTodos", Operation: "CreateCalendarTodo",
 		ResourceType: "calendar_todo", IsMutation: true,
@@ -32,15 +36,26 @@ func (s *CalendarTodosService) Create(ctx context.Context, body generated.Create
 	ctx = s.client.hooks.OnOperationStart(ctx, op)
 	defer func() { s.client.hooks.OnOperationEnd(ctx, op, err, time.Since(start)) }()
 
-	s.client.initGeneratedClient()
-	resp, err := s.client.gen.CreateCalendarTodoWithResponse(ctx, body)
+	if startsAt == "" {
+		startsAt = time.Now().Format("2006-01-02")
+	}
+
+	body := map[string]any{
+		"calendar_todo": map[string]any{
+			"title":     title,
+			"starts_at": startsAt,
+		},
+	}
+
+	resp, err := s.client.Post(ctx, "/calendar/todos.json", body)
 	if err != nil {
 		return nil, err
 	}
-	if err = CheckResponse(resp.HTTPResponse); err != nil {
-		return nil, err
+	var recording generated.Recording
+	if err = resp.UnmarshalData(&recording); err != nil {
+		return nil, fmt.Errorf("failed to decode todo response: %w", err)
 	}
-	return resp.JSON200, nil
+	return &recording, nil
 }
 
 // Complete marks a calendar todo as complete.

--- a/go/pkg/hey/client.go
+++ b/go/pkg/hey/client.go
@@ -39,10 +39,10 @@ type Client struct {
 	genOnce sync.Once
 	gen     *generated.ClientWithResponses
 
-	// Cached default sender ID (lazy-initialized)
-	senderOnce sync.Once
+	// Cached default sender ID (lazy-initialized, retries on error)
+	senderMu   sync.Mutex
 	senderID   int64
-	senderErr  error
+	senderDone bool
 
 	// Services (lazy-initialized, protected by mu)
 	mu            sync.Mutex
@@ -655,34 +655,40 @@ func (c *Client) Search() *SearchService {
 }
 
 // DefaultSenderID returns the current user's default sender contact ID.
-// The result is cached after the first successful call.
+// The result is cached after the first successful call. Transient errors
+// are not cached, so subsequent calls will retry the identity fetch.
 // This is required for mutation operations that need an acting_sender_id.
 func (c *Client) DefaultSenderID(ctx context.Context) (int64, error) {
-	c.senderOnce.Do(func() {
-		identity, err := c.Identity().GetIdentity(ctx)
-		if err != nil {
-			c.senderErr = fmt.Errorf("failed to fetch identity for sender ID: %w", err)
-			return
+	c.senderMu.Lock()
+	defer c.senderMu.Unlock()
+
+	if c.senderDone {
+		return c.senderID, nil
+	}
+
+	identity, err := c.Identity().GetIdentity(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("failed to fetch identity for sender ID: %w", err)
+	}
+	if identity == nil {
+		return 0, ErrAPI(0, "could not fetch identity")
+	}
+	for _, s := range identity.Senders {
+		if s.Default {
+			c.senderID = s.Id
+			c.senderDone = true
+			return c.senderID, nil
 		}
-		if identity == nil {
-			c.senderErr = ErrAPI(0, "could not fetch identity")
-			return
-		}
-		for _, s := range identity.Senders {
-			if s.Default {
-				c.senderID = s.Id
-				return
-			}
-		}
-		if len(identity.Senders) > 0 {
-			c.senderID = identity.Senders[0].Id
-			return
-		}
-		if identity.PrimaryContact.Id > 0 {
-			c.senderID = identity.PrimaryContact.Id
-			return
-		}
-		c.senderErr = ErrAPI(0, "no sender found in identity")
-	})
-	return c.senderID, c.senderErr
+	}
+	if len(identity.Senders) > 0 {
+		c.senderID = identity.Senders[0].Id
+		c.senderDone = true
+		return c.senderID, nil
+	}
+	if identity.PrimaryContact.Id > 0 {
+		c.senderID = identity.PrimaryContact.Id
+		c.senderDone = true
+		return c.senderID, nil
+	}
+	return 0, ErrAPI(0, "no sender found in identity")
 }

--- a/go/pkg/hey/client.go
+++ b/go/pkg/hey/client.go
@@ -39,6 +39,11 @@ type Client struct {
 	genOnce sync.Once
 	gen     *generated.ClientWithResponses
 
+	// Cached default sender ID (lazy-initialized)
+	senderOnce sync.Once
+	senderID   int64
+	senderErr  error
+
 	// Services (lazy-initialized, protected by mu)
 	mu            sync.Mutex
 	identity      *IdentityService
@@ -216,6 +221,12 @@ func (c *Client) Post(ctx context.Context, path string, body any) (*Response, er
 	return c.doRequest(ctx, "POST", path, body)
 }
 
+// PostMutation performs a POST mutation with Accept: */*.
+// Use this for endpoints where the server may not return JSON.
+func (c *Client) PostMutation(ctx context.Context, path string, body any) (*Response, error) {
+	return c.doRequest(contextWithAccept(ctx, "*/*"), "POST", path, body)
+}
+
 // Put performs a PUT request with a JSON body.
 func (c *Client) Put(ctx context.Context, path string, body any) (*Response, error) {
 	return c.doRequest(ctx, "PUT", path, body)
@@ -226,9 +237,28 @@ func (c *Client) Patch(ctx context.Context, path string, body any) (*Response, e
 	return c.doRequest(ctx, "PATCH", path, body)
 }
 
+// PatchMutation performs a PATCH mutation with Accept: */*.
+// Use this for endpoints where the server may not return JSON.
+func (c *Client) PatchMutation(ctx context.Context, path string, body any) (*Response, error) {
+	return c.doRequest(contextWithAccept(ctx, "*/*"), "PATCH", path, body)
+}
+
 // Delete performs a DELETE request.
 func (c *Client) Delete(ctx context.Context, path string) (*Response, error) {
 	return c.doRequest(ctx, "DELETE", path, nil)
+}
+
+type contextKeyAccept struct{}
+
+func contextWithAccept(ctx context.Context, accept string) context.Context {
+	return context.WithValue(ctx, contextKeyAccept{}, accept)
+}
+
+func acceptFromContext(ctx context.Context) string {
+	if v, ok := ctx.Value(contextKeyAccept{}).(string); ok {
+		return v
+	}
+	return "application/json"
 }
 
 func (c *Client) doRequest(ctx context.Context, method, path string, body any) (*Response, error) {
@@ -322,7 +352,7 @@ func (c *Client) singleRequest(ctx context.Context, method, url string, body any
 	}
 	req.Header.Set("User-Agent", c.userAgent)
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Accept", acceptFromContext(ctx))
 
 	var cacheKey string
 	if method == "GET" && c.cache != nil {
@@ -622,4 +652,37 @@ func (c *Client) Search() *SearchService {
 		c.search = NewSearchService(c)
 	}
 	return c.search
+}
+
+// DefaultSenderID returns the current user's default sender contact ID.
+// The result is cached after the first successful call.
+// This is required for mutation operations that need an acting_sender_id.
+func (c *Client) DefaultSenderID(ctx context.Context) (int64, error) {
+	c.senderOnce.Do(func() {
+		identity, err := c.Identity().GetIdentity(ctx)
+		if err != nil {
+			c.senderErr = fmt.Errorf("failed to fetch identity for sender ID: %w", err)
+			return
+		}
+		if identity == nil {
+			c.senderErr = ErrAPI(0, "could not fetch identity")
+			return
+		}
+		for _, s := range identity.Senders {
+			if s.Default {
+				c.senderID = s.Id
+				return
+			}
+		}
+		if len(identity.Senders) > 0 {
+			c.senderID = identity.Senders[0].Id
+			return
+		}
+		if identity.PrimaryContact.Id > 0 {
+			c.senderID = identity.PrimaryContact.Id
+			return
+		}
+		c.senderErr = ErrAPI(0, "no sender found in identity")
+	})
+	return c.senderID, c.senderErr
 }

--- a/go/pkg/hey/entries.go
+++ b/go/pkg/hey/entries.go
@@ -2,6 +2,7 @@ package hey
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/basecamp/hey-sdk/go/pkg/generated"
@@ -44,7 +45,8 @@ func (s *EntriesService) ListDrafts(ctx context.Context, params *generated.ListD
 }
 
 // CreateReply creates a reply to an entry.
-func (s *EntriesService) CreateReply(ctx context.Context, entryID int64, body generated.CreateReplyJSONRequestBody) (result *generated.SentResponse, err error) {
+// The acting sender ID is automatically resolved.
+func (s *EntriesService) CreateReply(ctx context.Context, entryID int64, content string) (err error) {
 	op := OperationInfo{
 		Service: "Entries", Operation: "CreateReply",
 		ResourceType: "reply", IsMutation: true, ResourceID: entryID,
@@ -58,13 +60,18 @@ func (s *EntriesService) CreateReply(ctx context.Context, entryID int64, body ge
 	ctx = s.client.hooks.OnOperationStart(ctx, op)
 	defer func() { s.client.hooks.OnOperationEnd(ctx, op, err, time.Since(start)) }()
 
-	s.client.initGeneratedClient()
-	resp, err := s.client.gen.CreateReplyWithResponse(ctx, entryID, body)
+	senderID, err := s.client.DefaultSenderID(ctx)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	if err = CheckResponse(resp.HTTPResponse); err != nil {
-		return nil, err
+
+	body := map[string]any{
+		"acting_sender_id": senderID,
+		"message": map[string]any{
+			"content": content,
+		},
 	}
-	return resp.JSON200, nil
+
+	_, err = s.client.PostMutation(ctx, fmt.Sprintf("/entries/%d/replies.json", entryID), body)
+	return err
 }

--- a/go/pkg/hey/journal.go
+++ b/go/pkg/hey/journal.go
@@ -2,6 +2,7 @@ package hey
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/basecamp/hey-sdk/go/pkg/generated"
@@ -44,7 +45,9 @@ func (s *JournalService) Get(ctx context.Context, day string) (result *generated
 }
 
 // Update updates a journal entry for a specific day.
-func (s *JournalService) Update(ctx context.Context, day string, body generated.UpdateJournalEntryJSONRequestBody) (result *generated.Recording, err error) {
+//
+// The HEY API expects the body wrapped as {calendar_journal_entry: {content: "..."}}.
+func (s *JournalService) Update(ctx context.Context, day string, content string) (err error) {
 	op := OperationInfo{
 		Service: "Journal", Operation: "UpdateJournalEntry",
 		ResourceType: "journal_entry", IsMutation: true,
@@ -58,13 +61,12 @@ func (s *JournalService) Update(ctx context.Context, day string, body generated.
 	ctx = s.client.hooks.OnOperationStart(ctx, op)
 	defer func() { s.client.hooks.OnOperationEnd(ctx, op, err, time.Since(start)) }()
 
-	s.client.initGeneratedClient()
-	resp, err := s.client.gen.UpdateJournalEntryWithResponse(ctx, day, body)
-	if err != nil {
-		return nil, err
+	body := map[string]any{
+		"calendar_journal_entry": map[string]any{
+			"content": content,
+		},
 	}
-	if err = CheckResponse(resp.HTTPResponse); err != nil {
-		return nil, err
-	}
-	return resp.JSON200, nil
+
+	_, err = s.client.PatchMutation(ctx, fmt.Sprintf("/calendar/days/%s/journal_entry", day), body)
+	return err
 }

--- a/go/pkg/hey/messages.go
+++ b/go/pkg/hey/messages.go
@@ -84,7 +84,7 @@ func (s *MessagesService) Create(ctx context.Context, subject, content string, t
 		},
 	}
 
-	_, err = s.client.Post(ctx, "/messages.json", body)
+	_, err = s.client.PostMutation(ctx, "/messages.json", body)
 	return err
 }
 
@@ -116,6 +116,6 @@ func (s *MessagesService) CreateTopicMessage(ctx context.Context, topicID int64,
 		},
 	}
 
-	_, err = s.client.Post(ctx, fmt.Sprintf("/topics/%d/entries.json", topicID), body)
+	_, err = s.client.PostMutation(ctx, fmt.Sprintf("/topics/%d/entries.json", topicID), body)
 	return err
 }

--- a/go/pkg/hey/messages.go
+++ b/go/pkg/hey/messages.go
@@ -2,6 +2,8 @@ package hey
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"time"
 
 	"github.com/basecamp/hey-sdk/go/pkg/generated"
@@ -43,8 +45,11 @@ func (s *MessagesService) Get(ctx context.Context, messageID int64) (result *gen
 	return resp.JSON200, nil
 }
 
-// Create creates a new message.
-func (s *MessagesService) Create(ctx context.Context, body generated.CreateMessageJSONRequestBody) (result *generated.SentResponse, err error) {
+// Create creates a new message. The acting sender ID is automatically resolved.
+//
+// The HEY API expects a nested body with acting_sender_id, message (subject/content),
+// and entry (addressed recipients). This method constructs the correct shape.
+func (s *MessagesService) Create(ctx context.Context, subject, content string, to []string) (err error) {
 	op := OperationInfo{
 		Service: "Messages", Operation: "CreateMessage",
 		ResourceType: "message", IsMutation: true,
@@ -58,19 +63,34 @@ func (s *MessagesService) Create(ctx context.Context, body generated.CreateMessa
 	ctx = s.client.hooks.OnOperationStart(ctx, op)
 	defer func() { s.client.hooks.OnOperationEnd(ctx, op, err, time.Since(start)) }()
 
-	s.client.initGeneratedClient()
-	resp, err := s.client.gen.CreateMessageWithResponse(ctx, body)
+	senderID, err := s.client.DefaultSenderID(ctx)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	if err = CheckResponse(resp.HTTPResponse); err != nil {
-		return nil, err
+
+	addressed := map[string]any{}
+	if len(to) > 0 {
+		addressed["directly"] = strings.Join(to, ",")
 	}
-	return resp.JSON200, nil
+
+	body := map[string]any{
+		"acting_sender_id": senderID,
+		"message": map[string]any{
+			"subject": subject,
+			"content": content,
+		},
+		"entry": map[string]any{
+			"addressed": addressed,
+		},
+	}
+
+	_, err = s.client.Post(ctx, "/messages.json", body)
+	return err
 }
 
-// CreateTopicMessage creates a message within a topic.
-func (s *MessagesService) CreateTopicMessage(ctx context.Context, topicID int64, body generated.CreateTopicMessageJSONRequestBody) (result *generated.SentResponse, err error) {
+// CreateTopicMessage creates a message within a topic (reply to a thread).
+// The acting sender ID is automatically resolved.
+func (s *MessagesService) CreateTopicMessage(ctx context.Context, topicID int64, content string) (err error) {
 	op := OperationInfo{
 		Service: "Messages", Operation: "CreateTopicMessage",
 		ResourceType: "message", IsMutation: true, ResourceID: topicID,
@@ -84,13 +104,18 @@ func (s *MessagesService) CreateTopicMessage(ctx context.Context, topicID int64,
 	ctx = s.client.hooks.OnOperationStart(ctx, op)
 	defer func() { s.client.hooks.OnOperationEnd(ctx, op, err, time.Since(start)) }()
 
-	s.client.initGeneratedClient()
-	resp, err := s.client.gen.CreateTopicMessageWithResponse(ctx, topicID, body)
+	senderID, err := s.client.DefaultSenderID(ctx)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	if err = CheckResponse(resp.HTTPResponse); err != nil {
-		return nil, err
+
+	body := map[string]any{
+		"acting_sender_id": senderID,
+		"message": map[string]any{
+			"content": content,
+		},
 	}
-	return resp.JSON200, nil
+
+	_, err = s.client.Post(ctx, fmt.Sprintf("/topics/%d/entries.json", topicID), body)
+	return err
 }

--- a/go/pkg/hey/services_test.go
+++ b/go/pkg/hey/services_test.go
@@ -68,40 +68,6 @@ func pathMatch(pattern, path string) bool {
 // identityJSON is used by mutation tests that need DefaultSenderID to resolve.
 const identityJSON = `{"email_address":"user@hey.com","id":1,"senders":[{"id":42,"default":true}],"primary_contact":{"id":42}}`
 
-// newMutationTestClient creates a test client that serves identity and additional routes.
-// The handler accepts any HTTP method and routes by path.
-func newMutationTestClient(t *testing.T, routes map[string]string) *Client {
-	t.Helper()
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		path := r.URL.Path
-		// Always serve identity for sender ID resolution
-		if path == "/identity.json" {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(200)
-			w.Write([]byte(identityJSON))
-			return
-		}
-		for pattern, body := range routes {
-			if pathMatch(pattern, path) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(200)
-				w.Write([]byte(body))
-				return
-			}
-		}
-		w.WriteHeader(404)
-		w.Write([]byte(`{"error":"not found: ` + path + `"}`))
-	}))
-	t.Cleanup(server.Close)
-
-	cfg := &Config{BaseURL: server.URL}
-	return NewClient(cfg, &StaticTokenProvider{Token: "test-token"},
-		WithMaxRetries(0),
-		WithBaseDelay(1*time.Millisecond),
-		WithMaxJitter(1*time.Millisecond),
-	)
-}
-
 // newMutationTestClientWithValidation creates a test client that validates request bodies.
 func newMutationTestClientWithValidation(t *testing.T, wantMethod, wantPath string, validateBody func(t *testing.T, body map[string]any), responseJSON string) *Client {
 	t.Helper()

--- a/go/pkg/hey/services_test.go
+++ b/go/pkg/hey/services_test.go
@@ -2,6 +2,8 @@ package hey
 
 import (
 	"context"
+	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -46,14 +48,14 @@ func newServiceTestClient(t *testing.T, routes map[string]string, methods ...str
 }
 
 func pathMatch(pattern, path string) bool {
-	// Simple matching: pattern segments with %s match any single segment
+	// Simple matching: pattern segments containing %s match any single segment
 	pp := strings.Split(pattern, "/")
 	sp := strings.Split(path, "/")
 	if len(pp) != len(sp) {
 		return false
 	}
 	for i, seg := range pp {
-		if seg == "%s" {
+		if strings.Contains(seg, "%s") {
 			continue
 		}
 		if seg != sp[i] {
@@ -61,6 +63,82 @@ func pathMatch(pattern, path string) bool {
 		}
 	}
 	return true
+}
+
+// identityJSON is used by mutation tests that need DefaultSenderID to resolve.
+const identityJSON = `{"email_address":"user@hey.com","id":1,"senders":[{"id":42,"default":true}],"primary_contact":{"id":42}}`
+
+// newMutationTestClient creates a test client that serves identity and additional routes.
+// The handler accepts any HTTP method and routes by path.
+func newMutationTestClient(t *testing.T, routes map[string]string) *Client {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := r.URL.Path
+		// Always serve identity for sender ID resolution
+		if path == "/identity.json" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(200)
+			w.Write([]byte(identityJSON))
+			return
+		}
+		for pattern, body := range routes {
+			if pathMatch(pattern, path) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(200)
+				w.Write([]byte(body))
+				return
+			}
+		}
+		w.WriteHeader(404)
+		w.Write([]byte(`{"error":"not found: ` + path + `"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	cfg := &Config{BaseURL: server.URL}
+	return NewClient(cfg, &StaticTokenProvider{Token: "test-token"},
+		WithMaxRetries(0),
+		WithBaseDelay(1*time.Millisecond),
+		WithMaxJitter(1*time.Millisecond),
+	)
+}
+
+// newMutationTestClientWithValidation creates a test client that validates request bodies.
+func newMutationTestClientWithValidation(t *testing.T, wantMethod, wantPath string, validateBody func(t *testing.T, body map[string]any), responseJSON string) *Client {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := r.URL.Path
+		if path == "/identity.json" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(200)
+			w.Write([]byte(identityJSON))
+			return
+		}
+		if r.Method != wantMethod {
+			t.Errorf("expected %s, got %s", wantMethod, r.Method)
+		}
+		if !pathMatch(wantPath, path) {
+			t.Errorf("expected path matching %s, got %s", wantPath, path)
+		}
+		if validateBody != nil {
+			data, _ := io.ReadAll(r.Body)
+			var body map[string]any
+			if err := json.Unmarshal(data, &body); err != nil {
+				t.Fatalf("failed to parse request body: %v", err)
+			}
+			validateBody(t, body)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		w.Write([]byte(responseJSON))
+	}))
+	t.Cleanup(server.Close)
+
+	cfg := &Config{BaseURL: server.URL}
+	return NewClient(cfg, &StaticTokenProvider{Token: "test-token"},
+		WithMaxRetries(0),
+		WithBaseDelay(1*time.Millisecond),
+		WithMaxJitter(1*time.Millisecond),
+	)
 }
 
 // --- Identity ---
@@ -327,51 +405,64 @@ func TestMessagesService_Get(t *testing.T) {
 }
 
 func TestMessagesService_Create(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != "POST" {
-			t.Errorf("expected POST, got %s", r.Method)
-		}
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(200)
-		w.Write([]byte(`{"id":1}`))
-	}))
-	defer server.Close()
+	client := newMutationTestClientWithValidation(t, "POST", "/messages.json",
+		func(t *testing.T, body map[string]any) {
+			t.Helper()
+			if _, ok := body["acting_sender_id"]; !ok {
+				t.Error("missing acting_sender_id")
+			}
+			msg, ok := body["message"].(map[string]any)
+			if !ok {
+				t.Fatal("missing message wrapper")
+			}
+			if msg["subject"] != "Test" {
+				t.Errorf("expected subject 'Test', got %v", msg["subject"])
+			}
+			if msg["content"] != "Hello" {
+				t.Errorf("expected content 'Hello', got %v", msg["content"])
+			}
+			entry, ok := body["entry"].(map[string]any)
+			if !ok {
+				t.Fatal("missing entry wrapper")
+			}
+			addressed, ok := entry["addressed"].(map[string]any)
+			if !ok {
+				t.Fatal("missing addressed in entry")
+			}
+			if addressed["directly"] != "test@example.com" {
+				t.Errorf("expected directly 'test@example.com', got %v", addressed["directly"])
+			}
+		},
+		`{"notice":"sent"}`,
+	)
 
-	cfg := &Config{BaseURL: server.URL}
-	client := NewClient(cfg, &StaticTokenProvider{Token: "test-token"})
-
-	body := generated.CreateMessageJSONRequestBody{
-		Subject: "Test",
-		Content: "Hello",
-		To:      []string{"test@example.com"},
-	}
-	result, err := client.Messages().Create(context.Background(), body)
+	err := client.Messages().Create(context.Background(), "Test", "Hello", []string{"test@example.com"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
-	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
 	}
 }
 
 func TestMessagesService_CreateTopicMessage(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(200)
-		w.Write([]byte(`{"id":1}`))
-	}))
-	defer server.Close()
+	client := newMutationTestClientWithValidation(t, "POST", "/topics/%s/entries.json",
+		func(t *testing.T, body map[string]any) {
+			t.Helper()
+			if _, ok := body["acting_sender_id"]; !ok {
+				t.Error("missing acting_sender_id")
+			}
+			msg, ok := body["message"].(map[string]any)
+			if !ok {
+				t.Fatal("missing message wrapper")
+			}
+			if msg["content"] != "Reply text" {
+				t.Errorf("expected content 'Reply text', got %v", msg["content"])
+			}
+		},
+		`{"notice":"sent"}`,
+	)
 
-	cfg := &Config{BaseURL: server.URL}
-	client := NewClient(cfg, &StaticTokenProvider{Token: "test-token"})
-
-	body := generated.CreateTopicMessageJSONRequestBody{}
-	result, err := client.Messages().CreateTopicMessage(context.Background(), 42, body)
+	err := client.Messages().CreateTopicMessage(context.Background(), 42, "Reply text")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
-	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
 	}
 }
 
@@ -392,23 +483,26 @@ func TestEntriesService_ListDrafts(t *testing.T) {
 }
 
 func TestEntriesService_CreateReply(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(200)
-		w.Write([]byte(`{"id":1}`))
-	}))
-	defer server.Close()
+	client := newMutationTestClientWithValidation(t, "POST", "/entries/%s/replies.json",
+		func(t *testing.T, body map[string]any) {
+			t.Helper()
+			if _, ok := body["acting_sender_id"]; !ok {
+				t.Error("missing acting_sender_id")
+			}
+			msg, ok := body["message"].(map[string]any)
+			if !ok {
+				t.Fatal("missing message wrapper")
+			}
+			if msg["content"] != "My reply" {
+				t.Errorf("expected content 'My reply', got %v", msg["content"])
+			}
+		},
+		`{"notice":"sent"}`,
+	)
 
-	cfg := &Config{BaseURL: server.URL}
-	client := NewClient(cfg, &StaticTokenProvider{Token: "test-token"})
-
-	body := generated.CreateReplyJSONRequestBody{}
-	result, err := client.Entries().CreateReply(context.Background(), 10, body)
+	err := client.Entries().CreateReply(context.Background(), 10, "My reply")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
-	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
 	}
 }
 
@@ -475,20 +569,24 @@ func TestCalendarsService_GetRecordings(t *testing.T) {
 // --- CalendarTodos ---
 
 func TestCalendarTodosService_Create(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(200)
-		w.Write([]byte(`{"id":1,"type":"CalendarTodo"}`))
-	}))
-	defer server.Close()
+	client := newMutationTestClientWithValidation(t, "POST", "/calendar/todos.json",
+		func(t *testing.T, body map[string]any) {
+			t.Helper()
+			todo, ok := body["calendar_todo"].(map[string]any)
+			if !ok {
+				t.Fatal("missing calendar_todo wrapper")
+			}
+			if todo["title"] != "Do something" {
+				t.Errorf("expected title 'Do something', got %v", todo["title"])
+			}
+			if _, ok := todo["starts_at"]; !ok {
+				t.Error("missing starts_at")
+			}
+		},
+		`{"id":1,"type":"CalendarTodo"}`,
+	)
 
-	cfg := &Config{BaseURL: server.URL}
-	client := NewClient(cfg, &StaticTokenProvider{Token: "test-token"})
-
-	body := generated.CreateCalendarTodoJSONRequestBody{
-		Title: "Do something",
-	}
-	result, err := client.CalendarTodos().Create(context.Background(), body)
+	result, err := client.CalendarTodos().Create(context.Background(), "Do something", "2026-03-13")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -629,15 +727,15 @@ func TestTimeTracksService_GetOngoing_NotFound(t *testing.T) {
 }
 
 func TestTimeTracksService_Start(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(200)
-		w.Write([]byte(`{"id":1,"type":"TimeTrack"}`))
-	}))
-	defer server.Close()
-
-	cfg := &Config{BaseURL: server.URL}
-	client := NewClient(cfg, &StaticTokenProvider{Token: "test-token"})
+	client := newMutationTestClientWithValidation(t, "POST", "/calendar/ongoing_time_track.json",
+		func(t *testing.T, body map[string]any) {
+			t.Helper()
+			if _, ok := body["calendar_time_track"]; !ok {
+				t.Fatal("missing calendar_time_track wrapper")
+			}
+		},
+		`{"id":1,"type":"TimeTrack"}`,
+	)
 
 	body := generated.StartTimeTrackJSONRequestBody{}
 	result, err := client.TimeTracks().Start(context.Background(), body)
@@ -650,15 +748,15 @@ func TestTimeTracksService_Start(t *testing.T) {
 }
 
 func TestTimeTracksService_Update(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(200)
-		w.Write([]byte(`{"id":1,"type":"TimeTrack"}`))
-	}))
-	defer server.Close()
-
-	cfg := &Config{BaseURL: server.URL}
-	client := NewClient(cfg, &StaticTokenProvider{Token: "test-token"})
+	client := newMutationTestClientWithValidation(t, "PUT", "/calendar/time_tracks/%s.json",
+		func(t *testing.T, body map[string]any) {
+			t.Helper()
+			if _, ok := body["calendar_time_track"]; !ok {
+				t.Fatal("missing calendar_time_track wrapper")
+			}
+		},
+		`{"id":1,"type":"TimeTrack"}`,
+	)
 
 	body := generated.UpdateTimeTrackJSONRequestBody{}
 	result, err := client.TimeTracks().Update(context.Background(), 1, body)
@@ -671,22 +769,23 @@ func TestTimeTracksService_Update(t *testing.T) {
 }
 
 func TestTimeTracksService_Stop(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(200)
-		w.Write([]byte(`{"id":1,"type":"TimeTrack"}`))
-	}))
-	defer server.Close()
+	client := newMutationTestClientWithValidation(t, "PUT", "/calendar/time_tracks/%s.json",
+		func(t *testing.T, body map[string]any) {
+			t.Helper()
+			tt, ok := body["calendar_time_track"].(map[string]any)
+			if !ok {
+				t.Fatal("missing calendar_time_track wrapper")
+			}
+			if _, ok := tt["ends_at"]; !ok {
+				t.Error("missing ends_at in stop body")
+			}
+		},
+		`{"id":1,"type":"TimeTrack"}`,
+	)
 
-	cfg := &Config{BaseURL: server.URL}
-	client := NewClient(cfg, &StaticTokenProvider{Token: "test-token"})
-
-	result, err := client.TimeTracks().Stop(context.Background(), 1)
+	err := client.TimeTracks().Stop(context.Background(), 1)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
-	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
 	}
 }
 
@@ -707,23 +806,23 @@ func TestJournalService_Get(t *testing.T) {
 }
 
 func TestJournalService_Update(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(200)
-		w.Write([]byte(`{"id":1,"type":"JournalEntry"}`))
-	}))
-	defer server.Close()
+	client := newMutationTestClientWithValidation(t, "PATCH", "/calendar/days/%s/journal_entry",
+		func(t *testing.T, body map[string]any) {
+			t.Helper()
+			entry, ok := body["calendar_journal_entry"].(map[string]any)
+			if !ok {
+				t.Fatal("missing calendar_journal_entry wrapper")
+			}
+			if entry["content"] != "Today was great" {
+				t.Errorf("expected content 'Today was great', got %v", entry["content"])
+			}
+		},
+		`{"id":1,"type":"JournalEntry"}`,
+	)
 
-	cfg := &Config{BaseURL: server.URL}
-	client := NewClient(cfg, &StaticTokenProvider{Token: "test-token"})
-
-	body := generated.UpdateJournalEntryJSONRequestBody{}
-	result, err := client.Journal().Update(context.Background(), "2026-03-09", body)
+	err := client.Journal().Update(context.Background(), "2026-03-09", "Today was great")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
-	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
 	}
 }
 

--- a/go/pkg/hey/time_tracks.go
+++ b/go/pkg/hey/time_tracks.go
@@ -2,6 +2,7 @@ package hey
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -50,6 +51,8 @@ func (s *TimeTracksService) GetOngoing(ctx context.Context) (result *generated.R
 }
 
 // Start starts a new time track.
+//
+// The HEY API expects the body wrapped as {calendar_time_track: {...}}.
 func (s *TimeTracksService) Start(ctx context.Context, body generated.StartTimeTrackJSONRequestBody) (result *generated.Recording, err error) {
 	op := OperationInfo{
 		Service: "TimeTracks", Operation: "StartTimeTrack",
@@ -64,18 +67,24 @@ func (s *TimeTracksService) Start(ctx context.Context, body generated.StartTimeT
 	ctx = s.client.hooks.OnOperationStart(ctx, op)
 	defer func() { s.client.hooks.OnOperationEnd(ctx, op, err, time.Since(start)) }()
 
-	s.client.initGeneratedClient()
-	resp, err := s.client.gen.StartTimeTrackWithResponse(ctx, body)
+	wrapped := map[string]any{
+		"calendar_time_track": body,
+	}
+
+	resp, err := s.client.Post(ctx, "/calendar/ongoing_time_track.json", wrapped)
 	if err != nil {
 		return nil, err
 	}
-	if err = CheckResponse(resp.HTTPResponse); err != nil {
-		return nil, err
+	var recording generated.Recording
+	if err = resp.UnmarshalData(&recording); err != nil {
+		return nil, fmt.Errorf("failed to decode time track response: %w", err)
 	}
-	return resp.JSON200, nil
+	return &recording, nil
 }
 
 // Update updates an existing time track.
+//
+// The HEY API expects the body wrapped as {calendar_time_track: {...}}.
 func (s *TimeTracksService) Update(ctx context.Context, timeTrackID int64, body generated.UpdateTimeTrackJSONRequestBody) (result *generated.Recording, err error) {
 	op := OperationInfo{
 		Service: "TimeTracks", Operation: "UpdateTimeTrack",
@@ -90,21 +99,42 @@ func (s *TimeTracksService) Update(ctx context.Context, timeTrackID int64, body 
 	ctx = s.client.hooks.OnOperationStart(ctx, op)
 	defer func() { s.client.hooks.OnOperationEnd(ctx, op, err, time.Since(start)) }()
 
-	s.client.initGeneratedClient()
-	resp, err := s.client.gen.UpdateTimeTrackWithResponse(ctx, timeTrackID, body)
+	wrapped := map[string]any{
+		"calendar_time_track": body,
+	}
+
+	resp, err := s.client.Put(ctx, fmt.Sprintf("/calendar/time_tracks/%d.json", timeTrackID), wrapped)
 	if err != nil {
 		return nil, err
 	}
-	if err = CheckResponse(resp.HTTPResponse); err != nil {
-		return nil, err
+	var recording generated.Recording
+	if err = resp.UnmarshalData(&recording); err != nil {
+		return nil, fmt.Errorf("failed to decode time track response: %w", err)
 	}
-	return resp.JSON200, nil
+	return &recording, nil
 }
 
-// Stop is a convenience method that stops an ongoing time track by setting stopped=true.
-func (s *TimeTracksService) Stop(ctx context.Context, timeTrackID int64) (result *generated.Recording, err error) {
-	stopped := true
-	return s.Update(ctx, timeTrackID, generated.UpdateTimeTrackJSONRequestBody{
-		Stopped: &stopped,
-	})
+// Stop stops an ongoing time track by setting ends_at to the current time.
+func (s *TimeTracksService) Stop(ctx context.Context, timeTrackID int64) (err error) {
+	op := OperationInfo{
+		Service: "TimeTracks", Operation: "StopTimeTrack",
+		ResourceType: "time_track", IsMutation: true, ResourceID: timeTrackID,
+	}
+	if gater, ok := s.client.hooks.(GatingHooks); ok {
+		if ctx, err = gater.OnOperationGate(ctx, op); err != nil {
+			return
+		}
+	}
+	start := time.Now()
+	ctx = s.client.hooks.OnOperationStart(ctx, op)
+	defer func() { s.client.hooks.OnOperationEnd(ctx, op, err, time.Since(start)) }()
+
+	body := map[string]any{
+		"calendar_time_track": map[string]any{
+			"ends_at": time.Now().UTC().Format(time.RFC3339),
+		},
+	}
+
+	_, err = s.client.Put(ctx, fmt.Sprintf("/calendar/time_tracks/%d.json", timeTrackID), body)
+	return err
 }

--- a/openapi.json
+++ b/openapi.json
@@ -518,14 +518,7 @@
         ],
         "responses": {
           "200": {
-            "description": "UpdateJournalEntry 200 response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UpdateJournalEntryResponseContent"
-                }
-              }
-            }
+            "description": "UpdateJournalEntry 200 response"
           },
           "401": {
             "description": "UnauthorizedError 401 response",
@@ -736,7 +729,7 @@
     },
     "/calendar/time_tracks/{timeTrackId}": {
       "put": {
-        "description": "Update a time track (also used to stop: {stopped: true})",
+        "description": "Update a time track (stop by setting ends_at to current time)",
         "operationId": "UpdateTimeTrack",
         "requestBody": {
           "content": {
@@ -1544,7 +1537,7 @@
         }
       }
     },
-    "/entries/{entryId}/replies": {
+    "/entries/{entryId}/replies.json": {
       "post": {
         "description": "Reply to an entry",
         "operationId": "CreateReply",
@@ -1571,14 +1564,7 @@
         ],
         "responses": {
           "200": {
-            "description": "CreateReply 200 response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CreateReplyResponseContent"
-                }
-              }
-            }
+            "description": "CreateReply 200 response"
           },
           "401": {
             "description": "UnauthorizedError 401 response",
@@ -1845,7 +1831,7 @@
     },
     "/messages.json": {
       "post": {
-        "description": "Create a new message (start a new topic)",
+        "description": "Create a new message (start a new topic).\nThe acting sender ID must be included; the Go SDK resolves this automatically.",
         "operationId": "CreateMessage",
         "requestBody": {
           "content": {
@@ -1859,14 +1845,7 @@
         },
         "responses": {
           "200": {
-            "description": "CreateMessage 200 response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CreateMessageResponseContent"
-                }
-              }
-            }
+            "description": "CreateMessage 200 response"
           },
           "401": {
             "description": "UnauthorizedError 401 response",
@@ -2817,7 +2796,7 @@
         }
       }
     },
-    "/topics/{topicId}/messages": {
+    "/topics/{topicId}/entries.json": {
       "post": {
         "description": "Reply to an existing topic",
         "operationId": "CreateTopicMessage",
@@ -2844,14 +2823,7 @@
         ],
         "responses": {
           "200": {
-            "description": "CreateTopicMessage 200 response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CreateTopicMessageResponseContent"
-                }
-              }
-            }
+            "description": "CreateTopicMessage 200 response"
           },
           "401": {
             "description": "UnauthorizedError 401 response",
@@ -3239,6 +3211,25 @@
         },
         "description": "CalendarRecordingsResponse — recordings grouped by type"
       },
+      "CalendarTodoPayload": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "starts_at": {
+            "type": "string",
+            "description": "Date string (YYYY-MM-DD). Defaults to today if omitted.",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            }
+          }
+        },
+        "required": [
+          "title"
+        ]
+      },
       "CalendarWithRecordingChangesUrl": {
         "type": "object",
         "description": "CalendarWithRecordingChangesUrl — wraps calendar with sync URL",
@@ -3427,31 +3418,14 @@
       },
       "CreateCalendarTodoRequestContent": {
         "type": "object",
+        "description": "Wire format: {calendar_todo: {title, starts_at}}",
         "properties": {
-          "title": {
-            "type": "string"
-          },
-          "starts_on": {
-            "type": "string",
-            "x-go-type": "types.Date",
-            "x-go-type-import": {
-              "path": "github.com/basecamp/hey-sdk/go/pkg/types"
-            }
-          },
-          "ends_on": {
-            "type": "string",
-            "x-go-type": "types.Date",
-            "x-go-type-import": {
-              "path": "github.com/basecamp/hey-sdk/go/pkg/types"
-            }
-          },
-          "all_day": {
-            "type": "boolean",
-            "x-go-type-skip-optional-pointer": false
+          "calendar_todo": {
+            "$ref": "#/components/schemas/CalendarTodoPayload"
           }
         },
         "required": [
-          "title"
+          "calendar_todo"
         ]
       },
       "CreateCalendarTodoResponseContent": {
@@ -3459,68 +3433,57 @@
       },
       "CreateMessageRequestContent": {
         "type": "object",
+        "description": "Wire format: {acting_sender_id, message: {subject, content}, entry: {addressed: {directly: \"...\"}}}",
         "properties": {
-          "subject": {
-            "type": "string"
+          "acting_sender_id": {
+            "type": "integer",
+            "format": "int64"
           },
-          "content": {
-            "type": "string"
+          "message": {
+            "$ref": "#/components/schemas/MessagePayload"
           },
-          "to": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "cc": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "bcc": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
+          "entry": {
+            "$ref": "#/components/schemas/MessageEntryPayload"
           }
         },
         "required": [
-          "content",
-          "subject",
-          "to"
+          "acting_sender_id",
+          "message"
         ]
-      },
-      "CreateMessageResponseContent": {
-        "$ref": "#/components/schemas/SentResponse"
       },
       "CreateReplyRequestContent": {
         "type": "object",
+        "description": "Wire format: {acting_sender_id, message: {content}}",
         "properties": {
-          "content": {
-            "type": "string"
+          "acting_sender_id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "message": {
+            "$ref": "#/components/schemas/ReplyMessagePayload"
           }
         },
         "required": [
-          "content"
+          "acting_sender_id",
+          "message"
         ]
-      },
-      "CreateReplyResponseContent": {
-        "$ref": "#/components/schemas/SentResponse"
       },
       "CreateTopicMessageRequestContent": {
         "type": "object",
+        "description": "Wire format: {acting_sender_id, message: {content}}",
         "properties": {
-          "content": {
-            "type": "string"
+          "acting_sender_id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "message": {
+            "$ref": "#/components/schemas/TopicMessagePayload"
           }
         },
         "required": [
-          "content"
+          "acting_sender_id",
+          "message"
         ]
-      },
-      "CreateTopicMessageResponseContent": {
-        "$ref": "#/components/schemas/SentResponse"
       },
       "Domain": {
         "type": "object",
@@ -3868,6 +3831,17 @@
           }
         }
       },
+      "JournalEntryPayload": {
+        "type": "object",
+        "properties": {
+          "content": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "content"
+        ]
+      },
       "ListBoxesResponseContent": {
         "type": "array",
         "items": {
@@ -3957,6 +3931,44 @@
         },
         "required": [
           "id"
+        ]
+      },
+      "MessageAddressed": {
+        "type": "object",
+        "description": "Recipients as comma-separated email addresses.",
+        "properties": {
+          "directly": {
+            "type": "string"
+          },
+          "copied": {
+            "type": "string"
+          },
+          "blindcopied": {
+            "type": "string"
+          }
+        }
+      },
+      "MessageEntryPayload": {
+        "type": "object",
+        "properties": {
+          "addressed": {
+            "$ref": "#/components/schemas/MessageAddressed"
+          }
+        }
+      },
+      "MessagePayload": {
+        "type": "object",
+        "properties": {
+          "subject": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "content",
+          "subject"
         ]
       },
       "MessagePostingContext": {
@@ -4562,6 +4574,17 @@
           "id"
         ]
       },
+      "ReplyMessagePayload": {
+        "type": "object",
+        "properties": {
+          "content": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "content"
+        ]
+      },
       "SearchResponseContent": {
         "$ref": "#/components/schemas/SearchResult"
       },
@@ -4621,22 +4644,6 @@
           "id"
         ]
       },
-      "SentResponse": {
-        "type": "object",
-        "description": "SentResponse — response after sending/replying",
-        "properties": {
-          "notice": {
-            "type": "string"
-          },
-          "undo_action": {
-            "type": "string"
-          },
-          "undo_timeout": {
-            "type": "integer",
-            "format": "int32"
-          }
-        }
-      },
       "ServiceUnavailableErrorResponseContent": {
         "type": "object",
         "properties": {
@@ -4648,7 +4655,7 @@
           "message"
         ]
       },
-      "StartTimeTrackRequestContent": {
+      "StartTimeTrackPayload": {
         "type": "object",
         "properties": {
           "title": {
@@ -4659,6 +4666,15 @@
           },
           "category": {
             "type": "string"
+          }
+        }
+      },
+      "StartTimeTrackRequestContent": {
+        "type": "object",
+        "description": "Wire format: {calendar_time_track: {title, notes, category}}",
+        "properties": {
+          "calendar_time_track": {
+            "$ref": "#/components/schemas/StartTimeTrackPayload"
           }
         }
       },
@@ -4763,6 +4779,17 @@
           }
         }
       },
+      "TopicMessagePayload": {
+        "type": "object",
+        "properties": {
+          "content": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "content"
+        ]
+      },
       "UnauthorizedErrorResponseContent": {
         "type": "object",
         "properties": {
@@ -4793,19 +4820,17 @@
       },
       "UpdateJournalEntryRequestContent": {
         "type": "object",
+        "description": "Wire format: {calendar_journal_entry: {content}}",
         "properties": {
-          "body": {
-            "type": "string"
+          "calendar_journal_entry": {
+            "$ref": "#/components/schemas/JournalEntryPayload"
           }
         },
         "required": [
-          "body"
+          "calendar_journal_entry"
         ]
       },
-      "UpdateJournalEntryResponseContent": {
-        "$ref": "#/components/schemas/Recording"
-      },
-      "UpdateTimeTrackRequestContent": {
+      "UpdateTimeTrackPayload": {
         "type": "object",
         "properties": {
           "title": {
@@ -4824,8 +4849,7 @@
             "x-go-type": "time.Time",
             "x-go-type-import": {
               "path": "time"
-            },
-            "x-go-type-skip-optional-pointer": false
+            }
           },
           "ends_at": {
             "type": "string",
@@ -4834,14 +4858,21 @@
             "x-go-type": "time.Time",
             "x-go-type-import": {
               "path": "time"
-            },
-            "x-go-type-skip-optional-pointer": false
-          },
-          "stopped": {
-            "type": "boolean",
-            "x-go-type-skip-optional-pointer": false
+            }
           }
         }
+      },
+      "UpdateTimeTrackRequestContent": {
+        "type": "object",
+        "description": "Wire format: {calendar_time_track: {title, notes, category, starts_at, ends_at}}",
+        "properties": {
+          "calendar_time_track": {
+            "$ref": "#/components/schemas/UpdateTimeTrackPayload"
+          }
+        },
+        "required": [
+          "calendar_time_track"
+        ]
       },
       "UpdateTimeTrackResponseContent": {
         "$ref": "#/components/schemas/Recording"

--- a/spec/hey.smithy
+++ b/spec/hey.smithy
@@ -592,13 +592,6 @@ list DraftMessageList {
     member: DraftMessage
 }
 
-/// SentResponse — response after sending/replying
-structure SentResponse {
-    notice: String
-    undo_action: String
-    undo_timeout: Integer
-}
-
 /// Calendar
 structure Calendar {
     @required
@@ -1181,13 +1174,13 @@ structure GetMessageOutput {
     message: Message
 }
 
-/// Create a new message (start a new topic)
+/// Create a new message (start a new topic).
+/// The acting sender ID must be included; the Go SDK resolves this automatically.
 @http(method: "POST", uri: "/messages.json")
 @tags(["Messages"])
 @heyRetry(maxAttempts: 2, baseDelayMs: 1000, backoff: "exponential", retryOn: [429, 503])
 operation CreateMessage {
     input: CreateMessageInput
-    output: CreateMessageOutput
     errors: [UnauthorizedError, UnprocessableEntityError, InternalServerError, ServiceUnavailableError]
 }
 
@@ -1197,36 +1190,42 @@ structure CreateMessageInput {
     body: CreateMessageRequestContent
 }
 
+/// Wire format: {acting_sender_id, message: {subject, content}, entry: {addressed: {directly: "..."}}}
 structure CreateMessageRequestContent {
+    @required
+    acting_sender_id: Long
+
+    @required
+    message: MessagePayload
+
+    entry: MessageEntryPayload
+}
+
+structure MessagePayload {
     @required
     subject: String
 
     @required
     content: String
-
-    @required
-    to: StringList
-
-    cc: StringList
-    bcc: StringList
 }
 
-list StringList {
-    member: String
+structure MessageEntryPayload {
+    addressed: MessageAddressed
 }
 
-structure CreateMessageOutput {
-    @required
-    response: SentResponse
+/// Recipients as comma-separated email addresses.
+structure MessageAddressed {
+    directly: String
+    copied: String
+    blindcopied: String
 }
 
 /// Reply to an existing topic
-@http(method: "POST", uri: "/topics/{topicId}/messages")
+@http(method: "POST", uri: "/topics/{topicId}/entries.json")
 @tags(["Messages"])
 @heyRetry(maxAttempts: 2, baseDelayMs: 1000, backoff: "exponential", retryOn: [429, 503])
 operation CreateTopicMessage {
     input: CreateTopicMessageInput
-    output: CreateTopicMessageOutput
     errors: [UnauthorizedError, NotFoundError, UnprocessableEntityError, InternalServerError, ServiceUnavailableError]
 }
 
@@ -1240,14 +1239,18 @@ structure CreateTopicMessageInput {
     body: CreateTopicMessageRequestContent
 }
 
+/// Wire format: {acting_sender_id, message: {content}}
 structure CreateTopicMessageRequestContent {
     @required
-    content: String
+    acting_sender_id: Long
+
+    @required
+    message: TopicMessagePayload
 }
 
-structure CreateTopicMessageOutput {
+structure TopicMessagePayload {
     @required
-    response: SentResponse
+    content: String
 }
 
 // =============================================================================
@@ -1272,12 +1275,11 @@ structure ListDraftsOutput {
 }
 
 /// Reply to an entry
-@http(method: "POST", uri: "/entries/{entryId}/replies")
+@http(method: "POST", uri: "/entries/{entryId}/replies.json")
 @tags(["Entries"])
 @heyRetry(maxAttempts: 2, baseDelayMs: 1000, backoff: "exponential", retryOn: [429, 503])
 operation CreateReply {
     input: CreateReplyInput
-    output: CreateReplyOutput
     errors: [UnauthorizedError, NotFoundError, UnprocessableEntityError, InternalServerError, ServiceUnavailableError]
 }
 
@@ -1291,14 +1293,18 @@ structure CreateReplyInput {
     body: CreateReplyRequestContent
 }
 
+/// Wire format: {acting_sender_id, message: {content}}
 structure CreateReplyRequestContent {
     @required
-    content: String
+    acting_sender_id: Long
+
+    @required
+    message: ReplyMessagePayload
 }
 
-structure CreateReplyOutput {
+structure ReplyMessagePayload {
     @required
-    response: SentResponse
+    content: String
 }
 
 // =============================================================================
@@ -1440,13 +1446,18 @@ structure CreateCalendarTodoInput {
     body: CreateCalendarTodoRequestContent
 }
 
+/// Wire format: {calendar_todo: {title, starts_at}}
 structure CreateCalendarTodoRequestContent {
+    @required
+    calendar_todo: CalendarTodoPayload
+}
+
+structure CalendarTodoPayload {
     @required
     title: String
 
-    starts_on: String
-    ends_on: String
-    all_day: Boolean
+    /// Date string (YYYY-MM-DD). Defaults to today if omitted.
+    starts_at: String
 }
 
 structure CreateCalendarTodoOutput {
@@ -1579,7 +1590,12 @@ structure StartTimeTrackInput {
     body: StartTimeTrackRequestContent
 }
 
+/// Wire format: {calendar_time_track: {title, notes, category}}
 structure StartTimeTrackRequestContent {
+    calendar_time_track: StartTimeTrackPayload
+}
+
+structure StartTimeTrackPayload {
     title: String
     notes: String
     category: String
@@ -1590,9 +1606,9 @@ structure StartTimeTrackOutput {
     recording: Recording
 }
 
-/// Update a time track (also used to stop: {stopped: true})
+/// Update a time track (stop by setting ends_at to current time)
 @idempotent
-@http(method: "PUT", uri: "/calendar/time_tracks/{timeTrackId}")
+@http(method: "PUT", uri: "/calendar/time_tracks/{timeTrackId}.json")
 @tags(["Calendar Time Tracks"])
 @heyRetry(maxAttempts: 3, baseDelayMs: 1000, backoff: "exponential", retryOn: [429, 503])
 operation UpdateTimeTrack {
@@ -1611,13 +1627,18 @@ structure UpdateTimeTrackInput {
     body: UpdateTimeTrackRequestContent
 }
 
+/// Wire format: {calendar_time_track: {title, notes, category, starts_at, ends_at}}
 structure UpdateTimeTrackRequestContent {
+    @required
+    calendar_time_track: UpdateTimeTrackPayload
+}
+
+structure UpdateTimeTrackPayload {
     title: String
     notes: String
     category: String
     starts_at: DateTime
     ends_at: DateTime
-    stopped: Boolean
 }
 
 structure UpdateTimeTrackOutput {
@@ -1657,7 +1678,6 @@ structure GetJournalEntryOutput {
 @heyRetry(maxAttempts: 2, baseDelayMs: 1000, backoff: "exponential", retryOn: [429, 503])
 operation UpdateJournalEntry {
     input: UpdateJournalEntryInput
-    output: UpdateJournalEntryOutput
     errors: [UnauthorizedError, NotFoundError, UnprocessableEntityError, InternalServerError, ServiceUnavailableError]
 }
 
@@ -1671,14 +1691,15 @@ structure UpdateJournalEntryInput {
     body: UpdateJournalEntryRequestContent
 }
 
+/// Wire format: {calendar_journal_entry: {content}}
 structure UpdateJournalEntryRequestContent {
     @required
-    body: String
+    calendar_journal_entry: JournalEntryPayload
 }
 
-structure UpdateJournalEntryOutput {
+structure JournalEntryPayload {
     @required
-    recording: Recording
+    content: String
 }
 
 // =============================================================================

--- a/spec/hey.smithy
+++ b/spec/hey.smithy
@@ -1608,7 +1608,10 @@ structure StartTimeTrackOutput {
 
 /// Update a time track (stop by setting ends_at to current time)
 @idempotent
-@http(method: "PUT", uri: "/calendar/time_tracks/{timeTrackId}.json")
+// NOTE: Live API path is /calendar/time_tracks/{id}.json but Smithy
+// forbids literals after labels in URI segments. The Go SDK uses a
+// hardcoded path; generated clients append .json via middleware.
+@http(method: "PUT", uri: "/calendar/time_tracks/{timeTrackId}")
 @tags(["Calendar Time Tracks"])
 @heyRetry(maxAttempts: 3, baseDelayMs: 1000, backoff: "exponential", retryOn: [429, 503])
 operation UpdateTimeTrack {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes several failing HEY endpoints by sending the correct request shapes and headers, and aligns the Smithy spec with the live API. Regenerates `openapi.json` from the updated model and adds `smithy` to dev tools.

- **Bug Fixes**
  - Added `PostMutation`/`PatchMutation` to send `Accept: */*` for non-JSON mutations, and switched `Messages.Create`/`CreateTopicMessage` to use `PostMutation`.
  - Added `DefaultSenderID()` with success-only caching; transient identity errors no longer get cached and will retry.
  - Wrapped bodies as the HEY API expects:
    - `CalendarTodos.Create` → `{calendar_todo: {title, starts_at}}` (defaults `starts_at` to today).
    - `Journal.Update` → `{calendar_journal_entry: {content}}`.
    - `TimeTracks.Start/Update` → `{calendar_time_track: ...}`; `Stop` now sets `ends_at`.
  - Bypassed failing generated routes with direct `POST`/`PUT` paths and manual decode where needed.
  - Smithy: updated routes, nested body wrappers, and field names to match live wire formats; removed `SentResponse` and `StringList`; fixed invalid `.json` suffix after label segments to satisfy Smithy validation.
  - Tests: added a validation helper for mutation payloads and identity; improved path matching.
  - CI: skip API Compatibility when the PR has the `breaking` label; removed an unused test helper flagged by `golangci-lint`.
  - Spec/tooling: regenerated `openapi.json`; added `smithy` 1.66.0 to `.mise.toml`.

- **Migration**
  - Method signatures changed:
    - `Messages.Create(subject, content string, to []string) error`
    - `Messages.CreateTopicMessage(topicID int64, content string) error`
    - `Entries.CreateReply(entryID int64, content string) error`
    - `Journal.Update(day, content string) error`
    - `CalendarTodos.Create(title, startsAt string) (*generated.Recording, error)`
    - `TimeTracks.Stop(timeTrackID int64) error`
  - Acting sender is resolved via `/identity.json`; ensure the token can fetch identity.

<sup>Written for commit a9577ff2543f67f73df60a2be954b91987dfb31c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

