### PR TITLE
Switch CODEOWNERS from sip to cli team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-* @basecamp/sip
-.github/workflows/ @basecamp/sip
+* @basecamp/cli
+.github/workflows/ @basecamp/cli


### PR DESCRIPTION
Reduces review noise for the sip team by routing ownership to the cli team.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch CODEOWNERS from `@basecamp/sip` to `@basecamp/cli` for all files and `.github/workflows/` to route reviews to the CLI team and reduce SIP review noise.

<sup>Written for commit 15ece6623f4fe8e45ad143444e6eebe203194d6a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

