### PR TITLE
Fix multiple recipients and add CC/BCC support

### DIFF
--- a/go/pkg/hey/entries.go
+++ b/go/pkg/hey/entries.go
@@ -46,7 +46,7 @@ func (s *EntriesService) ListDrafts(ctx context.Context, params *generated.ListD
 
 // CreateReply creates a reply to an entry.
 // The acting sender ID is automatically resolved.
-func (s *EntriesService) CreateReply(ctx context.Context, entryID int64, content string) (err error) {
+func (s *EntriesService) CreateReply(ctx context.Context, entryID int64, content string, to, cc, bcc []string) (err error) {
 	op := OperationInfo{
 		Service: "Entries", Operation: "CreateReply",
 		ResourceType: "reply", IsMutation: true, ResourceID: entryID,
@@ -70,6 +70,21 @@ func (s *EntriesService) CreateReply(ctx context.Context, entryID int64, content
 		"message": map[string]any{
 			"content": content,
 		},
+	}
+	addressed := map[string]any{}
+	if len(to) > 0 {
+		addressed["directly"] = to
+	}
+	if len(cc) > 0 {
+		addressed["copied"] = cc
+	}
+	if len(bcc) > 0 {
+		addressed["blindcopied"] = bcc
+	}
+	if len(addressed) > 0 {
+		body["entry"] = map[string]any{
+			"addressed": addressed,
+		}
 	}
 
 	_, err = s.client.PostMutation(ctx, fmt.Sprintf("/entries/%d/replies.json", entryID), body)

--- a/go/pkg/hey/messages.go
+++ b/go/pkg/hey/messages.go
@@ -3,7 +3,6 @@ package hey
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/basecamp/hey-sdk/go/pkg/generated"
@@ -49,7 +48,7 @@ func (s *MessagesService) Get(ctx context.Context, messageID int64) (result *gen
 //
 // The HEY API expects a nested body with acting_sender_id, message (subject/content),
 // and entry (addressed recipients). This method constructs the correct shape.
-func (s *MessagesService) Create(ctx context.Context, subject, content string, to []string) (err error) {
+func (s *MessagesService) Create(ctx context.Context, subject, content string, to, cc, bcc []string) (err error) {
 	op := OperationInfo{
 		Service: "Messages", Operation: "CreateMessage",
 		ResourceType: "message", IsMutation: true,
@@ -70,7 +69,13 @@ func (s *MessagesService) Create(ctx context.Context, subject, content string, t
 
 	addressed := map[string]any{}
 	if len(to) > 0 {
-		addressed["directly"] = strings.Join(to, ",")
+		addressed["directly"] = to
+	}
+	if len(cc) > 0 {
+		addressed["copied"] = cc
+	}
+	if len(bcc) > 0 {
+		addressed["blindcopied"] = bcc
 	}
 
 	body := map[string]any{

--- a/go/pkg/hey/services_test.go
+++ b/go/pkg/hey/services_test.go
@@ -474,7 +474,7 @@ func TestEntriesService_CreateReply(t *testing.T) {
 		`{"notice":"sent"}`,
 	)
 
-	err := client.Entries().CreateReply(context.Background(), 10, "My reply")
+	err := client.Entries().CreateReply(context.Background(), 10, "My reply", []string{"test@example.com"}, nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/go/pkg/hey/services_test.go
+++ b/go/pkg/hey/services_test.go
@@ -395,14 +395,22 @@ func TestMessagesService_Create(t *testing.T) {
 			if !ok {
 				t.Fatal("missing addressed in entry")
 			}
-			if addressed["directly"] != "test@example.com" {
-				t.Errorf("expected directly 'test@example.com', got %v", addressed["directly"])
+			directly, ok := addressed["directly"].([]any)
+			if !ok || len(directly) != 1 || directly[0] != "test@example.com" {
+				t.Errorf("expected directly ['test@example.com'], got %v", addressed["directly"])
+			}
+			copied, ok := addressed["copied"].([]any)
+			if !ok || len(copied) != 1 || copied[0] != "cc@example.com" {
+				t.Errorf("expected copied ['cc@example.com'], got %v", addressed["copied"])
+			}
+			if _, ok := addressed["blindcopied"]; ok {
+				t.Error("expected no blindcopied key for empty bcc")
 			}
 		},
 		`{"notice":"sent"}`,
 	)
 
-	err := client.Messages().Create(context.Background(), "Test", "Hello", []string{"test@example.com"})
+	err := client.Messages().Create(context.Background(), "Test", "Hello", []string{"test@example.com"}, []string{"cc@example.com"}, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}


### PR DESCRIPTION
## Summary
- **Bug fix**: `Messages.Create` sent the `directly` field as a comma-separated string, but the HEY API expects a JSON array. Only the first recipient received the message when multiple were specified.
- **Feature**: Added `cc` and `bcc` parameters to `Messages.Create`, mapped to the `copied` and `blindcopied` API fields.

## Test plan
- [x] Verified multiple `--to` recipients now all receive the message
- [x] Verified `--cc` appears correctly in email headers
- [x] Verified `--bcc` delivers without visible header
- [x] Unit tests updated and passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes multi-recipient sending by serializing `directly` as a JSON array, and adds CC/BCC mapped to HEY’s `copied`/`blindcopied` for messages and replies. All specified recipients now receive the message, and replies send immediately when recipients are provided.

- **Migration**
  - Update calls to `Messages.Create(ctx, subject, content, to)` → `Messages.Create(ctx, subject, content, to, cc, bcc)` and `Entries.CreateReply(ctx, entryID, content)` → `Entries.CreateReply(ctx, entryID, content, to, cc, bcc)`.
  - Provide `to`/`cc`/`bcc` to send immediately; pass nil or empty slices to keep a draft.

<sup>Written for commit 3edeca388f3f74269c79c04088dd08d20213b62f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

