### PR TITLE
Bump Go to 1.26

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,4 +1,4 @@
 [tools]
-go = "1.24"
+go = "1.26"
 golangci-lint = "2"
 smithy = "1.66.0"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 ## Prerequisites
 
 - Smithy CLI
-- Go 1.24+
+- Go 1.26+
 - Node.js 20+
 - Ruby 3.2+
 - Make

--- a/conformance/runner/go/go.mod
+++ b/conformance/runner/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/basecamp/hey-sdk/conformance/runner/go
 
-go 1.25.0
+go 1.26
 
 require github.com/basecamp/hey-sdk/go v0.0.0
 

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/basecamp/hey-sdk/go
 
-go 1.25.0
+go 1.26
 
 require (
 	github.com/oapi-codegen/runtime v1.2.0


### PR DESCRIPTION
## Summary
- Bumps the Go module version from 1.25 to 1.26 to match the project toolchain

## Test plan
- [ ] `make check-mvp` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)