### PR TITLE
Fix addressed fields to use comma-separated strings

### DIFF
--- a/go/pkg/hey/entries.go
+++ b/go/pkg/hey/entries.go
@@ -3,6 +3,7 @@ package hey
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/basecamp/hey-sdk/go/pkg/generated"
@@ -73,13 +74,13 @@ func (s *EntriesService) CreateReply(ctx context.Context, entryID int64, content
 	}
 	addressed := map[string]any{}
 	if len(to) > 0 {
-		addressed["directly"] = to
+		addressed["directly"] = strings.Join(to, ",")
 	}
 	if len(cc) > 0 {
-		addressed["copied"] = cc
+		addressed["copied"] = strings.Join(cc, ",")
 	}
 	if len(bcc) > 0 {
-		addressed["blindcopied"] = bcc
+		addressed["blindcopied"] = strings.Join(bcc, ",")
 	}
 	if len(addressed) > 0 {
 		body["entry"] = map[string]any{

--- a/go/pkg/hey/messages.go
+++ b/go/pkg/hey/messages.go
@@ -3,6 +3,7 @@ package hey
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/basecamp/hey-sdk/go/pkg/generated"
@@ -69,13 +70,13 @@ func (s *MessagesService) Create(ctx context.Context, subject, content string, t
 
 	addressed := map[string]any{}
 	if len(to) > 0 {
-		addressed["directly"] = to
+		addressed["directly"] = strings.Join(to, ",")
 	}
 	if len(cc) > 0 {
-		addressed["copied"] = cc
+		addressed["copied"] = strings.Join(cc, ",")
 	}
 	if len(bcc) > 0 {
-		addressed["blindcopied"] = bcc
+		addressed["blindcopied"] = strings.Join(bcc, ",")
 	}
 
 	body := map[string]any{

--- a/go/pkg/hey/services_test.go
+++ b/go/pkg/hey/services_test.go
@@ -437,13 +437,13 @@ func TestMessagesService_Create(t *testing.T) {
 			if !ok {
 				t.Fatal("missing addressed in entry")
 			}
-			directly, ok := addressed["directly"].([]any)
-			if !ok || len(directly) != 1 || directly[0] != "test@example.com" {
-				t.Errorf("expected directly ['test@example.com'], got %v", addressed["directly"])
+			directly, ok := addressed["directly"].(string)
+			if !ok || directly != "test@example.com" {
+				t.Errorf("expected directly 'test@example.com', got %v", addressed["directly"])
 			}
-			copied, ok := addressed["copied"].([]any)
-			if !ok || len(copied) != 1 || copied[0] != "cc@example.com" {
-				t.Errorf("expected copied ['cc@example.com'], got %v", addressed["copied"])
+			copied, ok := addressed["copied"].(string)
+			if !ok || copied != "cc@example.com" {
+				t.Errorf("expected copied 'cc@example.com', got %v", addressed["copied"])
 			}
 			if _, ok := addressed["blindcopied"]; ok {
 				t.Error("expected no blindcopied key for empty bcc")
@@ -511,6 +511,24 @@ func TestEntriesService_CreateReply(t *testing.T) {
 			}
 			if msg["content"] != "My reply" {
 				t.Errorf("expected content 'My reply', got %v", msg["content"])
+			}
+			entry, ok := body["entry"].(map[string]any)
+			if !ok {
+				t.Fatal("missing entry wrapper")
+			}
+			addressed, ok := entry["addressed"].(map[string]any)
+			if !ok {
+				t.Fatal("missing addressed in entry")
+			}
+			directly, ok := addressed["directly"].(string)
+			if !ok || directly != "test@example.com" {
+				t.Errorf("expected directly 'test@example.com', got %v", addressed["directly"])
+			}
+			if _, ok := addressed["copied"]; ok {
+				t.Error("expected no copied key for nil cc")
+			}
+			if _, ok := addressed["blindcopied"]; ok {
+				t.Error("expected no blindcopied key for nil bcc")
 			}
 		},
 		`{"notice":"sent"}`,


### PR DESCRIPTION
## Summary

- `CreateReply` and `Messages.Create` were sending `addressed` fields (`directly`, `copied`, `blindcopied`) as JSON arrays instead of comma-separated strings, causing 422 errors or silent draft creation
- `Messages.Create` originally used `strings.Join` correctly but was regressed in 495c2fb when CC/BCC support was added; `CreateReply` copied the broken pattern in c39876a
- Fixed both methods to use `strings.Join(addrs, ",")` matching the OpenAPI `MessageAddressed` spec (`type: string`)
- Fixed `TestMessagesService_Create` which was asserting the wrong type (`[]any` instead of `string`)
- Added `entry.addressed` validation to `TestEntriesService_CreateReply` which had none

Fixes basecamp/hey-cli#66

## Test plan

- [x] `go build ./...` compiles
- [x] `go test ./pkg/hey/...` passes (both fixed tests validate string types)
- [ ] Manual: `hey reply <thread-id> -m "test"` sends without 422
- [ ] Manual: `hey compose --to a@b.com --cc c@d.com` sends without 422

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix addressed fields to send comma-separated strings for compose and reply, matching the API spec and preventing 422 errors or silent draft creation. Aligns behavior in both paths and resolves basecamp/hey-cli#66.

- **Bug Fixes**
  - `CreateReply` and `Messages.Create` now send `directly`, `copied`, and `blindcopied` as comma-separated strings (via strings.Join), per OpenAPI `MessageAddressed` (type: string).
  - Tests updated: fix expected types in `TestMessagesService_Create` and add `addressed` validation in `TestEntriesService_CreateReply`.

<sup>Written for commit 6d33c63d400d351d52623d660b261f810b8804ac. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

