### PR TITLE
Add CreateHabit and DeleteHabit

### DIFF
--- a/behavior-model.json
+++ b/behavior-model.json
@@ -41,6 +41,19 @@
         ]
       }
     },
+    "CreateHabit": {
+      "idempotent": false,
+      "readonly": false,
+      "retry": {
+        "backoff": "exponential",
+        "base_delay_ms": 1000,
+        "max": 2,
+        "retry_on": [
+          429,
+          503
+        ]
+      }
+    },
     "CreateMessage": {
       "idempotent": false,
       "readonly": false,
@@ -81,6 +94,19 @@
       }
     },
     "DeleteCalendarTodo": {
+      "idempotent": true,
+      "readonly": false,
+      "retry": {
+        "backoff": "exponential",
+        "base_delay_ms": 1000,
+        "max": 3,
+        "retry_on": [
+          429,
+          503
+        ]
+      }
+    },
+    "DeleteHabit": {
       "idempotent": true,
       "readonly": false,
       "retry": {

--- a/conformance/runner/go/main.go
+++ b/conformance/runner/go/main.go
@@ -839,6 +839,13 @@ func executeOperation(client *generated.Client, ctx context.Context, tc TestCase
 		return client.DeleteCalendarTodo(ctx, todoId)
 
 	// Habits
+	case "CreateHabit":
+		body := generated.CreateHabitJSONRequestBody{
+			CalendarHabit: generated.HabitPayload{
+				Title: getStringParam(tc.RequestBody, "title"),
+			},
+		}
+		return client.CreateHabit(ctx, body)
 	case "CompleteHabit":
 		day := getStringParam(tc.PathParams, "day")
 		habitId := getInt64Param(tc.PathParams, "habitId")
@@ -847,6 +854,9 @@ func executeOperation(client *generated.Client, ctx context.Context, tc TestCase
 		day := getStringParam(tc.PathParams, "day")
 		habitId := getInt64Param(tc.PathParams, "habitId")
 		return client.UncompleteHabit(ctx, day, habitId)
+	case "DeleteHabit":
+		habitId := getInt64Param(tc.PathParams, "habitId")
+		return client.DeleteHabit(ctx, habitId)
 
 	// Time Tracks
 	case "GetOngoingTimeTrack":

--- a/conformance/tests/idempotency.json
+++ b/conformance/tests/idempotency.json
@@ -194,5 +194,38 @@
       "delete",
       "retry"
     ]
+  },
+  {
+    "name": "DELETE habit retries on 429",
+    "description": "Verifies that DeleteHabit retries on 429 Too Many Requests",
+    "operation": "DeleteHabit",
+    "method": "DELETE",
+    "path": "/calendar/habits/{habitId}",
+    "pathParams": {
+      "habitId": 12345
+    },
+    "mockResponses": [
+      {
+        "status": 429
+      },
+      {
+        "status": 204
+      }
+    ],
+    "assertions": [
+      {
+        "type": "requestCount",
+        "expected": 2
+      },
+      {
+        "type": "noError"
+      }
+    ],
+    "tags": [
+      "idempotent",
+      "delete",
+      "retry",
+      "429"
+    ]
   }
 ]

--- a/conformance/tests/idempotency.json
+++ b/conformance/tests/idempotency.json
@@ -5,15 +5,29 @@
     "operation": "CreateMessage",
     "method": "POST",
     "path": "/messages.json",
-    "requestBody": {"subject": "Hello", "content": "World"},
+    "requestBody": {
+      "subject": "Hello",
+      "content": "World"
+    },
     "mockResponses": [
-      {"status": 503}
+      {
+        "status": 503
+      }
     ],
     "assertions": [
-      {"type": "requestCount", "expected": 1},
-      {"type": "statusCode", "expected": 503}
+      {
+        "type": "requestCount",
+        "expected": 1
+      },
+      {
+        "type": "statusCode",
+        "expected": 503
+      }
     ],
-    "tags": ["no-retry", "post"]
+    "tags": [
+      "no-retry",
+      "post"
+    ]
   },
   {
     "name": "Idempotent GET retries on 503",
@@ -22,14 +36,28 @@
     "method": "GET",
     "path": "/boxes.json",
     "mockResponses": [
-      {"status": 503},
-      {"status": 200, "body": []}
+      {
+        "status": 503
+      },
+      {
+        "status": 200,
+        "body": []
+      }
     ],
     "assertions": [
-      {"type": "requestCount", "expected": 2},
-      {"type": "noError"}
+      {
+        "type": "requestCount",
+        "expected": 2
+      },
+      {
+        "type": "noError"
+      }
     ],
-    "tags": ["idempotent", "get", "retry"]
+    "tags": [
+      "idempotent",
+      "get",
+      "retry"
+    ]
   },
   {
     "name": "Idempotent POST (no body) retries on 503",
@@ -37,16 +65,32 @@
     "operation": "CompleteCalendarTodo",
     "method": "POST",
     "path": "/calendar/todos/{todoId}/completions",
-    "pathParams": {"todoId": 12345},
+    "pathParams": {
+      "todoId": 12345
+    },
     "mockResponses": [
-      {"status": 503},
-      {"status": 200, "body": {}}
+      {
+        "status": 503
+      },
+      {
+        "status": 200,
+        "body": {}
+      }
     ],
     "assertions": [
-      {"type": "requestCount", "expected": 2},
-      {"type": "noError"}
+      {
+        "type": "requestCount",
+        "expected": 2
+      },
+      {
+        "type": "noError"
+      }
     ],
-    "tags": ["idempotent", "post", "retry"]
+    "tags": [
+      "idempotent",
+      "post",
+      "retry"
+    ]
   },
   {
     "name": "PUT operation is naturally idempotent",
@@ -54,17 +98,38 @@
     "operation": "UpdateTimeTrack",
     "method": "PUT",
     "path": "/time_tracks/{timeTrackId}.json",
-    "pathParams": {"timeTrackId": 12345},
-    "requestBody": {"stopped": true},
+    "pathParams": {
+      "timeTrackId": 12345
+    },
+    "requestBody": {
+      "stopped": true
+    },
     "mockResponses": [
-      {"status": 503},
-      {"status": 200, "body": {"id": 12345, "type": "TimeTrack"}}
+      {
+        "status": 503
+      },
+      {
+        "status": 200,
+        "body": {
+          "id": 12345,
+          "type": "TimeTrack"
+        }
+      }
     ],
     "assertions": [
-      {"type": "requestCount", "expected": 2},
-      {"type": "noError"}
+      {
+        "type": "requestCount",
+        "expected": 2
+      },
+      {
+        "type": "noError"
+      }
     ],
-    "tags": ["idempotent", "put", "retry"]
+    "tags": [
+      "idempotent",
+      "put",
+      "retry"
+    ]
   },
   {
     "name": "DELETE operation is naturally idempotent",
@@ -72,15 +137,62 @@
     "operation": "DeleteCalendarTodo",
     "method": "DELETE",
     "path": "/calendar/todos/{todoId}",
-    "pathParams": {"todoId": 12345},
+    "pathParams": {
+      "todoId": 12345
+    },
     "mockResponses": [
-      {"status": 503},
-      {"status": 204}
+      {
+        "status": 503
+      },
+      {
+        "status": 204
+      }
     ],
     "assertions": [
-      {"type": "requestCount", "expected": 2},
-      {"type": "noError"}
+      {
+        "type": "requestCount",
+        "expected": 2
+      },
+      {
+        "type": "noError"
+      }
     ],
-    "tags": ["idempotent", "delete", "retry"]
+    "tags": [
+      "idempotent",
+      "delete",
+      "retry"
+    ]
+  },
+  {
+    "name": "DELETE habit is naturally idempotent",
+    "description": "Verifies that DeleteHabit can be safely retried on transient failures",
+    "operation": "DeleteHabit",
+    "method": "DELETE",
+    "path": "/calendar/habits/{habitId}",
+    "pathParams": {
+      "habitId": 12345
+    },
+    "mockResponses": [
+      {
+        "status": 503
+      },
+      {
+        "status": 204
+      }
+    ],
+    "assertions": [
+      {
+        "type": "requestCount",
+        "expected": 2
+      },
+      {
+        "type": "noError"
+      }
+    ],
+    "tags": [
+      "idempotent",
+      "delete",
+      "retry"
+    ]
   }
 ]

--- a/conformance/tests/paths.json
+++ b/conformance/tests/paths.json
@@ -5,15 +5,28 @@
     "operation": "CompleteCalendarTodo",
     "method": "POST",
     "path": "/calendar/todos/{todoId}/completions",
-    "pathParams": {"todoId": 456},
+    "pathParams": {
+      "todoId": 456
+    },
     "mockResponses": [
-      {"status": 200, "body": {}}
+      {
+        "status": 200,
+        "body": {}
+      }
     ],
     "assertions": [
-      {"type": "requestPath", "expected": "/calendar/todos/456/completions"},
-      {"type": "noError"}
+      {
+        "type": "requestPath",
+        "expected": "/calendar/todos/456/completions"
+      },
+      {
+        "type": "noError"
+      }
     ],
-    "tags": ["path", "calendar-todos"]
+    "tags": [
+      "path",
+      "calendar-todos"
+    ]
   },
   {
     "name": "CompleteHabit uses /calendar/days/{day}/habits/{habitId}/completions path",
@@ -21,15 +34,29 @@
     "operation": "CompleteHabit",
     "method": "POST",
     "path": "/calendar/days/{day}/habits/{habitId}/completions",
-    "pathParams": {"day": "2026-03-04", "habitId": 789},
+    "pathParams": {
+      "day": "2026-03-04",
+      "habitId": 789
+    },
     "mockResponses": [
-      {"status": 200, "body": {}}
+      {
+        "status": 200,
+        "body": {}
+      }
     ],
     "assertions": [
-      {"type": "requestPath", "expected": "/calendar/days/2026-03-04/habits/789/completions"},
-      {"type": "noError"}
+      {
+        "type": "requestPath",
+        "expected": "/calendar/days/2026-03-04/habits/789/completions"
+      },
+      {
+        "type": "noError"
+      }
     ],
-    "tags": ["path", "calendar-habits"]
+    "tags": [
+      "path",
+      "calendar-habits"
+    ]
   },
   {
     "name": "CreateCalendarTodo uses /calendar/todos.json path",
@@ -37,15 +64,63 @@
     "operation": "CreateCalendarTodo",
     "method": "POST",
     "path": "/calendar/todos.json",
-    "requestBody": {"title": "New todo"},
+    "requestBody": {
+      "title": "New todo"
+    },
     "mockResponses": [
-      {"status": 200, "body": {"id": 123, "title": "New todo"}}
+      {
+        "status": 200,
+        "body": {
+          "id": 123,
+          "title": "New todo"
+        }
+      }
     ],
     "assertions": [
-      {"type": "requestPath", "expected": "/calendar/todos.json"},
-      {"type": "noError"}
+      {
+        "type": "requestPath",
+        "expected": "/calendar/todos.json"
+      },
+      {
+        "type": "noError"
+      }
     ],
-    "tags": ["path", "calendar-todos"]
+    "tags": [
+      "path",
+      "calendar-todos"
+    ]
+  },
+  {
+    "name": "CreateHabit uses /calendar/habits.json path",
+    "description": "Verifies that CreateHabit constructs the URL path /calendar/habits.json",
+    "operation": "CreateHabit",
+    "method": "POST",
+    "path": "/calendar/habits.json",
+    "requestBody": {
+      "title": "Daily Exercise"
+    },
+    "mockResponses": [
+      {
+        "status": 200,
+        "body": {
+          "id": 1,
+          "type": "CalendarHabit"
+        }
+      }
+    ],
+    "assertions": [
+      {
+        "type": "requestPath",
+        "expected": "/calendar/habits.json"
+      },
+      {
+        "type": "noError"
+      }
+    ],
+    "tags": [
+      "path",
+      "calendar-habits"
+    ]
   },
   {
     "name": "CreateMessage uses /messages.json path",
@@ -53,15 +128,32 @@
     "operation": "CreateMessage",
     "method": "POST",
     "path": "/messages.json",
-    "requestBody": {"subject": "Test", "content": "Hello"},
+    "requestBody": {
+      "subject": "Test",
+      "content": "Hello"
+    },
     "mockResponses": [
-      {"status": 200, "body": {"id": 123, "subject": "Test"}}
+      {
+        "status": 200,
+        "body": {
+          "id": 123,
+          "subject": "Test"
+        }
+      }
     ],
     "assertions": [
-      {"type": "requestPath", "expected": "/messages.json"},
-      {"type": "noError"}
+      {
+        "type": "requestPath",
+        "expected": "/messages.json"
+      },
+      {
+        "type": "noError"
+      }
     ],
-    "tags": ["path", "messages"]
+    "tags": [
+      "path",
+      "messages"
+    ]
   },
   {
     "name": "CreateReply uses /entries/{entryId}/replies.json path",
@@ -69,16 +161,34 @@
     "operation": "CreateReply",
     "method": "POST",
     "path": "/entries/{entryId}/replies.json",
-    "pathParams": {"entryId": 456},
-    "requestBody": {"content": "Reply text"},
+    "pathParams": {
+      "entryId": 456
+    },
+    "requestBody": {
+      "content": "Reply text"
+    },
     "mockResponses": [
-      {"status": 200, "body": {"id": 789, "content": "Reply text"}}
+      {
+        "status": 200,
+        "body": {
+          "id": 789,
+          "content": "Reply text"
+        }
+      }
     ],
     "assertions": [
-      {"type": "requestPath", "expected": "/entries/456/replies.json"},
-      {"type": "noError"}
+      {
+        "type": "requestPath",
+        "expected": "/entries/456/replies.json"
+      },
+      {
+        "type": "noError"
+      }
     ],
-    "tags": ["path", "entries"]
+    "tags": [
+      "path",
+      "entries"
+    ]
   },
   {
     "name": "CreateTopicMessage uses /topics/{topicId}/entries.json path",
@@ -86,16 +196,34 @@
     "operation": "CreateTopicMessage",
     "method": "POST",
     "path": "/topics/{topicId}/entries.json",
-    "pathParams": {"topicId": 456},
-    "requestBody": {"content": "Topic reply"},
+    "pathParams": {
+      "topicId": 456
+    },
+    "requestBody": {
+      "content": "Topic reply"
+    },
     "mockResponses": [
-      {"status": 200, "body": {"id": 789, "content": "Topic reply"}}
+      {
+        "status": 200,
+        "body": {
+          "id": 789,
+          "content": "Topic reply"
+        }
+      }
     ],
     "assertions": [
-      {"type": "requestPath", "expected": "/topics/456/entries.json"},
-      {"type": "noError"}
+      {
+        "type": "requestPath",
+        "expected": "/topics/456/entries.json"
+      },
+      {
+        "type": "noError"
+      }
     ],
-    "tags": ["path", "topics"]
+    "tags": [
+      "path",
+      "topics"
+    ]
   },
   {
     "name": "DeleteCalendarTodo uses /calendar/todos/{todoId} path",
@@ -103,15 +231,55 @@
     "operation": "DeleteCalendarTodo",
     "method": "DELETE",
     "path": "/calendar/todos/{todoId}",
-    "pathParams": {"todoId": 456},
+    "pathParams": {
+      "todoId": 456
+    },
     "mockResponses": [
-      {"status": 200}
+      {
+        "status": 200
+      }
     ],
     "assertions": [
-      {"type": "requestPath", "expected": "/calendar/todos/456"},
-      {"type": "noError"}
+      {
+        "type": "requestPath",
+        "expected": "/calendar/todos/456"
+      },
+      {
+        "type": "noError"
+      }
     ],
-    "tags": ["path", "calendar-todos"]
+    "tags": [
+      "path",
+      "calendar-todos"
+    ]
+  },
+  {
+    "name": "DeleteHabit uses /calendar/habits/{habitId} path",
+    "description": "Verifies that DeleteHabit constructs the URL path /calendar/habits/{habitId}",
+    "operation": "DeleteHabit",
+    "method": "DELETE",
+    "path": "/calendar/habits/{habitId}",
+    "pathParams": {
+      "habitId": 123
+    },
+    "mockResponses": [
+      {
+        "status": 204
+      }
+    ],
+    "assertions": [
+      {
+        "type": "requestPath",
+        "expected": "/calendar/habits/123"
+      },
+      {
+        "type": "noError"
+      }
+    ],
+    "tags": [
+      "path",
+      "calendar-habits"
+    ]
   },
   {
     "name": "GetAsidebox uses /set_aside.json path",
@@ -120,13 +288,24 @@
     "method": "GET",
     "path": "/set_aside.json",
     "mockResponses": [
-      {"status": 200, "body": {}}
+      {
+        "status": 200,
+        "body": {}
+      }
     ],
     "assertions": [
-      {"type": "requestPath", "expected": "/set_aside.json"},
-      {"type": "noError"}
+      {
+        "type": "requestPath",
+        "expected": "/set_aside.json"
+      },
+      {
+        "type": "noError"
+      }
     ],
-    "tags": ["path", "boxes"]
+    "tags": [
+      "path",
+      "boxes"
+    ]
   },
   {
     "name": "GetBox uses /boxes/{boxId} path",
@@ -134,15 +313,30 @@
     "operation": "GetBox",
     "method": "GET",
     "path": "/boxes/{boxId}",
-    "pathParams": {"boxId": 123},
+    "pathParams": {
+      "boxId": 123
+    },
     "mockResponses": [
-      {"status": 200, "body": {"id": 123}}
+      {
+        "status": 200,
+        "body": {
+          "id": 123
+        }
+      }
     ],
     "assertions": [
-      {"type": "requestPath", "expected": "/boxes/123"},
-      {"type": "noError"}
+      {
+        "type": "requestPath",
+        "expected": "/boxes/123"
+      },
+      {
+        "type": "noError"
+      }
     ],
-    "tags": ["path", "boxes"]
+    "tags": [
+      "path",
+      "boxes"
+    ]
   },
   {
     "name": "GetBubblebox uses /bubble_up.json path",
@@ -151,13 +345,24 @@
     "method": "GET",
     "path": "/bubble_up.json",
     "mockResponses": [
-      {"status": 200, "body": {}}
+      {
+        "status": 200,
+        "body": {}
+      }
     ],
     "assertions": [
-      {"type": "requestPath", "expected": "/bubble_up.json"},
-      {"type": "noError"}
+      {
+        "type": "requestPath",
+        "expected": "/bubble_up.json"
+      },
+      {
+        "type": "noError"
+      }
     ],
-    "tags": ["path", "boxes"]
+    "tags": [
+      "path",
+      "boxes"
+    ]
   },
   {
     "name": "GetCalendarRecordings uses /calendars/{calendarId}/recordings path",
@@ -165,15 +370,28 @@
     "operation": "GetCalendarRecordings",
     "method": "GET",
     "path": "/calendars/{calendarId}/recordings",
-    "pathParams": {"calendarId": 456},
+    "pathParams": {
+      "calendarId": 456
+    },
     "mockResponses": [
-      {"status": 200, "body": []}
+      {
+        "status": 200,
+        "body": []
+      }
     ],
     "assertions": [
-      {"type": "requestPath", "expected": "/calendars/456/recordings"},
-      {"type": "noError"}
+      {
+        "type": "requestPath",
+        "expected": "/calendars/456/recordings"
+      },
+      {
+        "type": "noError"
+      }
     ],
-    "tags": ["path", "calendars"]
+    "tags": [
+      "path",
+      "calendars"
+    ]
   },
   {
     "name": "GetContact uses /contacts/{contactId} path",
@@ -181,15 +399,30 @@
     "operation": "GetContact",
     "method": "GET",
     "path": "/contacts/{contactId}",
-    "pathParams": {"contactId": 789},
+    "pathParams": {
+      "contactId": 789
+    },
     "mockResponses": [
-      {"status": 200, "body": {"id": 789}}
+      {
+        "status": 200,
+        "body": {
+          "id": 789
+        }
+      }
     ],
     "assertions": [
-      {"type": "requestPath", "expected": "/contacts/789"},
-      {"type": "noError"}
+      {
+        "type": "requestPath",
+        "expected": "/contacts/789"
+      },
+      {
+        "type": "noError"
+      }
     ],
-    "tags": ["path", "contacts"]
+    "tags": [
+      "path",
+      "contacts"
+    ]
   },
   {
     "name": "GetEverythingTopics uses /topics/everything.json path",
@@ -198,13 +431,24 @@
     "method": "GET",
     "path": "/topics/everything.json",
     "mockResponses": [
-      {"status": 200, "body": []}
+      {
+        "status": 200,
+        "body": []
+      }
     ],
     "assertions": [
-      {"type": "requestPath", "expected": "/topics/everything.json"},
-      {"type": "noError"}
+      {
+        "type": "requestPath",
+        "expected": "/topics/everything.json"
+      },
+      {
+        "type": "noError"
+      }
     ],
-    "tags": ["path", "topics"]
+    "tags": [
+      "path",
+      "topics"
+    ]
   },
   {
     "name": "GetFeedbox uses /feedbox.json path",
@@ -213,13 +457,24 @@
     "method": "GET",
     "path": "/feedbox.json",
     "mockResponses": [
-      {"status": 200, "body": {}}
+      {
+        "status": 200,
+        "body": {}
+      }
     ],
     "assertions": [
-      {"type": "requestPath", "expected": "/feedbox.json"},
-      {"type": "noError"}
+      {
+        "type": "requestPath",
+        "expected": "/feedbox.json"
+      },
+      {
+        "type": "noError"
+      }
     ],
-    "tags": ["path", "boxes"]
+    "tags": [
+      "path",
+      "boxes"
+    ]
   },
   {
     "name": "GetIdentity uses /identity.json path",
@@ -228,13 +483,27 @@
     "method": "GET",
     "path": "/identity.json",
     "mockResponses": [
-      {"status": 200, "body": {"id": 1, "email_address": "user@hey.com"}}
+      {
+        "status": 200,
+        "body": {
+          "id": 1,
+          "email_address": "user@hey.com"
+        }
+      }
     ],
     "assertions": [
-      {"type": "requestPath", "expected": "/identity.json"},
-      {"type": "noError"}
+      {
+        "type": "requestPath",
+        "expected": "/identity.json"
+      },
+      {
+        "type": "noError"
+      }
     ],
-    "tags": ["path", "identity"]
+    "tags": [
+      "path",
+      "identity"
+    ]
   },
   {
     "name": "GetImbox uses /imbox.json path",
@@ -243,13 +512,24 @@
     "method": "GET",
     "path": "/imbox.json",
     "mockResponses": [
-      {"status": 200, "body": {}}
+      {
+        "status": 200,
+        "body": {}
+      }
     ],
     "assertions": [
-      {"type": "requestPath", "expected": "/imbox.json"},
-      {"type": "noError"}
+      {
+        "type": "requestPath",
+        "expected": "/imbox.json"
+      },
+      {
+        "type": "noError"
+      }
     ],
-    "tags": ["path", "boxes"]
+    "tags": [
+      "path",
+      "boxes"
+    ]
   },
   {
     "name": "GetJournalEntry uses /calendar/days/{day}/journal_entry path",
@@ -257,15 +537,30 @@
     "operation": "GetJournalEntry",
     "method": "GET",
     "path": "/calendar/days/{day}/journal_entry",
-    "pathParams": {"day": "2026-03-04"},
+    "pathParams": {
+      "day": "2026-03-04"
+    },
     "mockResponses": [
-      {"status": 200, "body": {"body": "Today's entry"}}
+      {
+        "status": 200,
+        "body": {
+          "body": "Today's entry"
+        }
+      }
     ],
     "assertions": [
-      {"type": "requestPath", "expected": "/calendar/days/2026-03-04/journal_entry"},
-      {"type": "noError"}
+      {
+        "type": "requestPath",
+        "expected": "/calendar/days/2026-03-04/journal_entry"
+      },
+      {
+        "type": "noError"
+      }
     ],
-    "tags": ["path", "calendar-journal"]
+    "tags": [
+      "path",
+      "calendar-journal"
+    ]
   },
   {
     "name": "GetLaterbox uses /reply_later.json path",
@@ -274,13 +569,24 @@
     "method": "GET",
     "path": "/reply_later.json",
     "mockResponses": [
-      {"status": 200, "body": {}}
+      {
+        "status": 200,
+        "body": {}
+      }
     ],
     "assertions": [
-      {"type": "requestPath", "expected": "/reply_later.json"},
-      {"type": "noError"}
+      {
+        "type": "requestPath",
+        "expected": "/reply_later.json"
+      },
+      {
+        "type": "noError"
+      }
     ],
-    "tags": ["path", "boxes"]
+    "tags": [
+      "path",
+      "boxes"
+    ]
   },
   {
     "name": "GetMessage uses /messages/{messageId} path",
@@ -288,15 +594,31 @@
     "operation": "GetMessage",
     "method": "GET",
     "path": "/messages/{messageId}",
-    "pathParams": {"messageId": 456},
+    "pathParams": {
+      "messageId": 456
+    },
     "mockResponses": [
-      {"status": 200, "body": {"id": 456, "subject": "Hello"}}
+      {
+        "status": 200,
+        "body": {
+          "id": 456,
+          "subject": "Hello"
+        }
+      }
     ],
     "assertions": [
-      {"type": "requestPath", "expected": "/messages/456"},
-      {"type": "noError"}
+      {
+        "type": "requestPath",
+        "expected": "/messages/456"
+      },
+      {
+        "type": "noError"
+      }
     ],
-    "tags": ["path", "messages"]
+    "tags": [
+      "path",
+      "messages"
+    ]
   },
   {
     "name": "GetNavigation uses /my/navigation.json path",
@@ -305,13 +627,24 @@
     "method": "GET",
     "path": "/my/navigation.json",
     "mockResponses": [
-      {"status": 200, "body": {}}
+      {
+        "status": 200,
+        "body": {}
+      }
     ],
     "assertions": [
-      {"type": "requestPath", "expected": "/my/navigation.json"},
-      {"type": "noError"}
+      {
+        "type": "requestPath",
+        "expected": "/my/navigation.json"
+      },
+      {
+        "type": "noError"
+      }
     ],
-    "tags": ["path", "navigation"]
+    "tags": [
+      "path",
+      "navigation"
+    ]
   },
   {
     "name": "GetOngoingTimeTrack uses /calendar/ongoing_time_track.json path",
@@ -320,13 +653,27 @@
     "method": "GET",
     "path": "/calendar/ongoing_time_track.json",
     "mockResponses": [
-      {"status": 200, "body": {"id": 123, "started_at": "2026-03-04T10:00:00Z"}}
+      {
+        "status": 200,
+        "body": {
+          "id": 123,
+          "started_at": "2026-03-04T10:00:00Z"
+        }
+      }
     ],
     "assertions": [
-      {"type": "requestPath", "expected": "/calendar/ongoing_time_track.json"},
-      {"type": "noError"}
+      {
+        "type": "requestPath",
+        "expected": "/calendar/ongoing_time_track.json"
+      },
+      {
+        "type": "noError"
+      }
     ],
-    "tags": ["path", "calendar-time-tracks"]
+    "tags": [
+      "path",
+      "calendar-time-tracks"
+    ]
   },
   {
     "name": "GetSentTopics uses /topics/sent.json path",
@@ -335,13 +682,24 @@
     "method": "GET",
     "path": "/topics/sent.json",
     "mockResponses": [
-      {"status": 200, "body": []}
+      {
+        "status": 200,
+        "body": []
+      }
     ],
     "assertions": [
-      {"type": "requestPath", "expected": "/topics/sent.json"},
-      {"type": "noError"}
+      {
+        "type": "requestPath",
+        "expected": "/topics/sent.json"
+      },
+      {
+        "type": "noError"
+      }
     ],
-    "tags": ["path", "topics"]
+    "tags": [
+      "path",
+      "topics"
+    ]
   },
   {
     "name": "GetSpamTopics uses /topics/spam.json path",
@@ -350,13 +708,24 @@
     "method": "GET",
     "path": "/topics/spam.json",
     "mockResponses": [
-      {"status": 200, "body": []}
+      {
+        "status": 200,
+        "body": []
+      }
     ],
     "assertions": [
-      {"type": "requestPath", "expected": "/topics/spam.json"},
-      {"type": "noError"}
+      {
+        "type": "requestPath",
+        "expected": "/topics/spam.json"
+      },
+      {
+        "type": "noError"
+      }
     ],
-    "tags": ["path", "topics"]
+    "tags": [
+      "path",
+      "topics"
+    ]
   },
   {
     "name": "GetTopic uses /topics/{topicId} path",
@@ -364,15 +733,30 @@
     "operation": "GetTopic",
     "method": "GET",
     "path": "/topics/{topicId}",
-    "pathParams": {"topicId": 456},
+    "pathParams": {
+      "topicId": 456
+    },
     "mockResponses": [
-      {"status": 200, "body": {"id": 456}}
+      {
+        "status": 200,
+        "body": {
+          "id": 456
+        }
+      }
     ],
     "assertions": [
-      {"type": "requestPath", "expected": "/topics/456"},
-      {"type": "noError"}
+      {
+        "type": "requestPath",
+        "expected": "/topics/456"
+      },
+      {
+        "type": "noError"
+      }
     ],
-    "tags": ["path", "topics"]
+    "tags": [
+      "path",
+      "topics"
+    ]
   },
   {
     "name": "GetTopicEntries uses /topics/{topicId}/entries path",
@@ -380,15 +764,28 @@
     "operation": "GetTopicEntries",
     "method": "GET",
     "path": "/topics/{topicId}/entries",
-    "pathParams": {"topicId": 456},
+    "pathParams": {
+      "topicId": 456
+    },
     "mockResponses": [
-      {"status": 200, "body": []}
+      {
+        "status": 200,
+        "body": []
+      }
     ],
     "assertions": [
-      {"type": "requestPath", "expected": "/topics/456/entries"},
-      {"type": "noError"}
+      {
+        "type": "requestPath",
+        "expected": "/topics/456/entries"
+      },
+      {
+        "type": "noError"
+      }
     ],
-    "tags": ["path", "topics"]
+    "tags": [
+      "path",
+      "topics"
+    ]
   },
   {
     "name": "GetTrailbox uses /paper_trail.json path",
@@ -397,13 +794,24 @@
     "method": "GET",
     "path": "/paper_trail.json",
     "mockResponses": [
-      {"status": 200, "body": {}}
+      {
+        "status": 200,
+        "body": {}
+      }
     ],
     "assertions": [
-      {"type": "requestPath", "expected": "/paper_trail.json"},
-      {"type": "noError"}
+      {
+        "type": "requestPath",
+        "expected": "/paper_trail.json"
+      },
+      {
+        "type": "noError"
+      }
     ],
-    "tags": ["path", "boxes"]
+    "tags": [
+      "path",
+      "boxes"
+    ]
   },
   {
     "name": "GetTrashTopics uses /topics/trash.json path",
@@ -412,13 +820,24 @@
     "method": "GET",
     "path": "/topics/trash.json",
     "mockResponses": [
-      {"status": 200, "body": []}
+      {
+        "status": 200,
+        "body": []
+      }
     ],
     "assertions": [
-      {"type": "requestPath", "expected": "/topics/trash.json"},
-      {"type": "noError"}
+      {
+        "type": "requestPath",
+        "expected": "/topics/trash.json"
+      },
+      {
+        "type": "noError"
+      }
     ],
-    "tags": ["path", "topics"]
+    "tags": [
+      "path",
+      "topics"
+    ]
   },
   {
     "name": "ListBoxes uses /boxes.json path",
@@ -427,13 +846,24 @@
     "method": "GET",
     "path": "/boxes.json",
     "mockResponses": [
-      {"status": 200, "body": []}
+      {
+        "status": 200,
+        "body": []
+      }
     ],
     "assertions": [
-      {"type": "requestPath", "expected": "/boxes.json"},
-      {"type": "noError"}
+      {
+        "type": "requestPath",
+        "expected": "/boxes.json"
+      },
+      {
+        "type": "noError"
+      }
     ],
-    "tags": ["path", "boxes"]
+    "tags": [
+      "path",
+      "boxes"
+    ]
   },
   {
     "name": "ListCalendars uses /calendars.json path",
@@ -442,13 +872,24 @@
     "method": "GET",
     "path": "/calendars.json",
     "mockResponses": [
-      {"status": 200, "body": []}
+      {
+        "status": 200,
+        "body": []
+      }
     ],
     "assertions": [
-      {"type": "requestPath", "expected": "/calendars.json"},
-      {"type": "noError"}
+      {
+        "type": "requestPath",
+        "expected": "/calendars.json"
+      },
+      {
+        "type": "noError"
+      }
     ],
-    "tags": ["path", "calendars"]
+    "tags": [
+      "path",
+      "calendars"
+    ]
   },
   {
     "name": "ListContacts uses /contacts.json path",
@@ -457,13 +898,24 @@
     "method": "GET",
     "path": "/contacts.json",
     "mockResponses": [
-      {"status": 200, "body": []}
+      {
+        "status": 200,
+        "body": []
+      }
     ],
     "assertions": [
-      {"type": "requestPath", "expected": "/contacts.json"},
-      {"type": "noError"}
+      {
+        "type": "requestPath",
+        "expected": "/contacts.json"
+      },
+      {
+        "type": "noError"
+      }
     ],
-    "tags": ["path", "contacts"]
+    "tags": [
+      "path",
+      "contacts"
+    ]
   },
   {
     "name": "ListDrafts uses /entries/drafts.json path",
@@ -472,13 +924,24 @@
     "method": "GET",
     "path": "/entries/drafts.json",
     "mockResponses": [
-      {"status": 200, "body": []}
+      {
+        "status": 200,
+        "body": []
+      }
     ],
     "assertions": [
-      {"type": "requestPath", "expected": "/entries/drafts.json"},
-      {"type": "noError"}
+      {
+        "type": "requestPath",
+        "expected": "/entries/drafts.json"
+      },
+      {
+        "type": "noError"
+      }
     ],
-    "tags": ["path", "entries"]
+    "tags": [
+      "path",
+      "entries"
+    ]
   },
   {
     "name": "Search uses /search.json path",
@@ -486,15 +949,28 @@
     "operation": "Search",
     "method": "GET",
     "path": "/search.json",
-    "queryParams": {"q": "test query"},
+    "queryParams": {
+      "q": "test query"
+    },
     "mockResponses": [
-      {"status": 200, "body": []}
+      {
+        "status": 200,
+        "body": []
+      }
     ],
     "assertions": [
-      {"type": "requestPath", "expected": "/search.json"},
-      {"type": "noError"}
+      {
+        "type": "requestPath",
+        "expected": "/search.json"
+      },
+      {
+        "type": "noError"
+      }
     ],
-    "tags": ["path", "search"]
+    "tags": [
+      "path",
+      "search"
+    ]
   },
   {
     "name": "StartTimeTrack uses /calendar/ongoing_time_track.json path",
@@ -503,13 +979,27 @@
     "method": "POST",
     "path": "/calendar/ongoing_time_track.json",
     "mockResponses": [
-      {"status": 200, "body": {"id": 123, "started_at": "2026-03-04T10:00:00Z"}}
+      {
+        "status": 200,
+        "body": {
+          "id": 123,
+          "started_at": "2026-03-04T10:00:00Z"
+        }
+      }
     ],
     "assertions": [
-      {"type": "requestPath", "expected": "/calendar/ongoing_time_track.json"},
-      {"type": "noError"}
+      {
+        "type": "requestPath",
+        "expected": "/calendar/ongoing_time_track.json"
+      },
+      {
+        "type": "noError"
+      }
     ],
-    "tags": ["path", "calendar-time-tracks"]
+    "tags": [
+      "path",
+      "calendar-time-tracks"
+    ]
   },
   {
     "name": "UncompleteCalendarTodo uses /calendar/todos/{todoId}/completions path",
@@ -517,15 +1007,28 @@
     "operation": "UncompleteCalendarTodo",
     "method": "DELETE",
     "path": "/calendar/todos/{todoId}/completions",
-    "pathParams": {"todoId": 456},
+    "pathParams": {
+      "todoId": 456
+    },
     "mockResponses": [
-      {"status": 200, "body": {}}
+      {
+        "status": 200,
+        "body": {}
+      }
     ],
     "assertions": [
-      {"type": "requestPath", "expected": "/calendar/todos/456/completions"},
-      {"type": "noError"}
+      {
+        "type": "requestPath",
+        "expected": "/calendar/todos/456/completions"
+      },
+      {
+        "type": "noError"
+      }
     ],
-    "tags": ["path", "calendar-todos"]
+    "tags": [
+      "path",
+      "calendar-todos"
+    ]
   },
   {
     "name": "UncompleteHabit uses /calendar/days/{day}/habits/{habitId}/completions path",
@@ -533,15 +1036,29 @@
     "operation": "UncompleteHabit",
     "method": "DELETE",
     "path": "/calendar/days/{day}/habits/{habitId}/completions",
-    "pathParams": {"day": "2026-03-04", "habitId": 789},
+    "pathParams": {
+      "day": "2026-03-04",
+      "habitId": 789
+    },
     "mockResponses": [
-      {"status": 200, "body": {}}
+      {
+        "status": 200,
+        "body": {}
+      }
     ],
     "assertions": [
-      {"type": "requestPath", "expected": "/calendar/days/2026-03-04/habits/789/completions"},
-      {"type": "noError"}
+      {
+        "type": "requestPath",
+        "expected": "/calendar/days/2026-03-04/habits/789/completions"
+      },
+      {
+        "type": "noError"
+      }
     ],
-    "tags": ["path", "calendar-habits"]
+    "tags": [
+      "path",
+      "calendar-habits"
+    ]
   },
   {
     "name": "UpdateJournalEntry uses /calendar/days/{day}/journal_entry path",
@@ -549,16 +1066,33 @@
     "operation": "UpdateJournalEntry",
     "method": "PATCH",
     "path": "/calendar/days/{day}/journal_entry",
-    "pathParams": {"day": "2026-03-04"},
-    "requestBody": {"body": "Updated content"},
+    "pathParams": {
+      "day": "2026-03-04"
+    },
+    "requestBody": {
+      "body": "Updated content"
+    },
     "mockResponses": [
-      {"status": 200, "body": {"body": "Updated content"}}
+      {
+        "status": 200,
+        "body": {
+          "body": "Updated content"
+        }
+      }
     ],
     "assertions": [
-      {"type": "requestPath", "expected": "/calendar/days/2026-03-04/journal_entry"},
-      {"type": "noError"}
+      {
+        "type": "requestPath",
+        "expected": "/calendar/days/2026-03-04/journal_entry"
+      },
+      {
+        "type": "noError"
+      }
     ],
-    "tags": ["path", "calendar-journal"]
+    "tags": [
+      "path",
+      "calendar-journal"
+    ]
   },
   {
     "name": "UpdateTimeTrack uses /calendar/time_tracks/{timeTrackId} path",
@@ -566,15 +1100,33 @@
     "operation": "UpdateTimeTrack",
     "method": "PUT",
     "path": "/calendar/time_tracks/{timeTrackId}",
-    "pathParams": {"timeTrackId": 789},
-    "requestBody": {"stopped": true},
+    "pathParams": {
+      "timeTrackId": 789
+    },
+    "requestBody": {
+      "stopped": true
+    },
     "mockResponses": [
-      {"status": 200, "body": {"id": 789, "stopped": true}}
+      {
+        "status": 200,
+        "body": {
+          "id": 789,
+          "stopped": true
+        }
+      }
     ],
     "assertions": [
-      {"type": "requestPath", "expected": "/calendar/time_tracks/789"},
-      {"type": "noError"}
+      {
+        "type": "requestPath",
+        "expected": "/calendar/time_tracks/789"
+      },
+      {
+        "type": "noError"
+      }
     ],
-    "tags": ["path", "calendar-time-tracks"]
+    "tags": [
+      "path",
+      "calendar-time-tracks"
+    ]
   }
 ]

--- a/go/pkg/generated/client.gen.go
+++ b/go/pkg/generated/client.gen.go
@@ -218,6 +218,14 @@ type CreateCalendarTodoRequestContent struct {
 // CreateCalendarTodoResponseContent Recording — polymorphic by `type` (CalendarEvent, CalendarTodo, etc.)
 type CreateCalendarTodoResponseContent = Recording
 
+// CreateHabitRequestContent Wire format: {calendar_habit: {title, days}}
+type CreateHabitRequestContent struct {
+	CalendarHabit HabitPayload `json:"calendar_habit"`
+}
+
+// CreateHabitResponseContent Recording — polymorphic by `type` (CalendarEvent, CalendarTodo, etc.)
+type CreateHabitResponseContent = Recording
+
 // CreateMessageRequestContent Wire format: {acting_sender_id, message: {subject, content}, entry: {addressed: {directly: "..."}}}
 type CreateMessageRequestContent struct {
 	ActingSenderId int64               `json:"acting_sender_id"`
@@ -384,6 +392,13 @@ type GetTrailboxResponseContent = BoxShowResponse
 
 // GetTrashTopicsResponseContent TopicListResponse — wrapped topic list (sent, spam, trash, everything)
 type GetTrashTopicsResponseContent = TopicListResponse
+
+// HabitPayload defines model for HabitPayload.
+type HabitPayload struct {
+	// Days Days of week as integers (0=Sunday … 6=Saturday). Omit to accept server default.
+	Days  []int32 `json:"days,omitempty"`
+	Title string  `json:"title"`
+}
 
 // Identity defines model for Identity.
 type Identity struct {
@@ -959,6 +974,9 @@ type GetTopicEntriesParams struct {
 // UpdateJournalEntryJSONRequestBody defines body for UpdateJournalEntry for application/json ContentType.
 type UpdateJournalEntryJSONRequestBody = UpdateJournalEntryRequestContent
 
+// CreateHabitJSONRequestBody defines body for CreateHabit for application/json ContentType.
+type CreateHabitJSONRequestBody = CreateHabitRequestContent
+
 // StartTimeTrackJSONRequestBody defines body for StartTimeTrack for application/json ContentType.
 type StartTimeTrackJSONRequestBody = StartTimeTrackRequestContent
 
@@ -1234,6 +1252,14 @@ type ClientInterface interface {
 
 	UpdateJournalEntry(ctx context.Context, day string, body UpdateJournalEntryJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// CreateHabitWithBody request with any body
+	CreateHabitWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	CreateHabit(ctx context.Context, body CreateHabitJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// DeleteHabit request
+	DeleteHabit(ctx context.Context, habitId int64, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// GetOngoingTimeTrack request
 	GetOngoingTimeTrack(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -1452,6 +1478,46 @@ func (c *Client) UpdateJournalEntry(ctx context.Context, day string, body Update
 		return nil, err
 	}
 	return c.Client.Do(req)
+
+}
+
+// CreateHabitWithBody executes the CreateHabit operation.
+
+func (c *Client) CreateHabitWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+
+	req, err := NewCreateHabitRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+
+}
+
+func (c *Client) CreateHabit(ctx context.Context, body CreateHabitJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+
+	req, err := NewCreateHabitRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+
+}
+
+// DeleteHabit is marked as idempotent and will be retried on transient failures.
+
+func (c *Client) DeleteHabit(ctx context.Context, habitId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
+
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		return NewDeleteHabitRequest(c.Server, habitId)
+	}, true, "DeleteHabit", reqEditors...)
 
 }
 
@@ -2302,6 +2368,80 @@ func NewUpdateJournalEntryRequestWithBody(server string, day string, contentType
 	}
 
 	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewCreateHabitRequest calls the generic CreateHabit builder with application/json body
+func NewCreateHabitRequest(server string, body CreateHabitJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewCreateHabitRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewCreateHabitRequestWithBody generates requests for CreateHabit with any type of body
+func NewCreateHabitRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/calendar/habits.json")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewDeleteHabitRequest generates requests for DeleteHabit
+func NewDeleteHabitRequest(server string, habitId int64) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "habitId", runtime.ParamLocationPath, habitId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/calendar/habits/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("DELETE", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
 
 	return req, nil
 }
@@ -3876,6 +4016,8 @@ var operationMetadata = map[string]OperationMetadata{
 	"CompleteHabit":           {Idempotent: true, HasSensitiveParams: false},
 	"GetJournalEntry":         {Idempotent: true, HasSensitiveParams: false},
 	"UpdateJournalEntry":      {Idempotent: false, HasSensitiveParams: false},
+	"CreateHabit":             {Idempotent: false, HasSensitiveParams: false},
+	"DeleteHabit":             {Idempotent: true, HasSensitiveParams: false},
 	"GetOngoingTimeTrack":     {Idempotent: true, HasSensitiveParams: false},
 	"StartTimeTrack":          {Idempotent: false, HasSensitiveParams: false},
 	"UpdateTimeTrack":         {Idempotent: true, HasSensitiveParams: false},
@@ -4541,6 +4683,14 @@ type ClientWithResponsesInterface interface {
 
 	UpdateJournalEntryWithResponse(ctx context.Context, day string, body UpdateJournalEntryJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateJournalEntryResponse, error)
 
+	// CreateHabitWithBodyWithResponse request with any body
+	CreateHabitWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateHabitResponse, error)
+
+	CreateHabitWithResponse(ctx context.Context, body CreateHabitJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateHabitResponse, error)
+
+	// DeleteHabitWithResponse request
+	DeleteHabitWithResponse(ctx context.Context, habitId int64, reqEditors ...RequestEditorFn) (*DeleteHabitResponse, error)
+
 	// GetOngoingTimeTrackWithResponse request
 	GetOngoingTimeTrackWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetOngoingTimeTrackResponse, error)
 
@@ -4846,6 +4996,57 @@ func (r UpdateJournalEntryResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r UpdateJournalEntryResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type CreateHabitResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *CreateHabitResponseContent
+	JSON401      *UnauthorizedErrorResponseContent
+	JSON422      *UnprocessableEntityErrorResponseContent
+	JSON500      *InternalServerErrorResponseContent
+	JSON503      *ServiceUnavailableErrorResponseContent
+}
+
+// Status returns HTTPResponse.Status
+func (r CreateHabitResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r CreateHabitResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type DeleteHabitResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON401      *UnauthorizedErrorResponseContent
+	JSON404      *NotFoundErrorResponseContent
+	JSON500      *InternalServerErrorResponseContent
+	JSON503      *ServiceUnavailableErrorResponseContent
+}
+
+// Status returns HTTPResponse.Status
+func (r DeleteHabitResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r DeleteHabitResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -5884,6 +6085,32 @@ func (c *ClientWithResponses) UpdateJournalEntryWithResponse(ctx context.Context
 	return ParseUpdateJournalEntryResponse(rsp)
 }
 
+// CreateHabitWithBodyWithResponse request with arbitrary body returning *CreateHabitResponse
+func (c *ClientWithResponses) CreateHabitWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateHabitResponse, error) {
+	rsp, err := c.CreateHabitWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateHabitResponse(rsp)
+}
+
+func (c *ClientWithResponses) CreateHabitWithResponse(ctx context.Context, body CreateHabitJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateHabitResponse, error) {
+	rsp, err := c.CreateHabit(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateHabitResponse(rsp)
+}
+
+// DeleteHabitWithResponse request returning *DeleteHabitResponse
+func (c *ClientWithResponses) DeleteHabitWithResponse(ctx context.Context, habitId int64, reqEditors ...RequestEditorFn) (*DeleteHabitResponse, error) {
+	rsp, err := c.DeleteHabit(ctx, habitId, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseDeleteHabitResponse(rsp)
+}
+
 // GetOngoingTimeTrackWithResponse request returning *GetOngoingTimeTrackResponse
 func (c *ClientWithResponses) GetOngoingTimeTrackWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetOngoingTimeTrackResponse, error) {
 	rsp, err := c.GetOngoingTimeTrack(ctx, reqEditors...)
@@ -6634,6 +6861,107 @@ func ParseUpdateJournalEntryResponse(rsp *http.Response) (*UpdateJournalEntryRes
 			return nil, err
 		}
 		response.JSON422 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalServerErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 503:
+		var dest ServiceUnavailableErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON503 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseCreateHabitResponse parses an HTTP response from a CreateHabitWithResponse call
+func ParseCreateHabitResponse(rsp *http.Response) (*CreateHabitResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &CreateHabitResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest CreateHabitResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest UnauthorizedErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest UnprocessableEntityErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalServerErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 503:
+		var dest ServiceUnavailableErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON503 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseDeleteHabitResponse parses an HTTP response from a DeleteHabitWithResponse call
+func ParseDeleteHabitResponse(rsp *http.Response) (*DeleteHabitResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &DeleteHabitResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest UnauthorizedErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFoundErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest InternalServerErrorResponseContent

--- a/go/pkg/hey/calendar_todos.go
+++ b/go/pkg/hey/calendar_todos.go
@@ -130,5 +130,6 @@ func (s *CalendarTodosService) Delete(ctx context.Context, todoID int64) (err er
 	if err != nil {
 		return err
 	}
-	return CheckResponse(resp.HTTPResponse)
+	err = CheckResponse(resp.HTTPResponse)
+	return err
 }

--- a/go/pkg/hey/doc.go
+++ b/go/pkg/hey/doc.go
@@ -58,7 +58,7 @@
 //
 // Create a new habit (title required; days is optional — nil accepts the server default):
 //
-//	habit, err := client.Habits().Create(ctx, "Exercise", []int{1, 2, 3, 4, 5})
+//	habit, err := client.Habits().Create(ctx, "Exercise", []int32{1, 2, 3, 4, 5})
 //	if err != nil {
 //	    log.Fatal(err)
 //	}

--- a/go/pkg/hey/doc.go
+++ b/go/pkg/hey/doc.go
@@ -54,6 +54,23 @@
 //	    fmt.Println(b.Name)
 //	}
 //
+// # Working with Habits
+//
+// Create a new habit (title required; days is optional — nil accepts the server default):
+//
+//	habit, err := client.Habits().Create(ctx, "Exercise", []int{1, 2, 3, 4, 5})
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//
+// Complete a habit for a given day:
+//
+//	client.Habits().Complete(ctx, "2026-04-22", habit.Id)
+//
+// Delete a habit permanently:
+//
+//	err = client.Habits().Delete(ctx, habit.Id)
+//
 // # Pagination
 //
 // The SDK handles pagination automatically via FollowPagination:

--- a/go/pkg/hey/habits.go
+++ b/go/pkg/hey/habits.go
@@ -23,7 +23,7 @@ func NewHabitsService(client *Client) *HabitsService {
 // The HEY API expects the body wrapped as {calendar_habit: {title, days}}.
 // Pass nil or an empty slice for days to omit it from the request; the server
 // then applies its default (all days). A non-empty slice is sent verbatim.
-func (s *HabitsService) Create(ctx context.Context, title string, days []int) (result *generated.Recording, err error) {
+func (s *HabitsService) Create(ctx context.Context, title string, days []int32) (result *generated.Recording, err error) {
 	op := OperationInfo{
 		Service: "Habits", Operation: "CreateHabit",
 		ResourceType: "calendar_habit", IsMutation: true,

--- a/go/pkg/hey/habits.go
+++ b/go/pkg/hey/habits.go
@@ -26,7 +26,7 @@ func NewHabitsService(client *Client) *HabitsService {
 func (s *HabitsService) Create(ctx context.Context, title string, days []int32) (result *generated.Recording, err error) {
 	op := OperationInfo{
 		Service: "Habits", Operation: "CreateHabit",
-		ResourceType: "calendar_habit", IsMutation: true,
+		ResourceType: "habit", IsMutation: true,
 	}
 	if gater, ok := s.client.hooks.(GatingHooks); ok {
 		if ctx, err = gater.OnOperationGate(ctx, op); err != nil {
@@ -58,7 +58,7 @@ func (s *HabitsService) Create(ctx context.Context, title string, days []int32) 
 func (s *HabitsService) Delete(ctx context.Context, habitID int64) (err error) {
 	op := OperationInfo{
 		Service: "Habits", Operation: "DeleteHabit",
-		ResourceType: "calendar_habit", IsMutation: true, ResourceID: habitID,
+		ResourceType: "habit", IsMutation: true, ResourceID: habitID,
 	}
 	if gater, ok := s.client.hooks.(GatingHooks); ok {
 		if ctx, err = gater.OnOperationGate(ctx, op); err != nil {

--- a/go/pkg/hey/habits.go
+++ b/go/pkg/hey/habits.go
@@ -21,7 +21,8 @@ func NewHabitsService(client *Client) *HabitsService {
 // Create creates a new habit.
 //
 // The HEY API expects the body wrapped as {calendar_habit: {title, days}}.
-// Pass nil for days to accept the server default (all days).
+// Pass nil or an empty slice for days to omit it from the request; the server
+// then applies its default (all days). A non-empty slice is sent verbatim.
 func (s *HabitsService) Create(ctx context.Context, title string, days []int) (result *generated.Recording, err error) {
 	op := OperationInfo{
 		Service: "Habits", Operation: "CreateHabit",
@@ -73,7 +74,8 @@ func (s *HabitsService) Delete(ctx context.Context, habitID int64) (err error) {
 	if err != nil {
 		return err
 	}
-	return CheckResponse(resp.HTTPResponse)
+	err = CheckResponse(resp.HTTPResponse)
+	return err
 }
 
 // Complete marks a habit as complete for a given day.

--- a/go/pkg/hey/habits.go
+++ b/go/pkg/hey/habits.go
@@ -2,6 +2,7 @@ package hey
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/basecamp/hey-sdk/go/pkg/generated"
@@ -15,6 +16,64 @@ type HabitsService struct {
 // NewHabitsService creates a new HabitsService.
 func NewHabitsService(client *Client) *HabitsService {
 	return &HabitsService{client: client}
+}
+
+// Create creates a new habit.
+//
+// The HEY API expects the body wrapped as {calendar_habit: {title, days}}.
+// Pass nil for days to accept the server default (all days).
+func (s *HabitsService) Create(ctx context.Context, title string, days []int) (result *generated.Recording, err error) {
+	op := OperationInfo{
+		Service: "Habits", Operation: "CreateHabit",
+		ResourceType: "calendar_habit", IsMutation: true,
+	}
+	if gater, ok := s.client.hooks.(GatingHooks); ok {
+		if ctx, err = gater.OnOperationGate(ctx, op); err != nil {
+			return
+		}
+	}
+	start := time.Now()
+	ctx = s.client.hooks.OnOperationStart(ctx, op)
+	defer func() { s.client.hooks.OnOperationEnd(ctx, op, err, time.Since(start)) }()
+
+	habit := map[string]any{"title": title}
+	if len(days) > 0 {
+		habit["days"] = days
+	}
+	body := map[string]any{"calendar_habit": habit}
+
+	resp, err := s.client.Post(ctx, "/calendar/habits.json", body)
+	if err != nil {
+		return nil, err
+	}
+	var recording generated.Recording
+	if err = resp.UnmarshalData(&recording); err != nil {
+		return nil, fmt.Errorf("failed to decode habit response: %w", err)
+	}
+	return &recording, nil
+}
+
+// Delete deletes a habit.
+func (s *HabitsService) Delete(ctx context.Context, habitID int64) (err error) {
+	op := OperationInfo{
+		Service: "Habits", Operation: "DeleteHabit",
+		ResourceType: "calendar_habit", IsMutation: true, ResourceID: habitID,
+	}
+	if gater, ok := s.client.hooks.(GatingHooks); ok {
+		if ctx, err = gater.OnOperationGate(ctx, op); err != nil {
+			return
+		}
+	}
+	start := time.Now()
+	ctx = s.client.hooks.OnOperationStart(ctx, op)
+	defer func() { s.client.hooks.OnOperationEnd(ctx, op, err, time.Since(start)) }()
+
+	s.client.initGeneratedClient()
+	resp, err := s.client.gen.DeleteHabitWithResponse(ctx, habitID)
+	if err != nil {
+		return err
+	}
+	return CheckResponse(resp.HTTPResponse)
 }
 
 // Complete marks a habit as complete for a given day.

--- a/go/pkg/hey/services_test.go
+++ b/go/pkg/hey/services_test.go
@@ -722,12 +722,18 @@ func TestHabitsService_Create(t *testing.T) {
 			days, ok := habit["days"].([]any)
 			if !ok || len(days) != 3 {
 				t.Errorf("expected days [1 2 3], got %v", habit["days"])
+				return
+			}
+			for i, want := range []float64{1, 2, 3} {
+				if days[i] != want {
+					t.Errorf("days[%d] = %v, want %v", i, days[i], want)
+				}
 			}
 		},
 		`{"id":1,"type":"CalendarHabit"}`,
 	)
 
-	result, err := client.Habits().Create(context.Background(), "Exercise", []int{1, 2, 3})
+	result, err := client.Habits().Create(context.Background(), "Exercise", []int32{1, 2, 3})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/go/pkg/hey/services_test.go
+++ b/go/pkg/hey/services_test.go
@@ -762,6 +762,12 @@ func TestHabitsService_Create_NoDays(t *testing.T) {
 
 func TestHabitsService_Delete(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "DELETE" {
+			t.Errorf("expected DELETE, got %s", r.Method)
+		}
+		if !pathMatch("/calendar/habits/%s", r.URL.Path) {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
 		w.WriteHeader(204)
 	}))
 	defer server.Close()
@@ -772,6 +778,39 @@ func TestHabitsService_Delete(t *testing.T) {
 	err := client.Habits().Delete(context.Background(), 1)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestHabitsService_Create_Error(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(422)
+	}))
+	defer server.Close()
+
+	cfg := &Config{BaseURL: server.URL}
+	client := NewClient(cfg, &StaticTokenProvider{Token: "test-token"})
+
+	result, err := client.Habits().Create(context.Background(), "Exercise", nil)
+	if err == nil {
+		t.Fatal("expected error for 422 response, got nil")
+	}
+	if result != nil {
+		t.Errorf("expected nil result on error, got %v", result)
+	}
+}
+
+func TestHabitsService_Delete_Error(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(404)
+	}))
+	defer server.Close()
+
+	cfg := &Config{BaseURL: server.URL}
+	client := NewClient(cfg, &StaticTokenProvider{Token: "test-token"})
+
+	err := client.Habits().Delete(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for 404 response, got nil")
 	}
 }
 

--- a/go/pkg/hey/services_test.go
+++ b/go/pkg/hey/services_test.go
@@ -708,6 +708,73 @@ func TestHabitsService_Uncomplete(t *testing.T) {
 	}
 }
 
+func TestHabitsService_Create(t *testing.T) {
+	client := newMutationTestClientWithValidation(t, "POST", "/calendar/habits.json",
+		func(t *testing.T, body map[string]any) {
+			t.Helper()
+			habit, ok := body["calendar_habit"].(map[string]any)
+			if !ok {
+				t.Fatal("missing calendar_habit wrapper")
+			}
+			if habit["title"] != "Exercise" {
+				t.Errorf("expected title 'Exercise', got %v", habit["title"])
+			}
+			days, ok := habit["days"].([]any)
+			if !ok || len(days) != 3 {
+				t.Errorf("expected days [1 2 3], got %v", habit["days"])
+			}
+		},
+		`{"id":1,"type":"CalendarHabit"}`,
+	)
+
+	result, err := client.Habits().Create(context.Background(), "Exercise", []int{1, 2, 3})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+}
+
+func TestHabitsService_Create_NoDays(t *testing.T) {
+	client := newMutationTestClientWithValidation(t, "POST", "/calendar/habits.json",
+		func(t *testing.T, body map[string]any) {
+			t.Helper()
+			habit, ok := body["calendar_habit"].(map[string]any)
+			if !ok {
+				t.Fatal("missing calendar_habit wrapper")
+			}
+			if _, hasDays := habit["days"]; hasDays {
+				t.Error("days should be omitted when nil")
+			}
+		},
+		`{"id":2,"type":"CalendarHabit"}`,
+	)
+
+	result, err := client.Habits().Create(context.Background(), "Read", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+}
+
+func TestHabitsService_Delete(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(204)
+	}))
+	defer server.Close()
+
+	cfg := &Config{BaseURL: server.URL}
+	client := NewClient(cfg, &StaticTokenProvider{Token: "test-token"})
+
+	err := client.Habits().Delete(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 // --- TimeTracks ---
 
 func TestTimeTracksService_GetOngoing(t *testing.T) {

--- a/go/pkg/hey/services_test.go
+++ b/go/pkg/hey/services_test.go
@@ -766,6 +766,30 @@ func TestHabitsService_Create_NoDays(t *testing.T) {
 	}
 }
 
+func TestHabitsService_Create_EmptyDays(t *testing.T) {
+	client := newMutationTestClientWithValidation(t, "POST", "/calendar/habits.json",
+		func(t *testing.T, body map[string]any) {
+			t.Helper()
+			habit, ok := body["calendar_habit"].(map[string]any)
+			if !ok {
+				t.Fatal("missing calendar_habit wrapper")
+			}
+			if _, hasDays := habit["days"]; hasDays {
+				t.Error("days should be omitted when empty slice")
+			}
+		},
+		`{"id":3,"type":"CalendarHabit"}`,
+	)
+
+	result, err := client.Habits().Create(context.Background(), "Meditate", []int32{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+}
+
 func TestHabitsService_Delete(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != "DELETE" {

--- a/go/pkg/hey/url-routes.json
+++ b/go/pkg/hey/url-routes.json
@@ -65,6 +65,27 @@
       }
     },
     {
+      "pattern": "/calendar/habits",
+      "resource": "Calendar Habits",
+      "operations": {
+        "POST": "CreateHabit"
+      },
+      "params": {}
+    },
+    {
+      "pattern": "/calendar/habits/{habitId}",
+      "resource": "Calendar Habits",
+      "operations": {
+        "DELETE": "DeleteHabit"
+      },
+      "params": {
+        "habitId": {
+          "role": "recording",
+          "type": "int64"
+        }
+      }
+    },
+    {
       "pattern": "/calendar/ongoing_time_track",
       "resource": "Calendar Time Tracks",
       "operations": {

--- a/go/pkg/hey/url.go
+++ b/go/pkg/hey/url.go
@@ -133,7 +133,7 @@ func compilePattern(pattern string) (*regexp.Regexp, []string) {
 
 // sortRoutes sorts routes by descending segment count, then alphabetically.
 func sortRoutes(routes []routeEntry) {
-	sort.Slice(routes, func(i, j int) bool {
+	sort.SliceStable(routes, func(i, j int) bool {
 		si := strings.Count(routes[i].pattern, "/")
 		sj := strings.Count(routes[j].pattern, "/")
 		if si != sj {

--- a/go/pkg/hey/url_test.go
+++ b/go/pkg/hey/url_test.go
@@ -87,6 +87,19 @@ func TestRouterMatchPath(t *testing.T) {
 			wantRsrc: "Calendar Time Tracks",
 		},
 		{
+			name:     "calendar habit create",
+			input:    "/calendar/habits",
+			wantOp:   "CreateHabit",
+			wantRsrc: "Calendar Habits",
+		},
+		{
+			name:     "calendar habit delete",
+			input:    "/calendar/habits/123",
+			wantOp:   "DeleteHabit",
+			wantRes:  "123",
+			wantRsrc: "Calendar Habits",
+		},
+		{
 			name:     "search",
 			input:    "/search",
 			wantOp:   "Search",

--- a/openapi.json
+++ b/openapi.json
@@ -585,6 +585,160 @@
         }
       }
     },
+    "/calendar/habits.json": {
+      "post": {
+        "description": "Create a habit",
+        "operationId": "CreateHabit",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateHabitRequestContent"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "CreateHabit 200 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateHabitResponseContent"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "UnauthorizedError 401 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedErrorResponseContent"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "UnprocessableEntityError 422 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnprocessableEntityErrorResponseContent"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "InternalServerError 500 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerErrorResponseContent"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "ServiceUnavailableError 503 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceUnavailableErrorResponseContent"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Calendar Habits"
+        ],
+        "x-hey-retry": {
+          "maxAttempts": 2,
+          "baseDelayMs": 1000,
+          "backoff": "exponential",
+          "retryOn": [
+            429,
+            503
+          ]
+        }
+      }
+    },
+    "/calendar/habits/{habitId}": {
+      "delete": {
+        "description": "Delete a habit",
+        "operationId": "DeleteHabit",
+        "parameters": [
+          {
+            "name": "habitId",
+            "in": "path",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "DeleteHabit 200 response"
+          },
+          "401": {
+            "description": "UnauthorizedError 401 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedErrorResponseContent"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFoundError 404 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundErrorResponseContent"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "InternalServerError 500 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerErrorResponseContent"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "ServiceUnavailableError 503 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceUnavailableErrorResponseContent"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Calendar Habits"
+        ],
+        "x-hey-retry": {
+          "maxAttempts": 3,
+          "baseDelayMs": 1000,
+          "backoff": "exponential",
+          "retryOn": [
+            429,
+            503
+          ]
+        }
+      }
+    },
     "/calendar/ongoing_time_track.json": {
       "get": {
         "description": "Get the ongoing time track (404 = no active track; see ADR-004)",
@@ -4001,6 +4155,21 @@
       "CreateCalendarTodoResponseContent": {
         "$ref": "#/components/schemas/Recording"
       },
+      "CreateHabitRequestContent": {
+        "type": "object",
+        "description": "Wire format: {calendar_habit: {title, days}}",
+        "properties": {
+          "calendar_habit": {
+            "$ref": "#/components/schemas/HabitPayload"
+          }
+        },
+        "required": [
+          "calendar_habit"
+        ]
+      },
+      "CreateHabitResponseContent": {
+        "$ref": "#/components/schemas/Recording"
+      },
       "CreateMessageRequestContent": {
         "type": "object",
         "description": "Wire format: {acting_sender_id, message: {subject, content}, entry: {addressed: {directly: \"...\"}}}",
@@ -4315,6 +4484,25 @@
       },
       "GetTrashTopicsResponseContent": {
         "$ref": "#/components/schemas/TopicListResponse"
+      },
+      "HabitPayload": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "days": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "description": "Days of week as integers (0=Sunday … 6=Saturday). Omit to accept server default."
+          }
+        },
+        "required": [
+          "title"
+        ]
       },
       "Identity": {
         "type": "object",

--- a/spec/excluded-routes.json
+++ b/spec/excluded-routes.json
@@ -595,11 +595,6 @@
     "reason": "phase-2: calendar habit management"
   },
   {
-    "method": "POST",
-    "path": "/calendar/habits",
-    "reason": "phase-2: calendar habit management"
-  },
-  {
     "method": "DELETE",
     "path": "/calendar/habits/{habit_id}/stop",
     "reason": "phase-2: calendar habit management"
@@ -607,11 +602,6 @@
   {
     "method": "POST",
     "path": "/calendar/habits/{habit_id}/stop",
-    "reason": "phase-2: calendar habit management"
-  },
-  {
-    "method": "DELETE",
-    "path": "/calendar/habits/{id}",
     "reason": "phase-2: calendar habit management"
   },
   {

--- a/spec/hey.smithy
+++ b/spec/hey.smithy
@@ -106,9 +106,11 @@ service HEY {
         UncompleteCalendarTodo
         DeleteCalendarTodo
 
-        // Calendar Habits (2 MVP)
+        // Calendar Habits (4 MVP)
+        CreateHabit
         CompleteHabit
         UncompleteHabit
+        DeleteHabit
 
         // Calendar Time Tracks (3 MVP)
         GetOngoingTimeTrack
@@ -1567,6 +1569,57 @@ operation UncompleteHabit {
     input: HabitCompletionInput
     output: HabitCompletionOutput
     errors: [UnauthorizedError, NotFoundError, InternalServerError, ServiceUnavailableError]
+}
+
+/// Create a habit
+@http(method: "POST", uri: "/calendar/habits.json")
+@tags(["Calendar Habits"])
+@heyRetry(maxAttempts: 2, baseDelayMs: 1000, backoff: "exponential", retryOn: [429, 503])
+operation CreateHabit {
+    input: CreateHabitInput
+    output: CreateHabitOutput
+    errors: [UnauthorizedError, UnprocessableEntityError, InternalServerError, ServiceUnavailableError]
+}
+
+structure CreateHabitInput {
+    @httpPayload
+    @required
+    body: CreateHabitRequestContent
+}
+
+/// Wire format: {calendar_habit: {title, days}}
+structure CreateHabitRequestContent {
+    @required
+    calendar_habit: HabitPayload
+}
+
+structure HabitPayload {
+    @required
+    title: String
+
+    /// Days of week as integers (0=Sunday … 6=Saturday). Omit to accept server default.
+    days: DaysList
+}
+
+structure CreateHabitOutput {
+    @required
+    recording: Recording
+}
+
+/// Delete a habit
+@idempotent
+@http(method: "DELETE", uri: "/calendar/habits/{habitId}")
+@tags(["Calendar Habits"])
+@heyRetry(maxAttempts: 3, baseDelayMs: 1000, backoff: "exponential", retryOn: [429, 503])
+operation DeleteHabit {
+    input: DeleteHabitInput
+    errors: [UnauthorizedError, NotFoundError, InternalServerError, ServiceUnavailableError]
+}
+
+structure DeleteHabitInput {
+    @httpLabel
+    @required
+    habitId: Long
 }
 
 // =============================================================================

--- a/spec/route-coverage.json
+++ b/spec/route-coverage.json
@@ -16,23 +16,33 @@
   },
   {
     "method": "POST",
+    "operationId": "CreateHabit",
+    "path": "/calendar/habits.json"
+  },
+  {
+    "method": "POST",
     "operationId": "CreateMessage",
     "path": "/messages.json"
   },
   {
     "method": "POST",
     "operationId": "CreateReply",
-    "path": "/entries/{entryId}/replies"
+    "path": "/entries/{entryId}/replies.json"
   },
   {
     "method": "POST",
     "operationId": "CreateTopicMessage",
-    "path": "/topics/{topicId}/messages"
+    "path": "/topics/{topicId}/entries.json"
   },
   {
     "method": "DELETE",
     "operationId": "DeleteCalendarTodo",
     "path": "/calendar/todos/{todoId}"
+  },
+  {
+    "method": "DELETE",
+    "operationId": "DeleteHabit",
+    "path": "/calendar/habits/{habitId}"
   },
   {
     "method": "GET",
@@ -135,6 +145,11 @@
     "path": "/topics/trash.json"
   },
   {
+    "method": "POST",
+    "operationId": "IgnorePosting",
+    "path": "/postings/{postingId}/ignore.json"
+  },
+  {
     "method": "GET",
     "operationId": "ListBoxes",
     "path": "/boxes.json"
@@ -153,6 +168,41 @@
     "method": "GET",
     "operationId": "ListDrafts",
     "path": "/entries/drafts.json"
+  },
+  {
+    "method": "POST",
+    "operationId": "MarkPostingsSeen",
+    "path": "/postings/seen.json"
+  },
+  {
+    "method": "POST",
+    "operationId": "MarkPostingsUnseen",
+    "path": "/postings/unseen.json"
+  },
+  {
+    "method": "POST",
+    "operationId": "MovePostingToFeed",
+    "path": "/postings/{postingId}/move/feedbox.json"
+  },
+  {
+    "method": "POST",
+    "operationId": "MovePostingToPaperTrail",
+    "path": "/postings/{postingId}/move/trailbox.json"
+  },
+  {
+    "method": "POST",
+    "operationId": "MovePostingToReplyLater",
+    "path": "/postings/{postingId}/move/laterbox.json"
+  },
+  {
+    "method": "POST",
+    "operationId": "MovePostingToSetAside",
+    "path": "/postings/{postingId}/move/asidebox.json"
+  },
+  {
+    "method": "POST",
+    "operationId": "MovePostingToTrash",
+    "path": "/postings/{postingId}/trash.json"
   },
   {
     "method": "GET",


### PR DESCRIPTION
## What

Promotes `CreateHabit` and `DeleteHabit` from the phase-2 exclusion list through the full pipeline.

## Changes

- **Smithy spec**: `CreateHabit` (POST `/calendar/habits.json`) and `DeleteHabit` (DELETE `/calendar/habits/{habitId}`, `@idempotent`)
- **`HabitPayload`**: `title` (required), `days []int32` (optional — omit for server default)
- **Wire format**: `{calendar_habit: {title, days}}` — matches the `calendar_todo` / `calendar_event` convention
- **`spec/excluded-routes.json`**: removed the two phase-2 entries
- **Generated client**: regenerated — `DeleteHabit` uses `doWithRetry(..., true, ...)` per `@idempotent`
- **`HabitsService`**: `Create(ctx, title, days []int32)` and `Delete(ctx, habitID int64)`
- **`url-routes.json`** + **`url.go`**: regenerated; fixed `sort.Slice` → `sort.SliceStable` to preserve deterministic ordering when two routes share a pattern (the `/topics/{topicId}/entries` collision)

## Tests

- Unit: happy path, nil days, `[]int{}` edge case, method/path verification on Delete, error paths (422, 404)
- Conformance: path tests for both operations; idempotency tests for `DeleteHabit` on 503 and 429
- Routing: `TestRouterMatchPath` cases for both paths

## Checks

| Check | Result |
|-------|--------|
| Go vet + lint | 0 issues |
| Go tests | PASS |
| Conformance | 85/85 PASS |
| Smithy validation | ✓ |
| URL routes freshness | ✓ |

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `CreateHabit` (POST `/calendar/habits.json`) and `DeleteHabit` (DELETE `/calendar/habits/{habitId}`) to the SDK with end-to-end support. `DeleteHabit` is idempotent with retries; hooks metadata for habits is aligned.

- **New Features**
  - Added `CreateHabit` and `DeleteHabit` to `spec/hey.smithy` and OpenAPI; `DeleteHabit` retries on 429/503 with exponential backoff.
  - Introduced `HabitPayload` (title required; days `[]int32` optional) with JSON `{calendar_habit: {title, days}}`.
  - Regenerated Go client and added `HabitsService` methods: `Create(ctx, title string, days []int32)` and `Delete(ctx, habitID int64)`.
  - Updated routing and conformance: path tests for both ops and idempotency tests for delete; runner dispatch added; removed phase-2 exclusions.
  - Added “Working with Habits” examples to `doc.go`.

- **Bug Fixes**
  - Aligned `ResourceType` to "habit" for Create/Delete to keep hooks/gating consistent; added empty-slice days test.
  - Made route sorting deterministic by switching to `sort.SliceStable` for patterns that collide.
  - Ensured `CheckResponse` errors propagate to operation hooks in `calendar_todos.go` and `habits.go`.

<sup>Written for commit 9e312e636695456608295aaaa1a63541f6522fe8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

