### PR TITLE
Rewrite AGENTS.md around what this repo actually is

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,30 +1,41 @@
 # HEY SDK -- Agent Instructions
 
-## Hard Rules
+Go client for the HEY API, generated from the Smithy spec in `spec/`.
 
-1. **Never hand-write API methods.** All operations are generated from the Smithy spec.
-2. **Never construct URL paths manually.** Use the generated route table.
-3. **Every new operation needs tests.** Unit tests per language + conformance tests.
-4. **Run `make check` before committing.** All checks must pass.
+**This repo ships Go only.** The Makefile still carries `ts-`, `rb-`, `swift-` and `kt-`
+targets inherited from the shared SDK seed. They `cd` into `typescript/`, `ruby/`,
+`swift/` and `kotlin/`, none of which exist here, so they fail immediately -- as does
+`make check-full`, which invokes them. `make check` is the gate that works.
+
+## Hard rules
+
+1. **Never hand-write API methods.** Operations are generated from the Smithy spec.
+2. **Never construct URL paths manually.** Use the generated route table -- no
+   `fmt.Sprintf` for paths.
+3. **Every new operation needs tests.** Go unit tests, plus a conformance test when the
+   change is behavioral.
+4. **Run `make check` before committing.**
 
 ## Pipeline
 
 ```
-Smithy spec -> OpenAPI -> Behavior Model -> Per-language generators -> SDK code
+spec/hey.smithy -> openapi.json -> behavior-model.json -> Go generator -> go/pkg
 ```
 
-## Anti-Patterns
+`openapi.json`, `behavior-model.json` and the generated Go are all rebuilt from the
+spec. Editing any of them by hand loses the change on the next generate, and
+`go-check-drift` fails the build when they disagree with the spec.
 
-- Editing `openapi.json` directly (it is generated from Smithy)
-- Adding API methods without updating the Smithy spec
-- Skipping conformance tests for behavioral changes
-- Using `fmt.Sprintf` or template literals for API paths
+## Adding an operation
 
-## Development Workflow
+1. Edit `spec/hey.smithy`
+2. `make smithy-build` -- regenerates `openapi.json`
+3. `make go-generate` -- regenerates the Go service layer. Note the name: this repo has
+   no `go-generate-services` target, unlike the seed's vocabulary.
+4. Add Go unit tests, and a conformance case under `conformance/tests/` for behavioral
+   changes
+5. `make check`
 
-1. Edit the Smithy spec in `spec/`
-2. Run `make smithy-build` to regenerate OpenAPI
-3. Run per-language generators: `make {lang}-generate-services`
-4. Add/update tests
-5. Run `make check`
-6. Commit
+`make check` resolves to `check-mvp`: `smithy-check`, `behavior-model-check`,
+`drift-check-mvp`, `url-routes-check`, `go-check`, `go-check-drift` and
+`conformance-mvp`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,18 +37,23 @@ So it catches wrappers left behind by a regenerate, not spec-vs-OpenAPI drift.
 
 1. Edit `spec/hey.smithy`
 2. `make smithy-build` -- regenerates `openapi.json`
-3. Refresh the three artifacts `smithy-build` leaves behind. None of them has a make
-   target, and each is checked by `make check`:
+3. Refresh the three artifacts `smithy-build` leaves behind:
 
    ```bash
-   make url-routes                      # go/pkg/hey/url-routes.json  (url-routes-check)
-   ./scripts/generate-shape-fingerprint # spec/shape-fingerprint.json (drift-check-shape)
-   ./scripts/generate-route-coverage    # spec/route-coverage.json    (drift-check-forward)
+   make url-routes                      # go/pkg/hey/url-routes.json
+   ./scripts/generate-shape-fingerprint # spec/shape-fingerprint.json
+   ./scripts/generate-route-coverage    # spec/route-coverage.json
    ```
 
-   Route coverage is the quiet one: `drift-check-forward` compares the checked-in
-   `spec/route-coverage.json` against `spec/route-snapshot.json`, so a stale coverage
-   file lets the gate pass without ever looking at your new endpoint.
+   Only the first has a make target; the other two are standalone scripts. They differ in
+   how `make check` treats them, which matters more:
+
+   - `url-routes-check` and `drift-check-shape` **do** verify freshness and fail on a
+     stale file, so forgetting those two is loud.
+   - Nothing verifies `spec/route-coverage.json`. `drift-check-forward` just consumes the
+     checked-in file and compares it against `spec/route-snapshot.json`, so a stale
+     coverage file does not fail the build — the gate passes while never looking at your
+     new endpoint. That one is on you to regenerate.
 4. `make go-generate` -- regenerates `go/pkg/generated/client.gen.go` via oapi-codegen.
    Note the name: this repo has no `go-generate-services` target, unlike the seed's
    vocabulary, and this step does not touch `go/pkg/hey`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,22 +19,31 @@ targets inherited from the shared SDK seed. They `cd` into `typescript/`, `ruby/
 ## Pipeline
 
 ```
-spec/hey.smithy -> openapi.json -> behavior-model.json -> Go generator -> go/pkg
+spec/hey.smithy -> openapi.json -> oapi-codegen -> go/pkg/generated/client.gen.go
+                                                            |
+                                    hand-written wrappers in go/pkg/hey call into it
 ```
 
-`openapi.json`, `behavior-model.json` and the generated Go are all rebuilt from the
-spec. Editing any of them by hand loses the change on the next generate, and
-`go-check-drift` fails the build when they disagree with the spec.
+`openapi.json` and `go/pkg/generated/client.gen.go` are rebuilt from the spec; editing
+either by hand loses the change on the next generate. `go/pkg/hey` is **not** generated
+— those service wrappers are hand-written and you update them yourself.
+
+`go-check-drift` does not re-derive anything from the spec. It extracts the operations
+present in the checked-in `client.gen.go` and compares them with the `.gen.*WithResponse`
+calls in `go/pkg/hey`, failing when a wrapper calls an operation that no longer exists.
+So it catches wrappers left behind by a regenerate, not spec-vs-OpenAPI drift.
 
 ## Adding an operation
 
 1. Edit `spec/hey.smithy`
 2. `make smithy-build` -- regenerates `openapi.json`
-3. `make go-generate` -- regenerates the Go service layer. Note the name: this repo has
-   no `go-generate-services` target, unlike the seed's vocabulary.
-4. Add Go unit tests, and a conformance case under `conformance/tests/` for behavioral
+3. `make go-generate` -- regenerates `go/pkg/generated/client.gen.go` via oapi-codegen.
+   Note the name: this repo has no `go-generate-services` target, unlike the seed's
+   vocabulary, and this step does not touch `go/pkg/hey`.
+4. Add or update the hand-written wrapper in `go/pkg/hey` so the operation is reachable
+5. Add Go unit tests, and a conformance case under `conformance/tests/` for behavioral
    changes
-5. `make check`
+6. `make check`
 
 `make check` resolves to `check-mvp`: `smithy-check`, `behavior-model-check`,
 `drift-check-mvp`, `url-routes-check`, `go-check`, `go-check-drift` and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,13 +37,16 @@ So it catches wrappers left behind by a regenerate, not spec-vs-OpenAPI drift.
 
 1. Edit `spec/hey.smithy`
 2. `make smithy-build` -- regenerates `openapi.json`
-3. `make go-generate` -- regenerates `go/pkg/generated/client.gen.go` via oapi-codegen.
+3. `make url-routes` -- rebuilds the embedded route table at
+   `go/pkg/hey/url-routes.json`. `smithy-build` does not do this, and `url-routes-check`
+   (part of `make check`) fails on a stale one.
+4. `make go-generate` -- regenerates `go/pkg/generated/client.gen.go` via oapi-codegen.
    Note the name: this repo has no `go-generate-services` target, unlike the seed's
    vocabulary, and this step does not touch `go/pkg/hey`.
-4. Add or update the hand-written wrapper in `go/pkg/hey` so the operation is reachable
-5. Add Go unit tests, and a conformance case under `conformance/tests/` for behavioral
+5. Add or update the hand-written wrapper in `go/pkg/hey` so the operation is reachable
+6. Add Go unit tests, and a conformance case under `conformance/tests/` for behavioral
    changes
-6. `make check`
+7. `make check`
 
 `make check` resolves to `check-mvp`: `smithy-check`, `behavior-model-check`,
 `drift-check-mvp`, `url-routes-check`, `go-check`, `go-check-drift` and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,9 +37,18 @@ So it catches wrappers left behind by a regenerate, not spec-vs-OpenAPI drift.
 
 1. Edit `spec/hey.smithy`
 2. `make smithy-build` -- regenerates `openapi.json`
-3. `make url-routes` -- rebuilds the embedded route table at
-   `go/pkg/hey/url-routes.json`. `smithy-build` does not do this, and `url-routes-check`
-   (part of `make check`) fails on a stale one.
+3. Refresh the three artifacts `smithy-build` leaves behind. None of them has a make
+   target, and each is checked by `make check`:
+
+   ```bash
+   make url-routes                      # go/pkg/hey/url-routes.json  (url-routes-check)
+   ./scripts/generate-shape-fingerprint # spec/shape-fingerprint.json (drift-check-shape)
+   ./scripts/generate-route-coverage    # spec/route-coverage.json    (drift-check-forward)
+   ```
+
+   Route coverage is the quiet one: `drift-check-forward` compares the checked-in
+   `spec/route-coverage.json` against `spec/route-snapshot.json`, so a stale coverage
+   file lets the gate pass without ever looking at your new endpoint.
 4. `make go-generate` -- regenerates `go/pkg/generated/client.gen.go` via oapi-codegen.
    Note the name: this repo has no `go-generate-services` target, unlike the seed's
    vocabulary, and this step does not touch `go/pkg/hey`.


### PR DESCRIPTION
The file was the shared SDK seed template with "HEY" substituted and nothing
else changed, so every specific it gave was wrong for this repo.

Its workflow step was `make {lang}-generate-services` -- a placeholder that
instantiation never expanded. There is no target by that name here for any
language, and not even a go-generate-services; the Go target is go-generate.

The repo is Go-only. The Makefile still carries ts-, rb-, swift- and kt-
targets from the seed that cd into typescript/, ruby/, swift/ and kotlin/,
none of which exist, so they fail immediately -- and check-full invokes them.
An agent following the old file would have run a nonexistent target, then
reached for the wrong gate. Both are now stated plainly, along with the gate
that does work.

Slightly longer than what it replaces, because the template was generic enough
to be free. Every command and path in it was checked against the Makefile and
the working tree.


---
Checked against `main` at 212ceb7d1fe6e54d84b780f35031eb1de0fed0c1.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rewrote AGENTS.md to match the Go-only workflow. Documents the full post-Smithy steps, clarifies `go-generate` and `go-check-drift`, makes `make check` the gate, and explains which derived artifacts are actually gated.

- **Migration**
  - After a Smithy change: `make smithy-build` → refresh artifacts (`make url-routes`, `./scripts/generate-shape-fingerprint`, `./scripts/generate-route-coverage`) → `make go-generate` → update `go/pkg/hey` wrappers by hand.
  - `go-check-drift` compares operations in the checked-in client to `.gen.*WithResponse` calls in `go/pkg/hey`; it does not read the spec or regenerate.
  - Gating: `url-routes-check` and `drift-check-shape` fail on stale files; `spec/route-coverage.json` is not verified — `drift-check-forward` only consumes it, so regenerate it manually.
  - Use `make check`; `check-full` still runs vestigial `ts-`, `rb-`, `swift-`, and `kt-` targets and fails.

<sup>Written for commit 6449c717b82e248e722ca1ed4b22015462e99800. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-sdk/pull/59?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

