### PR TITLE
Add entry trash operation

### DIFF
--- a/behavior-model.json
+++ b/behavior-model.json
@@ -512,6 +512,19 @@
         ]
       }
     },
+    "TrashEntry": {
+      "idempotent": true,
+      "readonly": false,
+      "retry": {
+        "backoff": "exponential",
+        "base_delay_ms": 1000,
+        "max": 2,
+        "retry_on": [
+          429,
+          503
+        ]
+      }
+    },
     "TrashPostings": {
       "idempotent": false,
       "readonly": false,

--- a/conformance/runner/go/main.go
+++ b/conformance/runner/go/main.go
@@ -795,6 +795,9 @@ func executeOperation(client *generated.Client, ctx context.Context, tc TestCase
 			},
 		}
 		return client.CreateReply(ctx, entryId, body)
+	case "TrashEntry":
+		entryId := getInt64Param(tc.PathParams, "entryId")
+		return client.TrashEntry(ctx, entryId)
 
 	// Contacts
 	case "ListContacts":

--- a/conformance/tests/paths.json
+++ b/conformance/tests/paths.json
@@ -159,6 +159,35 @@
     ]
   },
   {
+    "name": "TrashEntry uses /entries/{entryId}/status/trashed path",
+    "description": "Verifies that TrashEntry constructs the URL path /entries/{entryId}/status/trashed",
+    "operation": "TrashEntry",
+    "method": "PUT",
+    "path": "/entries/{entryId}/status/trashed",
+    "pathParams": {
+      "entryId": 456
+    },
+    "mockResponses": [
+      {
+        "status": 200,
+        "body": {}
+      }
+    ],
+    "assertions": [
+      {
+        "type": "requestPath",
+        "expected": "/entries/456/status/trashed"
+      },
+      {
+        "type": "noError"
+      }
+    ],
+    "tags": [
+      "path",
+      "entries"
+    ]
+  },
+  {
     "name": "DeleteCalendarTodo uses /calendar/todos/{todoId} path",
     "description": "Verifies that DeleteCalendarTodo constructs the URL path /calendar/todos/{todoId}",
     "operation": "DeleteCalendarTodo",

--- a/go/pkg/generated/client.gen.go
+++ b/go/pkg/generated/client.gen.go
@@ -1293,6 +1293,9 @@ type ClientInterface interface {
 
 	CreateReply(ctx context.Context, entryId int64, body CreateReplyJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// TrashEntry request
+	TrashEntry(ctx context.Context, entryId int64, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// GetFeedbox request
 	GetFeedbox(ctx context.Context, params *GetFeedboxParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -1657,6 +1660,16 @@ func (c *Client) CreateReply(ctx context.Context, entryId int64, body CreateRepl
 		return nil, err
 	}
 	return c.Client.Do(req)
+
+}
+
+// TrashEntry is marked as idempotent and will be retried on transient failures.
+
+func (c *Client) TrashEntry(ctx context.Context, entryId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
+
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		return NewTrashEntryRequest(c.Server, entryId)
+	}, true, "TrashEntry", reqEditors...)
 
 }
 
@@ -2817,6 +2830,40 @@ func NewCreateReplyRequestWithBody(server string, entryId int64, contentType str
 	return req, nil
 }
 
+// NewTrashEntryRequest generates requests for TrashEntry
+func NewTrashEntryRequest(server string, entryId int64) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "entryId", runtime.ParamLocationPath, entryId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/entries/%s/status/trashed", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("PUT", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewGetFeedboxRequest generates requests for GetFeedbox
 func NewGetFeedboxRequest(server string, params *GetFeedboxParams) (*http.Request, error) {
 	var err error
@@ -3784,6 +3831,7 @@ var operationMetadata = map[string]OperationMetadata{
 	"GetContact":             {Idempotent: true, HasSensitiveParams: false},
 	"ListDrafts":             {Idempotent: true, HasSensitiveParams: false},
 	"CreateReply":            {Idempotent: false, HasSensitiveParams: false},
+	"TrashEntry":             {Idempotent: true, HasSensitiveParams: false},
 	"GetFeedbox":             {Idempotent: true, HasSensitiveParams: false},
 	"GetIdentity":            {Idempotent: true, HasSensitiveParams: false},
 	"GetImbox":               {Idempotent: true, HasSensitiveParams: false},
@@ -4585,6 +4633,13 @@ type ClientWithResponsesInterface interface {
 	//
 	// Reply to an entry.
 	CreateReplyWithResponse(ctx context.Context, entryId int64, body CreateReplyJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateReplyResponse, error)
+
+	// TrashEntryWithResponse performs a PUT /entries/{entryId}/status/trashed (the `TrashEntry` operationId) request.
+	//
+	// Move an entry to Trash.
+	//
+	// Returns a wrapper object for the known response body format(s).
+	TrashEntryWithResponse(ctx context.Context, entryId int64, reqEditors ...RequestEditorFn) (*TrashEntryResponse, error)
 
 	// GetFeedboxWithResponse performs a GET /feedbox.json (the `GetFeedbox` operationId) request.
 	//
@@ -6133,6 +6188,68 @@ func (r CreateReplyResponse) StatusCode() int {
 
 // ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
 func (r CreateReplyResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type TrashEntryResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	// JSON401 the response for an HTTP 401 `application/json` response
+	JSON401 *UnauthorizedErrorResponseContent
+	// JSON404 the response for an HTTP 404 `application/json` response
+	JSON404 *NotFoundErrorResponseContent
+	// JSON500 the response for an HTTP 500 `application/json` response
+	JSON500 *InternalServerErrorResponseContent
+	// JSON503 the response for an HTTP 503 `application/json` response
+	JSON503 *ServiceUnavailableErrorResponseContent
+}
+
+// GetJSON401 returns the response for an HTTP 401 `application/json` response
+func (r TrashEntryResponse) GetJSON401() *UnauthorizedErrorResponseContent {
+	return r.JSON401
+}
+
+// GetJSON404 returns the response for an HTTP 404 `application/json` response
+func (r TrashEntryResponse) GetJSON404() *NotFoundErrorResponseContent {
+	return r.JSON404
+}
+
+// GetJSON500 returns the response for an HTTP 500 `application/json` response
+func (r TrashEntryResponse) GetJSON500() *InternalServerErrorResponseContent {
+	return r.JSON500
+}
+
+// GetJSON503 returns the response for an HTTP 503 `application/json` response
+func (r TrashEntryResponse) GetJSON503() *ServiceUnavailableErrorResponseContent {
+	return r.JSON503
+}
+
+// GetBody returns the raw response body bytes
+func (r TrashEntryResponse) GetBody() []byte {
+	return r.Body
+}
+
+// Status returns HTTPResponse.Status
+func (r TrashEntryResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r TrashEntryResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r TrashEntryResponse) ContentType() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Header.Get("Content-Type")
 	}
@@ -7835,6 +7952,19 @@ func (c *ClientWithResponses) CreateReplyWithResponse(ctx context.Context, entry
 	return ParseCreateReplyResponse(rsp)
 }
 
+// TrashEntryWithResponse performs a PUT /entries/{entryId}/status/trashed (the `TrashEntry` operationId) request.
+//
+// Move an entry to Trash.
+//
+// Returns a wrapper object for the known response body format(s).
+func (c *ClientWithResponses) TrashEntryWithResponse(ctx context.Context, entryId int64, reqEditors ...RequestEditorFn) (*TrashEntryResponse, error) {
+	rsp, err := c.TrashEntry(ctx, entryId, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseTrashEntryResponse(rsp)
+}
+
 // GetFeedboxWithResponse performs a GET /feedbox.json (the `GetFeedbox` operationId) request.
 //
 // Get the Feed.
@@ -9244,6 +9374,56 @@ func ParseCreateReplyResponse(rsp *http.Response) (*CreateReplyResponse, error) 
 			return nil, err
 		}
 		response.JSON422 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalServerErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 503:
+		var dest ServiceUnavailableErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON503 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseTrashEntryResponse parses an HTTP response from a TrashEntryWithResponse call
+func ParseTrashEntryResponse(rsp *http.Response) (*TrashEntryResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &TrashEntryResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case rsp.StatusCode == 200:
+		break // No content-type
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest UnauthorizedErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFoundErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest InternalServerErrorResponseContent

--- a/go/pkg/hey/entries.go
+++ b/go/pkg/hey/entries.go
@@ -91,3 +91,26 @@ func (s *EntriesService) CreateReply(ctx context.Context, entryID int64, content
 	}
 	return CheckResponse(resp.HTTPResponse)
 }
+
+// Trash moves an entry to Trash.
+func (s *EntriesService) Trash(ctx context.Context, entryID int64) (err error) {
+	op := OperationInfo{
+		Service: "Entries", Operation: "TrashEntry",
+		ResourceType: "entry", IsMutation: true, ResourceID: entryID,
+	}
+	if gater, ok := s.client.hooks.(GatingHooks); ok {
+		if ctx, err = gater.OnOperationGate(ctx, op); err != nil {
+			return
+		}
+	}
+	start := time.Now()
+	ctx = s.client.hooks.OnOperationStart(ctx, op)
+	defer func() { s.client.hooks.OnOperationEnd(ctx, op, err, time.Since(start)) }()
+
+	s.client.initGeneratedClient()
+	resp, err := s.client.gen.TrashEntryWithResponse(ctx, entryID)
+	if err != nil {
+		return err
+	}
+	return CheckResponse(resp.HTTPResponse)
+}

--- a/go/pkg/hey/services_test.go
+++ b/go/pkg/hey/services_test.go
@@ -541,6 +541,21 @@ func TestEntriesService_CreateReply_RecipientsAreArrays(t *testing.T) {
 	}
 }
 
+func TestEntriesService_Trash(t *testing.T) {
+	client := newMutationTestClientWithValidation(
+		t,
+		"PUT",
+		"/entries/%s/status/trashed",
+		nil,
+		`{}`,
+	)
+
+	err := client.Entries().Trash(context.Background(), 10)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 // --- Contacts ---
 
 func TestContactsService_List(t *testing.T) {

--- a/go/pkg/hey/url-routes.json
+++ b/go/pkg/hey/url-routes.json
@@ -185,6 +185,19 @@
       }
     },
     {
+      "pattern": "/entries/{entryId}/status/trashed",
+      "resource": "Entries",
+      "operations": {
+        "PUT": "TrashEntry"
+      },
+      "params": {
+        "entryId": {
+          "role": "parent",
+          "type": "int64"
+        }
+      }
+    },
+    {
       "pattern": "/feedbox",
       "resource": "Boxes",
       "operations": {

--- a/openapi.json
+++ b/openapi.json
@@ -1631,6 +1631,80 @@
         }
       }
     },
+    "/entries/{entryId}/status/trashed": {
+      "put": {
+        "description": "Move an entry to Trash",
+        "operationId": "TrashEntry",
+        "parameters": [
+          {
+            "name": "entryId",
+            "in": "path",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "TrashEntry 200 response"
+          },
+          "401": {
+            "description": "UnauthorizedError 401 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedErrorResponseContent"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFoundError 404 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundErrorResponseContent"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "InternalServerError 500 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerErrorResponseContent"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "ServiceUnavailableError 503 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceUnavailableErrorResponseContent"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Entries"
+        ],
+        "x-hey-retry": {
+          "maxAttempts": 2,
+          "baseDelayMs": 1000,
+          "backoff": "exponential",
+          "retryOn": [
+            429,
+            503
+          ]
+        }
+      }
+    },
     "/feedbox.json": {
       "get": {
         "description": "Get the Feed",

--- a/spec/excluded-routes.json
+++ b/spec/excluded-routes.json
@@ -1710,11 +1710,6 @@
     "reason": "phase-2: entry CRUD"
   },
   {
-    "method": "PUT",
-    "path": "/entries/{entry_id}/status/trashed",
-    "reason": "phase-2: entry CRUD"
-  },
-  {
     "method": "GET",
     "path": "/entries/{id}",
     "reason": "phase-2: entry CRUD"

--- a/spec/hey.smithy
+++ b/spec/hey.smithy
@@ -87,9 +87,10 @@ service HEY {
         GetMessage
         CreateMessage
 
-        // Entries (2 MVP)
+        // Entries (3 MVP)
         ListDrafts
         CreateReply
+        TrashEntry
 
         // Contacts (2 MVP)
         ListContacts
@@ -1291,6 +1292,22 @@ structure CreateReplyRequestContent {
 structure ReplyMessagePayload {
     @required
     content: String
+}
+
+/// Move an entry to Trash
+@idempotent
+@http(method: "PUT", uri: "/entries/{entryId}/status/trashed")
+@tags(["Entries"])
+@heyRetry(maxAttempts: 2, baseDelayMs: 1000, backoff: "exponential", retryOn: [429, 503])
+operation TrashEntry {
+    input: TrashEntryInput
+    errors: [UnauthorizedError, NotFoundError, InternalServerError, ServiceUnavailableError]
+}
+
+structure TrashEntryInput {
+    @httpLabel
+    @required
+    entryId: Long
 }
 
 // =============================================================================

--- a/spec/route-coverage.json
+++ b/spec/route-coverage.json
@@ -180,6 +180,11 @@
     "path": "/calendar/ongoing_time_track.json"
   },
   {
+    "method": "PUT",
+    "operationId": "TrashEntry",
+    "path": "/entries/{entryId}/status/trashed"
+  },
+  {
     "method": "POST",
     "operationId": "TrashPostings",
     "path": "/postings/trash.json"


### PR DESCRIPTION
# What changed

Adds the SDK operation for moving one email entry to Trash:

- Models `PUT /entries/{entryId}/status/trashed` in Smithy.
- Exposes it as `EntriesService.Trash`.
- Removes the route from `excluded-routes.json`.
- Regenerates the OpenAPI document, Go client, behavior model, and route metadata.
- Adds service and conformance coverage.

PR #61 now carries the bulk posting and topic-route fixes from the original version of this PR. This version keeps only the independent entry-trash operation and is stacked on #61 so the full SDK gate can run cleanly. It can be retargeted to `main` after #61 merges.

# Tests

- `GOWORK=off mise x -- make check`
- 87 conformance cases
