### PR TITLE
Gate route coverage and reverse drift; refresh the haystack pin

### DIFF
--- a/.github/workflows/smithy-verify.yml
+++ b/.github/workflows/smithy-verify.yml
@@ -50,3 +50,7 @@ jobs:
           fi
           rm -f openapi.generated.json
           echo "openapi.json is up to date"
+
+      - name: Verify behavior model is up to date
+        working-directory: .
+        run: make behavior-model-check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,12 +119,13 @@ jobs:
         with:
           persist-credentials: false
 
-      # Everything here is derived from openapi.json with bash + jq: the behavior
-      # model, url-routes.json, route-coverage.json, the shape fingerprint, and the
-      # forward/reverse drift checks against the haystack route snapshot. These are
-      # what stop the SDK modelling routes HEY does not serve.
+      # Everything here is derived from openapi.json with bash + jq: url-routes.json,
+      # route-coverage.json, the shape fingerprint, and the forward/reverse drift
+      # checks against the haystack route snapshot. These are what stop the SDK
+      # modelling routes HEY does not serve. (behavior-model-check needs the Smithy
+      # AST, so it lives in the smithy-verify workflow.)
       - name: Check generated artifacts and route drift
-        run: make behavior-model-check url-routes-check drift-check-mvp
+        run: make url-routes-check drift-check-mvp
 
   api-compat:
     name: API Compatibility

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -109,6 +109,23 @@ jobs:
       - name: Run conformance tests
         run: go run .
 
+  spec-drift:
+    name: Spec Drift
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      # Everything here is derived from openapi.json with bash + jq: the behavior
+      # model, url-routes.json, route-coverage.json, the shape fingerprint, and the
+      # forward/reverse drift checks against the haystack route snapshot. These are
+      # what stop the SDK modelling routes HEY does not serve.
+      - name: Check generated artifacts and route drift
+        run: make behavior-model-check url-routes-check drift-check-mvp
+
   api-compat:
     name: API Compatibility
     if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'breaking')

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,15 +45,9 @@ So it catches wrappers left behind by a regenerate, not spec-vs-OpenAPI drift.
    ./scripts/generate-route-coverage    # spec/route-coverage.json
    ```
 
-   Only the first has a make target; the other two are standalone scripts. They differ in
-   how `make check` treats them, which matters more:
-
-   - `url-routes-check` and `drift-check-shape` **do** verify freshness and fail on a
-     stale file, so forgetting those two is loud.
-   - Nothing verifies `spec/route-coverage.json`. `drift-check-forward` just consumes the
-     checked-in file and compares it against `spec/route-snapshot.json`, so a stale
-     coverage file does not fail the build — the gate passes while never looking at your
-     new endpoint. That one is on you to regenerate.
+   Only the first has a make target; the other two are standalone scripts. All three
+   are verified by `make check` (`url-routes-check`, `drift-check-shape` and
+   `drift-check-coverage`), so forgetting any of them fails the build loudly.
 4. `make go-generate` -- regenerates `go/pkg/generated/client.gen.go` via oapi-codegen.
    Note the name: this repo has no `go-generate-services` target, unlike the seed's
    vocabulary, and this step does not touch `go/pkg/hey`.
@@ -64,4 +58,12 @@ So it catches wrappers left behind by a regenerate, not spec-vs-OpenAPI drift.
 
 `make check` resolves to `check-mvp`: `smithy-check`, `behavior-model-check`,
 `drift-check-mvp`, `url-routes-check`, `go-check`, `go-check-drift` and
-`conformance-mvp`.
+`conformance-mvp`. `drift-check-mvp` is coverage freshness + forward (every modelled
+route exists in `spec/route-snapshot.json`) + reverse (every JSON-capable snapshot
+route is modelled or listed in `spec/excluded-routes.json` with a reason) + shape
+fingerprint. Adding an operation for a route that haystack does not serve, or
+forgetting to regenerate coverage, fails the gate.
+
+The snapshot comes from a haystack checkout: `make drift-regen HAYSTACK_DIR=…` then
+`./scripts/sync-provenance HAYSTACK_DIR` to record the pinned SHA in
+`spec/api-provenance.json`.

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,13 @@ url-routes-check:
 # Drift detection
 #------------------------------------------------------------------------------
 
-.PHONY: drift-check drift-check-mvp drift-check-full drift-regen
+.PHONY: drift-check drift-check-mvp drift-check-full drift-check-coverage drift-check-forward drift-check-reverse drift-check-shape drift-regen
+
+# route-coverage.json is derived from openapi.json and read by both drift checks;
+# a stale file means the gate never sees new operations. Refuse that.
+drift-check-coverage:
+	@echo "==> Drift check (route coverage freshness)..."
+	@./scripts/generate-route-coverage --check
 
 # Forward-only: every modeled operation has a matching route
 drift-check-forward:
@@ -95,11 +101,11 @@ drift-check-reverse:
 	@echo "==> Drift check (reverse)..."
 	@./scripts/drift-check-reverse
 
-# MVP: forward + shape only
-drift-check-mvp: drift-check-forward drift-check-shape
+# MVP: coverage freshness + forward + reverse + shape
+drift-check-mvp: drift-check-coverage drift-check-forward drift-check-reverse drift-check-shape
 
-# Full: forward + reverse + shape
-drift-check-full: drift-check-forward drift-check-reverse drift-check-shape
+# Full: same as MVP (kept as an alias for check-full)
+drift-check-full: drift-check-mvp
 
 # Convenience alias
 drift-check: drift-check-mvp

--- a/behavior-model.json
+++ b/behavior-model.json
@@ -67,19 +67,6 @@
         ]
       }
     },
-    "CreateTopicMessage": {
-      "idempotent": false,
-      "readonly": false,
-      "retry": {
-        "backoff": "exponential",
-        "base_delay_ms": 1000,
-        "max": 2,
-        "retry_on": [
-          429,
-          503
-        ]
-      }
-    },
     "DeleteCalendarTodo": {
       "idempotent": true,
       "readonly": false,
@@ -379,19 +366,6 @@
         ]
       }
     },
-    "IgnorePosting": {
-      "idempotent": false,
-      "readonly": false,
-      "retry": {
-        "backoff": "exponential",
-        "base_delay_ms": 1000,
-        "max": 2,
-        "retry_on": [
-          429,
-          503
-        ]
-      }
-    },
     "ListBoxes": {
       "idempotent": false,
       "pagination": {
@@ -482,7 +456,7 @@
         ]
       }
     },
-    "MovePostingToFeed": {
+    "MovePostings": {
       "idempotent": false,
       "readonly": false,
       "retry": {
@@ -495,46 +469,7 @@
         ]
       }
     },
-    "MovePostingToPaperTrail": {
-      "idempotent": false,
-      "readonly": false,
-      "retry": {
-        "backoff": "exponential",
-        "base_delay_ms": 1000,
-        "max": 2,
-        "retry_on": [
-          429,
-          503
-        ]
-      }
-    },
-    "MovePostingToReplyLater": {
-      "idempotent": false,
-      "readonly": false,
-      "retry": {
-        "backoff": "exponential",
-        "base_delay_ms": 1000,
-        "max": 2,
-        "retry_on": [
-          429,
-          503
-        ]
-      }
-    },
-    "MovePostingToSetAside": {
-      "idempotent": false,
-      "readonly": false,
-      "retry": {
-        "backoff": "exponential",
-        "base_delay_ms": 1000,
-        "max": 2,
-        "retry_on": [
-          429,
-          503
-        ]
-      }
-    },
-    "MovePostingToTrash": {
+    "MutePostings": {
       "idempotent": false,
       "readonly": false,
       "retry": {
@@ -577,6 +512,19 @@
         ]
       }
     },
+    "TrashPostings": {
+      "idempotent": false,
+      "readonly": false,
+      "retry": {
+        "backoff": "exponential",
+        "base_delay_ms": 1000,
+        "max": 2,
+        "retry_on": [
+          429,
+          503
+        ]
+      }
+    },
     "UncompleteCalendarTodo": {
       "idempotent": true,
       "readonly": false,
@@ -597,6 +545,19 @@
         "backoff": "exponential",
         "base_delay_ms": 1000,
         "max": 3,
+        "retry_on": [
+          429,
+          503
+        ]
+      }
+    },
+    "UnmutePostings": {
+      "idempotent": true,
+      "readonly": false,
+      "retry": {
+        "backoff": "exponential",
+        "base_delay_ms": 1000,
+        "max": 2,
         "retry_on": [
           429,
           503

--- a/conformance/runner/go/main.go
+++ b/conformance/runner/go/main.go
@@ -785,16 +785,6 @@ func executeOperation(client *generated.Client, ctx context.Context, tc TestCase
 			},
 		}
 		return client.CreateMessage(ctx, body)
-	case "CreateTopicMessage":
-		topicId := getInt64Param(tc.PathParams, "topicId")
-		body := generated.CreateTopicMessageJSONRequestBody{
-			Message: generated.TopicMessagePayload{
-				Content: getStringParam(tc.RequestBody, "content"),
-			},
-		}
-		return client.CreateTopicMessage(ctx, topicId, body)
-
-	// Entries
 	case "ListDrafts":
 		return client.ListDrafts(ctx, nil)
 	case "CreateReply":
@@ -891,24 +881,25 @@ func executeOperation(client *generated.Client, ctx context.Context, tc TestCase
 			PostingIds: getInt64SliceParam(tc.RequestBody, "posting_ids"),
 		}
 		return client.MarkPostingsUnseen(ctx, body)
-	case "MovePostingToFeed":
-		postingId := getInt64Param(tc.PathParams, "postingId")
-		return client.MovePostingToFeed(ctx, postingId)
-	case "MovePostingToSetAside":
-		postingId := getInt64Param(tc.PathParams, "postingId")
-		return client.MovePostingToSetAside(ctx, postingId)
-	case "MovePostingToReplyLater":
-		postingId := getInt64Param(tc.PathParams, "postingId")
-		return client.MovePostingToReplyLater(ctx, postingId)
-	case "MovePostingToPaperTrail":
-		postingId := getInt64Param(tc.PathParams, "postingId")
-		return client.MovePostingToPaperTrail(ctx, postingId)
-	case "MovePostingToTrash":
-		postingId := getInt64Param(tc.PathParams, "postingId")
-		return client.MovePostingToTrash(ctx, postingId)
-	case "IgnorePosting":
-		postingId := getInt64Param(tc.PathParams, "postingId")
-		return client.IgnorePosting(ctx, postingId)
+	case "MovePostings":
+		body := generated.MovePostingsJSONRequestBody{
+			PostingIds: getInt64SliceParam(tc.RequestBody, "posting_ids"),
+			BoxId:      getInt64Param(tc.RequestBody, "box_id"),
+		}
+		return client.MovePostings(ctx, body)
+	case "TrashPostings":
+		body := generated.TrashPostingsJSONRequestBody{
+			PostingIds: getInt64SliceParam(tc.RequestBody, "posting_ids"),
+		}
+		return client.TrashPostings(ctx, body)
+	case "MutePostings":
+		body := generated.MutePostingsJSONRequestBody{
+			PostingIds: getInt64SliceParam(tc.RequestBody, "posting_ids"),
+		}
+		return client.MutePostings(ctx, body)
+	case "UnmutePostings":
+		params := &generated.UnmutePostingsParams{PostingIds: getStringParam(tc.QueryParams, "posting_ids")}
+		return client.UnmutePostings(ctx, params)
 
 	default:
 		return nil, fmt.Errorf("unknown operation: %s", tc.Operation)

--- a/conformance/tests/paths.json
+++ b/conformance/tests/paths.json
@@ -5,15 +5,28 @@
     "operation": "CompleteCalendarTodo",
     "method": "POST",
     "path": "/calendar/todos/{todoId}/completions",
-    "pathParams": {"todoId": 456},
+    "pathParams": {
+      "todoId": 456
+    },
     "mockResponses": [
-      {"status": 200, "body": {}}
+      {
+        "status": 200,
+        "body": {}
+      }
     ],
     "assertions": [
-      {"type": "requestPath", "expected": "/calendar/todos/456/completions"},
-      {"type": "noError"}
+      {
+        "type": "requestPath",
+        "expected": "/calendar/todos/456/completions"
+      },
+      {
+        "type": "noError"
+      }
     ],
-    "tags": ["path", "calendar-todos"]
+    "tags": [
+      "path",
+      "calendar-todos"
+    ]
   },
   {
     "name": "CompleteHabit uses /calendar/days/{day}/habits/{habitId}/completions path",
@@ -21,15 +34,29 @@
     "operation": "CompleteHabit",
     "method": "POST",
     "path": "/calendar/days/{day}/habits/{habitId}/completions",
-    "pathParams": {"day": "2026-03-04", "habitId": 789},
+    "pathParams": {
+      "day": "2026-03-04",
+      "habitId": 789
+    },
     "mockResponses": [
-      {"status": 200, "body": {}}
+      {
+        "status": 200,
+        "body": {}
+      }
     ],
     "assertions": [
-      {"type": "requestPath", "expected": "/calendar/days/2026-03-04/habits/789/completions"},
-      {"type": "noError"}
+      {
+        "type": "requestPath",
+        "expected": "/calendar/days/2026-03-04/habits/789/completions"
+      },
+      {
+        "type": "noError"
+      }
     ],
-    "tags": ["path", "calendar-habits"]
+    "tags": [
+      "path",
+      "calendar-habits"
+    ]
   },
   {
     "name": "CreateCalendarTodo uses /calendar/todos.json path",
@@ -37,15 +64,31 @@
     "operation": "CreateCalendarTodo",
     "method": "POST",
     "path": "/calendar/todos.json",
-    "requestBody": {"title": "New todo"},
+    "requestBody": {
+      "title": "New todo"
+    },
     "mockResponses": [
-      {"status": 200, "body": {"id": 123, "title": "New todo"}}
+      {
+        "status": 200,
+        "body": {
+          "id": 123,
+          "title": "New todo"
+        }
+      }
     ],
     "assertions": [
-      {"type": "requestPath", "expected": "/calendar/todos.json"},
-      {"type": "noError"}
+      {
+        "type": "requestPath",
+        "expected": "/calendar/todos.json"
+      },
+      {
+        "type": "noError"
+      }
     ],
-    "tags": ["path", "calendar-todos"]
+    "tags": [
+      "path",
+      "calendar-todos"
+    ]
   },
   {
     "name": "CreateMessage uses /messages.json path",
@@ -53,15 +96,32 @@
     "operation": "CreateMessage",
     "method": "POST",
     "path": "/messages.json",
-    "requestBody": {"subject": "Test", "content": "Hello"},
+    "requestBody": {
+      "subject": "Test",
+      "content": "Hello"
+    },
     "mockResponses": [
-      {"status": 200, "body": {"id": 123, "subject": "Test"}}
+      {
+        "status": 200,
+        "body": {
+          "id": 123,
+          "subject": "Test"
+        }
+      }
     ],
     "assertions": [
-      {"type": "requestPath", "expected": "/messages.json"},
-      {"type": "noError"}
+      {
+        "type": "requestPath",
+        "expected": "/messages.json"
+      },
+      {
+        "type": "noError"
+      }
     ],
-    "tags": ["path", "messages"]
+    "tags": [
+      "path",
+      "messages"
+    ]
   },
   {
     "name": "CreateReply uses /entries/{entryId}/replies.json path",
@@ -69,33 +129,34 @@
     "operation": "CreateReply",
     "method": "POST",
     "path": "/entries/{entryId}/replies.json",
-    "pathParams": {"entryId": 456},
-    "requestBody": {"content": "Reply text"},
+    "pathParams": {
+      "entryId": 456
+    },
+    "requestBody": {
+      "content": "Reply text"
+    },
     "mockResponses": [
-      {"status": 200, "body": {"id": 789, "content": "Reply text"}}
+      {
+        "status": 200,
+        "body": {
+          "id": 789,
+          "content": "Reply text"
+        }
+      }
     ],
     "assertions": [
-      {"type": "requestPath", "expected": "/entries/456/replies.json"},
-      {"type": "noError"}
+      {
+        "type": "requestPath",
+        "expected": "/entries/456/replies.json"
+      },
+      {
+        "type": "noError"
+      }
     ],
-    "tags": ["path", "entries"]
-  },
-  {
-    "name": "CreateTopicMessage uses /topics/{topicId}/entries.json path",
-    "description": "Verifies that CreateTopicMessage constructs the URL path /topics/{topicId}/entries.json",
-    "operation": "CreateTopicMessage",
-    "method": "POST",
-    "path": "/topics/{topicId}/entries.json",
-    "pathParams": {"topicId": 456},
-    "requestBody": {"content": "Topic reply"},
-    "mockResponses": [
-      {"status": 200, "body": {"id": 789, "content": "Topic reply"}}
-    ],
-    "assertions": [
-      {"type": "requestPath", "expected": "/topics/456/entries.json"},
-      {"type": "noError"}
-    ],
-    "tags": ["path", "topics"]
+    "tags": [
+      "path",
+      "entries"
+    ]
   },
   {
     "name": "DeleteCalendarTodo uses /calendar/todos/{todoId} path",
@@ -103,15 +164,27 @@
     "operation": "DeleteCalendarTodo",
     "method": "DELETE",
     "path": "/calendar/todos/{todoId}",
-    "pathParams": {"todoId": 456},
+    "pathParams": {
+      "todoId": 456
+    },
     "mockResponses": [
-      {"status": 200}
+      {
+        "status": 200
+      }
     ],
     "assertions": [
-      {"type": "requestPath", "expected": "/calendar/todos/456"},
-      {"type": "noError"}
+      {
+        "type": "requestPath",
+        "expected": "/calendar/todos/456"
+      },
+      {
+        "type": "noError"
+      }
     ],
-    "tags": ["path", "calendar-todos"]
+    "tags": [
+      "path",
+      "calendar-todos"
+    ]
   },
   {
     "name": "GetAsidebox uses /set_aside.json path",
@@ -120,13 +193,24 @@
     "method": "GET",
     "path": "/set_aside.json",
     "mockResponses": [
-      {"status": 200, "body": {}}
+      {
+        "status": 200,
+        "body": {}
+      }
     ],
     "assertions": [
-      {"type": "requestPath", "expected": "/set_aside.json"},
-      {"type": "noError"}
+      {
+        "type": "requestPath",
+        "expected": "/set_aside.json"
+      },
+      {
+        "type": "noError"
+      }
     ],
-    "tags": ["path", "boxes"]
+    "tags": [
+      "path",
+      "boxes"
+    ]
   },
   {
     "name": "GetBox uses /boxes/{boxId} path",
@@ -134,15 +218,30 @@
     "operation": "GetBox",
     "method": "GET",
     "path": "/boxes/{boxId}",
-    "pathParams": {"boxId": 123},
+    "pathParams": {
+      "boxId": 123
+    },
     "mockResponses": [
-      {"status": 200, "body": {"id": 123}}
+      {
+        "status": 200,
+        "body": {
+          "id": 123
+        }
+      }
     ],
     "assertions": [
-      {"type": "requestPath", "expected": "/boxes/123"},
-      {"type": "noError"}
+      {
+        "type": "requestPath",
+        "expected": "/boxes/123"
+      },
+      {
+        "type": "noError"
+      }
     ],
-    "tags": ["path", "boxes"]
+    "tags": [
+      "path",
+      "boxes"
+    ]
   },
   {
     "name": "GetBubblebox uses /bubble_up.json path",
@@ -151,13 +250,24 @@
     "method": "GET",
     "path": "/bubble_up.json",
     "mockResponses": [
-      {"status": 200, "body": {}}
+      {
+        "status": 200,
+        "body": {}
+      }
     ],
     "assertions": [
-      {"type": "requestPath", "expected": "/bubble_up.json"},
-      {"type": "noError"}
+      {
+        "type": "requestPath",
+        "expected": "/bubble_up.json"
+      },
+      {
+        "type": "noError"
+      }
     ],
-    "tags": ["path", "boxes"]
+    "tags": [
+      "path",
+      "boxes"
+    ]
   },
   {
     "name": "GetCalendarRecordings uses /calendars/{calendarId}/recordings path",
@@ -165,15 +275,28 @@
     "operation": "GetCalendarRecordings",
     "method": "GET",
     "path": "/calendars/{calendarId}/recordings",
-    "pathParams": {"calendarId": 456},
+    "pathParams": {
+      "calendarId": 456
+    },
     "mockResponses": [
-      {"status": 200, "body": []}
+      {
+        "status": 200,
+        "body": []
+      }
     ],
     "assertions": [
-      {"type": "requestPath", "expected": "/calendars/456/recordings"},
-      {"type": "noError"}
+      {
+        "type": "requestPath",
+        "expected": "/calendars/456/recordings"
+      },
+      {
+        "type": "noError"
+      }
     ],
-    "tags": ["path", "calendars"]
+    "tags": [
+      "path",
+      "calendars"
+    ]
   },
   {
     "name": "GetContact uses /contacts/{contactId} path",
@@ -181,15 +304,30 @@
     "operation": "GetContact",
     "method": "GET",
     "path": "/contacts/{contactId}",
-    "pathParams": {"contactId": 789},
+    "pathParams": {
+      "contactId": 789
+    },
     "mockResponses": [
-      {"status": 200, "body": {"id": 789}}
+      {
+        "status": 200,
+        "body": {
+          "id": 789
+        }
+      }
     ],
     "assertions": [
-      {"type": "requestPath", "expected": "/contacts/789"},
-      {"type": "noError"}
+      {
+        "type": "requestPath",
+        "expected": "/contacts/789"
+      },
+      {
+        "type": "noError"
+      }
     ],
-    "tags": ["path", "contacts"]
+    "tags": [
+      "path",
+      "contacts"
+    ]
   },
   {
     "name": "GetEverythingTopics uses /topics/everything.json path",
@@ -198,13 +336,24 @@
     "method": "GET",
     "path": "/topics/everything.json",
     "mockResponses": [
-      {"status": 200, "body": []}
+      {
+        "status": 200,
+        "body": []
+      }
     ],
     "assertions": [
-      {"type": "requestPath", "expected": "/topics/everything.json"},
-      {"type": "noError"}
+      {
+        "type": "requestPath",
+        "expected": "/topics/everything.json"
+      },
+      {
+        "type": "noError"
+      }
     ],
-    "tags": ["path", "topics"]
+    "tags": [
+      "path",
+      "topics"
+    ]
   },
   {
     "name": "GetFeedbox uses /feedbox.json path",
@@ -213,13 +362,24 @@
     "method": "GET",
     "path": "/feedbox.json",
     "mockResponses": [
-      {"status": 200, "body": {}}
+      {
+        "status": 200,
+        "body": {}
+      }
     ],
     "assertions": [
-      {"type": "requestPath", "expected": "/feedbox.json"},
-      {"type": "noError"}
+      {
+        "type": "requestPath",
+        "expected": "/feedbox.json"
+      },
+      {
+        "type": "noError"
+      }
     ],
-    "tags": ["path", "boxes"]
+    "tags": [
+      "path",
+      "boxes"
+    ]
   },
   {
     "name": "GetIdentity uses /identity.json path",
@@ -228,13 +388,27 @@
     "method": "GET",
     "path": "/identity.json",
     "mockResponses": [
-      {"status": 200, "body": {"id": 1, "email_address": "user@hey.com"}}
+      {
+        "status": 200,
+        "body": {
+          "id": 1,
+          "email_address": "user@hey.com"
+        }
+      }
     ],
     "assertions": [
-      {"type": "requestPath", "expected": "/identity.json"},
-      {"type": "noError"}
+      {
+        "type": "requestPath",
+        "expected": "/identity.json"
+      },
+      {
+        "type": "noError"
+      }
     ],
-    "tags": ["path", "identity"]
+    "tags": [
+      "path",
+      "identity"
+    ]
   },
   {
     "name": "GetImbox uses /imbox.json path",
@@ -243,13 +417,24 @@
     "method": "GET",
     "path": "/imbox.json",
     "mockResponses": [
-      {"status": 200, "body": {}}
+      {
+        "status": 200,
+        "body": {}
+      }
     ],
     "assertions": [
-      {"type": "requestPath", "expected": "/imbox.json"},
-      {"type": "noError"}
+      {
+        "type": "requestPath",
+        "expected": "/imbox.json"
+      },
+      {
+        "type": "noError"
+      }
     ],
-    "tags": ["path", "boxes"]
+    "tags": [
+      "path",
+      "boxes"
+    ]
   },
   {
     "name": "GetJournalEntry uses /calendar/days/{day}/journal_entry path",
@@ -257,15 +442,30 @@
     "operation": "GetJournalEntry",
     "method": "GET",
     "path": "/calendar/days/{day}/journal_entry",
-    "pathParams": {"day": "2026-03-04"},
+    "pathParams": {
+      "day": "2026-03-04"
+    },
     "mockResponses": [
-      {"status": 200, "body": {"body": "Today's entry"}}
+      {
+        "status": 200,
+        "body": {
+          "body": "Today's entry"
+        }
+      }
     ],
     "assertions": [
-      {"type": "requestPath", "expected": "/calendar/days/2026-03-04/journal_entry"},
-      {"type": "noError"}
+      {
+        "type": "requestPath",
+        "expected": "/calendar/days/2026-03-04/journal_entry"
+      },
+      {
+        "type": "noError"
+      }
     ],
-    "tags": ["path", "calendar-journal"]
+    "tags": [
+      "path",
+      "calendar-journal"
+    ]
   },
   {
     "name": "GetLaterbox uses /reply_later.json path",
@@ -274,13 +474,24 @@
     "method": "GET",
     "path": "/reply_later.json",
     "mockResponses": [
-      {"status": 200, "body": {}}
+      {
+        "status": 200,
+        "body": {}
+      }
     ],
     "assertions": [
-      {"type": "requestPath", "expected": "/reply_later.json"},
-      {"type": "noError"}
+      {
+        "type": "requestPath",
+        "expected": "/reply_later.json"
+      },
+      {
+        "type": "noError"
+      }
     ],
-    "tags": ["path", "boxes"]
+    "tags": [
+      "path",
+      "boxes"
+    ]
   },
   {
     "name": "GetMessage uses /messages/{messageId} path",
@@ -288,15 +499,31 @@
     "operation": "GetMessage",
     "method": "GET",
     "path": "/messages/{messageId}",
-    "pathParams": {"messageId": 456},
+    "pathParams": {
+      "messageId": 456
+    },
     "mockResponses": [
-      {"status": 200, "body": {"id": 456, "subject": "Hello"}}
+      {
+        "status": 200,
+        "body": {
+          "id": 456,
+          "subject": "Hello"
+        }
+      }
     ],
     "assertions": [
-      {"type": "requestPath", "expected": "/messages/456"},
-      {"type": "noError"}
+      {
+        "type": "requestPath",
+        "expected": "/messages/456"
+      },
+      {
+        "type": "noError"
+      }
     ],
-    "tags": ["path", "messages"]
+    "tags": [
+      "path",
+      "messages"
+    ]
   },
   {
     "name": "GetNavigation uses /my/navigation.json path",
@@ -305,13 +532,24 @@
     "method": "GET",
     "path": "/my/navigation.json",
     "mockResponses": [
-      {"status": 200, "body": {}}
+      {
+        "status": 200,
+        "body": {}
+      }
     ],
     "assertions": [
-      {"type": "requestPath", "expected": "/my/navigation.json"},
-      {"type": "noError"}
+      {
+        "type": "requestPath",
+        "expected": "/my/navigation.json"
+      },
+      {
+        "type": "noError"
+      }
     ],
-    "tags": ["path", "navigation"]
+    "tags": [
+      "path",
+      "navigation"
+    ]
   },
   {
     "name": "GetOngoingTimeTrack uses /calendar/ongoing_time_track.json path",
@@ -320,13 +558,27 @@
     "method": "GET",
     "path": "/calendar/ongoing_time_track.json",
     "mockResponses": [
-      {"status": 200, "body": {"id": 123, "started_at": "2026-03-04T10:00:00Z"}}
+      {
+        "status": 200,
+        "body": {
+          "id": 123,
+          "started_at": "2026-03-04T10:00:00Z"
+        }
+      }
     ],
     "assertions": [
-      {"type": "requestPath", "expected": "/calendar/ongoing_time_track.json"},
-      {"type": "noError"}
+      {
+        "type": "requestPath",
+        "expected": "/calendar/ongoing_time_track.json"
+      },
+      {
+        "type": "noError"
+      }
     ],
-    "tags": ["path", "calendar-time-tracks"]
+    "tags": [
+      "path",
+      "calendar-time-tracks"
+    ]
   },
   {
     "name": "GetSentTopics uses /topics/sent.json path",
@@ -335,13 +587,24 @@
     "method": "GET",
     "path": "/topics/sent.json",
     "mockResponses": [
-      {"status": 200, "body": []}
+      {
+        "status": 200,
+        "body": []
+      }
     ],
     "assertions": [
-      {"type": "requestPath", "expected": "/topics/sent.json"},
-      {"type": "noError"}
+      {
+        "type": "requestPath",
+        "expected": "/topics/sent.json"
+      },
+      {
+        "type": "noError"
+      }
     ],
-    "tags": ["path", "topics"]
+    "tags": [
+      "path",
+      "topics"
+    ]
   },
   {
     "name": "GetSpamTopics uses /topics/spam.json path",
@@ -350,13 +613,24 @@
     "method": "GET",
     "path": "/topics/spam.json",
     "mockResponses": [
-      {"status": 200, "body": []}
+      {
+        "status": 200,
+        "body": []
+      }
     ],
     "assertions": [
-      {"type": "requestPath", "expected": "/topics/spam.json"},
-      {"type": "noError"}
+      {
+        "type": "requestPath",
+        "expected": "/topics/spam.json"
+      },
+      {
+        "type": "noError"
+      }
     ],
-    "tags": ["path", "topics"]
+    "tags": [
+      "path",
+      "topics"
+    ]
   },
   {
     "name": "GetTopic uses /topics/{topicId} path",
@@ -364,15 +638,30 @@
     "operation": "GetTopic",
     "method": "GET",
     "path": "/topics/{topicId}",
-    "pathParams": {"topicId": 456},
+    "pathParams": {
+      "topicId": 456
+    },
     "mockResponses": [
-      {"status": 200, "body": {"id": 456}}
+      {
+        "status": 200,
+        "body": {
+          "id": 456
+        }
+      }
     ],
     "assertions": [
-      {"type": "requestPath", "expected": "/topics/456"},
-      {"type": "noError"}
+      {
+        "type": "requestPath",
+        "expected": "/topics/456"
+      },
+      {
+        "type": "noError"
+      }
     ],
-    "tags": ["path", "topics"]
+    "tags": [
+      "path",
+      "topics"
+    ]
   },
   {
     "name": "GetTopicEntries uses /topics/{topicId}/entries path",
@@ -380,15 +669,28 @@
     "operation": "GetTopicEntries",
     "method": "GET",
     "path": "/topics/{topicId}/entries",
-    "pathParams": {"topicId": 456},
+    "pathParams": {
+      "topicId": 456
+    },
     "mockResponses": [
-      {"status": 200, "body": []}
+      {
+        "status": 200,
+        "body": []
+      }
     ],
     "assertions": [
-      {"type": "requestPath", "expected": "/topics/456/entries"},
-      {"type": "noError"}
+      {
+        "type": "requestPath",
+        "expected": "/topics/456/entries"
+      },
+      {
+        "type": "noError"
+      }
     ],
-    "tags": ["path", "topics"]
+    "tags": [
+      "path",
+      "topics"
+    ]
   },
   {
     "name": "GetTrailbox uses /paper_trail.json path",
@@ -397,13 +699,24 @@
     "method": "GET",
     "path": "/paper_trail.json",
     "mockResponses": [
-      {"status": 200, "body": {}}
+      {
+        "status": 200,
+        "body": {}
+      }
     ],
     "assertions": [
-      {"type": "requestPath", "expected": "/paper_trail.json"},
-      {"type": "noError"}
+      {
+        "type": "requestPath",
+        "expected": "/paper_trail.json"
+      },
+      {
+        "type": "noError"
+      }
     ],
-    "tags": ["path", "boxes"]
+    "tags": [
+      "path",
+      "boxes"
+    ]
   },
   {
     "name": "GetTrashTopics uses /topics/trash.json path",
@@ -412,13 +725,24 @@
     "method": "GET",
     "path": "/topics/trash.json",
     "mockResponses": [
-      {"status": 200, "body": []}
+      {
+        "status": 200,
+        "body": []
+      }
     ],
     "assertions": [
-      {"type": "requestPath", "expected": "/topics/trash.json"},
-      {"type": "noError"}
+      {
+        "type": "requestPath",
+        "expected": "/topics/trash.json"
+      },
+      {
+        "type": "noError"
+      }
     ],
-    "tags": ["path", "topics"]
+    "tags": [
+      "path",
+      "topics"
+    ]
   },
   {
     "name": "ListBoxes uses /boxes.json path",
@@ -427,13 +751,24 @@
     "method": "GET",
     "path": "/boxes.json",
     "mockResponses": [
-      {"status": 200, "body": []}
+      {
+        "status": 200,
+        "body": []
+      }
     ],
     "assertions": [
-      {"type": "requestPath", "expected": "/boxes.json"},
-      {"type": "noError"}
+      {
+        "type": "requestPath",
+        "expected": "/boxes.json"
+      },
+      {
+        "type": "noError"
+      }
     ],
-    "tags": ["path", "boxes"]
+    "tags": [
+      "path",
+      "boxes"
+    ]
   },
   {
     "name": "ListCalendars uses /calendars.json path",
@@ -442,13 +777,24 @@
     "method": "GET",
     "path": "/calendars.json",
     "mockResponses": [
-      {"status": 200, "body": []}
+      {
+        "status": 200,
+        "body": []
+      }
     ],
     "assertions": [
-      {"type": "requestPath", "expected": "/calendars.json"},
-      {"type": "noError"}
+      {
+        "type": "requestPath",
+        "expected": "/calendars.json"
+      },
+      {
+        "type": "noError"
+      }
     ],
-    "tags": ["path", "calendars"]
+    "tags": [
+      "path",
+      "calendars"
+    ]
   },
   {
     "name": "ListContacts uses /contacts.json path",
@@ -457,13 +803,24 @@
     "method": "GET",
     "path": "/contacts.json",
     "mockResponses": [
-      {"status": 200, "body": []}
+      {
+        "status": 200,
+        "body": []
+      }
     ],
     "assertions": [
-      {"type": "requestPath", "expected": "/contacts.json"},
-      {"type": "noError"}
+      {
+        "type": "requestPath",
+        "expected": "/contacts.json"
+      },
+      {
+        "type": "noError"
+      }
     ],
-    "tags": ["path", "contacts"]
+    "tags": [
+      "path",
+      "contacts"
+    ]
   },
   {
     "name": "ListDrafts uses /entries/drafts.json path",
@@ -472,13 +829,24 @@
     "method": "GET",
     "path": "/entries/drafts.json",
     "mockResponses": [
-      {"status": 200, "body": []}
+      {
+        "status": 200,
+        "body": []
+      }
     ],
     "assertions": [
-      {"type": "requestPath", "expected": "/entries/drafts.json"},
-      {"type": "noError"}
+      {
+        "type": "requestPath",
+        "expected": "/entries/drafts.json"
+      },
+      {
+        "type": "noError"
+      }
     ],
-    "tags": ["path", "entries"]
+    "tags": [
+      "path",
+      "entries"
+    ]
   },
   {
     "name": "Search uses /search.json path",
@@ -486,15 +854,28 @@
     "operation": "Search",
     "method": "GET",
     "path": "/search.json",
-    "queryParams": {"q": "test query"},
+    "queryParams": {
+      "q": "test query"
+    },
     "mockResponses": [
-      {"status": 200, "body": []}
+      {
+        "status": 200,
+        "body": []
+      }
     ],
     "assertions": [
-      {"type": "requestPath", "expected": "/search.json"},
-      {"type": "noError"}
+      {
+        "type": "requestPath",
+        "expected": "/search.json"
+      },
+      {
+        "type": "noError"
+      }
     ],
-    "tags": ["path", "search"]
+    "tags": [
+      "path",
+      "search"
+    ]
   },
   {
     "name": "StartTimeTrack uses /calendar/ongoing_time_track.json path",
@@ -503,13 +884,27 @@
     "method": "POST",
     "path": "/calendar/ongoing_time_track.json",
     "mockResponses": [
-      {"status": 200, "body": {"id": 123, "started_at": "2026-03-04T10:00:00Z"}}
+      {
+        "status": 200,
+        "body": {
+          "id": 123,
+          "started_at": "2026-03-04T10:00:00Z"
+        }
+      }
     ],
     "assertions": [
-      {"type": "requestPath", "expected": "/calendar/ongoing_time_track.json"},
-      {"type": "noError"}
+      {
+        "type": "requestPath",
+        "expected": "/calendar/ongoing_time_track.json"
+      },
+      {
+        "type": "noError"
+      }
     ],
-    "tags": ["path", "calendar-time-tracks"]
+    "tags": [
+      "path",
+      "calendar-time-tracks"
+    ]
   },
   {
     "name": "UncompleteCalendarTodo uses /calendar/todos/{todoId}/completions path",
@@ -517,15 +912,28 @@
     "operation": "UncompleteCalendarTodo",
     "method": "DELETE",
     "path": "/calendar/todos/{todoId}/completions",
-    "pathParams": {"todoId": 456},
+    "pathParams": {
+      "todoId": 456
+    },
     "mockResponses": [
-      {"status": 200, "body": {}}
+      {
+        "status": 200,
+        "body": {}
+      }
     ],
     "assertions": [
-      {"type": "requestPath", "expected": "/calendar/todos/456/completions"},
-      {"type": "noError"}
+      {
+        "type": "requestPath",
+        "expected": "/calendar/todos/456/completions"
+      },
+      {
+        "type": "noError"
+      }
     ],
-    "tags": ["path", "calendar-todos"]
+    "tags": [
+      "path",
+      "calendar-todos"
+    ]
   },
   {
     "name": "UncompleteHabit uses /calendar/days/{day}/habits/{habitId}/completions path",
@@ -533,15 +941,29 @@
     "operation": "UncompleteHabit",
     "method": "DELETE",
     "path": "/calendar/days/{day}/habits/{habitId}/completions",
-    "pathParams": {"day": "2026-03-04", "habitId": 789},
+    "pathParams": {
+      "day": "2026-03-04",
+      "habitId": 789
+    },
     "mockResponses": [
-      {"status": 200, "body": {}}
+      {
+        "status": 200,
+        "body": {}
+      }
     ],
     "assertions": [
-      {"type": "requestPath", "expected": "/calendar/days/2026-03-04/habits/789/completions"},
-      {"type": "noError"}
+      {
+        "type": "requestPath",
+        "expected": "/calendar/days/2026-03-04/habits/789/completions"
+      },
+      {
+        "type": "noError"
+      }
     ],
-    "tags": ["path", "calendar-habits"]
+    "tags": [
+      "path",
+      "calendar-habits"
+    ]
   },
   {
     "name": "UpdateJournalEntry uses /calendar/days/{day}/journal_entry path",
@@ -549,16 +971,33 @@
     "operation": "UpdateJournalEntry",
     "method": "PATCH",
     "path": "/calendar/days/{day}/journal_entry",
-    "pathParams": {"day": "2026-03-04"},
-    "requestBody": {"body": "Updated content"},
+    "pathParams": {
+      "day": "2026-03-04"
+    },
+    "requestBody": {
+      "body": "Updated content"
+    },
     "mockResponses": [
-      {"status": 200, "body": {"body": "Updated content"}}
+      {
+        "status": 200,
+        "body": {
+          "body": "Updated content"
+        }
+      }
     ],
     "assertions": [
-      {"type": "requestPath", "expected": "/calendar/days/2026-03-04/journal_entry"},
-      {"type": "noError"}
+      {
+        "type": "requestPath",
+        "expected": "/calendar/days/2026-03-04/journal_entry"
+      },
+      {
+        "type": "noError"
+      }
     ],
-    "tags": ["path", "calendar-journal"]
+    "tags": [
+      "path",
+      "calendar-journal"
+    ]
   },
   {
     "name": "UpdateTimeTrack uses /calendar/time_tracks/{timeTrackId} path",
@@ -566,15 +1005,223 @@
     "operation": "UpdateTimeTrack",
     "method": "PUT",
     "path": "/calendar/time_tracks/{timeTrackId}",
-    "pathParams": {"timeTrackId": 789},
-    "requestBody": {"stopped": true},
+    "pathParams": {
+      "timeTrackId": 789
+    },
+    "requestBody": {
+      "stopped": true
+    },
     "mockResponses": [
-      {"status": 200, "body": {"id": 789, "stopped": true}}
+      {
+        "status": 200,
+        "body": {
+          "id": 789,
+          "stopped": true
+        }
+      }
     ],
     "assertions": [
-      {"type": "requestPath", "expected": "/calendar/time_tracks/789"},
-      {"type": "noError"}
+      {
+        "type": "requestPath",
+        "expected": "/calendar/time_tracks/789"
+      },
+      {
+        "type": "noError"
+      }
     ],
-    "tags": ["path", "calendar-time-tracks"]
+    "tags": [
+      "path",
+      "calendar-time-tracks"
+    ]
+  },
+  {
+    "name": "MarkPostingsSeen uses /postings/seen.json path",
+    "description": "Verifies that MarkPostingsSeen constructs the URL path /postings/seen.json",
+    "operation": "MarkPostingsSeen",
+    "method": "POST",
+    "path": "/postings/seen.json",
+    "requestBody": {
+      "posting_ids": [
+        1,
+        2
+      ]
+    },
+    "mockResponses": [
+      {
+        "status": 201,
+        "body": {}
+      }
+    ],
+    "assertions": [
+      {
+        "type": "requestPath",
+        "expected": "/postings/seen.json"
+      },
+      {
+        "type": "noError"
+      }
+    ],
+    "tags": [
+      "path",
+      "postings"
+    ]
+  },
+  {
+    "name": "MarkPostingsUnseen uses /postings/unseen.json path",
+    "description": "Verifies that MarkPostingsUnseen constructs the URL path /postings/unseen.json",
+    "operation": "MarkPostingsUnseen",
+    "method": "POST",
+    "path": "/postings/unseen.json",
+    "requestBody": {
+      "posting_ids": [
+        1,
+        2
+      ]
+    },
+    "mockResponses": [
+      {
+        "status": 201,
+        "body": {}
+      }
+    ],
+    "assertions": [
+      {
+        "type": "requestPath",
+        "expected": "/postings/unseen.json"
+      },
+      {
+        "type": "noError"
+      }
+    ],
+    "tags": [
+      "path",
+      "postings"
+    ]
+  },
+  {
+    "name": "MovePostings uses /postings/moves.json path",
+    "description": "Verifies that MovePostings constructs the URL path /postings/moves.json",
+    "operation": "MovePostings",
+    "method": "POST",
+    "path": "/postings/moves.json",
+    "requestBody": {
+      "posting_ids": [
+        1,
+        2
+      ],
+      "box_id": 24089
+    },
+    "mockResponses": [
+      {
+        "status": 204,
+        "body": {}
+      }
+    ],
+    "assertions": [
+      {
+        "type": "requestPath",
+        "expected": "/postings/moves.json"
+      },
+      {
+        "type": "noError"
+      }
+    ],
+    "tags": [
+      "path",
+      "postings"
+    ]
+  },
+  {
+    "name": "TrashPostings uses /postings/trash.json path",
+    "description": "Verifies that TrashPostings constructs the URL path /postings/trash.json",
+    "operation": "TrashPostings",
+    "method": "POST",
+    "path": "/postings/trash.json",
+    "requestBody": {
+      "posting_ids": [
+        1,
+        2
+      ]
+    },
+    "mockResponses": [
+      {
+        "status": 204,
+        "body": {}
+      }
+    ],
+    "assertions": [
+      {
+        "type": "requestPath",
+        "expected": "/postings/trash.json"
+      },
+      {
+        "type": "noError"
+      }
+    ],
+    "tags": [
+      "path",
+      "postings"
+    ]
+  },
+  {
+    "name": "MutePostings uses /postings/mutings.json path",
+    "description": "Verifies that MutePostings constructs the URL path /postings/mutings.json",
+    "operation": "MutePostings",
+    "method": "POST",
+    "path": "/postings/mutings.json",
+    "requestBody": {
+      "posting_ids": [
+        1,
+        2
+      ]
+    },
+    "mockResponses": [
+      {
+        "status": 201,
+        "body": {}
+      }
+    ],
+    "assertions": [
+      {
+        "type": "requestPath",
+        "expected": "/postings/mutings.json"
+      },
+      {
+        "type": "noError"
+      }
+    ],
+    "tags": [
+      "path",
+      "postings"
+    ]
+  },
+  {
+    "name": "UnmutePostings uses /postings/mutings.json path",
+    "description": "Verifies that UnmutePostings constructs the URL path /postings/mutings.json",
+    "operation": "UnmutePostings",
+    "method": "DELETE",
+    "path": "/postings/mutings.json",
+    "queryParams": {
+      "posting_ids": "1,2"
+    },
+    "mockResponses": [
+      {
+        "status": 201,
+        "body": {}
+      }
+    ],
+    "assertions": [
+      {
+        "type": "requestPath",
+        "expected": "/postings/mutings.json"
+      },
+      {
+        "type": "noError"
+      }
+    ],
+    "tags": [
+      "path",
+      "postings"
+    ]
   }
 ]

--- a/go/pkg/generated/client.gen.go
+++ b/go/pkg/generated/client.gen.go
@@ -225,16 +225,11 @@ type CreateMessageRequestContent struct {
 	Message        MessagePayload      `json:"message"`
 }
 
-// CreateReplyRequestContent Wire format: {acting_sender_id, message: {content}}
+// CreateReplyRequestContent Wire format: {acting_sender_id, message: {content}, entry: {addressed: {directly: [...]}}}
 type CreateReplyRequestContent struct {
 	ActingSenderId int64               `json:"acting_sender_id"`
+	Entry          MessageEntryPayload `json:"entry,omitempty"`
 	Message        ReplyMessagePayload `json:"message"`
-}
-
-// CreateTopicMessageRequestContent Wire format: {acting_sender_id, message: {content}}
-type CreateTopicMessageRequestContent struct {
-	ActingSenderId int64               `json:"acting_sender_id"`
-	Message        TopicMessagePayload `json:"message"`
 }
 
 // Domain Domain — email domain
@@ -471,16 +466,20 @@ type Message struct {
 	Url       string    `json:"url,omitempty"`
 }
 
-// MessageAddressed Recipients as comma-separated email addresses.
+// MessageAddressed Recipients per kind, each a list of email addresses.
+// haystack applies Array() to each kind, so a JSON array is the correct wire format
+// (a bare string would be treated as a single address, not split on commas).
 type MessageAddressed struct {
-	Blindcopied string `json:"blindcopied,omitempty"`
-	Copied      string `json:"copied,omitempty"`
-	Directly    string `json:"directly,omitempty"`
+	Blindcopied []string `json:"blindcopied,omitempty"`
+	Copied      []string `json:"copied,omitempty"`
+	Directly    []string `json:"directly,omitempty"`
 }
 
 // MessageEntryPayload defines model for MessageEntryPayload.
 type MessageEntryPayload struct {
-	// Addressed Recipients as comma-separated email addresses.
+	// Addressed Recipients per kind, each a list of email addresses.
+	// haystack applies Array() to each kind, so a JSON array is the correct wire format
+	// (a bare string would be treated as a single address, not split on commas).
 	Addressed MessageAddressed `json:"addressed,omitempty"`
 }
 
@@ -493,6 +492,12 @@ type MessagePayload struct {
 // MessagePostingContext MessagePostingContext — posting context for a message
 type MessagePostingContext struct {
 	Box string `json:"box,omitempty"`
+}
+
+// MovePostingsRequestContent defines model for MovePostingsRequestContent.
+type MovePostingsRequestContent struct {
+	BoxId      int64   `json:"box_id"`
+	PostingIds []int64 `json:"posting_ids"`
 }
 
 // NavigationIcon NavigationIcon
@@ -774,11 +779,6 @@ type TopicListResponse struct {
 	Topics      []Topic `json:"topics,omitempty"`
 }
 
-// TopicMessagePayload defines model for TopicMessagePayload.
-type TopicMessagePayload struct {
-	Content string `json:"content"`
-}
-
 // UnauthorizedErrorResponseContent defines model for UnauthorizedErrorResponseContent.
 type UnauthorizedErrorResponseContent struct {
 	Message string `json:"message"`
@@ -915,6 +915,12 @@ type GetTrailboxParams struct {
 	Page string `form:"page,omitempty" json:"page,omitempty"`
 }
 
+// UnmutePostingsParams defines parameters for UnmutePostings.
+type UnmutePostingsParams struct {
+	// PostingIds Comma-separated posting IDs, e.g. "123,456"
+	PostingIds string `form:"posting_ids" json:"posting_ids"`
+}
+
 // GetLaterboxParams defines parameters for GetLaterbox.
 type GetLaterboxParams struct {
 	Page string `form:"page,omitempty" json:"page,omitempty"`
@@ -974,14 +980,20 @@ type CreateReplyJSONRequestBody = CreateReplyRequestContent
 // CreateMessageJSONRequestBody defines body for CreateMessage for application/json ContentType.
 type CreateMessageJSONRequestBody = CreateMessageRequestContent
 
+// MovePostingsJSONRequestBody defines body for MovePostings for application/json ContentType.
+type MovePostingsJSONRequestBody = MovePostingsRequestContent
+
+// MutePostingsJSONRequestBody defines body for MutePostings for application/json ContentType.
+type MutePostingsJSONRequestBody = MarkPostingsRequestContent
+
 // MarkPostingsSeenJSONRequestBody defines body for MarkPostingsSeen for application/json ContentType.
 type MarkPostingsSeenJSONRequestBody = MarkPostingsRequestContent
 
+// TrashPostingsJSONRequestBody defines body for TrashPostings for application/json ContentType.
+type TrashPostingsJSONRequestBody = MarkPostingsRequestContent
+
 // MarkPostingsUnseenJSONRequestBody defines body for MarkPostingsUnseen for application/json ContentType.
 type MarkPostingsUnseenJSONRequestBody = MarkPostingsRequestContent
-
-// CreateTopicMessageJSONRequestBody defines body for CreateTopicMessage for application/json ContentType.
-type CreateTopicMessageJSONRequestBody = CreateTopicMessageRequestContent
 
 // RequestEditorFn is the function signature for the RequestEditor callback function
 type RequestEditorFn func(ctx context.Context, req *http.Request) error
@@ -1304,33 +1316,33 @@ type ClientInterface interface {
 	// GetTrailbox request
 	GetTrailbox(ctx context.Context, params *GetTrailboxParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// MovePostingsWithBody request with any body
+	MovePostingsWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	MovePostings(ctx context.Context, body MovePostingsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UnmutePostings request
+	UnmutePostings(ctx context.Context, params *UnmutePostingsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// MutePostingsWithBody request with any body
+	MutePostingsWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	MutePostings(ctx context.Context, body MutePostingsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// MarkPostingsSeenWithBody request with any body
 	MarkPostingsSeenWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	MarkPostingsSeen(ctx context.Context, body MarkPostingsSeenJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// TrashPostingsWithBody request with any body
+	TrashPostingsWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	TrashPostings(ctx context.Context, body TrashPostingsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// MarkPostingsUnseenWithBody request with any body
 	MarkPostingsUnseenWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	MarkPostingsUnseen(ctx context.Context, body MarkPostingsUnseenJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
-
-	// IgnorePosting request
-	IgnorePosting(ctx context.Context, postingId int64, reqEditors ...RequestEditorFn) (*http.Response, error)
-
-	// MovePostingToSetAside request
-	MovePostingToSetAside(ctx context.Context, postingId int64, reqEditors ...RequestEditorFn) (*http.Response, error)
-
-	// MovePostingToFeed request
-	MovePostingToFeed(ctx context.Context, postingId int64, reqEditors ...RequestEditorFn) (*http.Response, error)
-
-	// MovePostingToReplyLater request
-	MovePostingToReplyLater(ctx context.Context, postingId int64, reqEditors ...RequestEditorFn) (*http.Response, error)
-
-	// MovePostingToPaperTrail request
-	MovePostingToPaperTrail(ctx context.Context, postingId int64, reqEditors ...RequestEditorFn) (*http.Response, error)
-
-	// MovePostingToTrash request
-	MovePostingToTrash(ctx context.Context, postingId int64, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetLaterbox request
 	GetLaterbox(ctx context.Context, params *GetLaterboxParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -1358,11 +1370,6 @@ type ClientInterface interface {
 
 	// GetTopicEntries request
 	GetTopicEntries(ctx context.Context, topicId int64, params *GetTopicEntriesParams, reqEditors ...RequestEditorFn) (*http.Response, error)
-
-	// CreateTopicMessageWithBody request with any body
-	CreateTopicMessageWithBody(ctx context.Context, topicId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
-
-	CreateTopicMessage(ctx context.Context, topicId int64, body CreateTopicMessageJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 }
 
 // ListBoxes is marked as idempotent and will be retried on transient failures.
@@ -1743,6 +1750,76 @@ func (c *Client) GetTrailbox(ctx context.Context, params *GetTrailboxParams, req
 
 }
 
+// MovePostingsWithBody executes the MovePostings operation.
+
+func (c *Client) MovePostingsWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+
+	req, err := NewMovePostingsRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+
+}
+
+func (c *Client) MovePostings(ctx context.Context, body MovePostingsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+
+	req, err := NewMovePostingsRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+
+}
+
+// UnmutePostings is marked as idempotent and will be retried on transient failures.
+
+func (c *Client) UnmutePostings(ctx context.Context, params *UnmutePostingsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		return NewUnmutePostingsRequest(c.Server, params)
+	}, true, "UnmutePostings", reqEditors...)
+
+}
+
+// MutePostingsWithBody executes the MutePostings operation.
+
+func (c *Client) MutePostingsWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+
+	req, err := NewMutePostingsRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+
+}
+
+func (c *Client) MutePostings(ctx context.Context, body MutePostingsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+
+	req, err := NewMutePostingsRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+
+}
+
 // MarkPostingsSeenWithBody executes the MarkPostingsSeen operation.
 
 func (c *Client) MarkPostingsSeenWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
@@ -1773,6 +1850,36 @@ func (c *Client) MarkPostingsSeen(ctx context.Context, body MarkPostingsSeenJSON
 
 }
 
+// TrashPostingsWithBody executes the TrashPostings operation.
+
+func (c *Client) TrashPostingsWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+
+	req, err := NewTrashPostingsRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+
+}
+
+func (c *Client) TrashPostings(ctx context.Context, body TrashPostingsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+
+	req, err := NewTrashPostingsRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+
+}
+
 // MarkPostingsUnseenWithBody executes the MarkPostingsUnseen operation.
 
 func (c *Client) MarkPostingsUnseenWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
@@ -1792,102 +1899,6 @@ func (c *Client) MarkPostingsUnseenWithBody(ctx context.Context, contentType str
 func (c *Client) MarkPostingsUnseen(ctx context.Context, body MarkPostingsUnseenJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 
 	req, err := NewMarkPostingsUnseenRequest(c.Server, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
-}
-
-// IgnorePosting executes the IgnorePosting operation.
-
-func (c *Client) IgnorePosting(ctx context.Context, postingId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewIgnorePostingRequest(c.Server, postingId)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
-}
-
-// MovePostingToSetAside executes the MovePostingToSetAside operation.
-
-func (c *Client) MovePostingToSetAside(ctx context.Context, postingId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewMovePostingToSetAsideRequest(c.Server, postingId)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
-}
-
-// MovePostingToFeed executes the MovePostingToFeed operation.
-
-func (c *Client) MovePostingToFeed(ctx context.Context, postingId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewMovePostingToFeedRequest(c.Server, postingId)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
-}
-
-// MovePostingToReplyLater executes the MovePostingToReplyLater operation.
-
-func (c *Client) MovePostingToReplyLater(ctx context.Context, postingId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewMovePostingToReplyLaterRequest(c.Server, postingId)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
-}
-
-// MovePostingToPaperTrail executes the MovePostingToPaperTrail operation.
-
-func (c *Client) MovePostingToPaperTrail(ctx context.Context, postingId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewMovePostingToPaperTrailRequest(c.Server, postingId)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
-}
-
-// MovePostingToTrash executes the MovePostingToTrash operation.
-
-func (c *Client) MovePostingToTrash(ctx context.Context, postingId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewMovePostingToTrashRequest(c.Server, postingId)
 	if err != nil {
 		return nil, err
 	}
@@ -1986,36 +1997,6 @@ func (c *Client) GetTopicEntries(ctx context.Context, topicId int64, params *Get
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewGetTopicEntriesRequest(c.Server, topicId, params)
 	}, true, "GetTopicEntries", reqEditors...)
-
-}
-
-// CreateTopicMessageWithBody executes the CreateTopicMessage operation.
-
-func (c *Client) CreateTopicMessageWithBody(ctx context.Context, topicId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewCreateTopicMessageRequestWithBody(c.Server, topicId, contentType, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
-}
-
-func (c *Client) CreateTopicMessage(ctx context.Context, topicId int64, body CreateTopicMessageJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewCreateTopicMessageRequest(c.Server, topicId, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
 
 }
 
@@ -3099,6 +3080,131 @@ func NewGetTrailboxRequest(server string, params *GetTrailboxParams) (*http.Requ
 	return req, nil
 }
 
+// NewMovePostingsRequest calls the generic MovePostings builder with application/json body
+func NewMovePostingsRequest(server string, body MovePostingsJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewMovePostingsRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewMovePostingsRequestWithBody generates requests for MovePostings with any type of body
+func NewMovePostingsRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/postings/moves.json")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewUnmutePostingsRequest generates requests for UnmutePostings
+func NewUnmutePostingsRequest(server string, params *UnmutePostingsParams) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/postings/mutings.json")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "posting_ids", runtime.ParamLocationQuery, params.PostingIds); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("DELETE", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewMutePostingsRequest calls the generic MutePostings builder with application/json body
+func NewMutePostingsRequest(server string, body MutePostingsJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewMutePostingsRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewMutePostingsRequestWithBody generates requests for MutePostings with any type of body
+func NewMutePostingsRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/postings/mutings.json")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
 // NewMarkPostingsSeenRequest calls the generic MarkPostingsSeen builder with application/json body
 func NewMarkPostingsSeenRequest(server string, body MarkPostingsSeenJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
@@ -3120,6 +3226,46 @@ func NewMarkPostingsSeenRequestWithBody(server string, contentType string, body 
 	}
 
 	operationPath := fmt.Sprintf("/postings/seen.json")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewTrashPostingsRequest calls the generic TrashPostings builder with application/json body
+func NewTrashPostingsRequest(server string, body TrashPostingsJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewTrashPostingsRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewTrashPostingsRequestWithBody generates requests for TrashPostings with any type of body
+func NewTrashPostingsRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/postings/trash.json")
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -3175,210 +3321,6 @@ func NewMarkPostingsUnseenRequestWithBody(server string, contentType string, bod
 	}
 
 	req.Header.Add("Content-Type", contentType)
-
-	return req, nil
-}
-
-// NewIgnorePostingRequest generates requests for IgnorePosting
-func NewIgnorePostingRequest(server string, postingId int64) (*http.Request, error) {
-	var err error
-
-	var pathParam0 string
-
-	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "postingId", runtime.ParamLocationPath, postingId)
-	if err != nil {
-		return nil, err
-	}
-
-	serverURL, err := url.Parse(server)
-	if err != nil {
-		return nil, err
-	}
-
-	operationPath := fmt.Sprintf("/postings/%s/ignore.json", pathParam0)
-	if operationPath[0] == '/' {
-		operationPath = "." + operationPath
-	}
-
-	queryURL, err := serverURL.Parse(operationPath)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequest("POST", queryURL.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	return req, nil
-}
-
-// NewMovePostingToSetAsideRequest generates requests for MovePostingToSetAside
-func NewMovePostingToSetAsideRequest(server string, postingId int64) (*http.Request, error) {
-	var err error
-
-	var pathParam0 string
-
-	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "postingId", runtime.ParamLocationPath, postingId)
-	if err != nil {
-		return nil, err
-	}
-
-	serverURL, err := url.Parse(server)
-	if err != nil {
-		return nil, err
-	}
-
-	operationPath := fmt.Sprintf("/postings/%s/move/asidebox.json", pathParam0)
-	if operationPath[0] == '/' {
-		operationPath = "." + operationPath
-	}
-
-	queryURL, err := serverURL.Parse(operationPath)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequest("POST", queryURL.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	return req, nil
-}
-
-// NewMovePostingToFeedRequest generates requests for MovePostingToFeed
-func NewMovePostingToFeedRequest(server string, postingId int64) (*http.Request, error) {
-	var err error
-
-	var pathParam0 string
-
-	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "postingId", runtime.ParamLocationPath, postingId)
-	if err != nil {
-		return nil, err
-	}
-
-	serverURL, err := url.Parse(server)
-	if err != nil {
-		return nil, err
-	}
-
-	operationPath := fmt.Sprintf("/postings/%s/move/feedbox.json", pathParam0)
-	if operationPath[0] == '/' {
-		operationPath = "." + operationPath
-	}
-
-	queryURL, err := serverURL.Parse(operationPath)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequest("POST", queryURL.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	return req, nil
-}
-
-// NewMovePostingToReplyLaterRequest generates requests for MovePostingToReplyLater
-func NewMovePostingToReplyLaterRequest(server string, postingId int64) (*http.Request, error) {
-	var err error
-
-	var pathParam0 string
-
-	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "postingId", runtime.ParamLocationPath, postingId)
-	if err != nil {
-		return nil, err
-	}
-
-	serverURL, err := url.Parse(server)
-	if err != nil {
-		return nil, err
-	}
-
-	operationPath := fmt.Sprintf("/postings/%s/move/laterbox.json", pathParam0)
-	if operationPath[0] == '/' {
-		operationPath = "." + operationPath
-	}
-
-	queryURL, err := serverURL.Parse(operationPath)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequest("POST", queryURL.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	return req, nil
-}
-
-// NewMovePostingToPaperTrailRequest generates requests for MovePostingToPaperTrail
-func NewMovePostingToPaperTrailRequest(server string, postingId int64) (*http.Request, error) {
-	var err error
-
-	var pathParam0 string
-
-	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "postingId", runtime.ParamLocationPath, postingId)
-	if err != nil {
-		return nil, err
-	}
-
-	serverURL, err := url.Parse(server)
-	if err != nil {
-		return nil, err
-	}
-
-	operationPath := fmt.Sprintf("/postings/%s/move/trailbox.json", pathParam0)
-	if operationPath[0] == '/' {
-		operationPath = "." + operationPath
-	}
-
-	queryURL, err := serverURL.Parse(operationPath)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequest("POST", queryURL.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	return req, nil
-}
-
-// NewMovePostingToTrashRequest generates requests for MovePostingToTrash
-func NewMovePostingToTrashRequest(server string, postingId int64) (*http.Request, error) {
-	var err error
-
-	var pathParam0 string
-
-	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "postingId", runtime.ParamLocationPath, postingId)
-	if err != nil {
-		return nil, err
-	}
-
-	serverURL, err := url.Parse(server)
-	if err != nil {
-		return nil, err
-	}
-
-	operationPath := fmt.Sprintf("/postings/%s/trash.json", pathParam0)
-	if operationPath[0] == '/' {
-		operationPath = "." + operationPath
-	}
-
-	queryURL, err := serverURL.Parse(operationPath)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequest("POST", queryURL.String(), nil)
-	if err != nil {
-		return nil, err
-	}
 
 	return req, nil
 }
@@ -3796,53 +3738,6 @@ func NewGetTopicEntriesRequest(server string, topicId int64, params *GetTopicEnt
 	return req, nil
 }
 
-// NewCreateTopicMessageRequest calls the generic CreateTopicMessage builder with application/json body
-func NewCreateTopicMessageRequest(server string, topicId int64, body CreateTopicMessageJSONRequestBody) (*http.Request, error) {
-	var bodyReader io.Reader
-	buf, err := json.Marshal(body)
-	if err != nil {
-		return nil, err
-	}
-	bodyReader = bytes.NewReader(buf)
-	return NewCreateTopicMessageRequestWithBody(server, topicId, "application/json", bodyReader)
-}
-
-// NewCreateTopicMessageRequestWithBody generates requests for CreateTopicMessage with any type of body
-func NewCreateTopicMessageRequestWithBody(server string, topicId int64, contentType string, body io.Reader) (*http.Request, error) {
-	var err error
-
-	var pathParam0 string
-
-	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "topicId", runtime.ParamLocationPath, topicId)
-	if err != nil {
-		return nil, err
-	}
-
-	serverURL, err := url.Parse(server)
-	if err != nil {
-		return nil, err
-	}
-
-	operationPath := fmt.Sprintf("/topics/%s/entries.json", pathParam0)
-	if operationPath[0] == '/' {
-		operationPath = "." + operationPath
-	}
-
-	queryURL, err := serverURL.Parse(operationPath)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequest("POST", queryURL.String(), body)
-	if err != nil {
-		return nil, err
-	}
-
-	req.Header.Add("Content-Type", contentType)
-
-	return req, nil
-}
-
 func (c *Client) applyEditors(ctx context.Context, req *http.Request, additionalEditors []RequestEditorFn) error {
 	for _, r := range c.RequestEditors {
 		if err := r(ctx, req); err != nil {
@@ -3869,51 +3764,48 @@ type OperationMetadata struct {
 // This is generated from x-hey-* extensions in the OpenAPI spec.
 // GET/HEAD/PUT/DELETE operations are always considered idempotent for retry purposes.
 var operationMetadata = map[string]OperationMetadata{
-	"ListBoxes":               {Idempotent: true, HasSensitiveParams: false},
-	"GetBox":                  {Idempotent: true, HasSensitiveParams: false},
-	"GetBubblebox":            {Idempotent: true, HasSensitiveParams: false},
-	"UncompleteHabit":         {Idempotent: true, HasSensitiveParams: false},
-	"CompleteHabit":           {Idempotent: true, HasSensitiveParams: false},
-	"GetJournalEntry":         {Idempotent: true, HasSensitiveParams: false},
-	"UpdateJournalEntry":      {Idempotent: false, HasSensitiveParams: false},
-	"GetOngoingTimeTrack":     {Idempotent: true, HasSensitiveParams: false},
-	"StartTimeTrack":          {Idempotent: false, HasSensitiveParams: false},
-	"UpdateTimeTrack":         {Idempotent: true, HasSensitiveParams: false},
-	"CreateCalendarTodo":      {Idempotent: false, HasSensitiveParams: false},
-	"DeleteCalendarTodo":      {Idempotent: true, HasSensitiveParams: false},
-	"UncompleteCalendarTodo":  {Idempotent: true, HasSensitiveParams: false},
-	"CompleteCalendarTodo":    {Idempotent: true, HasSensitiveParams: false},
-	"ListCalendars":           {Idempotent: true, HasSensitiveParams: false},
-	"GetCalendarRecordings":   {Idempotent: true, HasSensitiveParams: false},
-	"ListContacts":            {Idempotent: true, HasSensitiveParams: false},
-	"GetContact":              {Idempotent: true, HasSensitiveParams: false},
-	"ListDrafts":              {Idempotent: true, HasSensitiveParams: false},
-	"CreateReply":             {Idempotent: false, HasSensitiveParams: false},
-	"GetFeedbox":              {Idempotent: true, HasSensitiveParams: false},
-	"GetIdentity":             {Idempotent: true, HasSensitiveParams: false},
-	"GetImbox":                {Idempotent: true, HasSensitiveParams: false},
-	"CreateMessage":           {Idempotent: false, HasSensitiveParams: false},
-	"GetMessage":              {Idempotent: true, HasSensitiveParams: false},
-	"GetNavigation":           {Idempotent: true, HasSensitiveParams: false},
-	"GetTrailbox":             {Idempotent: true, HasSensitiveParams: false},
-	"MarkPostingsSeen":        {Idempotent: false, HasSensitiveParams: false},
-	"MarkPostingsUnseen":      {Idempotent: false, HasSensitiveParams: false},
-	"IgnorePosting":           {Idempotent: false, HasSensitiveParams: false},
-	"MovePostingToSetAside":   {Idempotent: false, HasSensitiveParams: false},
-	"MovePostingToFeed":       {Idempotent: false, HasSensitiveParams: false},
-	"MovePostingToReplyLater": {Idempotent: false, HasSensitiveParams: false},
-	"MovePostingToPaperTrail": {Idempotent: false, HasSensitiveParams: false},
-	"MovePostingToTrash":      {Idempotent: false, HasSensitiveParams: false},
-	"GetLaterbox":             {Idempotent: true, HasSensitiveParams: false},
-	"Search":                  {Idempotent: true, HasSensitiveParams: false},
-	"GetAsidebox":             {Idempotent: true, HasSensitiveParams: false},
-	"GetEverythingTopics":     {Idempotent: true, HasSensitiveParams: false},
-	"GetSentTopics":           {Idempotent: true, HasSensitiveParams: false},
-	"GetSpamTopics":           {Idempotent: true, HasSensitiveParams: false},
-	"GetTrashTopics":          {Idempotent: true, HasSensitiveParams: false},
-	"GetTopic":                {Idempotent: true, HasSensitiveParams: false},
-	"GetTopicEntries":         {Idempotent: true, HasSensitiveParams: false},
-	"CreateTopicMessage":      {Idempotent: false, HasSensitiveParams: false},
+	"ListBoxes":              {Idempotent: true, HasSensitiveParams: false},
+	"GetBox":                 {Idempotent: true, HasSensitiveParams: false},
+	"GetBubblebox":           {Idempotent: true, HasSensitiveParams: false},
+	"UncompleteHabit":        {Idempotent: true, HasSensitiveParams: false},
+	"CompleteHabit":          {Idempotent: true, HasSensitiveParams: false},
+	"GetJournalEntry":        {Idempotent: true, HasSensitiveParams: false},
+	"UpdateJournalEntry":     {Idempotent: false, HasSensitiveParams: false},
+	"GetOngoingTimeTrack":    {Idempotent: true, HasSensitiveParams: false},
+	"StartTimeTrack":         {Idempotent: false, HasSensitiveParams: false},
+	"UpdateTimeTrack":        {Idempotent: true, HasSensitiveParams: false},
+	"CreateCalendarTodo":     {Idempotent: false, HasSensitiveParams: false},
+	"DeleteCalendarTodo":     {Idempotent: true, HasSensitiveParams: false},
+	"UncompleteCalendarTodo": {Idempotent: true, HasSensitiveParams: false},
+	"CompleteCalendarTodo":   {Idempotent: true, HasSensitiveParams: false},
+	"ListCalendars":          {Idempotent: true, HasSensitiveParams: false},
+	"GetCalendarRecordings":  {Idempotent: true, HasSensitiveParams: false},
+	"ListContacts":           {Idempotent: true, HasSensitiveParams: false},
+	"GetContact":             {Idempotent: true, HasSensitiveParams: false},
+	"ListDrafts":             {Idempotent: true, HasSensitiveParams: false},
+	"CreateReply":            {Idempotent: false, HasSensitiveParams: false},
+	"GetFeedbox":             {Idempotent: true, HasSensitiveParams: false},
+	"GetIdentity":            {Idempotent: true, HasSensitiveParams: false},
+	"GetImbox":               {Idempotent: true, HasSensitiveParams: false},
+	"CreateMessage":          {Idempotent: false, HasSensitiveParams: false},
+	"GetMessage":             {Idempotent: true, HasSensitiveParams: false},
+	"GetNavigation":          {Idempotent: true, HasSensitiveParams: false},
+	"GetTrailbox":            {Idempotent: true, HasSensitiveParams: false},
+	"MovePostings":           {Idempotent: false, HasSensitiveParams: false},
+	"UnmutePostings":         {Idempotent: true, HasSensitiveParams: false},
+	"MutePostings":           {Idempotent: false, HasSensitiveParams: false},
+	"MarkPostingsSeen":       {Idempotent: false, HasSensitiveParams: false},
+	"TrashPostings":          {Idempotent: false, HasSensitiveParams: false},
+	"MarkPostingsUnseen":     {Idempotent: false, HasSensitiveParams: false},
+	"GetLaterbox":            {Idempotent: true, HasSensitiveParams: false},
+	"Search":                 {Idempotent: true, HasSensitiveParams: false},
+	"GetAsidebox":            {Idempotent: true, HasSensitiveParams: false},
+	"GetEverythingTopics":    {Idempotent: true, HasSensitiveParams: false},
+	"GetSentTopics":          {Idempotent: true, HasSensitiveParams: false},
+	"GetSpamTopics":          {Idempotent: true, HasSensitiveParams: false},
+	"GetTrashTopics":         {Idempotent: true, HasSensitiveParams: false},
+	"GetTopic":               {Idempotent: true, HasSensitiveParams: false},
+	"GetTopicEntries":        {Idempotent: true, HasSensitiveParams: false},
 }
 
 // GetOperationMetadata returns metadata for the given operation ID.
@@ -4752,6 +4644,51 @@ type ClientWithResponsesInterface interface {
 	// Returns a wrapper object for the known response body format(s).
 	GetTrailboxWithResponse(ctx context.Context, params *GetTrailboxParams, reqEditors ...RequestEditorFn) (*GetTrailboxResponse, error)
 
+	// MovePostingsWithBodyWithResponse performs a POST /postings/moves.json (the `MovePostings` operationId) request,
+	// with any type of body and a specified content type.
+	//
+	// Move postings to a box (bulk).
+	// Mirrors HEY's Postings::MovesController: `posting_ids` plus the target `box_id`
+	// (an ID from ListBoxes; the box `kind` field identifies imbox, feedbox, asidebox,
+	// laterbox, trailbox). Responds 204 No Content.
+	//
+	// Returns a wrapper object for the known response body format(s).
+	MovePostingsWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*MovePostingsResponse, error)
+
+	// MovePostingsWithResponse performs a POST /postings/moves.json (the `MovePostings` operationId) request.
+	// Takes a body of the `application/json` content type, and returns a wrapper object for the known response body format(s).
+	//
+	// Move postings to a box (bulk).
+	// Mirrors HEY's Postings::MovesController: `posting_ids` plus the target `box_id`
+	// (an ID from ListBoxes; the box `kind` field identifies imbox, feedbox, asidebox,
+	// laterbox, trailbox). Responds 204 No Content.
+	MovePostingsWithResponse(ctx context.Context, body MovePostingsJSONRequestBody, reqEditors ...RequestEditorFn) (*MovePostingsResponse, error)
+
+	// UnmutePostingsWithResponse performs a DELETE /postings/mutings.json (the `UnmutePostings` operationId) request.
+	//
+	// Unmute postings (bulk).
+	// Mirrors HEY's Postings::MutingsController#destroy. `posting_ids` is sent as a
+	// comma-separated query string because DELETE carries no body. Responds 201 Created.
+	//
+	// Returns a wrapper object for the known response body format(s).
+	UnmutePostingsWithResponse(ctx context.Context, params *UnmutePostingsParams, reqEditors ...RequestEditorFn) (*UnmutePostingsResponse, error)
+
+	// MutePostingsWithBodyWithResponse performs a POST /postings/mutings.json (the `MutePostings` operationId) request,
+	// with any type of body and a specified content type.
+	//
+	// Mute postings (bulk) — stop notifications for their threads.
+	// Mirrors HEY's Postings::MutingsController#create. Responds 201 Created.
+	//
+	// Returns a wrapper object for the known response body format(s).
+	MutePostingsWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*MutePostingsResponse, error)
+
+	// MutePostingsWithResponse performs a POST /postings/mutings.json (the `MutePostings` operationId) request.
+	// Takes a body of the `application/json` content type, and returns a wrapper object for the known response body format(s).
+	//
+	// Mute postings (bulk) — stop notifications for their threads.
+	// Mirrors HEY's Postings::MutingsController#create. Responds 201 Created.
+	MutePostingsWithResponse(ctx context.Context, body MutePostingsJSONRequestBody, reqEditors ...RequestEditorFn) (*MutePostingsResponse, error)
+
 	// MarkPostingsSeenWithBodyWithResponse performs a POST /postings/seen.json (the `MarkPostingsSeen` operationId) request,
 	// with any type of body and a specified content type.
 	//
@@ -4766,6 +4703,26 @@ type ClientWithResponsesInterface interface {
 	// Mark postings as seen.
 	MarkPostingsSeenWithResponse(ctx context.Context, body MarkPostingsSeenJSONRequestBody, reqEditors ...RequestEditorFn) (*MarkPostingsSeenResponse, error)
 
+	// TrashPostingsWithBodyWithResponse performs a POST /postings/trash.json (the `TrashPostings` operationId) request,
+	// with any type of body and a specified content type.
+	//
+	// Move postings to the trash (bulk).
+	// Mirrors HEY's Postings::TrashController. For JSON requests the server treats
+	// the removal decision as made (shared topics: your access is removed).
+	// Responds 204 No Content.
+	//
+	// Returns a wrapper object for the known response body format(s).
+	TrashPostingsWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*TrashPostingsResponse, error)
+
+	// TrashPostingsWithResponse performs a POST /postings/trash.json (the `TrashPostings` operationId) request.
+	// Takes a body of the `application/json` content type, and returns a wrapper object for the known response body format(s).
+	//
+	// Move postings to the trash (bulk).
+	// Mirrors HEY's Postings::TrashController. For JSON requests the server treats
+	// the removal decision as made (shared topics: your access is removed).
+	// Responds 204 No Content.
+	TrashPostingsWithResponse(ctx context.Context, body TrashPostingsJSONRequestBody, reqEditors ...RequestEditorFn) (*TrashPostingsResponse, error)
+
 	// MarkPostingsUnseenWithBodyWithResponse performs a POST /postings/unseen.json (the `MarkPostingsUnseen` operationId) request,
 	// with any type of body and a specified content type.
 	//
@@ -4779,48 +4736,6 @@ type ClientWithResponsesInterface interface {
 	//
 	// Mark postings as unseen.
 	MarkPostingsUnseenWithResponse(ctx context.Context, body MarkPostingsUnseenJSONRequestBody, reqEditors ...RequestEditorFn) (*MarkPostingsUnseenResponse, error)
-
-	// IgnorePostingWithResponse performs a POST /postings/{postingId}/ignore.json (the `IgnorePosting` operationId) request.
-	//
-	// Ignore a posting (stop notifications).
-	//
-	// Returns a wrapper object for the known response body format(s).
-	IgnorePostingWithResponse(ctx context.Context, postingId int64, reqEditors ...RequestEditorFn) (*IgnorePostingResponse, error)
-
-	// MovePostingToSetAsideWithResponse performs a POST /postings/{postingId}/move/asidebox.json (the `MovePostingToSetAside` operationId) request.
-	//
-	// Move posting to Set Aside.
-	//
-	// Returns a wrapper object for the known response body format(s).
-	MovePostingToSetAsideWithResponse(ctx context.Context, postingId int64, reqEditors ...RequestEditorFn) (*MovePostingToSetAsideResponse, error)
-
-	// MovePostingToFeedWithResponse performs a POST /postings/{postingId}/move/feedbox.json (the `MovePostingToFeed` operationId) request.
-	//
-	// Move posting to The Feed.
-	//
-	// Returns a wrapper object for the known response body format(s).
-	MovePostingToFeedWithResponse(ctx context.Context, postingId int64, reqEditors ...RequestEditorFn) (*MovePostingToFeedResponse, error)
-
-	// MovePostingToReplyLaterWithResponse performs a POST /postings/{postingId}/move/laterbox.json (the `MovePostingToReplyLater` operationId) request.
-	//
-	// Move posting to Reply Later.
-	//
-	// Returns a wrapper object for the known response body format(s).
-	MovePostingToReplyLaterWithResponse(ctx context.Context, postingId int64, reqEditors ...RequestEditorFn) (*MovePostingToReplyLaterResponse, error)
-
-	// MovePostingToPaperTrailWithResponse performs a POST /postings/{postingId}/move/trailbox.json (the `MovePostingToPaperTrail` operationId) request.
-	//
-	// Move posting to Paper Trail.
-	//
-	// Returns a wrapper object for the known response body format(s).
-	MovePostingToPaperTrailWithResponse(ctx context.Context, postingId int64, reqEditors ...RequestEditorFn) (*MovePostingToPaperTrailResponse, error)
-
-	// MovePostingToTrashWithResponse performs a POST /postings/{postingId}/trash.json (the `MovePostingToTrash` operationId) request.
-	//
-	// Move posting to trash.
-	//
-	// Returns a wrapper object for the known response body format(s).
-	MovePostingToTrashWithResponse(ctx context.Context, postingId int64, reqEditors ...RequestEditorFn) (*MovePostingToTrashResponse, error)
 
 	// GetLaterboxWithResponse performs a GET /reply_later.json (the `GetLaterbox` operationId) request.
 	//
@@ -4884,20 +4799,6 @@ type ClientWithResponsesInterface interface {
 	//
 	// Returns a wrapper object for the known response body format(s).
 	GetTopicEntriesWithResponse(ctx context.Context, topicId int64, params *GetTopicEntriesParams, reqEditors ...RequestEditorFn) (*GetTopicEntriesResponse, error)
-
-	// CreateTopicMessageWithBodyWithResponse performs a POST /topics/{topicId}/entries.json (the `CreateTopicMessage` operationId) request,
-	// with any type of body and a specified content type.
-	//
-	// Reply to an existing topic.
-	//
-	// Returns a wrapper object for the known response body format(s).
-	CreateTopicMessageWithBodyWithResponse(ctx context.Context, topicId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateTopicMessageResponse, error)
-
-	// CreateTopicMessageWithResponse performs a POST /topics/{topicId}/entries.json (the `CreateTopicMessage` operationId) request.
-	// Takes a body of the `application/json` content type, and returns a wrapper object for the known response body format(s).
-	//
-	// Reply to an existing topic.
-	CreateTopicMessageWithResponse(ctx context.Context, topicId int64, body CreateTopicMessageJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateTopicMessageResponse, error)
 }
 
 type ListBoxesResponse struct {
@@ -6679,6 +6580,192 @@ func (r GetTrailboxResponse) ContentType() string {
 	return ""
 }
 
+type MovePostingsResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	// JSON401 the response for an HTTP 401 `application/json` response
+	JSON401 *UnauthorizedErrorResponseContent
+	// JSON404 the response for an HTTP 404 `application/json` response
+	JSON404 *NotFoundErrorResponseContent
+	// JSON500 the response for an HTTP 500 `application/json` response
+	JSON500 *InternalServerErrorResponseContent
+	// JSON503 the response for an HTTP 503 `application/json` response
+	JSON503 *ServiceUnavailableErrorResponseContent
+}
+
+// GetJSON401 returns the response for an HTTP 401 `application/json` response
+func (r MovePostingsResponse) GetJSON401() *UnauthorizedErrorResponseContent {
+	return r.JSON401
+}
+
+// GetJSON404 returns the response for an HTTP 404 `application/json` response
+func (r MovePostingsResponse) GetJSON404() *NotFoundErrorResponseContent {
+	return r.JSON404
+}
+
+// GetJSON500 returns the response for an HTTP 500 `application/json` response
+func (r MovePostingsResponse) GetJSON500() *InternalServerErrorResponseContent {
+	return r.JSON500
+}
+
+// GetJSON503 returns the response for an HTTP 503 `application/json` response
+func (r MovePostingsResponse) GetJSON503() *ServiceUnavailableErrorResponseContent {
+	return r.JSON503
+}
+
+// GetBody returns the raw response body bytes
+func (r MovePostingsResponse) GetBody() []byte {
+	return r.Body
+}
+
+// Status returns HTTPResponse.Status
+func (r MovePostingsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r MovePostingsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r MovePostingsResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type UnmutePostingsResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	// JSON401 the response for an HTTP 401 `application/json` response
+	JSON401 *UnauthorizedErrorResponseContent
+	// JSON404 the response for an HTTP 404 `application/json` response
+	JSON404 *NotFoundErrorResponseContent
+	// JSON500 the response for an HTTP 500 `application/json` response
+	JSON500 *InternalServerErrorResponseContent
+	// JSON503 the response for an HTTP 503 `application/json` response
+	JSON503 *ServiceUnavailableErrorResponseContent
+}
+
+// GetJSON401 returns the response for an HTTP 401 `application/json` response
+func (r UnmutePostingsResponse) GetJSON401() *UnauthorizedErrorResponseContent {
+	return r.JSON401
+}
+
+// GetJSON404 returns the response for an HTTP 404 `application/json` response
+func (r UnmutePostingsResponse) GetJSON404() *NotFoundErrorResponseContent {
+	return r.JSON404
+}
+
+// GetJSON500 returns the response for an HTTP 500 `application/json` response
+func (r UnmutePostingsResponse) GetJSON500() *InternalServerErrorResponseContent {
+	return r.JSON500
+}
+
+// GetJSON503 returns the response for an HTTP 503 `application/json` response
+func (r UnmutePostingsResponse) GetJSON503() *ServiceUnavailableErrorResponseContent {
+	return r.JSON503
+}
+
+// GetBody returns the raw response body bytes
+func (r UnmutePostingsResponse) GetBody() []byte {
+	return r.Body
+}
+
+// Status returns HTTPResponse.Status
+func (r UnmutePostingsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UnmutePostingsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r UnmutePostingsResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type MutePostingsResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	// JSON401 the response for an HTTP 401 `application/json` response
+	JSON401 *UnauthorizedErrorResponseContent
+	// JSON404 the response for an HTTP 404 `application/json` response
+	JSON404 *NotFoundErrorResponseContent
+	// JSON500 the response for an HTTP 500 `application/json` response
+	JSON500 *InternalServerErrorResponseContent
+	// JSON503 the response for an HTTP 503 `application/json` response
+	JSON503 *ServiceUnavailableErrorResponseContent
+}
+
+// GetJSON401 returns the response for an HTTP 401 `application/json` response
+func (r MutePostingsResponse) GetJSON401() *UnauthorizedErrorResponseContent {
+	return r.JSON401
+}
+
+// GetJSON404 returns the response for an HTTP 404 `application/json` response
+func (r MutePostingsResponse) GetJSON404() *NotFoundErrorResponseContent {
+	return r.JSON404
+}
+
+// GetJSON500 returns the response for an HTTP 500 `application/json` response
+func (r MutePostingsResponse) GetJSON500() *InternalServerErrorResponseContent {
+	return r.JSON500
+}
+
+// GetJSON503 returns the response for an HTTP 503 `application/json` response
+func (r MutePostingsResponse) GetJSON503() *ServiceUnavailableErrorResponseContent {
+	return r.JSON503
+}
+
+// GetBody returns the raw response body bytes
+func (r MutePostingsResponse) GetBody() []byte {
+	return r.Body
+}
+
+// Status returns HTTPResponse.Status
+func (r MutePostingsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r MutePostingsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r MutePostingsResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
 type MarkPostingsSeenResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -6734,6 +6821,68 @@ func (r MarkPostingsSeenResponse) ContentType() string {
 	return ""
 }
 
+type TrashPostingsResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	// JSON401 the response for an HTTP 401 `application/json` response
+	JSON401 *UnauthorizedErrorResponseContent
+	// JSON404 the response for an HTTP 404 `application/json` response
+	JSON404 *NotFoundErrorResponseContent
+	// JSON500 the response for an HTTP 500 `application/json` response
+	JSON500 *InternalServerErrorResponseContent
+	// JSON503 the response for an HTTP 503 `application/json` response
+	JSON503 *ServiceUnavailableErrorResponseContent
+}
+
+// GetJSON401 returns the response for an HTTP 401 `application/json` response
+func (r TrashPostingsResponse) GetJSON401() *UnauthorizedErrorResponseContent {
+	return r.JSON401
+}
+
+// GetJSON404 returns the response for an HTTP 404 `application/json` response
+func (r TrashPostingsResponse) GetJSON404() *NotFoundErrorResponseContent {
+	return r.JSON404
+}
+
+// GetJSON500 returns the response for an HTTP 500 `application/json` response
+func (r TrashPostingsResponse) GetJSON500() *InternalServerErrorResponseContent {
+	return r.JSON500
+}
+
+// GetJSON503 returns the response for an HTTP 503 `application/json` response
+func (r TrashPostingsResponse) GetJSON503() *ServiceUnavailableErrorResponseContent {
+	return r.JSON503
+}
+
+// GetBody returns the raw response body bytes
+func (r TrashPostingsResponse) GetBody() []byte {
+	return r.Body
+}
+
+// Status returns HTTPResponse.Status
+func (r TrashPostingsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r TrashPostingsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r TrashPostingsResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
 type MarkPostingsUnseenResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -6783,378 +6932,6 @@ func (r MarkPostingsUnseenResponse) StatusCode() int {
 
 // ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
 func (r MarkPostingsUnseenResponse) ContentType() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Header.Get("Content-Type")
-	}
-	return ""
-}
-
-type IgnorePostingResponse struct {
-	Body         []byte
-	HTTPResponse *http.Response
-	// JSON401 the response for an HTTP 401 `application/json` response
-	JSON401 *UnauthorizedErrorResponseContent
-	// JSON404 the response for an HTTP 404 `application/json` response
-	JSON404 *NotFoundErrorResponseContent
-	// JSON500 the response for an HTTP 500 `application/json` response
-	JSON500 *InternalServerErrorResponseContent
-	// JSON503 the response for an HTTP 503 `application/json` response
-	JSON503 *ServiceUnavailableErrorResponseContent
-}
-
-// GetJSON401 returns the response for an HTTP 401 `application/json` response
-func (r IgnorePostingResponse) GetJSON401() *UnauthorizedErrorResponseContent {
-	return r.JSON401
-}
-
-// GetJSON404 returns the response for an HTTP 404 `application/json` response
-func (r IgnorePostingResponse) GetJSON404() *NotFoundErrorResponseContent {
-	return r.JSON404
-}
-
-// GetJSON500 returns the response for an HTTP 500 `application/json` response
-func (r IgnorePostingResponse) GetJSON500() *InternalServerErrorResponseContent {
-	return r.JSON500
-}
-
-// GetJSON503 returns the response for an HTTP 503 `application/json` response
-func (r IgnorePostingResponse) GetJSON503() *ServiceUnavailableErrorResponseContent {
-	return r.JSON503
-}
-
-// GetBody returns the raw response body bytes
-func (r IgnorePostingResponse) GetBody() []byte {
-	return r.Body
-}
-
-// Status returns HTTPResponse.Status
-func (r IgnorePostingResponse) Status() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Status
-	}
-	return http.StatusText(0)
-}
-
-// StatusCode returns HTTPResponse.StatusCode
-func (r IgnorePostingResponse) StatusCode() int {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.StatusCode
-	}
-	return 0
-}
-
-// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
-func (r IgnorePostingResponse) ContentType() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Header.Get("Content-Type")
-	}
-	return ""
-}
-
-type MovePostingToSetAsideResponse struct {
-	Body         []byte
-	HTTPResponse *http.Response
-	// JSON401 the response for an HTTP 401 `application/json` response
-	JSON401 *UnauthorizedErrorResponseContent
-	// JSON404 the response for an HTTP 404 `application/json` response
-	JSON404 *NotFoundErrorResponseContent
-	// JSON500 the response for an HTTP 500 `application/json` response
-	JSON500 *InternalServerErrorResponseContent
-	// JSON503 the response for an HTTP 503 `application/json` response
-	JSON503 *ServiceUnavailableErrorResponseContent
-}
-
-// GetJSON401 returns the response for an HTTP 401 `application/json` response
-func (r MovePostingToSetAsideResponse) GetJSON401() *UnauthorizedErrorResponseContent {
-	return r.JSON401
-}
-
-// GetJSON404 returns the response for an HTTP 404 `application/json` response
-func (r MovePostingToSetAsideResponse) GetJSON404() *NotFoundErrorResponseContent {
-	return r.JSON404
-}
-
-// GetJSON500 returns the response for an HTTP 500 `application/json` response
-func (r MovePostingToSetAsideResponse) GetJSON500() *InternalServerErrorResponseContent {
-	return r.JSON500
-}
-
-// GetJSON503 returns the response for an HTTP 503 `application/json` response
-func (r MovePostingToSetAsideResponse) GetJSON503() *ServiceUnavailableErrorResponseContent {
-	return r.JSON503
-}
-
-// GetBody returns the raw response body bytes
-func (r MovePostingToSetAsideResponse) GetBody() []byte {
-	return r.Body
-}
-
-// Status returns HTTPResponse.Status
-func (r MovePostingToSetAsideResponse) Status() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Status
-	}
-	return http.StatusText(0)
-}
-
-// StatusCode returns HTTPResponse.StatusCode
-func (r MovePostingToSetAsideResponse) StatusCode() int {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.StatusCode
-	}
-	return 0
-}
-
-// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
-func (r MovePostingToSetAsideResponse) ContentType() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Header.Get("Content-Type")
-	}
-	return ""
-}
-
-type MovePostingToFeedResponse struct {
-	Body         []byte
-	HTTPResponse *http.Response
-	// JSON401 the response for an HTTP 401 `application/json` response
-	JSON401 *UnauthorizedErrorResponseContent
-	// JSON404 the response for an HTTP 404 `application/json` response
-	JSON404 *NotFoundErrorResponseContent
-	// JSON500 the response for an HTTP 500 `application/json` response
-	JSON500 *InternalServerErrorResponseContent
-	// JSON503 the response for an HTTP 503 `application/json` response
-	JSON503 *ServiceUnavailableErrorResponseContent
-}
-
-// GetJSON401 returns the response for an HTTP 401 `application/json` response
-func (r MovePostingToFeedResponse) GetJSON401() *UnauthorizedErrorResponseContent {
-	return r.JSON401
-}
-
-// GetJSON404 returns the response for an HTTP 404 `application/json` response
-func (r MovePostingToFeedResponse) GetJSON404() *NotFoundErrorResponseContent {
-	return r.JSON404
-}
-
-// GetJSON500 returns the response for an HTTP 500 `application/json` response
-func (r MovePostingToFeedResponse) GetJSON500() *InternalServerErrorResponseContent {
-	return r.JSON500
-}
-
-// GetJSON503 returns the response for an HTTP 503 `application/json` response
-func (r MovePostingToFeedResponse) GetJSON503() *ServiceUnavailableErrorResponseContent {
-	return r.JSON503
-}
-
-// GetBody returns the raw response body bytes
-func (r MovePostingToFeedResponse) GetBody() []byte {
-	return r.Body
-}
-
-// Status returns HTTPResponse.Status
-func (r MovePostingToFeedResponse) Status() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Status
-	}
-	return http.StatusText(0)
-}
-
-// StatusCode returns HTTPResponse.StatusCode
-func (r MovePostingToFeedResponse) StatusCode() int {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.StatusCode
-	}
-	return 0
-}
-
-// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
-func (r MovePostingToFeedResponse) ContentType() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Header.Get("Content-Type")
-	}
-	return ""
-}
-
-type MovePostingToReplyLaterResponse struct {
-	Body         []byte
-	HTTPResponse *http.Response
-	// JSON401 the response for an HTTP 401 `application/json` response
-	JSON401 *UnauthorizedErrorResponseContent
-	// JSON404 the response for an HTTP 404 `application/json` response
-	JSON404 *NotFoundErrorResponseContent
-	// JSON500 the response for an HTTP 500 `application/json` response
-	JSON500 *InternalServerErrorResponseContent
-	// JSON503 the response for an HTTP 503 `application/json` response
-	JSON503 *ServiceUnavailableErrorResponseContent
-}
-
-// GetJSON401 returns the response for an HTTP 401 `application/json` response
-func (r MovePostingToReplyLaterResponse) GetJSON401() *UnauthorizedErrorResponseContent {
-	return r.JSON401
-}
-
-// GetJSON404 returns the response for an HTTP 404 `application/json` response
-func (r MovePostingToReplyLaterResponse) GetJSON404() *NotFoundErrorResponseContent {
-	return r.JSON404
-}
-
-// GetJSON500 returns the response for an HTTP 500 `application/json` response
-func (r MovePostingToReplyLaterResponse) GetJSON500() *InternalServerErrorResponseContent {
-	return r.JSON500
-}
-
-// GetJSON503 returns the response for an HTTP 503 `application/json` response
-func (r MovePostingToReplyLaterResponse) GetJSON503() *ServiceUnavailableErrorResponseContent {
-	return r.JSON503
-}
-
-// GetBody returns the raw response body bytes
-func (r MovePostingToReplyLaterResponse) GetBody() []byte {
-	return r.Body
-}
-
-// Status returns HTTPResponse.Status
-func (r MovePostingToReplyLaterResponse) Status() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Status
-	}
-	return http.StatusText(0)
-}
-
-// StatusCode returns HTTPResponse.StatusCode
-func (r MovePostingToReplyLaterResponse) StatusCode() int {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.StatusCode
-	}
-	return 0
-}
-
-// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
-func (r MovePostingToReplyLaterResponse) ContentType() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Header.Get("Content-Type")
-	}
-	return ""
-}
-
-type MovePostingToPaperTrailResponse struct {
-	Body         []byte
-	HTTPResponse *http.Response
-	// JSON401 the response for an HTTP 401 `application/json` response
-	JSON401 *UnauthorizedErrorResponseContent
-	// JSON404 the response for an HTTP 404 `application/json` response
-	JSON404 *NotFoundErrorResponseContent
-	// JSON500 the response for an HTTP 500 `application/json` response
-	JSON500 *InternalServerErrorResponseContent
-	// JSON503 the response for an HTTP 503 `application/json` response
-	JSON503 *ServiceUnavailableErrorResponseContent
-}
-
-// GetJSON401 returns the response for an HTTP 401 `application/json` response
-func (r MovePostingToPaperTrailResponse) GetJSON401() *UnauthorizedErrorResponseContent {
-	return r.JSON401
-}
-
-// GetJSON404 returns the response for an HTTP 404 `application/json` response
-func (r MovePostingToPaperTrailResponse) GetJSON404() *NotFoundErrorResponseContent {
-	return r.JSON404
-}
-
-// GetJSON500 returns the response for an HTTP 500 `application/json` response
-func (r MovePostingToPaperTrailResponse) GetJSON500() *InternalServerErrorResponseContent {
-	return r.JSON500
-}
-
-// GetJSON503 returns the response for an HTTP 503 `application/json` response
-func (r MovePostingToPaperTrailResponse) GetJSON503() *ServiceUnavailableErrorResponseContent {
-	return r.JSON503
-}
-
-// GetBody returns the raw response body bytes
-func (r MovePostingToPaperTrailResponse) GetBody() []byte {
-	return r.Body
-}
-
-// Status returns HTTPResponse.Status
-func (r MovePostingToPaperTrailResponse) Status() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Status
-	}
-	return http.StatusText(0)
-}
-
-// StatusCode returns HTTPResponse.StatusCode
-func (r MovePostingToPaperTrailResponse) StatusCode() int {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.StatusCode
-	}
-	return 0
-}
-
-// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
-func (r MovePostingToPaperTrailResponse) ContentType() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Header.Get("Content-Type")
-	}
-	return ""
-}
-
-type MovePostingToTrashResponse struct {
-	Body         []byte
-	HTTPResponse *http.Response
-	// JSON401 the response for an HTTP 401 `application/json` response
-	JSON401 *UnauthorizedErrorResponseContent
-	// JSON404 the response for an HTTP 404 `application/json` response
-	JSON404 *NotFoundErrorResponseContent
-	// JSON500 the response for an HTTP 500 `application/json` response
-	JSON500 *InternalServerErrorResponseContent
-	// JSON503 the response for an HTTP 503 `application/json` response
-	JSON503 *ServiceUnavailableErrorResponseContent
-}
-
-// GetJSON401 returns the response for an HTTP 401 `application/json` response
-func (r MovePostingToTrashResponse) GetJSON401() *UnauthorizedErrorResponseContent {
-	return r.JSON401
-}
-
-// GetJSON404 returns the response for an HTTP 404 `application/json` response
-func (r MovePostingToTrashResponse) GetJSON404() *NotFoundErrorResponseContent {
-	return r.JSON404
-}
-
-// GetJSON500 returns the response for an HTTP 500 `application/json` response
-func (r MovePostingToTrashResponse) GetJSON500() *InternalServerErrorResponseContent {
-	return r.JSON500
-}
-
-// GetJSON503 returns the response for an HTTP 503 `application/json` response
-func (r MovePostingToTrashResponse) GetJSON503() *ServiceUnavailableErrorResponseContent {
-	return r.JSON503
-}
-
-// GetBody returns the raw response body bytes
-func (r MovePostingToTrashResponse) GetBody() []byte {
-	return r.Body
-}
-
-// Status returns HTTPResponse.Status
-func (r MovePostingToTrashResponse) Status() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Status
-	}
-	return http.StatusText(0)
-}
-
-// StatusCode returns HTTPResponse.StatusCode
-func (r MovePostingToTrashResponse) StatusCode() int {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.StatusCode
-	}
-	return 0
-}
-
-// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
-func (r MovePostingToTrashResponse) ContentType() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Header.Get("Content-Type")
 	}
@@ -7733,75 +7510,6 @@ func (r GetTopicEntriesResponse) ContentType() string {
 	return ""
 }
 
-type CreateTopicMessageResponse struct {
-	Body         []byte
-	HTTPResponse *http.Response
-	// JSON401 the response for an HTTP 401 `application/json` response
-	JSON401 *UnauthorizedErrorResponseContent
-	// JSON404 the response for an HTTP 404 `application/json` response
-	JSON404 *NotFoundErrorResponseContent
-	// JSON422 the response for an HTTP 422 `application/json` response
-	JSON422 *UnprocessableEntityErrorResponseContent
-	// JSON500 the response for an HTTP 500 `application/json` response
-	JSON500 *InternalServerErrorResponseContent
-	// JSON503 the response for an HTTP 503 `application/json` response
-	JSON503 *ServiceUnavailableErrorResponseContent
-}
-
-// GetJSON401 returns the response for an HTTP 401 `application/json` response
-func (r CreateTopicMessageResponse) GetJSON401() *UnauthorizedErrorResponseContent {
-	return r.JSON401
-}
-
-// GetJSON404 returns the response for an HTTP 404 `application/json` response
-func (r CreateTopicMessageResponse) GetJSON404() *NotFoundErrorResponseContent {
-	return r.JSON404
-}
-
-// GetJSON422 returns the response for an HTTP 422 `application/json` response
-func (r CreateTopicMessageResponse) GetJSON422() *UnprocessableEntityErrorResponseContent {
-	return r.JSON422
-}
-
-// GetJSON500 returns the response for an HTTP 500 `application/json` response
-func (r CreateTopicMessageResponse) GetJSON500() *InternalServerErrorResponseContent {
-	return r.JSON500
-}
-
-// GetJSON503 returns the response for an HTTP 503 `application/json` response
-func (r CreateTopicMessageResponse) GetJSON503() *ServiceUnavailableErrorResponseContent {
-	return r.JSON503
-}
-
-// GetBody returns the raw response body bytes
-func (r CreateTopicMessageResponse) GetBody() []byte {
-	return r.Body
-}
-
-// Status returns HTTPResponse.Status
-func (r CreateTopicMessageResponse) Status() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Status
-	}
-	return http.StatusText(0)
-}
-
-// StatusCode returns HTTPResponse.StatusCode
-func (r CreateTopicMessageResponse) StatusCode() int {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.StatusCode
-	}
-	return 0
-}
-
-// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
-func (r CreateTopicMessageResponse) ContentType() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Header.Get("Content-Type")
-	}
-	return ""
-}
-
 // ListBoxesWithResponse performs a GET /boxes.json (the `ListBoxes` operationId) request.
 //
 // List all boxes.
@@ -8233,6 +7941,81 @@ func (c *ClientWithResponses) GetTrailboxWithResponse(ctx context.Context, param
 	return ParseGetTrailboxResponse(rsp)
 }
 
+// MovePostingsWithBodyWithResponse performs a POST /postings/moves.json (the `MovePostings` operationId) request,
+// with any type of body and a specified content type.
+//
+// Move postings to a box (bulk).
+// Mirrors HEY's Postings::MovesController: `posting_ids` plus the target `box_id`
+// (an ID from ListBoxes; the box `kind` field identifies imbox, feedbox, asidebox,
+// laterbox, trailbox). Responds 204 No Content.
+//
+// Returns a wrapper object for the known response body format(s).
+func (c *ClientWithResponses) MovePostingsWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*MovePostingsResponse, error) {
+	rsp, err := c.MovePostingsWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseMovePostingsResponse(rsp)
+}
+
+// MovePostingsWithResponse performs a POST /postings/moves.json (the `MovePostings` operationId) request.
+// Takes a body of the `application/json` content type, and returns a wrapper object for the known response body format(s).
+//
+// Move postings to a box (bulk).
+// Mirrors HEY's Postings::MovesController: `posting_ids` plus the target `box_id`
+// (an ID from ListBoxes; the box `kind` field identifies imbox, feedbox, asidebox,
+// laterbox, trailbox). Responds 204 No Content.
+func (c *ClientWithResponses) MovePostingsWithResponse(ctx context.Context, body MovePostingsJSONRequestBody, reqEditors ...RequestEditorFn) (*MovePostingsResponse, error) {
+	rsp, err := c.MovePostings(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseMovePostingsResponse(rsp)
+}
+
+// UnmutePostingsWithResponse performs a DELETE /postings/mutings.json (the `UnmutePostings` operationId) request.
+//
+// Unmute postings (bulk).
+// Mirrors HEY's Postings::MutingsController#destroy. `posting_ids` is sent as a
+// comma-separated query string because DELETE carries no body. Responds 201 Created.
+//
+// Returns a wrapper object for the known response body format(s).
+func (c *ClientWithResponses) UnmutePostingsWithResponse(ctx context.Context, params *UnmutePostingsParams, reqEditors ...RequestEditorFn) (*UnmutePostingsResponse, error) {
+	rsp, err := c.UnmutePostings(ctx, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUnmutePostingsResponse(rsp)
+}
+
+// MutePostingsWithBodyWithResponse performs a POST /postings/mutings.json (the `MutePostings` operationId) request,
+// with any type of body and a specified content type.
+//
+// Mute postings (bulk) — stop notifications for their threads.
+// Mirrors HEY's Postings::MutingsController#create. Responds 201 Created.
+//
+// Returns a wrapper object for the known response body format(s).
+func (c *ClientWithResponses) MutePostingsWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*MutePostingsResponse, error) {
+	rsp, err := c.MutePostingsWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseMutePostingsResponse(rsp)
+}
+
+// MutePostingsWithResponse performs a POST /postings/mutings.json (the `MutePostings` operationId) request.
+// Takes a body of the `application/json` content type, and returns a wrapper object for the known response body format(s).
+//
+// Mute postings (bulk) — stop notifications for their threads.
+// Mirrors HEY's Postings::MutingsController#create. Responds 201 Created.
+func (c *ClientWithResponses) MutePostingsWithResponse(ctx context.Context, body MutePostingsJSONRequestBody, reqEditors ...RequestEditorFn) (*MutePostingsResponse, error) {
+	rsp, err := c.MutePostings(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseMutePostingsResponse(rsp)
+}
+
 // MarkPostingsSeenWithBodyWithResponse performs a POST /postings/seen.json (the `MarkPostingsSeen` operationId) request,
 // with any type of body and a specified content type.
 //
@@ -8259,6 +8042,38 @@ func (c *ClientWithResponses) MarkPostingsSeenWithResponse(ctx context.Context, 
 	return ParseMarkPostingsSeenResponse(rsp)
 }
 
+// TrashPostingsWithBodyWithResponse performs a POST /postings/trash.json (the `TrashPostings` operationId) request,
+// with any type of body and a specified content type.
+//
+// Move postings to the trash (bulk).
+// Mirrors HEY's Postings::TrashController. For JSON requests the server treats
+// the removal decision as made (shared topics: your access is removed).
+// Responds 204 No Content.
+//
+// Returns a wrapper object for the known response body format(s).
+func (c *ClientWithResponses) TrashPostingsWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*TrashPostingsResponse, error) {
+	rsp, err := c.TrashPostingsWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseTrashPostingsResponse(rsp)
+}
+
+// TrashPostingsWithResponse performs a POST /postings/trash.json (the `TrashPostings` operationId) request.
+// Takes a body of the `application/json` content type, and returns a wrapper object for the known response body format(s).
+//
+// Move postings to the trash (bulk).
+// Mirrors HEY's Postings::TrashController. For JSON requests the server treats
+// the removal decision as made (shared topics: your access is removed).
+// Responds 204 No Content.
+func (c *ClientWithResponses) TrashPostingsWithResponse(ctx context.Context, body TrashPostingsJSONRequestBody, reqEditors ...RequestEditorFn) (*TrashPostingsResponse, error) {
+	rsp, err := c.TrashPostings(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseTrashPostingsResponse(rsp)
+}
+
 // MarkPostingsUnseenWithBodyWithResponse performs a POST /postings/unseen.json (the `MarkPostingsUnseen` operationId) request,
 // with any type of body and a specified content type.
 //
@@ -8283,84 +8098,6 @@ func (c *ClientWithResponses) MarkPostingsUnseenWithResponse(ctx context.Context
 		return nil, err
 	}
 	return ParseMarkPostingsUnseenResponse(rsp)
-}
-
-// IgnorePostingWithResponse performs a POST /postings/{postingId}/ignore.json (the `IgnorePosting` operationId) request.
-//
-// Ignore a posting (stop notifications).
-//
-// Returns a wrapper object for the known response body format(s).
-func (c *ClientWithResponses) IgnorePostingWithResponse(ctx context.Context, postingId int64, reqEditors ...RequestEditorFn) (*IgnorePostingResponse, error) {
-	rsp, err := c.IgnorePosting(ctx, postingId, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseIgnorePostingResponse(rsp)
-}
-
-// MovePostingToSetAsideWithResponse performs a POST /postings/{postingId}/move/asidebox.json (the `MovePostingToSetAside` operationId) request.
-//
-// Move posting to Set Aside.
-//
-// Returns a wrapper object for the known response body format(s).
-func (c *ClientWithResponses) MovePostingToSetAsideWithResponse(ctx context.Context, postingId int64, reqEditors ...RequestEditorFn) (*MovePostingToSetAsideResponse, error) {
-	rsp, err := c.MovePostingToSetAside(ctx, postingId, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseMovePostingToSetAsideResponse(rsp)
-}
-
-// MovePostingToFeedWithResponse performs a POST /postings/{postingId}/move/feedbox.json (the `MovePostingToFeed` operationId) request.
-//
-// Move posting to The Feed.
-//
-// Returns a wrapper object for the known response body format(s).
-func (c *ClientWithResponses) MovePostingToFeedWithResponse(ctx context.Context, postingId int64, reqEditors ...RequestEditorFn) (*MovePostingToFeedResponse, error) {
-	rsp, err := c.MovePostingToFeed(ctx, postingId, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseMovePostingToFeedResponse(rsp)
-}
-
-// MovePostingToReplyLaterWithResponse performs a POST /postings/{postingId}/move/laterbox.json (the `MovePostingToReplyLater` operationId) request.
-//
-// Move posting to Reply Later.
-//
-// Returns a wrapper object for the known response body format(s).
-func (c *ClientWithResponses) MovePostingToReplyLaterWithResponse(ctx context.Context, postingId int64, reqEditors ...RequestEditorFn) (*MovePostingToReplyLaterResponse, error) {
-	rsp, err := c.MovePostingToReplyLater(ctx, postingId, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseMovePostingToReplyLaterResponse(rsp)
-}
-
-// MovePostingToPaperTrailWithResponse performs a POST /postings/{postingId}/move/trailbox.json (the `MovePostingToPaperTrail` operationId) request.
-//
-// Move posting to Paper Trail.
-//
-// Returns a wrapper object for the known response body format(s).
-func (c *ClientWithResponses) MovePostingToPaperTrailWithResponse(ctx context.Context, postingId int64, reqEditors ...RequestEditorFn) (*MovePostingToPaperTrailResponse, error) {
-	rsp, err := c.MovePostingToPaperTrail(ctx, postingId, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseMovePostingToPaperTrailResponse(rsp)
-}
-
-// MovePostingToTrashWithResponse performs a POST /postings/{postingId}/trash.json (the `MovePostingToTrash` operationId) request.
-//
-// Move posting to trash.
-//
-// Returns a wrapper object for the known response body format(s).
-func (c *ClientWithResponses) MovePostingToTrashWithResponse(ctx context.Context, postingId int64, reqEditors ...RequestEditorFn) (*MovePostingToTrashResponse, error) {
-	rsp, err := c.MovePostingToTrash(ctx, postingId, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseMovePostingToTrashResponse(rsp)
 }
 
 // GetLaterboxWithResponse performs a GET /reply_later.json (the `GetLaterbox` operationId) request.
@@ -8478,32 +8215,6 @@ func (c *ClientWithResponses) GetTopicEntriesWithResponse(ctx context.Context, t
 		return nil, err
 	}
 	return ParseGetTopicEntriesResponse(rsp)
-}
-
-// CreateTopicMessageWithBodyWithResponse performs a POST /topics/{topicId}/entries.json (the `CreateTopicMessage` operationId) request,
-// with any type of body and a specified content type.
-//
-// Reply to an existing topic.
-//
-// Returns a wrapper object for the known response body format(s).
-func (c *ClientWithResponses) CreateTopicMessageWithBodyWithResponse(ctx context.Context, topicId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateTopicMessageResponse, error) {
-	rsp, err := c.CreateTopicMessageWithBody(ctx, topicId, contentType, body, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseCreateTopicMessageResponse(rsp)
-}
-
-// CreateTopicMessageWithResponse performs a POST /topics/{topicId}/entries.json (the `CreateTopicMessage` operationId) request.
-// Takes a body of the `application/json` content type, and returns a wrapper object for the known response body format(s).
-//
-// Reply to an existing topic.
-func (c *ClientWithResponses) CreateTopicMessageWithResponse(ctx context.Context, topicId int64, body CreateTopicMessageJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateTopicMessageResponse, error) {
-	rsp, err := c.CreateTopicMessage(ctx, topicId, body, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseCreateTopicMessageResponse(rsp)
 }
 
 // ParseListBoxesResponse parses an HTTP response from a ListBoxesWithResponse call
@@ -9892,6 +9603,156 @@ func ParseGetTrailboxResponse(rsp *http.Response) (*GetTrailboxResponse, error) 
 	return response, nil
 }
 
+// ParseMovePostingsResponse parses an HTTP response from a MovePostingsWithResponse call
+func ParseMovePostingsResponse(rsp *http.Response) (*MovePostingsResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &MovePostingsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case rsp.StatusCode == 200:
+		break // No content-type
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest UnauthorizedErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFoundErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalServerErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 503:
+		var dest ServiceUnavailableErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON503 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUnmutePostingsResponse parses an HTTP response from a UnmutePostingsWithResponse call
+func ParseUnmutePostingsResponse(rsp *http.Response) (*UnmutePostingsResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UnmutePostingsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case rsp.StatusCode == 200:
+		break // No content-type
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest UnauthorizedErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFoundErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalServerErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 503:
+		var dest ServiceUnavailableErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON503 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseMutePostingsResponse parses an HTTP response from a MutePostingsWithResponse call
+func ParseMutePostingsResponse(rsp *http.Response) (*MutePostingsResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &MutePostingsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case rsp.StatusCode == 200:
+		break // No content-type
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest UnauthorizedErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFoundErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalServerErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 503:
+		var dest ServiceUnavailableErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON503 = &dest
+
+	}
+
+	return response, nil
+}
+
 // ParseMarkPostingsSeenResponse parses an HTTP response from a MarkPostingsSeenWithResponse call
 func ParseMarkPostingsSeenResponse(rsp *http.Response) (*MarkPostingsSeenResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
@@ -9935,6 +9796,56 @@ func ParseMarkPostingsSeenResponse(rsp *http.Response) (*MarkPostingsSeenRespons
 	return response, nil
 }
 
+// ParseTrashPostingsResponse parses an HTTP response from a TrashPostingsWithResponse call
+func ParseTrashPostingsResponse(rsp *http.Response) (*TrashPostingsResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &TrashPostingsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case rsp.StatusCode == 200:
+		break // No content-type
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest UnauthorizedErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFoundErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalServerErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 503:
+		var dest ServiceUnavailableErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON503 = &dest
+
+	}
+
+	return response, nil
+}
+
 // ParseMarkPostingsUnseenResponse parses an HTTP response from a MarkPostingsUnseenWithResponse call
 func ParseMarkPostingsUnseenResponse(rsp *http.Response) (*MarkPostingsUnseenResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
@@ -9958,306 +9869,6 @@ func ParseMarkPostingsUnseenResponse(rsp *http.Response) (*MarkPostingsUnseenRes
 			return nil, err
 		}
 		response.JSON401 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
-		var dest InternalServerErrorResponseContent
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON500 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 503:
-		var dest ServiceUnavailableErrorResponseContent
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON503 = &dest
-
-	}
-
-	return response, nil
-}
-
-// ParseIgnorePostingResponse parses an HTTP response from a IgnorePostingWithResponse call
-func ParseIgnorePostingResponse(rsp *http.Response) (*IgnorePostingResponse, error) {
-	bodyBytes, err := io.ReadAll(rsp.Body)
-	defer func() { _ = rsp.Body.Close() }()
-	if err != nil {
-		return nil, err
-	}
-
-	response := &IgnorePostingResponse{
-		Body:         bodyBytes,
-		HTTPResponse: rsp,
-	}
-
-	switch {
-	case rsp.StatusCode == 200:
-		break // No content-type
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
-		var dest UnauthorizedErrorResponseContent
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON401 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
-		var dest NotFoundErrorResponseContent
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON404 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
-		var dest InternalServerErrorResponseContent
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON500 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 503:
-		var dest ServiceUnavailableErrorResponseContent
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON503 = &dest
-
-	}
-
-	return response, nil
-}
-
-// ParseMovePostingToSetAsideResponse parses an HTTP response from a MovePostingToSetAsideWithResponse call
-func ParseMovePostingToSetAsideResponse(rsp *http.Response) (*MovePostingToSetAsideResponse, error) {
-	bodyBytes, err := io.ReadAll(rsp.Body)
-	defer func() { _ = rsp.Body.Close() }()
-	if err != nil {
-		return nil, err
-	}
-
-	response := &MovePostingToSetAsideResponse{
-		Body:         bodyBytes,
-		HTTPResponse: rsp,
-	}
-
-	switch {
-	case rsp.StatusCode == 200:
-		break // No content-type
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
-		var dest UnauthorizedErrorResponseContent
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON401 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
-		var dest NotFoundErrorResponseContent
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON404 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
-		var dest InternalServerErrorResponseContent
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON500 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 503:
-		var dest ServiceUnavailableErrorResponseContent
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON503 = &dest
-
-	}
-
-	return response, nil
-}
-
-// ParseMovePostingToFeedResponse parses an HTTP response from a MovePostingToFeedWithResponse call
-func ParseMovePostingToFeedResponse(rsp *http.Response) (*MovePostingToFeedResponse, error) {
-	bodyBytes, err := io.ReadAll(rsp.Body)
-	defer func() { _ = rsp.Body.Close() }()
-	if err != nil {
-		return nil, err
-	}
-
-	response := &MovePostingToFeedResponse{
-		Body:         bodyBytes,
-		HTTPResponse: rsp,
-	}
-
-	switch {
-	case rsp.StatusCode == 200:
-		break // No content-type
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
-		var dest UnauthorizedErrorResponseContent
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON401 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
-		var dest NotFoundErrorResponseContent
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON404 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
-		var dest InternalServerErrorResponseContent
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON500 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 503:
-		var dest ServiceUnavailableErrorResponseContent
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON503 = &dest
-
-	}
-
-	return response, nil
-}
-
-// ParseMovePostingToReplyLaterResponse parses an HTTP response from a MovePostingToReplyLaterWithResponse call
-func ParseMovePostingToReplyLaterResponse(rsp *http.Response) (*MovePostingToReplyLaterResponse, error) {
-	bodyBytes, err := io.ReadAll(rsp.Body)
-	defer func() { _ = rsp.Body.Close() }()
-	if err != nil {
-		return nil, err
-	}
-
-	response := &MovePostingToReplyLaterResponse{
-		Body:         bodyBytes,
-		HTTPResponse: rsp,
-	}
-
-	switch {
-	case rsp.StatusCode == 200:
-		break // No content-type
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
-		var dest UnauthorizedErrorResponseContent
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON401 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
-		var dest NotFoundErrorResponseContent
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON404 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
-		var dest InternalServerErrorResponseContent
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON500 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 503:
-		var dest ServiceUnavailableErrorResponseContent
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON503 = &dest
-
-	}
-
-	return response, nil
-}
-
-// ParseMovePostingToPaperTrailResponse parses an HTTP response from a MovePostingToPaperTrailWithResponse call
-func ParseMovePostingToPaperTrailResponse(rsp *http.Response) (*MovePostingToPaperTrailResponse, error) {
-	bodyBytes, err := io.ReadAll(rsp.Body)
-	defer func() { _ = rsp.Body.Close() }()
-	if err != nil {
-		return nil, err
-	}
-
-	response := &MovePostingToPaperTrailResponse{
-		Body:         bodyBytes,
-		HTTPResponse: rsp,
-	}
-
-	switch {
-	case rsp.StatusCode == 200:
-		break // No content-type
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
-		var dest UnauthorizedErrorResponseContent
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON401 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
-		var dest NotFoundErrorResponseContent
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON404 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
-		var dest InternalServerErrorResponseContent
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON500 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 503:
-		var dest ServiceUnavailableErrorResponseContent
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON503 = &dest
-
-	}
-
-	return response, nil
-}
-
-// ParseMovePostingToTrashResponse parses an HTTP response from a MovePostingToTrashWithResponse call
-func ParseMovePostingToTrashResponse(rsp *http.Response) (*MovePostingToTrashResponse, error) {
-	bodyBytes, err := io.ReadAll(rsp.Body)
-	defer func() { _ = rsp.Body.Close() }()
-	if err != nil {
-		return nil, err
-	}
-
-	response := &MovePostingToTrashResponse{
-		Body:         bodyBytes,
-		HTTPResponse: rsp,
-	}
-
-	switch {
-	case rsp.StatusCode == 200:
-		break // No content-type
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
-		var dest UnauthorizedErrorResponseContent
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON401 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
-		var dest NotFoundErrorResponseContent
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON404 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest InternalServerErrorResponseContent
@@ -10695,63 +10306,6 @@ func ParseGetTopicEntriesResponse(rsp *http.Response) (*GetTopicEntriesResponse,
 			return nil, err
 		}
 		response.JSON404 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
-		var dest InternalServerErrorResponseContent
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON500 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 503:
-		var dest ServiceUnavailableErrorResponseContent
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON503 = &dest
-
-	}
-
-	return response, nil
-}
-
-// ParseCreateTopicMessageResponse parses an HTTP response from a CreateTopicMessageWithResponse call
-func ParseCreateTopicMessageResponse(rsp *http.Response) (*CreateTopicMessageResponse, error) {
-	bodyBytes, err := io.ReadAll(rsp.Body)
-	defer func() { _ = rsp.Body.Close() }()
-	if err != nil {
-		return nil, err
-	}
-
-	response := &CreateTopicMessageResponse{
-		Body:         bodyBytes,
-		HTTPResponse: rsp,
-	}
-
-	switch {
-	case rsp.StatusCode == 200:
-		break // No content-type
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
-		var dest UnauthorizedErrorResponseContent
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON401 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
-		var dest NotFoundErrorResponseContent
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON404 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
-		var dest UnprocessableEntityErrorResponseContent
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON422 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest InternalServerErrorResponseContent

--- a/go/pkg/hey/client.go
+++ b/go/pkg/hey/client.go
@@ -45,6 +45,10 @@ type Client struct {
 	senderID   int64
 	senderDone bool
 
+	// Cached box IDs by kind (imbox, feedbox, ...), lazy-initialized from ListBoxes
+	boxMu     sync.Mutex
+	boxByKind map[string]int64
+
 	// Services (lazy-initialized, protected by mu)
 	mu             sync.Mutex
 	identity       *IdentityService

--- a/go/pkg/hey/entries.go
+++ b/go/pkg/hey/entries.go
@@ -1,8 +1,9 @@
 package hey
 
 import (
+	"bytes"
 	"context"
-	"fmt"
+	"encoding/json"
 	"time"
 
 	"github.com/basecamp/hey-sdk/go/pkg/generated"
@@ -44,8 +45,12 @@ func (s *EntriesService) ListDrafts(ctx context.Context, params *generated.ListD
 	return resp.JSON200, nil
 }
 
-// CreateReply creates a reply to an entry.
+// CreateReply replies to an entry (POST /entries/{entryId}/replies.json) and delivers it.
 // The acting sender ID is automatically resolved.
+//
+// If to/cc/bcc are all empty the "entry" key is omitted so HEY falls back to the
+// thread's existing recipients (reply-all). Sending an empty addressed hash would
+// clear the recipient list, because Entry#enter_reply treats {} as an explicit choice.
 func (s *EntriesService) CreateReply(ctx context.Context, entryID int64, content string, to, cc, bcc []string) (err error) {
 	op := OperationInfo{
 		Service: "Entries", Operation: "CreateReply",
@@ -71,22 +76,18 @@ func (s *EntriesService) CreateReply(ctx context.Context, entryID int64, content
 			"content": content,
 		},
 	}
-	addressed := map[string]any{}
-	if len(to) > 0 {
-		addressed["directly"] = to
+	if addressed := addressedPayload(to, cc, bcc); len(addressed) > 0 {
+		body["entry"] = map[string]any{"addressed": addressed}
 	}
-	if len(cc) > 0 {
-		addressed["copied"] = cc
-	}
-	if len(bcc) > 0 {
-		addressed["blindcopied"] = bcc
-	}
-	if len(addressed) > 0 {
-		body["entry"] = map[string]any{
-			"addressed": addressed,
-		}
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return err
 	}
 
-	_, err = s.client.PostMutation(ctx, fmt.Sprintf("/entries/%d/replies.json", entryID), body)
-	return err
+	s.client.initGeneratedClient()
+	resp, err := s.client.gen.CreateReplyWithBodyWithResponse(ctx, entryID, "application/json", bytes.NewReader(payload))
+	if err != nil {
+		return err
+	}
+	return CheckResponse(resp.HTTPResponse)
 }

--- a/go/pkg/hey/messages.go
+++ b/go/pkg/hey/messages.go
@@ -1,8 +1,9 @@
 package hey
 
 import (
+	"bytes"
 	"context"
-	"fmt"
+	"encoding/json"
 	"time"
 
 	"github.com/basecamp/hey-sdk/go/pkg/generated"
@@ -44,10 +45,12 @@ func (s *MessagesService) Get(ctx context.Context, messageID int64) (result *gen
 	return resp.JSON200, nil
 }
 
-// Create creates a new message. The acting sender ID is automatically resolved.
+// Create creates a new message (starts a new thread) and delivers it.
+// The acting sender ID is automatically resolved.
 //
-// The HEY API expects a nested body with acting_sender_id, message (subject/content),
-// and entry (addressed recipients). This method constructs the correct shape.
+// Wire format (MessagesController#create): {acting_sender_id, message: {subject, content},
+// entry: {addressed: {directly: [...], copied: [...], blindcopied: [...]}}}.
+// Recipient lists are JSON arrays; haystack applies Array() to each kind.
 func (s *MessagesService) Create(ctx context.Context, subject, content string, to, cc, bcc []string) (err error) {
 	op := OperationInfo{
 		Service: "Messages", Operation: "CreateMessage",
@@ -67,6 +70,31 @@ func (s *MessagesService) Create(ctx context.Context, subject, content string, t
 		return err
 	}
 
+	body := map[string]any{
+		"acting_sender_id": senderID,
+		"message": map[string]any{
+			"subject": subject,
+			"content": content,
+		},
+		"entry": map[string]any{
+			"addressed": addressedPayload(to, cc, bcc),
+		},
+	}
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return err
+	}
+
+	s.client.initGeneratedClient()
+	resp, err := s.client.gen.CreateMessageWithBodyWithResponse(ctx, "application/json", bytes.NewReader(payload))
+	if err != nil {
+		return err
+	}
+	return CheckResponse(resp.HTTPResponse)
+}
+
+// addressedPayload builds the entry.addressed map, omitting empty kinds.
+func addressedPayload(to, cc, bcc []string) map[string]any {
 	addressed := map[string]any{}
 	if len(to) > 0 {
 		addressed["directly"] = to
@@ -77,50 +105,5 @@ func (s *MessagesService) Create(ctx context.Context, subject, content string, t
 	if len(bcc) > 0 {
 		addressed["blindcopied"] = bcc
 	}
-
-	body := map[string]any{
-		"acting_sender_id": senderID,
-		"message": map[string]any{
-			"subject": subject,
-			"content": content,
-		},
-		"entry": map[string]any{
-			"addressed": addressed,
-		},
-	}
-
-	_, err = s.client.PostMutation(ctx, "/messages.json", body)
-	return err
-}
-
-// CreateTopicMessage creates a message within a topic (reply to a thread).
-// The acting sender ID is automatically resolved.
-func (s *MessagesService) CreateTopicMessage(ctx context.Context, topicID int64, content string) (err error) {
-	op := OperationInfo{
-		Service: "Messages", Operation: "CreateTopicMessage",
-		ResourceType: "message", IsMutation: true, ResourceID: topicID,
-	}
-	if gater, ok := s.client.hooks.(GatingHooks); ok {
-		if ctx, err = gater.OnOperationGate(ctx, op); err != nil {
-			return
-		}
-	}
-	start := time.Now()
-	ctx = s.client.hooks.OnOperationStart(ctx, op)
-	defer func() { s.client.hooks.OnOperationEnd(ctx, op, err, time.Since(start)) }()
-
-	senderID, err := s.client.DefaultSenderID(ctx)
-	if err != nil {
-		return err
-	}
-
-	body := map[string]any{
-		"acting_sender_id": senderID,
-		"message": map[string]any{
-			"content": content,
-		},
-	}
-
-	_, err = s.client.PostMutation(ctx, fmt.Sprintf("/topics/%d/entries.json", topicID), body)
-	return err
+	return addressed
 }

--- a/go/pkg/hey/postings.go
+++ b/go/pkg/hey/postings.go
@@ -2,12 +2,28 @@ package hey
 
 import (
 	"context"
+	"fmt"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/basecamp/hey-sdk/go/pkg/generated"
 )
 
-// PostingsService handles posting-level actions (move, seen, trash, etc.).
+// Box kinds as reported by ListBoxes. Use with MoveToBox.
+const (
+	BoxKindImbox    = "imbox"
+	BoxKindFeed     = "feedbox"
+	BoxKindSetAside = "asidebox"
+	BoxKindLater    = "laterbox"
+	BoxKindTrail    = "trailbox"
+	BoxKindBubbleUp = "bubblebox"
+)
+
+// PostingsService handles posting-level actions (seen, move, trash, mute).
+//
+// HEY exposes these as bulk endpoints that take a list of posting IDs, so every
+// method here accepts one or more IDs.
 type PostingsService struct {
 	client *Client
 }
@@ -19,12 +35,8 @@ func NewPostingsService(client *Client) *PostingsService {
 
 // MarkSeen marks one or more postings as seen/read.
 func (s *PostingsService) MarkSeen(ctx context.Context, postingIDs []int64) (err error) {
-	op := OperationInfo{
-		Service: "Postings", Operation: "MarkPostingsSeen",
-		ResourceType: "posting", IsMutation: true,
-	}
-	return s.bulkAction(ctx, op, postingIDs, func(ctx context.Context, body generated.MarkPostingsRequestContent) error {
-		resp, err := s.genClient().MarkPostingsSeenWithResponse(ctx, body)
+	return s.bulkAction(ctx, "MarkPostingsSeen", postingIDs, func(ctx context.Context, ids []int64) error {
+		resp, err := s.genClient().MarkPostingsSeenWithResponse(ctx, generated.MarkPostingsRequestContent{PostingIds: ids})
 		if err != nil {
 			return err
 		}
@@ -34,12 +46,68 @@ func (s *PostingsService) MarkSeen(ctx context.Context, postingIDs []int64) (err
 
 // MarkUnseen marks one or more postings as unseen/unread.
 func (s *PostingsService) MarkUnseen(ctx context.Context, postingIDs []int64) (err error) {
-	op := OperationInfo{
-		Service: "Postings", Operation: "MarkPostingsUnseen",
-		ResourceType: "posting", IsMutation: true,
+	return s.bulkAction(ctx, "MarkPostingsUnseen", postingIDs, func(ctx context.Context, ids []int64) error {
+		resp, err := s.genClient().MarkPostingsUnseenWithResponse(ctx, generated.MarkPostingsRequestContent{PostingIds: ids})
+		if err != nil {
+			return err
+		}
+		return CheckResponse(resp.HTTPResponse)
+	})
+}
+
+// Move moves one or more postings to the box with the given ID
+// (POST /postings/moves). Box IDs come from Boxes().List.
+func (s *PostingsService) Move(ctx context.Context, boxID int64, postingIDs ...int64) (err error) {
+	return s.bulkAction(ctx, "MovePostings", postingIDs, func(ctx context.Context, ids []int64) error {
+		resp, err := s.genClient().MovePostingsWithResponse(ctx, generated.MovePostingsRequestContent{PostingIds: ids, BoxId: boxID})
+		if err != nil {
+			return err
+		}
+		return CheckResponse(resp.HTTPResponse)
+	})
+}
+
+// MoveToBox moves one or more postings to the box of the given kind
+// (BoxKindImbox, BoxKindFeed, ...). The kind→ID mapping is resolved once via
+// ListBoxes and cached on the client.
+func (s *PostingsService) MoveToBox(ctx context.Context, kind string, postingIDs ...int64) error {
+	boxID, err := s.client.BoxIDByKind(ctx, kind)
+	if err != nil {
+		return err
 	}
-	return s.bulkAction(ctx, op, postingIDs, func(ctx context.Context, body generated.MarkPostingsRequestContent) error {
-		resp, err := s.genClient().MarkPostingsUnseenWithResponse(ctx, body)
+	return s.Move(ctx, boxID, postingIDs...)
+}
+
+// MoveToImbox moves postings to the Imbox.
+func (s *PostingsService) MoveToImbox(ctx context.Context, postingIDs ...int64) error {
+	return s.MoveToBox(ctx, BoxKindImbox, postingIDs...)
+}
+
+// MoveToFeed moves postings to The Feed.
+func (s *PostingsService) MoveToFeed(ctx context.Context, postingIDs ...int64) error {
+	return s.MoveToBox(ctx, BoxKindFeed, postingIDs...)
+}
+
+// MoveToSetAside moves postings to Set Aside.
+func (s *PostingsService) MoveToSetAside(ctx context.Context, postingIDs ...int64) error {
+	return s.MoveToBox(ctx, BoxKindSetAside, postingIDs...)
+}
+
+// MoveToReplyLater moves postings to Reply Later.
+func (s *PostingsService) MoveToReplyLater(ctx context.Context, postingIDs ...int64) error {
+	return s.MoveToBox(ctx, BoxKindLater, postingIDs...)
+}
+
+// MoveToPaperTrail moves postings to the Paper Trail.
+func (s *PostingsService) MoveToPaperTrail(ctx context.Context, postingIDs ...int64) error {
+	return s.MoveToBox(ctx, BoxKindTrail, postingIDs...)
+}
+
+// MoveToTrash moves one or more postings to the trash (POST /postings/trash).
+// For shared topics HEY removes your access rather than trashing for everyone.
+func (s *PostingsService) MoveToTrash(ctx context.Context, postingIDs ...int64) (err error) {
+	return s.bulkAction(ctx, "TrashPostings", postingIDs, func(ctx context.Context, ids []int64) error {
+		resp, err := s.genClient().TrashPostingsWithResponse(ctx, generated.MarkPostingsRequestContent{PostingIds: ids})
 		if err != nil {
 			return err
 		}
@@ -47,10 +115,11 @@ func (s *PostingsService) MarkUnseen(ctx context.Context, postingIDs []int64) (e
 	})
 }
 
-// MoveToFeed moves a posting to The Feed.
-func (s *PostingsService) MoveToFeed(ctx context.Context, postingID int64) error {
-	return s.singleAction(ctx, "MovePostingToFeed", postingID, func(ctx context.Context, id int64) error {
-		resp, err := s.genClient().MovePostingToFeedWithResponse(ctx, id)
+// Mute mutes one or more postings so their threads stop notifying
+// (POST /postings/mutings).
+func (s *PostingsService) Mute(ctx context.Context, postingIDs ...int64) (err error) {
+	return s.bulkAction(ctx, "MutePostings", postingIDs, func(ctx context.Context, ids []int64) error {
+		resp, err := s.genClient().MutePostingsWithResponse(ctx, generated.MarkPostingsRequestContent{PostingIds: ids})
 		if err != nil {
 			return err
 		}
@@ -58,10 +127,11 @@ func (s *PostingsService) MoveToFeed(ctx context.Context, postingID int64) error
 	})
 }
 
-// MoveToSetAside moves a posting to Set Aside.
-func (s *PostingsService) MoveToSetAside(ctx context.Context, postingID int64) error {
-	return s.singleAction(ctx, "MovePostingToSetAside", postingID, func(ctx context.Context, id int64) error {
-		resp, err := s.genClient().MovePostingToSetAsideWithResponse(ctx, id)
+// Unmute unmutes one or more postings (DELETE /postings/mutings).
+func (s *PostingsService) Unmute(ctx context.Context, postingIDs ...int64) (err error) {
+	return s.bulkAction(ctx, "UnmutePostings", postingIDs, func(ctx context.Context, ids []int64) error {
+		params := &generated.UnmutePostingsParams{PostingIds: joinIDs(ids)}
+		resp, err := s.genClient().UnmutePostingsWithResponse(ctx, params)
 		if err != nil {
 			return err
 		}
@@ -69,61 +139,54 @@ func (s *PostingsService) MoveToSetAside(ctx context.Context, postingID int64) e
 	})
 }
 
-// MoveToReplyLater moves a posting to Reply Later.
-func (s *PostingsService) MoveToReplyLater(ctx context.Context, postingID int64) error {
-	return s.singleAction(ctx, "MovePostingToReplyLater", postingID, func(ctx context.Context, id int64) error {
-		resp, err := s.genClient().MovePostingToReplyLaterWithResponse(ctx, id)
-		if err != nil {
-			return err
-		}
-		return CheckResponse(resp.HTTPResponse)
-	})
-}
+// BoxIDByKind returns the ID of the caller's box with the given kind
+// ("imbox", "feedbox", "asidebox", "laterbox", "trailbox", "bubblebox"),
+// resolving via ListBoxes on first use and caching the result.
+func (c *Client) BoxIDByKind(ctx context.Context, kind string) (int64, error) {
+	c.boxMu.Lock()
+	defer c.boxMu.Unlock()
 
-// MoveToPaperTrail moves a posting to the Paper Trail.
-func (s *PostingsService) MoveToPaperTrail(ctx context.Context, postingID int64) error {
-	return s.singleAction(ctx, "MovePostingToPaperTrail", postingID, func(ctx context.Context, id int64) error {
-		resp, err := s.genClient().MovePostingToPaperTrailWithResponse(ctx, id)
-		if err != nil {
-			return err
-		}
-		return CheckResponse(resp.HTTPResponse)
-	})
-}
+	if id, ok := c.boxByKind[kind]; ok {
+		return id, nil
+	}
 
-// MoveToTrash moves a posting to the trash.
-func (s *PostingsService) MoveToTrash(ctx context.Context, postingID int64) error {
-	return s.singleAction(ctx, "MovePostingToTrash", postingID, func(ctx context.Context, id int64) error {
-		resp, err := s.genClient().MovePostingToTrashWithResponse(ctx, id)
-		if err != nil {
-			return err
+	boxes, err := c.Boxes().List(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("failed to list boxes to resolve %q: %w", kind, err)
+	}
+	if boxes == nil {
+		return 0, ErrAPI(0, "could not list boxes")
+	}
+	byKind := make(map[string]int64, len(*boxes))
+	for _, b := range *boxes {
+		if b.Kind != "" {
+			byKind[b.Kind] = b.Id
 		}
-		return CheckResponse(resp.HTTPResponse)
-	})
-}
+	}
+	c.boxByKind = byKind
 
-// Ignore ignores a posting (stops notifications).
-func (s *PostingsService) Ignore(ctx context.Context, postingID int64) error {
-	return s.singleAction(ctx, "IgnorePosting", postingID, func(ctx context.Context, id int64) error {
-		resp, err := s.genClient().IgnorePostingWithResponse(ctx, id)
-		if err != nil {
-			return err
-		}
-		return CheckResponse(resp.HTTPResponse)
-	})
+	id, ok := byKind[kind]
+	if !ok {
+		return 0, ErrAPI(0, fmt.Sprintf("no box of kind %q", kind))
+	}
+	return id, nil
 }
-
-// --- Helpers ---
 
 func (s *PostingsService) genClient() *generated.ClientWithResponses {
 	s.client.initGeneratedClient()
 	return s.client.gen
 }
 
-func (s *PostingsService) singleAction(ctx context.Context, operation string, postingID int64, fn func(context.Context, int64) error) (err error) {
+func (s *PostingsService) bulkAction(ctx context.Context, operation string, ids []int64, fn func(context.Context, []int64) error) (err error) {
+	if len(ids) == 0 {
+		return ErrUsage("at least one posting ID is required")
+	}
 	op := OperationInfo{
 		Service: "Postings", Operation: operation,
-		ResourceType: "posting", IsMutation: true, ResourceID: postingID,
+		ResourceType: "posting", IsMutation: true,
+	}
+	if len(ids) == 1 {
+		op.ResourceID = ids[0]
 	}
 	if gater, ok := s.client.hooks.(GatingHooks); ok {
 		if ctx, err = gater.OnOperationGate(ctx, op); err != nil {
@@ -134,19 +197,13 @@ func (s *PostingsService) singleAction(ctx context.Context, operation string, po
 	ctx = s.client.hooks.OnOperationStart(ctx, op)
 	defer func() { s.client.hooks.OnOperationEnd(ctx, op, err, time.Since(start)) }()
 
-	return fn(ctx, postingID)
+	return fn(ctx, ids)
 }
 
-func (s *PostingsService) bulkAction(ctx context.Context, op OperationInfo, ids []int64, fn func(context.Context, generated.MarkPostingsRequestContent) error) (err error) {
-	if gater, ok := s.client.hooks.(GatingHooks); ok {
-		if ctx, err = gater.OnOperationGate(ctx, op); err != nil {
-			return
-		}
+func joinIDs(ids []int64) string {
+	parts := make([]string, len(ids))
+	for i, id := range ids {
+		parts[i] = strconv.FormatInt(id, 10)
 	}
-	start := time.Now()
-	ctx = s.client.hooks.OnOperationStart(ctx, op)
-	defer func() { s.client.hooks.OnOperationEnd(ctx, op, err, time.Since(start)) }()
-
-	body := generated.MarkPostingsRequestContent{PostingIds: ids}
-	return fn(ctx, body)
+	return strings.Join(parts, ",")
 }

--- a/go/pkg/hey/postings_test.go
+++ b/go/pkg/hey/postings_test.go
@@ -1,0 +1,168 @@
+package hey
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+const boxesJSON = `[{"id":24088,"kind":"imbox","name":"Imbox"},{"id":24089,"kind":"feedbox","name":"The Feed"},{"id":24090,"kind":"asidebox","name":"Set Aside"},{"id":24091,"kind":"laterbox","name":"Reply Later"},{"id":24092,"kind":"trailbox","name":"Paper Trail"}]`
+
+type recordedRequest struct {
+	Method string
+	Path   string
+	Query  string
+	Body   map[string]any
+}
+
+// newPostingsTestClient serves /boxes.json and records every other request.
+func newPostingsTestClient(t *testing.T, status int) (*Client, *[]recordedRequest, *int32) {
+	t.Helper()
+	var reqs []recordedRequest
+	var boxCalls int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/boxes.json" {
+			atomic.AddInt32(&boxCalls, 1)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(boxesJSON))
+			return
+		}
+		rec := recordedRequest{Method: r.Method, Path: r.URL.Path, Query: r.URL.RawQuery}
+		if b, _ := io.ReadAll(r.Body); len(b) > 0 {
+			_ = json.Unmarshal(b, &rec.Body)
+		}
+		reqs = append(reqs, rec)
+		w.WriteHeader(status)
+	}))
+	t.Cleanup(server.Close)
+	cfg := &Config{BaseURL: server.URL}
+	c := NewClient(cfg, &StaticTokenProvider{Token: "test-token"},
+		WithMaxRetries(0), WithBaseDelay(time.Millisecond), WithMaxJitter(time.Millisecond))
+	return c, &reqs, &boxCalls
+}
+
+func idsOf(body map[string]any) []float64 {
+	raw, _ := body["posting_ids"].([]any)
+	out := make([]float64, 0, len(raw))
+	for _, v := range raw {
+		out = append(out, v.(float64))
+	}
+	return out
+}
+
+func TestPostingsService_BulkEndpoints(t *testing.T) {
+	ctx := context.Background()
+	cases := []struct {
+		name     string
+		call     func(c *Client) error
+		method   string
+		path     string
+		wantIDs  []float64
+		wantBox  float64
+		wantQry  string
+		boxCalls int32
+	}{
+		{"MarkSeen", func(c *Client) error { return c.Postings().MarkSeen(ctx, []int64{1, 2}) }, "POST", "/postings/seen.json", []float64{1, 2}, 0, "", 0},
+		{"MarkUnseen", func(c *Client) error { return c.Postings().MarkUnseen(ctx, []int64{3}) }, "POST", "/postings/unseen.json", []float64{3}, 0, "", 0},
+		{"Move", func(c *Client) error { return c.Postings().Move(ctx, 999, 1, 2) }, "POST", "/postings/moves.json", []float64{1, 2}, 999, "", 0},
+		{"MoveToFeed", func(c *Client) error { return c.Postings().MoveToFeed(ctx, 5) }, "POST", "/postings/moves.json", []float64{5}, 24089, "", 1},
+		{"MoveToSetAside", func(c *Client) error { return c.Postings().MoveToSetAside(ctx, 5) }, "POST", "/postings/moves.json", []float64{5}, 24090, "", 1},
+		{"MoveToReplyLater", func(c *Client) error { return c.Postings().MoveToReplyLater(ctx, 5) }, "POST", "/postings/moves.json", []float64{5}, 24091, "", 1},
+		{"MoveToPaperTrail", func(c *Client) error { return c.Postings().MoveToPaperTrail(ctx, 5) }, "POST", "/postings/moves.json", []float64{5}, 24092, "", 1},
+		{"MoveToImbox", func(c *Client) error { return c.Postings().MoveToImbox(ctx, 5, 6) }, "POST", "/postings/moves.json", []float64{5, 6}, 24088, "", 1},
+		{"MoveToTrash", func(c *Client) error { return c.Postings().MoveToTrash(ctx, 7) }, "POST", "/postings/trash.json", []float64{7}, 0, "", 0},
+		{"Mute", func(c *Client) error { return c.Postings().Mute(ctx, 8, 9) }, "POST", "/postings/mutings.json", []float64{8, 9}, 0, "", 0},
+		{"Unmute", func(c *Client) error { return c.Postings().Unmute(ctx, 8, 9) }, "DELETE", "/postings/mutings.json", nil, 0, "posting_ids=8%2C9", 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c, reqs, boxCalls := newPostingsTestClient(t, 204)
+			if err := tc.call(c); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(*reqs) != 1 {
+				t.Fatalf("expected 1 request, got %d", len(*reqs))
+			}
+			r := (*reqs)[0]
+			if r.Method != tc.method || r.Path != tc.path {
+				t.Errorf("got %s %s, want %s %s", r.Method, r.Path, tc.method, tc.path)
+			}
+			if tc.wantQry != "" && r.Query != tc.wantQry {
+				t.Errorf("query = %q, want %q", r.Query, tc.wantQry)
+			}
+			if tc.wantIDs != nil {
+				got := idsOf(r.Body)
+				if len(got) != len(tc.wantIDs) {
+					t.Fatalf("posting_ids = %v, want %v", got, tc.wantIDs)
+				}
+				for i := range got {
+					if got[i] != tc.wantIDs[i] {
+						t.Errorf("posting_ids = %v, want %v", got, tc.wantIDs)
+					}
+				}
+			}
+			if tc.wantBox != 0 && r.Body["box_id"] != tc.wantBox {
+				t.Errorf("box_id = %v, want %v", r.Body["box_id"], tc.wantBox)
+			}
+			if atomic.LoadInt32(boxCalls) != tc.boxCalls {
+				t.Errorf("ListBoxes calls = %d, want %d", *boxCalls, tc.boxCalls)
+			}
+		})
+	}
+}
+
+func TestPostingsService_BoxKindResolvedOnce(t *testing.T) {
+	ctx := context.Background()
+	c, reqs, boxCalls := newPostingsTestClient(t, 204)
+	for i := 0; i < 3; i++ {
+		if err := c.Postings().MoveToFeed(ctx, int64(i+1)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := c.Postings().MoveToPaperTrail(ctx, 9); err != nil {
+		t.Fatal(err)
+	}
+	if got := atomic.LoadInt32(boxCalls); got != 1 {
+		t.Errorf("ListBoxes called %d times, want 1 (cached)", got)
+	}
+	if len(*reqs) != 4 {
+		t.Errorf("expected 4 move requests, got %d", len(*reqs))
+	}
+}
+
+func TestPostingsService_UnknownBoxKind(t *testing.T) {
+	c, reqs, _ := newPostingsTestClient(t, 204)
+	err := c.Postings().MoveToBox(context.Background(), "nope", 1)
+	if err == nil {
+		t.Fatal("expected error for unknown box kind")
+	}
+	if len(*reqs) != 0 {
+		t.Errorf("no move request should be sent, got %d", len(*reqs))
+	}
+}
+
+func TestPostingsService_RequiresIDs(t *testing.T) {
+	c, reqs, _ := newPostingsTestClient(t, 204)
+	if err := c.Postings().MoveToTrash(context.Background()); err == nil {
+		t.Fatal("expected error for empty IDs")
+	}
+	if err := c.Postings().MarkSeen(context.Background(), nil); err == nil {
+		t.Fatal("expected error for empty IDs")
+	}
+	if len(*reqs) != 0 {
+		t.Errorf("no request should be sent, got %d", len(*reqs))
+	}
+}
+
+func TestPostingsService_ServerErrorSurfaced(t *testing.T) {
+	c, _, _ := newPostingsTestClient(t, 500)
+	if err := c.Postings().Mute(context.Background(), 1); err == nil {
+		t.Fatal("expected error on 500")
+	}
+}

--- a/go/pkg/hey/services_test.go
+++ b/go/pkg/hey/services_test.go
@@ -458,30 +458,6 @@ func TestMessagesService_Create(t *testing.T) {
 	}
 }
 
-func TestMessagesService_CreateTopicMessage(t *testing.T) {
-	client := newMutationTestClientWithValidation(t, "POST", "/topics/%s/entries.json",
-		func(t *testing.T, body map[string]any) {
-			t.Helper()
-			if _, ok := body["acting_sender_id"]; !ok {
-				t.Error("missing acting_sender_id")
-			}
-			msg, ok := body["message"].(map[string]any)
-			if !ok {
-				t.Fatal("missing message wrapper")
-			}
-			if msg["content"] != "Reply text" {
-				t.Errorf("expected content 'Reply text', got %v", msg["content"])
-			}
-		},
-		`{"notice":"sent"}`,
-	)
-
-	err := client.Messages().CreateTopicMessage(context.Background(), 42, "Reply text")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
 // --- Entries ---
 
 func TestEntriesService_ListDrafts(t *testing.T) {
@@ -517,6 +493,49 @@ func TestEntriesService_CreateReply(t *testing.T) {
 	)
 
 	err := client.Entries().CreateReply(context.Background(), 10, "My reply", []string{"test@example.com"}, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestEntriesService_CreateReply_OmitsEntryWithoutRecipients(t *testing.T) {
+	client := newMutationTestClientWithValidation(t, "POST", "/entries/%s/replies.json",
+		func(t *testing.T, body map[string]any) {
+			t.Helper()
+			// An empty entry.addressed would clear the recipient list server-side
+			// (Entry#enter_reply treats {} as explicit), so it must be omitted.
+			if _, present := body["entry"]; present {
+				t.Errorf("entry must be omitted when no recipients are given, got %v", body["entry"])
+			}
+		},
+		`{"notice":"sent"}`,
+	)
+
+	if err := client.Entries().CreateReply(context.Background(), 10, "Reply-all", nil, nil, nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestEntriesService_CreateReply_RecipientsAreArrays(t *testing.T) {
+	client := newMutationTestClientWithValidation(t, "POST", "/entries/%s/replies.json",
+		func(t *testing.T, body map[string]any) {
+			t.Helper()
+			entry, _ := body["entry"].(map[string]any)
+			addressed, _ := entry["addressed"].(map[string]any)
+			if _, ok := addressed["directly"].([]any); !ok {
+				t.Errorf("directly must be a JSON array, got %T", addressed["directly"])
+			}
+			if _, ok := addressed["blindcopied"].([]any); !ok {
+				t.Errorf("blindcopied must be a JSON array, got %T", addressed["blindcopied"])
+			}
+			if _, present := addressed["copied"]; present {
+				t.Errorf("empty cc must be omitted, got %v", addressed["copied"])
+			}
+		},
+		`{"notice":"sent"}`,
+	)
+
+	err := client.Entries().CreateReply(context.Background(), 10, "hi", []string{"a@x.com"}, nil, []string{"b@x.com"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/go/pkg/hey/url-routes.json
+++ b/go/pkg/hey/url-routes.json
@@ -246,10 +246,35 @@
       "params": {}
     },
     {
+      "pattern": "/postings/moves",
+      "resource": "Postings",
+      "operations": {
+        "POST": "MovePostings"
+      },
+      "params": {}
+    },
+    {
+      "pattern": "/postings/mutings",
+      "resource": "Postings",
+      "operations": {
+        "DELETE": "UnmutePostings",
+        "POST": "MutePostings"
+      },
+      "params": {}
+    },
+    {
       "pattern": "/postings/seen",
       "resource": "Postings",
       "operations": {
         "POST": "MarkPostingsSeen"
+      },
+      "params": {}
+    },
+    {
+      "pattern": "/postings/trash",
+      "resource": "Postings",
+      "operations": {
+        "POST": "TrashPostings"
       },
       "params": {}
     },
@@ -260,84 +285,6 @@
         "POST": "MarkPostingsUnseen"
       },
       "params": {}
-    },
-    {
-      "pattern": "/postings/{postingId}/ignore",
-      "resource": "Postings",
-      "operations": {
-        "POST": "IgnorePosting"
-      },
-      "params": {
-        "postingId": {
-          "role": "parent",
-          "type": "int64"
-        }
-      }
-    },
-    {
-      "pattern": "/postings/{postingId}/move/asidebox",
-      "resource": "Postings",
-      "operations": {
-        "POST": "MovePostingToSetAside"
-      },
-      "params": {
-        "postingId": {
-          "role": "parent",
-          "type": "int64"
-        }
-      }
-    },
-    {
-      "pattern": "/postings/{postingId}/move/feedbox",
-      "resource": "Postings",
-      "operations": {
-        "POST": "MovePostingToFeed"
-      },
-      "params": {
-        "postingId": {
-          "role": "parent",
-          "type": "int64"
-        }
-      }
-    },
-    {
-      "pattern": "/postings/{postingId}/move/laterbox",
-      "resource": "Postings",
-      "operations": {
-        "POST": "MovePostingToReplyLater"
-      },
-      "params": {
-        "postingId": {
-          "role": "parent",
-          "type": "int64"
-        }
-      }
-    },
-    {
-      "pattern": "/postings/{postingId}/move/trailbox",
-      "resource": "Postings",
-      "operations": {
-        "POST": "MovePostingToPaperTrail"
-      },
-      "params": {
-        "postingId": {
-          "role": "parent",
-          "type": "int64"
-        }
-      }
-    },
-    {
-      "pattern": "/postings/{postingId}/trash",
-      "resource": "Postings",
-      "operations": {
-        "POST": "MovePostingToTrash"
-      },
-      "params": {
-        "postingId": {
-          "role": "parent",
-          "type": "int64"
-        }
-      }
     },
     {
       "pattern": "/reply_later",
@@ -413,19 +360,6 @@
       "resource": "Topics",
       "operations": {
         "GET": "GetTopicEntries"
-      },
-      "params": {
-        "topicId": {
-          "role": "parent",
-          "type": "int64"
-        }
-      }
-    },
-    {
-      "pattern": "/topics/{topicId}/entries",
-      "resource": "Messages",
-      "operations": {
-        "POST": "CreateTopicMessage"
       },
       "params": {
         "topicId": {

--- a/openapi.json
+++ b/openapi.json
@@ -2112,6 +2112,225 @@
         }
       }
     },
+    "/postings/moves.json": {
+      "post": {
+        "description": "Move postings to a box (bulk).\nMirrors HEY's Postings::MovesController: `posting_ids` plus the target `box_id`\n(an ID from ListBoxes; the box `kind` field identifies imbox, feedbox, asidebox,\nlaterbox, trailbox). Responds 204 No Content.",
+        "operationId": "MovePostings",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MovePostingsRequestContent"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "MovePostings 200 response"
+          },
+          "401": {
+            "description": "UnauthorizedError 401 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedErrorResponseContent"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFoundError 404 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundErrorResponseContent"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "InternalServerError 500 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerErrorResponseContent"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "ServiceUnavailableError 503 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceUnavailableErrorResponseContent"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Postings"
+        ],
+        "x-hey-retry": {
+          "maxAttempts": 2,
+          "baseDelayMs": 1000,
+          "backoff": "exponential",
+          "retryOn": [
+            429,
+            503
+          ]
+        }
+      }
+    },
+    "/postings/mutings.json": {
+      "delete": {
+        "description": "Unmute postings (bulk).\nMirrors HEY's Postings::MutingsController#destroy. `posting_ids` is sent as a\ncomma-separated query string because DELETE carries no body. Responds 201 Created.",
+        "operationId": "UnmutePostings",
+        "parameters": [
+          {
+            "name": "posting_ids",
+            "in": "query",
+            "description": "Comma-separated posting IDs, e.g. \"123,456\"",
+            "schema": {
+              "type": "string",
+              "description": "Comma-separated posting IDs, e.g. \"123,456\""
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "UnmutePostings 200 response"
+          },
+          "401": {
+            "description": "UnauthorizedError 401 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedErrorResponseContent"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFoundError 404 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundErrorResponseContent"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "InternalServerError 500 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerErrorResponseContent"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "ServiceUnavailableError 503 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceUnavailableErrorResponseContent"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Postings"
+        ],
+        "x-hey-retry": {
+          "maxAttempts": 2,
+          "baseDelayMs": 1000,
+          "backoff": "exponential",
+          "retryOn": [
+            429,
+            503
+          ]
+        }
+      },
+      "post": {
+        "description": "Mute postings (bulk) — stop notifications for their threads.\nMirrors HEY's Postings::MutingsController#create. Responds 201 Created.",
+        "operationId": "MutePostings",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MarkPostingsRequestContent"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "MutePostings 200 response"
+          },
+          "401": {
+            "description": "UnauthorizedError 401 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedErrorResponseContent"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFoundError 404 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundErrorResponseContent"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "InternalServerError 500 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerErrorResponseContent"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "ServiceUnavailableError 503 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceUnavailableErrorResponseContent"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Postings"
+        ],
+        "x-hey-retry": {
+          "maxAttempts": 2,
+          "baseDelayMs": 1000,
+          "backoff": "exponential",
+          "retryOn": [
+            429,
+            503
+          ]
+        }
+      }
+    },
     "/postings/seen.json": {
       "post": {
         "description": "Mark postings as seen",
@@ -2175,6 +2394,79 @@
         }
       }
     },
+    "/postings/trash.json": {
+      "post": {
+        "description": "Move postings to the trash (bulk).\nMirrors HEY's Postings::TrashController. For JSON requests the server treats\nthe removal decision as made (shared topics: your access is removed).\nResponds 204 No Content.",
+        "operationId": "TrashPostings",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MarkPostingsRequestContent"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "TrashPostings 200 response"
+          },
+          "401": {
+            "description": "UnauthorizedError 401 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedErrorResponseContent"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFoundError 404 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundErrorResponseContent"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "InternalServerError 500 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerErrorResponseContent"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "ServiceUnavailableError 503 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceUnavailableErrorResponseContent"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Postings"
+        ],
+        "x-hey-retry": {
+          "maxAttempts": 2,
+          "baseDelayMs": 1000,
+          "backoff": "exponential",
+          "retryOn": [
+            429,
+            503
+          ]
+        }
+      }
+    },
     "/postings/unseen.json": {
       "post": {
         "description": "Mark postings as unseen",
@@ -2199,450 +2491,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/UnauthorizedErrorResponseContent"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "InternalServerError 500 response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/InternalServerErrorResponseContent"
-                }
-              }
-            }
-          },
-          "503": {
-            "description": "ServiceUnavailableError 503 response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ServiceUnavailableErrorResponseContent"
-                }
-              }
-            }
-          }
-        },
-        "tags": [
-          "Postings"
-        ],
-        "x-hey-retry": {
-          "maxAttempts": 2,
-          "baseDelayMs": 1000,
-          "backoff": "exponential",
-          "retryOn": [
-            429,
-            503
-          ]
-        }
-      }
-    },
-    "/postings/{postingId}/ignore.json": {
-      "post": {
-        "description": "Ignore a posting (stop notifications)",
-        "operationId": "IgnorePosting",
-        "parameters": [
-          {
-            "name": "postingId",
-            "in": "path",
-            "schema": {
-              "type": "integer",
-              "format": "int64"
-            },
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "IgnorePosting 200 response"
-          },
-          "401": {
-            "description": "UnauthorizedError 401 response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UnauthorizedErrorResponseContent"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "NotFoundError 404 response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/NotFoundErrorResponseContent"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "InternalServerError 500 response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/InternalServerErrorResponseContent"
-                }
-              }
-            }
-          },
-          "503": {
-            "description": "ServiceUnavailableError 503 response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ServiceUnavailableErrorResponseContent"
-                }
-              }
-            }
-          }
-        },
-        "tags": [
-          "Postings"
-        ],
-        "x-hey-retry": {
-          "maxAttempts": 2,
-          "baseDelayMs": 1000,
-          "backoff": "exponential",
-          "retryOn": [
-            429,
-            503
-          ]
-        }
-      }
-    },
-    "/postings/{postingId}/move/asidebox.json": {
-      "post": {
-        "description": "Move posting to Set Aside",
-        "operationId": "MovePostingToSetAside",
-        "parameters": [
-          {
-            "name": "postingId",
-            "in": "path",
-            "schema": {
-              "type": "integer",
-              "format": "int64"
-            },
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "MovePostingToSetAside 200 response"
-          },
-          "401": {
-            "description": "UnauthorizedError 401 response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UnauthorizedErrorResponseContent"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "NotFoundError 404 response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/NotFoundErrorResponseContent"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "InternalServerError 500 response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/InternalServerErrorResponseContent"
-                }
-              }
-            }
-          },
-          "503": {
-            "description": "ServiceUnavailableError 503 response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ServiceUnavailableErrorResponseContent"
-                }
-              }
-            }
-          }
-        },
-        "tags": [
-          "Postings"
-        ],
-        "x-hey-retry": {
-          "maxAttempts": 2,
-          "baseDelayMs": 1000,
-          "backoff": "exponential",
-          "retryOn": [
-            429,
-            503
-          ]
-        }
-      }
-    },
-    "/postings/{postingId}/move/feedbox.json": {
-      "post": {
-        "description": "Move posting to The Feed",
-        "operationId": "MovePostingToFeed",
-        "parameters": [
-          {
-            "name": "postingId",
-            "in": "path",
-            "schema": {
-              "type": "integer",
-              "format": "int64"
-            },
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "MovePostingToFeed 200 response"
-          },
-          "401": {
-            "description": "UnauthorizedError 401 response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UnauthorizedErrorResponseContent"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "NotFoundError 404 response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/NotFoundErrorResponseContent"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "InternalServerError 500 response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/InternalServerErrorResponseContent"
-                }
-              }
-            }
-          },
-          "503": {
-            "description": "ServiceUnavailableError 503 response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ServiceUnavailableErrorResponseContent"
-                }
-              }
-            }
-          }
-        },
-        "tags": [
-          "Postings"
-        ],
-        "x-hey-retry": {
-          "maxAttempts": 2,
-          "baseDelayMs": 1000,
-          "backoff": "exponential",
-          "retryOn": [
-            429,
-            503
-          ]
-        }
-      }
-    },
-    "/postings/{postingId}/move/laterbox.json": {
-      "post": {
-        "description": "Move posting to Reply Later",
-        "operationId": "MovePostingToReplyLater",
-        "parameters": [
-          {
-            "name": "postingId",
-            "in": "path",
-            "schema": {
-              "type": "integer",
-              "format": "int64"
-            },
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "MovePostingToReplyLater 200 response"
-          },
-          "401": {
-            "description": "UnauthorizedError 401 response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UnauthorizedErrorResponseContent"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "NotFoundError 404 response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/NotFoundErrorResponseContent"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "InternalServerError 500 response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/InternalServerErrorResponseContent"
-                }
-              }
-            }
-          },
-          "503": {
-            "description": "ServiceUnavailableError 503 response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ServiceUnavailableErrorResponseContent"
-                }
-              }
-            }
-          }
-        },
-        "tags": [
-          "Postings"
-        ],
-        "x-hey-retry": {
-          "maxAttempts": 2,
-          "baseDelayMs": 1000,
-          "backoff": "exponential",
-          "retryOn": [
-            429,
-            503
-          ]
-        }
-      }
-    },
-    "/postings/{postingId}/move/trailbox.json": {
-      "post": {
-        "description": "Move posting to Paper Trail",
-        "operationId": "MovePostingToPaperTrail",
-        "parameters": [
-          {
-            "name": "postingId",
-            "in": "path",
-            "schema": {
-              "type": "integer",
-              "format": "int64"
-            },
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "MovePostingToPaperTrail 200 response"
-          },
-          "401": {
-            "description": "UnauthorizedError 401 response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UnauthorizedErrorResponseContent"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "NotFoundError 404 response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/NotFoundErrorResponseContent"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "InternalServerError 500 response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/InternalServerErrorResponseContent"
-                }
-              }
-            }
-          },
-          "503": {
-            "description": "ServiceUnavailableError 503 response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ServiceUnavailableErrorResponseContent"
-                }
-              }
-            }
-          }
-        },
-        "tags": [
-          "Postings"
-        ],
-        "x-hey-retry": {
-          "maxAttempts": 2,
-          "baseDelayMs": 1000,
-          "backoff": "exponential",
-          "retryOn": [
-            429,
-            503
-          ]
-        }
-      }
-    },
-    "/postings/{postingId}/trash.json": {
-      "post": {
-        "description": "Move posting to trash",
-        "operationId": "MovePostingToTrash",
-        "parameters": [
-          {
-            "name": "postingId",
-            "in": "path",
-            "schema": {
-              "type": "integer",
-              "format": "int64"
-            },
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "MovePostingToTrash 200 response"
-          },
-          "401": {
-            "description": "UnauthorizedError 401 response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UnauthorizedErrorResponseContent"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "NotFoundError 404 response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/NotFoundErrorResponseContent"
                 }
               }
             }
@@ -3365,100 +3213,6 @@
           ]
         }
       }
-    },
-    "/topics/{topicId}/entries.json": {
-      "post": {
-        "description": "Reply to an existing topic",
-        "operationId": "CreateTopicMessage",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CreateTopicMessageRequestContent"
-              }
-            }
-          },
-          "required": true
-        },
-        "parameters": [
-          {
-            "name": "topicId",
-            "in": "path",
-            "schema": {
-              "type": "integer",
-              "format": "int64"
-            },
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "CreateTopicMessage 200 response"
-          },
-          "401": {
-            "description": "UnauthorizedError 401 response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UnauthorizedErrorResponseContent"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "NotFoundError 404 response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/NotFoundErrorResponseContent"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "UnprocessableEntityError 422 response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UnprocessableEntityErrorResponseContent"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "InternalServerError 500 response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/InternalServerErrorResponseContent"
-                }
-              }
-            }
-          },
-          "503": {
-            "description": "ServiceUnavailableError 503 response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ServiceUnavailableErrorResponseContent"
-                }
-              }
-            }
-          }
-        },
-        "tags": [
-          "Messages"
-        ],
-        "x-hey-retry": {
-          "maxAttempts": 2,
-          "baseDelayMs": 1000,
-          "backoff": "exponential",
-          "retryOn": [
-            429,
-            503
-          ]
-        }
-      }
     }
   },
   "components": {
@@ -4023,7 +3777,7 @@
       },
       "CreateReplyRequestContent": {
         "type": "object",
-        "description": "Wire format: {acting_sender_id, message: {content}}",
+        "description": "Wire format: {acting_sender_id, message: {content}, entry: {addressed: {directly: [...]}}}",
         "properties": {
           "acting_sender_id": {
             "type": "integer",
@@ -4031,23 +3785,9 @@
           },
           "message": {
             "$ref": "#/components/schemas/ReplyMessagePayload"
-          }
-        },
-        "required": [
-          "acting_sender_id",
-          "message"
-        ]
-      },
-      "CreateTopicMessageRequestContent": {
-        "type": "object",
-        "description": "Wire format: {acting_sender_id, message: {content}}",
-        "properties": {
-          "acting_sender_id": {
-            "type": "integer",
-            "format": "int64"
           },
-          "message": {
-            "$ref": "#/components/schemas/TopicMessagePayload"
+          "entry": {
+            "$ref": "#/components/schemas/MessageEntryPayload"
           }
         },
         "required": [
@@ -4520,16 +4260,25 @@
       },
       "MessageAddressed": {
         "type": "object",
-        "description": "Recipients as comma-separated email addresses.",
+        "description": "Recipients per kind, each a list of email addresses.\nhaystack applies Array() to each kind, so a JSON array is the correct wire format\n(a bare string would be treated as a single address, not split on commas).",
         "properties": {
           "directly": {
-            "type": "string"
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           },
           "copied": {
-            "type": "string"
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           },
           "blindcopied": {
-            "type": "string"
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
         }
       },
@@ -4564,6 +4313,26 @@
             "type": "string"
           }
         }
+      },
+      "MovePostingsRequestContent": {
+        "type": "object",
+        "properties": {
+          "posting_ids": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          "box_id": {
+            "type": "integer",
+            "format": "int64"
+          }
+        },
+        "required": [
+          "box_id",
+          "posting_ids"
+        ]
       },
       "NavigationIcon": {
         "type": "object",
@@ -5363,17 +5132,6 @@
             }
           }
         }
-      },
-      "TopicMessagePayload": {
-        "type": "object",
-        "properties": {
-          "content": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "content"
-        ]
       },
       "UnauthorizedErrorResponseContent": {
         "type": "object",

--- a/scripts/generate-route-coverage
+++ b/scripts/generate-route-coverage
@@ -3,24 +3,58 @@
 #
 # Reads: openapi.json
 # Writes: spec/route-coverage.json
+#
+# Usage:
+#   ./scripts/generate-route-coverage           # regenerate
+#   ./scripts/generate-route-coverage --check   # fail if the checked-in file is stale
+#
+# route-coverage.json is what the forward/reverse drift checks read, so a stale
+# file means the drift gate silently ignores new or renamed operations. The
+# --check mode exists so `make check` can refuse that.
 set -euo pipefail
 
-OPENAPI_FILE="${1:-openapi.json}"
-OUTPUT_FILE="spec/route-coverage.json"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+
+CHECK_MODE=false
+if [ "${1:-}" = "--check" ]; then
+  CHECK_MODE=true
+  shift
+fi
+
+OPENAPI_FILE="${1:-$ROOT_DIR/openapi.json}"
+OUTPUT_FILE="$ROOT_DIR/spec/route-coverage.json"
 
 if [[ ! -f "$OPENAPI_FILE" ]]; then
     echo "ERROR: $OPENAPI_FILE not found. Run 'make smithy-build' first."
     exit 1
 fi
 
-jq -S '[
-  .paths | to_entries[] | .key as $path |
-  .value | to_entries[] | select(.key != "parameters") |
-  {
-    operationId: .value.operationId,
-    method: (.key | ascii_upcase),
-    path: $path
-  }
-] | sort_by(.operationId)' "$OPENAPI_FILE" > "$OUTPUT_FILE"
+generate() {
+  jq -S '[
+    .paths | to_entries[] | .key as $path |
+    .value | to_entries[] | select(.key != "parameters") |
+    {
+      operationId: .value.operationId,
+      method: (.key | ascii_upcase),
+      path: $path
+    }
+  ] | sort_by(.operationId)' "$OPENAPI_FILE"
+}
 
+if [ "$CHECK_MODE" = true ]; then
+  if [ ! -f "$OUTPUT_FILE" ]; then
+    echo "ERROR: $OUTPUT_FILE not found. Run './scripts/generate-route-coverage'."
+    exit 1
+  fi
+  if ! diff -q <(generate) "$OUTPUT_FILE" > /dev/null; then
+    echo "ERROR: spec/route-coverage.json is out of date. Run './scripts/generate-route-coverage'."
+    diff <(generate) "$OUTPUT_FILE" | head -20 || true
+    exit 1
+  fi
+  echo "route-coverage.json is up to date."
+  exit 0
+fi
+
+generate > "$OUTPUT_FILE"
 echo "Generated $OUTPUT_FILE with $(jq length "$OUTPUT_FILE") operations"

--- a/spec/api-provenance.json
+++ b/spec/api-provenance.json
@@ -1,6 +1,6 @@
 {
   "source": "haystack",
-  "sha": "33f9a7e29abd7066ff997f7326164009c1e2add8",
-  "date": "2026-03-09",
+  "sha": "b34a99a027244d05e6136cfd163b838189034b5c",
+  "date": "2026-08-17",
   "notes": "Pinned from haystack master. Update with: make provenance-sync"
 }

--- a/spec/excluded-routes.json
+++ b/spec/excluded-routes.json
@@ -4043,5 +4043,10 @@
     "method": "GET",
     "path": "/workflows/{workflow_id}/toolbar",
     "reason": "web-ui: workflow toolbar"
+  },
+  {
+    "method": "POST",
+    "path": "/topics/{topic_id}/messages",
+    "reason": "html-only: responds with a redirect even for JSON; thread replies use POST /entries/{entry_id}/replies (CreateReply)"
   }
 ]

--- a/spec/hey.smithy
+++ b/spec/hey.smithy
@@ -86,7 +86,6 @@ service HEY {
         // Messages (3 MVP)
         GetMessage
         CreateMessage
-        CreateTopicMessage
 
         // Entries (2 MVP)
         ListDrafts
@@ -122,15 +121,13 @@ service HEY {
         // Search (1 MVP)
         Search
 
-        // Postings (8 MVP)
+        // Postings (6 MVP)
         MarkPostingsSeen
         MarkPostingsUnseen
-        MovePostingToFeed
-        MovePostingToSetAside
-        MovePostingToReplyLater
-        MovePostingToPaperTrail
-        MovePostingToTrash
-        IgnorePosting
+        MovePostings
+        TrashPostings
+        MutePostings
+        UnmutePostings
     ]
 }
 
@@ -1227,44 +1224,17 @@ structure MessageEntryPayload {
     addressed: MessageAddressed
 }
 
-/// Recipients as comma-separated email addresses.
+/// Recipients per kind, each a list of email addresses.
+/// haystack applies Array() to each kind, so a JSON array is the correct wire format
+/// (a bare string would be treated as a single address, not split on commas).
 structure MessageAddressed {
-    directly: String
-    copied: String
-    blindcopied: String
+    directly: EmailAddressList
+    copied: EmailAddressList
+    blindcopied: EmailAddressList
 }
 
-/// Reply to an existing topic
-@http(method: "POST", uri: "/topics/{topicId}/entries.json")
-@tags(["Messages"])
-@heyRetry(maxAttempts: 2, baseDelayMs: 1000, backoff: "exponential", retryOn: [429, 503])
-operation CreateTopicMessage {
-    input: CreateTopicMessageInput
-    errors: [UnauthorizedError, NotFoundError, UnprocessableEntityError, InternalServerError, ServiceUnavailableError]
-}
-
-structure CreateTopicMessageInput {
-    @httpLabel
-    @required
-    topicId: Long
-
-    @httpPayload
-    @required
-    body: CreateTopicMessageRequestContent
-}
-
-/// Wire format: {acting_sender_id, message: {content}}
-structure CreateTopicMessageRequestContent {
-    @required
-    acting_sender_id: Long
-
-    @required
-    message: TopicMessagePayload
-}
-
-structure TopicMessagePayload {
-    @required
-    content: String
+list EmailAddressList {
+    member: String
 }
 
 // =============================================================================
@@ -1307,13 +1277,15 @@ structure CreateReplyInput {
     body: CreateReplyRequestContent
 }
 
-/// Wire format: {acting_sender_id, message: {content}}
+/// Wire format: {acting_sender_id, message: {content}, entry: {addressed: {directly: [...]}}}
 structure CreateReplyRequestContent {
     @required
     acting_sender_id: Long
 
     @required
     message: ReplyMessagePayload
+
+    entry: MessageEntryPayload
 }
 
 structure ReplyMessagePayload {
@@ -1750,7 +1722,7 @@ structure SearchOutput {
 }
 
 // =============================================================================
-// POSTINGS — mark seen/unseen, move between boxes, trash, ignore
+// POSTINGS — mark seen/unseen, move between boxes, trash, mute (all bulk)
 // =============================================================================
 
 /// Mark postings as seen
@@ -1782,63 +1754,69 @@ structure MarkPostingsRequestContent {
     posting_ids: PostingIdList
 }
 
-/// Move posting to The Feed
-@http(method: "POST", uri: "/postings/{postingId}/move/feedbox.json")
+/// Move postings to a box (bulk).
+/// Mirrors HEY's Postings::MovesController: `posting_ids` plus the target `box_id`
+/// (an ID from ListBoxes; the box `kind` field identifies imbox, feedbox, asidebox,
+/// laterbox, trailbox). Responds 204 No Content.
+@http(method: "POST", uri: "/postings/moves.json")
 @tags(["Postings"])
 @heyRetry(maxAttempts: 2, baseDelayMs: 1000, backoff: "exponential", retryOn: [429, 503])
-operation MovePostingToFeed {
-    input: PostingActionInput
+operation MovePostings {
+    input: MovePostingsInput
     errors: [UnauthorizedError, NotFoundError, InternalServerError, ServiceUnavailableError]
 }
 
-/// Move posting to Set Aside
-@http(method: "POST", uri: "/postings/{postingId}/move/asidebox.json")
-@tags(["Postings"])
-@heyRetry(maxAttempts: 2, baseDelayMs: 1000, backoff: "exponential", retryOn: [429, 503])
-operation MovePostingToSetAside {
-    input: PostingActionInput
-    errors: [UnauthorizedError, NotFoundError, InternalServerError, ServiceUnavailableError]
-}
-
-/// Move posting to Reply Later
-@http(method: "POST", uri: "/postings/{postingId}/move/laterbox.json")
-@tags(["Postings"])
-@heyRetry(maxAttempts: 2, baseDelayMs: 1000, backoff: "exponential", retryOn: [429, 503])
-operation MovePostingToReplyLater {
-    input: PostingActionInput
-    errors: [UnauthorizedError, NotFoundError, InternalServerError, ServiceUnavailableError]
-}
-
-/// Move posting to Paper Trail
-@http(method: "POST", uri: "/postings/{postingId}/move/trailbox.json")
-@tags(["Postings"])
-@heyRetry(maxAttempts: 2, baseDelayMs: 1000, backoff: "exponential", retryOn: [429, 503])
-operation MovePostingToPaperTrail {
-    input: PostingActionInput
-    errors: [UnauthorizedError, NotFoundError, InternalServerError, ServiceUnavailableError]
-}
-
-/// Move posting to trash
-@http(method: "POST", uri: "/postings/{postingId}/trash.json")
-@tags(["Postings"])
-@heyRetry(maxAttempts: 2, baseDelayMs: 1000, backoff: "exponential", retryOn: [429, 503])
-operation MovePostingToTrash {
-    input: PostingActionInput
-    errors: [UnauthorizedError, NotFoundError, InternalServerError, ServiceUnavailableError]
-}
-
-/// Ignore a posting (stop notifications)
-@http(method: "POST", uri: "/postings/{postingId}/ignore.json")
-@tags(["Postings"])
-@heyRetry(maxAttempts: 2, baseDelayMs: 1000, backoff: "exponential", retryOn: [429, 503])
-operation IgnorePosting {
-    input: PostingActionInput
-    errors: [UnauthorizedError, NotFoundError, InternalServerError, ServiceUnavailableError]
-}
-
-/// Input for single-posting actions (move, trash, ignore)
-structure PostingActionInput {
-    @httpLabel
+structure MovePostingsInput {
+    @httpPayload
     @required
-    postingId: Long
+    body: MovePostingsRequestContent
+}
+
+structure MovePostingsRequestContent {
+    @required
+    posting_ids: PostingIdList
+
+    @required
+    box_id: Long
+}
+
+/// Move postings to the trash (bulk).
+/// Mirrors HEY's Postings::TrashController. For JSON requests the server treats
+/// the removal decision as made (shared topics: your access is removed).
+/// Responds 204 No Content.
+@http(method: "POST", uri: "/postings/trash.json")
+@tags(["Postings"])
+@heyRetry(maxAttempts: 2, baseDelayMs: 1000, backoff: "exponential", retryOn: [429, 503])
+operation TrashPostings {
+    input: MarkPostingsInput
+    errors: [UnauthorizedError, NotFoundError, InternalServerError, ServiceUnavailableError]
+}
+
+/// Mute postings (bulk) — stop notifications for their threads.
+/// Mirrors HEY's Postings::MutingsController#create. Responds 201 Created.
+@http(method: "POST", uri: "/postings/mutings.json")
+@tags(["Postings"])
+@heyRetry(maxAttempts: 2, baseDelayMs: 1000, backoff: "exponential", retryOn: [429, 503])
+operation MutePostings {
+    input: MarkPostingsInput
+    errors: [UnauthorizedError, NotFoundError, InternalServerError, ServiceUnavailableError]
+}
+
+/// Unmute postings (bulk).
+/// Mirrors HEY's Postings::MutingsController#destroy. `posting_ids` is sent as a
+/// comma-separated query string because DELETE carries no body. Responds 201 Created.
+@idempotent
+@http(method: "DELETE", uri: "/postings/mutings.json")
+@tags(["Postings"])
+@heyRetry(maxAttempts: 2, baseDelayMs: 1000, backoff: "exponential", retryOn: [429, 503])
+operation UnmutePostings {
+    input: UnmutePostingsInput
+    errors: [UnauthorizedError, NotFoundError, InternalServerError, ServiceUnavailableError]
+}
+
+structure UnmutePostingsInput {
+    /// Comma-separated posting IDs, e.g. "123,456"
+    @httpQuery("posting_ids")
+    @required
+    posting_ids: String
 }

--- a/spec/route-coverage.json
+++ b/spec/route-coverage.json
@@ -22,12 +22,7 @@
   {
     "method": "POST",
     "operationId": "CreateReply",
-    "path": "/entries/{entryId}/replies"
-  },
-  {
-    "method": "POST",
-    "operationId": "CreateTopicMessage",
-    "path": "/topics/{topicId}/messages"
+    "path": "/entries/{entryId}/replies.json"
   },
   {
     "method": "DELETE",
@@ -155,6 +150,26 @@
     "path": "/entries/drafts.json"
   },
   {
+    "method": "POST",
+    "operationId": "MarkPostingsSeen",
+    "path": "/postings/seen.json"
+  },
+  {
+    "method": "POST",
+    "operationId": "MarkPostingsUnseen",
+    "path": "/postings/unseen.json"
+  },
+  {
+    "method": "POST",
+    "operationId": "MovePostings",
+    "path": "/postings/moves.json"
+  },
+  {
+    "method": "POST",
+    "operationId": "MutePostings",
+    "path": "/postings/mutings.json"
+  },
+  {
     "method": "GET",
     "operationId": "Search",
     "path": "/search.json"
@@ -165,6 +180,11 @@
     "path": "/calendar/ongoing_time_track.json"
   },
   {
+    "method": "POST",
+    "operationId": "TrashPostings",
+    "path": "/postings/trash.json"
+  },
+  {
     "method": "DELETE",
     "operationId": "UncompleteCalendarTodo",
     "path": "/calendar/todos/{todoId}/completions"
@@ -173,6 +193,11 @@
     "method": "DELETE",
     "operationId": "UncompleteHabit",
     "path": "/calendar/days/{day}/habits/{habitId}/completions"
+  },
+  {
+    "method": "DELETE",
+    "operationId": "UnmutePostings",
+    "path": "/postings/mutings.json"
   },
   {
     "method": "PATCH",

--- a/spec/route-snapshot.json
+++ b/spec/route-snapshot.json
@@ -72,6 +72,10 @@
     "path": "/accounts"
   },
   {
+    "method": "POST",
+    "path": "/accounts/bulk_spam_cancellation"
+  },
+  {
     "method": "GET",
     "path": "/accounts/{account_id}/billing"
   },
@@ -3510,10 +3514,6 @@
   {
     "method": "PUT",
     "path": "/entries/{entry_id}/status/trashed"
-  },
-  {
-    "method": "GET",
-    "path": "/entries/{id}"
   },
   {
     "method": "GET",


### PR DESCRIPTION
Stacked on #61 — review that first; this retargets to `main` when it merges.

The forward drift check reads `spec/route-coverage.json`, but nothing verified that file was fresh, so operations added after the last regenerate were invisible to the gate. That's how the phantom routes fixed in #61 got in. This closes that hole.

## What changed

- `generate-route-coverage --check` and a `drift-check-coverage` target; `drift-check-mvp` is now **coverage freshness + forward + reverse + shape**. Reverse means every JSON-capable haystack route is either modelled or listed in `excluded-routes.json` with a reason.
- **New "Spec Drift" CI job** running `behavior-model-check`, `url-routes-check` and `drift-check-mvp`. Until now these only ran in local `make check`.
- Refreshed `route-snapshot.json` and `api-provenance.json` from haystack `b34a99a0` (2026-08-14). Only two routes changed since the March pin.
- Excluded `POST /topics/{topic_id}/messages` (HTML-only; redirects for JSON — thread replies use `CreateReply`).
- `AGENTS.md` describes the gate as it now is.

`make check` is green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gates route coverage freshness and reverse drift in CI, and runs the behavior-model check where the Smithy AST exists. Old behavior: the forward drift check could pass with a stale `spec/route-coverage.json`, missing new endpoints. New behavior: `drift-check-mvp` requires coverage freshness, forward + reverse + shape checks, and CI enforces them.

**Review Notes**
- Adds `--check` to `scripts/generate-route-coverage` and a `drift-check-coverage` Make target; `drift-check-mvp` is now coverage freshness + forward + reverse + shape. `drift-check-full` is an alias.
- Adds a “Spec Drift” CI job that runs `url-routes-check` and `drift-check-mvp`. Runs `behavior-model-check` in the `smithy-verify` workflow where the Smithy AST is available.
- Refreshes `spec/route-snapshot.json` and `spec/api-provenance.json` to the Aug 17, 2026 haystack pin; adds `POST /accounts/bulk_spam_cancellation` and removes `GET /entries/{id}`.
- Excludes `POST /topics/{topic_id}/messages` (HTML-only; redirects for JSON). Thread replies use `CreateReply`.
- Updates `AGENTS.md` to document the gate.

**Migration**
- After any OpenAPI change, run `./scripts/generate-route-coverage` and commit the result; CI fails on stale `spec/route-coverage.json`.
- If a haystack JSON route is not modeled, list it in `spec/excluded-routes.json` with a reason; reverse drift enforces this.
- To refresh the snapshot/pin, run `make drift-regen HAYSTACK_DIR=…` and `./scripts/sync-provenance HAYSTACK_DIR` to update `spec/api-provenance.json`.

<sup>Written for commit 1b6e5741d0c3a74efad49b0cb8f47c1dceae1206. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-sdk/pull/63?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

