### PR TITLE
Make optional request dates pointers so partial updates stay partial

### DIFF
--- a/go/pkg/generated/client.gen.go
+++ b/go/pkg/generated/client.gen.go
@@ -164,8 +164,8 @@ type CalendarRecordingsResponse map[string][]Recording
 // CalendarTodoPayload defines model for CalendarTodoPayload.
 type CalendarTodoPayload struct {
 	// StartsAt Date string (YYYY-MM-DD). Defaults to today if omitted.
-	StartsAt time.Time `json:"starts_at,omitempty"`
-	Title    string    `json:"title"`
+	StartsAt *time.Time `json:"starts_at,omitempty"`
+	Title    string     `json:"title"`
 }
 
 // CalendarWithRecordingChangesUrl CalendarWithRecordingChangesUrl — wraps calendar with sync URL
@@ -1022,12 +1022,12 @@ type UpdateTimeTrackPayload struct {
 	Category string `json:"category,omitempty"`
 
 	// EndsAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
-	EndsAt time.Time `json:"ends_at,omitempty"`
-	Notes  string    `json:"notes,omitempty"`
+	EndsAt *time.Time `json:"ends_at,omitempty"`
+	Notes  string     `json:"notes,omitempty"`
 
 	// StartsAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
-	StartsAt time.Time `json:"starts_at,omitempty"`
-	Title    string    `json:"title,omitempty"`
+	StartsAt *time.Time `json:"starts_at,omitempty"`
+	Title    string     `json:"title,omitempty"`
 }
 
 // UpdateTimeTrackRequestContent Wire format: {calendar_time_track: {title, notes, category, starts_at, ends_at}}

--- a/go/pkg/hey/services_test.go
+++ b/go/pkg/hey/services_test.go
@@ -854,6 +854,13 @@ func TestTimeTracksService_Stop(t *testing.T) {
 			if _, ok := tt["ends_at"]; !ok {
 				t.Error("missing ends_at in stop body")
 			}
+			// Stop must not touch the start: a zero-valued starts_at would be
+			// applied by the server and rewrite the track to year 0001.
+			for _, k := range []string{"starts_at", "category", "notes", "title"} {
+				if v, present := tt[k]; present {
+					t.Errorf("stop body must only carry ends_at; got %s=%v", k, v)
+				}
+			}
 		},
 		`{"id":1,"type":"TimeTrack"}`,
 	)

--- a/go/pkg/hey/time_tracks.go
+++ b/go/pkg/hey/time_tracks.go
@@ -112,8 +112,9 @@ func (s *TimeTracksService) Update(ctx context.Context, timeTrackID int64, body 
 
 // Stop stops an ongoing time track by setting ends_at to the current time.
 func (s *TimeTracksService) Stop(ctx context.Context, timeTrackID int64) error {
+	now := time.Now().UTC()
 	_, err := s.Update(ctx, timeTrackID, generated.UpdateTimeTrackJSONRequestBody{
-		CalendarTimeTrack: generated.UpdateTimeTrackPayload{EndsAt: time.Now().UTC()},
+		CalendarTimeTrack: generated.UpdateTimeTrackPayload{EndsAt: &now},
 	})
 	return err
 }

--- a/openapi.json
+++ b/openapi.json
@@ -6795,7 +6795,8 @@
             "x-go-type": "time.Time",
             "x-go-type-import": {
               "path": "time"
-            }
+            },
+            "x-go-type-skip-optional-pointer": false
           }
         },
         "required": [
@@ -8640,14 +8641,16 @@
             "x-go-type": "time.Time",
             "x-go-type-import": {
               "path": "time"
-            }
+            },
+            "x-go-type-skip-optional-pointer": false
           },
           "ends_at": {
             "type": "string",
             "x-go-type": "time.Time",
             "x-go-type-import": {
               "path": "time"
-            }
+            },
+            "x-go-type-skip-optional-pointer": false
           },
           "category_title": {
             "type": "string"
@@ -8864,7 +8867,8 @@
             "x-go-type": "time.Time",
             "x-go-type-import": {
               "path": "time"
-            }
+            },
+            "x-go-type-skip-optional-pointer": false
           },
           "ends_at": {
             "type": "string",
@@ -8873,7 +8877,8 @@
             "x-go-type": "time.Time",
             "x-go-type-import": {
               "path": "time"
-            }
+            },
+            "x-go-type-skip-optional-pointer": false
           }
         }
       },

--- a/scripts/check-service-drift.sh
+++ b/scripts/check-service-drift.sh
@@ -40,8 +40,10 @@ for f in "$SERVICE_DIR"/*.go; do
   case "$f" in
     *_test.go) continue ;;
   esac
-  grep "\.gen\.[A-Za-z]*WithResponse" "$f" 2>/dev/null || true
-done | sed 's/.*\.gen\.\([A-Za-z]*\)WithResponse.*/\1/' \
+  # Wrappers reach the generated client either as c.gen.Xxx or via the
+  # genClient() accessor; match both.
+  grep -oE "(\.gen|genClient\(\))\.[A-Za-z]*WithResponse" "$f" 2>/dev/null || true
+done | sed -E 's/.*\.([A-Za-z]*)WithResponse.*/\1/' \
   | sed 's/WithBody$//' \
   | sort -u > "$SVC_OPS"
 

--- a/scripts/drift-check-reverse
+++ b/scripts/drift-check-reverse
@@ -59,16 +59,33 @@ normalize() {
 # ---- Build lookup sets from coverage + excluded ----
 
 declare -A accounted_set
+declare -A coverage_set
 
 while IFS=$'\t' read -r method path; do
   key=$(normalize "$method" "$path")
   accounted_set["$key"]=1
+  coverage_set["$key"]=1
 done < <(jq -r '.[] | [.method, .path] | @tsv' "$COVERAGE_FILE")
 
-while IFS=$'\t' read -r method path; do
+# A route that is both modelled and excluded is a contradiction: the exclusion
+# reason is stale, and worse, if the operation is later removed or its URI
+# mistyped, the stale exclusion keeps this check green. Refuse the overlap.
+overlap=0
+while IFS=$'\t' read -r method path reason; do
   key=$(normalize "$method" "$path")
+  if [ -n "${coverage_set[$key]:-}" ]; then
+    echo "OVERLAP: $method $path is modelled in route-coverage.json but still excluded (\"$reason\")"
+    overlap=$((overlap + 1))
+  fi
   accounted_set["$key"]=1
-done < <(jq -r '.[] | [.method, .path] | @tsv' "$EXCLUDED_FILE")
+done < <(jq -r '.[] | [.method, .path, (.reason // "")] | @tsv' "$EXCLUDED_FILE")
+
+if [ "$overlap" -gt 0 ]; then
+  echo ""
+  echo "$overlap route(s) are in both route-coverage.json and excluded-routes.json."
+  echo "Remove them from spec/excluded-routes.json — modelled routes need no exclusion."
+  exit 1
+fi
 
 # ---- Filter snapshot to JSON-capable routes ----
 #

--- a/scripts/enhance-openapi-go-types.sh
+++ b/scripts/enhance-openapi-go-types.sh
@@ -36,15 +36,17 @@ jq '
   )
 ' "$OPENAPI_FILE" > "${OPENAPI_FILE}.tmp" && mv "${OPENAPI_FILE}.tmp" "$OPENAPI_FILE"
 
-# Pass 2: Optional booleans and timestamps in RequestContent schemas → pointers
+# Pass 2: Optional booleans and timestamps in request schemas → pointers
 # Without this, Go's JSON encoder sends zero-valued time.Time as "0001-01-01T00:00:00Z"
 # and false booleans even when the caller didn't set them — `omitempty` does not omit a
 # struct or a false bool. That is how a partial update (e.g. stopping a time track by
 # sending only ends_at) ends up rewriting starts_at on the server.
 #
-# Applies to every schema reachable from a request body (RequestContent, nested
-# *Payload, and anything they reference), for every property that pass 1 or the
-# format turns into time.Time / types.Date, plus booleans.
+# Applies to every component schema reachable by $ref from a request body
+# (RequestContent, nested *Payload, and anything they reference), for every property
+# that pass 1 or the format turns into time.Time / types.Date, plus booleans.
+# Smithy always emits request bodies as $ref to a component schema, so inline
+# requestBody schemas do not occur here and are not walked.
 jq '
   def refname: sub("^#/components/schemas/"; "");
   . as $root

--- a/scripts/enhance-openapi-go-types.sh
+++ b/scripts/enhance-openapi-go-types.sh
@@ -38,26 +38,42 @@ jq '
 
 # Pass 2: Optional booleans and timestamps in RequestContent schemas → pointers
 # Without this, Go's JSON encoder sends zero-valued time.Time as "0001-01-01T00:00:00Z"
-# and false booleans even when the caller didn't set them.
+# and false booleans even when the caller didn't set them — `omitempty` does not omit a
+# struct or a false bool. That is how a partial update (e.g. stopping a time track by
+# sending only ends_at) ends up rewriting starts_at on the server.
+#
+# Applies to every schema reachable from a request body (RequestContent, nested
+# *Payload, and anything they reference), for every property that pass 1 or the
+# format turns into time.Time / types.Date, plus booleans.
 jq '
-  (.components.schemas // {}) |= with_entries(
-    if (.key | test("RequestContent$")) then
-      .value |= (
-        if .properties then
-          .properties |= with_entries(
-            if .value.type == "boolean" then
-              .value += {"x-go-type-skip-optional-pointer": false}
-            elif (.value.type == "string" and .value.format == "date-time") then
-              .value += {"x-go-type-skip-optional-pointer": false}
-            else .
-            end
-          )
-        else .
-        end
-      )
-    else .
-    end
-  )
+  def refname: sub("^#/components/schemas/"; "");
+  . as $root
+  | [ .paths[] | .[] | objects | .requestBody? // empty | .. | .["$ref"]? // empty | refname ] | unique as $seeds
+  | def expand($set):
+      ($set + [ $set[] | $root.components.schemas[.] | .. | .["$ref"]? // empty | refname ] | unique) as $n
+      | if ($n | length) == ($set | length) then $set else expand($n) end;
+    expand($seeds) as $request_schemas
+  | $root
+  | (.components.schemas // {}) |= with_entries(
+      if (.key as $k | $request_schemas | index($k)) then
+        .value |= (
+          if .properties then
+            .properties |= with_entries(
+              if .value.type == "boolean" then
+                .value += {"x-go-type-skip-optional-pointer": false}
+              elif (.value.type == "string" and (.value.format == "date-time" or .value.format == "date")) then
+                .value += {"x-go-type-skip-optional-pointer": false}
+              elif (.value.type == "string" and (.key | test("_at$|_on$"))) then
+                .value += {"x-go-type-skip-optional-pointer": false}
+              else .
+              end
+            )
+          else .
+          end
+        )
+      else .
+      end
+    )
 ' "$OPENAPI_FILE" > "${OPENAPI_FILE}.tmp" && mv "${OPENAPI_FILE}.tmp" "$OPENAPI_FILE"
 
 # Pass 3: Nothing here — self-referential types are fixed via post-codegen sed

--- a/spec/api-provenance.json
+++ b/spec/api-provenance.json
@@ -1,6 +1,6 @@
 {
   "source": "haystack",
-  "sha": "b34a99a027244d05e6136cfd163b838189034b5c",
+  "sha": "3310b0725af2a3e50dea0c861eb68e5b1e13982d",
   "date": "2026-08-17",
   "notes": "Pinned from haystack master. Update with: make provenance-sync"
 }

--- a/spec/excluded-routes.json
+++ b/spec/excluded-routes.json
@@ -595,32 +595,7 @@
     "reason": "phase-2: calendar habit management"
   },
   {
-    "method": "POST",
-    "path": "/calendar/habits",
-    "reason": "phase-2: calendar habit management"
-  },
-  {
-    "method": "DELETE",
-    "path": "/calendar/habits/{habit_id}/stop",
-    "reason": "phase-2: calendar habit management"
-  },
-  {
-    "method": "POST",
-    "path": "/calendar/habits/{habit_id}/stop",
-    "reason": "phase-2: calendar habit management"
-  },
-  {
-    "method": "DELETE",
-    "path": "/calendar/habits/{id}",
-    "reason": "phase-2: calendar habit management"
-  },
-  {
     "method": "GET",
-    "path": "/calendar/habits/{id}",
-    "reason": "phase-2: calendar habit management"
-  },
-  {
-    "method": "PATCH",
     "path": "/calendar/habits/{id}",
     "reason": "phase-2: calendar habit management"
   },
@@ -1000,11 +975,6 @@
     "reason": "phase-2: calendar search"
   },
   {
-    "method": "POST",
-    "path": "/calendar/time_tracks",
-    "reason": "phase-2: calendar time tracking"
-  },
-  {
     "method": "GET",
     "path": "/calendar/time_tracks/categories",
     "reason": "phase-2: calendar time tracking"
@@ -1062,11 +1032,6 @@
   {
     "method": "GET",
     "path": "/calendar/time_tracks/exports",
-    "reason": "phase-2: calendar time tracking"
-  },
-  {
-    "method": "DELETE",
-    "path": "/calendar/time_tracks/{id}",
     "reason": "phase-2: calendar time tracking"
   },
   {
@@ -1350,11 +1315,6 @@
     "reason": "phase-2: clip management"
   },
   {
-    "method": "GET",
-    "path": "/collections",
-    "reason": "phase-2: collections"
-  },
-  {
     "method": "POST",
     "path": "/collections",
     "reason": "phase-2: collections"
@@ -1406,11 +1366,6 @@
   },
   {
     "method": "GET",
-    "path": "/collections/{id}",
-    "reason": "phase-2: collections"
-  },
-  {
-    "method": "PATCH",
     "path": "/collections/{id}",
     "reason": "phase-2: collections"
   },
@@ -1481,26 +1436,11 @@
   },
   {
     "method": "DELETE",
-    "path": "/contacts/{contact_id}/bundle",
-    "reason": "phase-2: contact bundling"
-  },
-  {
-    "method": "POST",
-    "path": "/contacts/{contact_id}/bundle",
-    "reason": "phase-2: contact bundling"
-  },
-  {
-    "method": "DELETE",
     "path": "/contacts/{contact_id}/clearance",
     "reason": "phase-2: contact clearance"
   },
   {
     "method": "GET",
-    "path": "/contacts/{contact_id}/clearance",
-    "reason": "phase-2: contact clearance"
-  },
-  {
-    "method": "PATCH",
     "path": "/contacts/{contact_id}/clearance",
     "reason": "phase-2: contact clearance"
   },
@@ -1825,11 +1765,6 @@
     "reason": "phase-2: entry spam reports"
   },
   {
-    "method": "PUT",
-    "path": "/entries/{entry_id}/status/spam",
-    "reason": "phase-2: entry spam reports"
-  },
-  {
     "method": "GET",
     "path": "/folders",
     "reason": "phase-2: folder management"
@@ -1851,11 +1786,6 @@
   },
   {
     "method": "DELETE",
-    "path": "/folders/{id}",
-    "reason": "phase-2: folder management"
-  },
-  {
-    "method": "GET",
     "path": "/folders/{id}",
     "reason": "phase-2: folder management"
   },
@@ -1995,16 +1925,6 @@
     "reason": "phase-2: mobile triage surface"
   },
   {
-    "method": "POST",
-    "path": "/boxes/{box_id}/designations",
-    "reason": "phase-2: mobile triage surface"
-  },
-  {
-    "method": "DELETE",
-    "path": "/boxes/{box_id}/designations/{id}",
-    "reason": "phase-2: mobile triage surface"
-  },
-  {
     "method": "DELETE",
     "path": "/boxes/{box_id}/glance",
     "reason": "phase-2: mobile triage surface"
@@ -2027,21 +1947,6 @@
   {
     "method": "PUT",
     "path": "/boxes/{box_id}/glance",
-    "reason": "phase-2: mobile triage surface"
-  },
-  {
-    "method": "GET",
-    "path": "/boxes/{box_id}/groups",
-    "reason": "phase-2: mobile triage surface"
-  },
-  {
-    "method": "POST",
-    "path": "/boxes/{box_id}/groups",
-    "reason": "phase-2: mobile triage surface"
-  },
-  {
-    "method": "DELETE",
-    "path": "/boxes/{box_id}/groups/{id}",
     "reason": "phase-2: mobile triage surface"
   },
   {
@@ -2081,11 +1986,6 @@
   },
   {
     "method": "PATCH",
-    "path": "/boxes/{box_id}/observation",
-    "reason": "phase-2: mobile triage surface"
-  },
-  {
-    "method": "POST",
     "path": "/boxes/{box_id}/observation",
     "reason": "phase-2: mobile triage surface"
   },
@@ -2865,21 +2765,6 @@
     "reason": "phase-2: personal settings and preferences"
   },
   {
-    "method": "DELETE",
-    "path": "/postings/box_groups",
-    "reason": "phase-2: posting box groups"
-  },
-  {
-    "method": "POST",
-    "path": "/postings/box_groups",
-    "reason": "phase-2: posting box groups"
-  },
-  {
-    "method": "DELETE",
-    "path": "/postings/bubble_up",
-    "reason": "phase-2: posting bubble up"
-  },
-  {
     "method": "POST",
     "path": "/postings/bubble_up",
     "reason": "phase-2: posting bubble up"
@@ -2915,11 +2800,6 @@
     "reason": "phase-2: posting bulk bubble up"
   },
   {
-    "method": "POST",
-    "path": "/postings/bulk_bubble_up_now",
-    "reason": "phase-2: posting bulk bubble up"
-  },
-  {
     "method": "PUT",
     "path": "/postings/bulk_bubble_up_now",
     "reason": "phase-2: posting bulk bubble up"
@@ -2945,31 +2825,11 @@
     "reason": "phase-2: posting collections"
   },
   {
-    "method": "DELETE",
-    "path": "/postings/filings",
-    "reason": "phase-2: posting filings"
-  },
-  {
-    "method": "POST",
-    "path": "/postings/filings",
-    "reason": "phase-2: posting filings"
-  },
-  {
-    "method": "POST",
-    "path": "/postings/folders",
-    "reason": "phase-2: posting folders"
-  },
-  {
     "method": "POST",
     "path": "/postings/{posting_id}/bundles/seen",
     "reason": "phase-2: posting management"
   },
   {
-    "method": "POST",
-    "path": "/postings/moves",
-    "reason": "phase-2: posting moves"
-  },
-  {
     "method": "DELETE",
     "path": "/postings/{posting_id}/muting",
     "reason": "phase-2: posting muting"
@@ -2978,16 +2838,6 @@
     "method": "POST",
     "path": "/postings/{posting_id}/muting",
     "reason": "phase-2: posting muting"
-  },
-  {
-    "method": "DELETE",
-    "path": "/postings/mutings",
-    "reason": "phase-2: posting mutings"
-  },
-  {
-    "method": "POST",
-    "path": "/postings/mutings",
-    "reason": "phase-2: posting mutings"
   },
   {
     "method": "DELETE",
@@ -3013,26 +2863,6 @@
     "method": "GET",
     "path": "/postings/readings/all",
     "reason": "phase-2: posting readings"
-  },
-  {
-    "method": "POST",
-    "path": "/postings/seen",
-    "reason": "phase-2: posting seen tracking"
-  },
-  {
-    "method": "POST",
-    "path": "/postings/spam",
-    "reason": "phase-2: posting spam actions"
-  },
-  {
-    "method": "POST",
-    "path": "/postings/trash",
-    "reason": "phase-2: posting trash actions"
-  },
-  {
-    "method": "POST",
-    "path": "/postings/unseen",
-    "reason": "phase-2: posting unseen tracking"
   },
   {
     "method": "POST",
@@ -3103,11 +2933,6 @@
     "method": "PUT",
     "path": "/recent_searches",
     "reason": "phase-2: recent search history"
-  },
-  {
-    "method": "GET",
-    "path": "/clearances",
-    "reason": "phase-2: screener clearances"
   },
   {
     "method": "POST",
@@ -3415,37 +3240,7 @@
     "reason": "phase-2: shared calendar toggle"
   },
   {
-    "method": "DELETE",
-    "path": "/topics/spam/all",
-    "reason": "phase-2: spam bulk actions"
-  },
-  {
     "method": "GET",
-    "path": "/stickies",
-    "reason": "phase-2: stickies"
-  },
-  {
-    "method": "POST",
-    "path": "/stickies",
-    "reason": "phase-2: stickies"
-  },
-  {
-    "method": "POST",
-    "path": "/stickies/moves",
-    "reason": "phase-2: stickies"
-  },
-  {
-    "method": "DELETE",
-    "path": "/stickies/{id}",
-    "reason": "phase-2: stickies"
-  },
-  {
-    "method": "GET",
-    "path": "/stickies/{id}",
-    "reason": "phase-2: stickies"
-  },
-  {
-    "method": "PATCH",
     "path": "/stickies/{id}",
     "reason": "phase-2: stickies"
   },
@@ -3755,11 +3550,6 @@
     "reason": "phase-2: topic metadata"
   },
   {
-    "method": "POST",
-    "path": "/topics/{topic_id}/moves",
-    "reason": "phase-2: topic moves"
-  },
-  {
     "method": "GET",
     "path": "/topics/{topic_id}/muting",
     "reason": "phase-2: topic muting"
@@ -3830,21 +3620,6 @@
     "reason": "phase-2: topic roster"
   },
   {
-    "method": "PUT",
-    "path": "/topics/{topic_id}/status/active",
-    "reason": "phase-2: topic status changes"
-  },
-  {
-    "method": "PUT",
-    "path": "/topics/{topic_id}/status/ham",
-    "reason": "phase-2: topic status changes"
-  },
-  {
-    "method": "PUT",
-    "path": "/topics/{topic_id}/status/trashed",
-    "reason": "phase-2: topic status changes"
-  },
-  {
     "method": "POST",
     "path": "/topics/{topic_id}/undo_send",
     "reason": "phase-2: topic undo send"
@@ -3888,11 +3663,6 @@
     "method": "PUT",
     "path": "/topics/{topic_id}/workflows/{workflow_id}/stagings",
     "reason": "phase-2: topic workflows"
-  },
-  {
-    "method": "DELETE",
-    "path": "/topics/trash/all",
-    "reason": "phase-2: trash bulk actions"
   },
   {
     "method": "DELETE",
@@ -3977,11 +3747,6 @@
   {
     "method": "GET",
     "path": "/advanced_search",
-    "reason": "web-ui: advanced search form"
-  },
-  {
-    "method": "GET",
-    "path": "/advanced_search_filters",
     "reason": "web-ui: advanced search form"
   },
   {

--- a/spec/route-snapshot.json
+++ b/spec/route-snapshot.json
@@ -385,38 +385,6 @@
   },
   {
     "method": "GET",
-    "path": "/accounts/{account_id}/extenzions"
-  },
-  {
-    "method": "POST",
-    "path": "/accounts/{account_id}/extenzions"
-  },
-  {
-    "method": "GET",
-    "path": "/accounts/{account_id}/extenzions/new"
-  },
-  {
-    "method": "DELETE",
-    "path": "/accounts/{account_id}/extenzions/{id}"
-  },
-  {
-    "method": "GET",
-    "path": "/accounts/{account_id}/extenzions/{id}"
-  },
-  {
-    "method": "PATCH",
-    "path": "/accounts/{account_id}/extenzions/{id}"
-  },
-  {
-    "method": "PUT",
-    "path": "/accounts/{account_id}/extenzions/{id}"
-  },
-  {
-    "method": "GET",
-    "path": "/accounts/{account_id}/extenzions/{id}/edit"
-  },
-  {
-    "method": "GET",
     "path": "/accounts/{account_id}/families"
   },
   {


### PR DESCRIPTION
Follow-up to #64.

## The bug

`TimeTracks().Stop()` sends `starts_at: "0001-01-01T00:00:00Z"` alongside `ends_at`. `UpdateTimeTrackPayload.StartsAt` is a value `time.Time` and `omitempty` doesn't omit a struct; haystack permits `starts_at` on update, so the track's start gets rewritten to year 1. `CalendarTodoPayload.StartsAt` has the same shape.

## The fix

At the generator, not in `Stop`. The pointer pass in `enhance-openapi-go-types.sh` only looked at `*RequestContent` schemas; it now covers every schema reachable from a request body and every field that ends up `time.Time` / `types.Date` / `bool`. Those three fields become pointers and are omitted unless set. `Stop` sends only `ends_at` again, and its test asserts nothing else is present.

## Gate tightening (while here)

- `check-service-drift.sh` didn't recognise the `genClient()` accessor #64 introduced, so it reported 31/83 wrapped and couldn't see most wrappers. Now 69/83.
- `drift-check-reverse` fails when a route is both modelled and excluded — a stale exclusion would otherwise keep the check green after an operation is removed or its URI mistyped. Removed the 47 exclusions #64 made stale.
- Refreshed the haystack pin to `3310b072` (#8623 removed the dead `accounts/extenzions` routes).

`make check` green (127 conformance).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop sending zero-valued timestamps in request bodies so partial updates stay partial. Previously, `TimeTracks().Stop()` sent `starts_at: "0001-01-01T00:00:00Z"` alongside `ends_at`; now Stop sends only `ends_at`.

- Extend the generator (`scripts/enhance-openapi-go-types.sh`) to walk all schemas reachable from a request body and mark time/date/bool properties as pointer-optional; `openapi.json` sets `x-go-type-skip-optional-pointer: false` on those fields, including `date` formats and string fields ending in `_at`/`_on`.
- Generated types now use pointers: `UpdateTimeTrackPayload.starts_at`, `UpdateTimeTrackPayload.ends_at`, and `CalendarTodoPayload.starts_at`.
- `TimeTracksService.Stop` sets `ends_at` via pointer; the test asserts the body only includes `ends_at`.
- Tighten drift checks: `scripts/check-service-drift.sh` detects `genClient()` calls; `scripts/drift-check-reverse` fails on overlap between modelled and excluded routes; remove stale exclusions and refresh Haystack pin to `3310b072` (drops dead `accounts/extenzions` routes).

**Migration**
- Update call sites that build request payloads: assign pointer fields (e.g., `payload.StartsAt = &t`); leave `nil` to omit.
- Only request payloads change; response types and read paths are unaffected.

<sup>Written for commit 44f0f9bd0985db9f60ecf291b2d52cc0edfb21b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-sdk/pull/65?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

