### PR TITLE
Route the hand-built wrappers through the generated client

### DIFF
--- a/conformance/runner/go/main.go
+++ b/conformance/runner/go/main.go
@@ -923,7 +923,10 @@ func executeOperation(client *generated.Client, ctx context.Context, tc TestCase
 	case "UnfilePostings":
 		params := &generated.UnfilePostingsParams{
 			PostingIds: getStringParam(tc.QueryParams, "posting_ids"),
-			FolderId:   getInt64Param(tc.QueryParams, "folder_id"),
+		}
+		if _, ok := tc.QueryParams["folder_id"]; ok {
+			folderID := getInt64Param(tc.QueryParams, "folder_id")
+			params.FolderId = &folderID
 		}
 		return client.UnfilePostings(ctx, params)
 	case "CreateFolderForPostings":
@@ -944,7 +947,11 @@ func executeOperation(client *generated.Client, ctx context.Context, tc TestCase
 	// Topic status and moves
 	case "TrashTopic":
 		topicId := getInt64Param(tc.PathParams, "topicId")
-		params := &generated.TrashTopicParams{ConfirmDestroy: getStringParam(tc.QueryParams, "confirm_destroy")}
+		params := &generated.TrashTopicParams{}
+		if _, ok := tc.QueryParams["confirm_destroy"]; ok {
+			confirm := getStringParam(tc.QueryParams, "confirm_destroy")
+			params.ConfirmDestroy = &confirm
+		}
 		return client.TrashTopic(ctx, topicId, params)
 	case "RestoreTopic":
 		topicId := getInt64Param(tc.PathParams, "topicId")
@@ -1029,7 +1036,11 @@ func executeOperation(client *generated.Client, ctx context.Context, tc TestCase
 
 	// Stickies
 	case "ListStickies":
-		params := &generated.ListStickiesParams{Limit: getInt32Param(tc.QueryParams, "limit")}
+		params := &generated.ListStickiesParams{}
+		if _, ok := tc.QueryParams["limit"]; ok {
+			limit := getInt32Param(tc.QueryParams, "limit")
+			params.Limit = &limit
+		}
 		return client.ListStickies(ctx, params)
 	case "CreateSticky":
 		return client.CreateSticky(ctx, stickyBody(tc))

--- a/go/pkg/generated/client.gen.go
+++ b/go/pkg/generated/client.gen.go
@@ -1009,6 +1009,9 @@ type UpdateContactClearanceRequestContent struct {
 	Status string `json:"status"`
 }
 
+// UpdateHabitResponseContent Recording — polymorphic by `type` (CalendarEvent, CalendarTodo, etc.)
+type UpdateHabitResponseContent = Recording
+
 // UpdateJournalEntryRequestContent Wire format: {calendar_journal_entry: {content}}
 type UpdateJournalEntryRequestContent struct {
 	CalendarJournalEntry JournalEntryPayload `json:"calendar_journal_entry"`
@@ -1092,49 +1095,49 @@ func (s SensitiveString) Value() string {
 
 // GetBoxParams defines parameters for GetBox.
 type GetBoxParams struct {
-	Page string `form:"page,omitempty" json:"page,omitempty"`
+	Page *string `form:"page,omitempty" json:"page,omitempty"`
 }
 
 // GetBubbleboxParams defines parameters for GetBubblebox.
 type GetBubbleboxParams struct {
-	Page string `form:"page,omitempty" json:"page,omitempty"`
+	Page *string `form:"page,omitempty" json:"page,omitempty"`
 }
 
 // GetCalendarRecordingsParams defines parameters for GetCalendarRecordings.
 type GetCalendarRecordingsParams struct {
-	StartsOn string `form:"starts_on,omitempty" json:"starts_on,omitempty"`
-	EndsOn   string `form:"ends_on,omitempty" json:"ends_on,omitempty"`
+	StartsOn *string `form:"starts_on,omitempty" json:"starts_on,omitempty"`
+	EndsOn   *string `form:"ends_on,omitempty" json:"ends_on,omitempty"`
 }
 
 // ListContactsParams defines parameters for ListContacts.
 type ListContactsParams struct {
-	Page string `form:"page,omitempty" json:"page,omitempty"`
-	Q    string `form:"q,omitempty" json:"q,omitempty"`
+	Page *string `form:"page,omitempty" json:"page,omitempty"`
+	Q    *string `form:"q,omitempty" json:"q,omitempty"`
 }
 
 // ListDraftsParams defines parameters for ListDrafts.
 type ListDraftsParams struct {
-	Page string `form:"page,omitempty" json:"page,omitempty"`
+	Page *string `form:"page,omitempty" json:"page,omitempty"`
 }
 
 // GetFeedboxParams defines parameters for GetFeedbox.
 type GetFeedboxParams struct {
-	Page string `form:"page,omitempty" json:"page,omitempty"`
+	Page *string `form:"page,omitempty" json:"page,omitempty"`
 }
 
 // GetFolderParams defines parameters for GetFolder.
 type GetFolderParams struct {
-	Page string `form:"page,omitempty" json:"page,omitempty"`
+	Page *string `form:"page,omitempty" json:"page,omitempty"`
 }
 
 // GetImboxParams defines parameters for GetImbox.
 type GetImboxParams struct {
-	Page string `form:"page,omitempty" json:"page,omitempty"`
+	Page *string `form:"page,omitempty" json:"page,omitempty"`
 }
 
 // GetTrailboxParams defines parameters for GetTrailbox.
 type GetTrailboxParams struct {
-	Page string `form:"page,omitempty" json:"page,omitempty"`
+	Page *string `form:"page,omitempty" json:"page,omitempty"`
 }
 
 // RemovePostingsFromBoxGroupParams defines parameters for RemovePostingsFromBoxGroup.
@@ -1153,7 +1156,7 @@ type CancelPostingsBubbleUpParams struct {
 type UnfilePostingsParams struct {
 	// PostingIds Posting ids as a comma-joined string, for verbs that carry no body
 	PostingIds string `form:"posting_ids" json:"posting_ids"`
-	FolderId   int64  `form:"folder_id,omitempty" json:"folder_id,omitempty"`
+	FolderId   *int64 `form:"folder_id,omitempty" json:"folder_id,omitempty"`
 }
 
 // UnmutePostingsParams defines parameters for UnmutePostings.
@@ -1164,48 +1167,48 @@ type UnmutePostingsParams struct {
 
 // GetLaterboxParams defines parameters for GetLaterbox.
 type GetLaterboxParams struct {
-	Page string `form:"page,omitempty" json:"page,omitempty"`
+	Page *string `form:"page,omitempty" json:"page,omitempty"`
 }
 
 // GetAsideboxParams defines parameters for GetAsidebox.
 type GetAsideboxParams struct {
-	Page string `form:"page,omitempty" json:"page,omitempty"`
+	Page *string `form:"page,omitempty" json:"page,omitempty"`
 }
 
 // ListStickiesParams defines parameters for ListStickies.
 type ListStickiesParams struct {
 	// Limit Clamped server-side to 1..100
-	Limit int32 `form:"limit,omitempty" json:"limit,omitempty"`
+	Limit *int32 `form:"limit,omitempty" json:"limit,omitempty"`
 }
 
 // GetEverythingTopicsParams defines parameters for GetEverythingTopics.
 type GetEverythingTopicsParams struct {
-	Page string `form:"page,omitempty" json:"page,omitempty"`
+	Page *string `form:"page,omitempty" json:"page,omitempty"`
 }
 
 // GetSentTopicsParams defines parameters for GetSentTopics.
 type GetSentTopicsParams struct {
-	Page string `form:"page,omitempty" json:"page,omitempty"`
+	Page *string `form:"page,omitempty" json:"page,omitempty"`
 }
 
 // GetSpamTopicsParams defines parameters for GetSpamTopics.
 type GetSpamTopicsParams struct {
-	Page string `form:"page,omitempty" json:"page,omitempty"`
+	Page *string `form:"page,omitempty" json:"page,omitempty"`
 }
 
 // GetTrashTopicsParams defines parameters for GetTrashTopics.
 type GetTrashTopicsParams struct {
-	Page string `form:"page,omitempty" json:"page,omitempty"`
+	Page *string `form:"page,omitempty" json:"page,omitempty"`
 }
 
 // GetTopicEntriesParams defines parameters for GetTopicEntries.
 type GetTopicEntriesParams struct {
-	Page string `form:"page,omitempty" json:"page,omitempty"`
+	Page *string `form:"page,omitempty" json:"page,omitempty"`
 }
 
 // TrashTopicParams defines parameters for TrashTopic.
 type TrashTopicParams struct {
-	ConfirmDestroy string `form:"confirm_destroy,omitempty" json:"confirm_destroy,omitempty"`
+	ConfirmDestroy *string `form:"confirm_destroy,omitempty" json:"confirm_destroy,omitempty"`
 }
 
 // CreateBoxDesignationJSONRequestBody defines body for CreateBoxDesignation for application/json ContentType.
@@ -3280,16 +3283,20 @@ func NewGetBoxRequest(server string, boxId int64, params *GetBoxParams) (*http.R
 	if params != nil {
 		queryValues := queryURL.Query()
 
-		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "page", runtime.ParamLocationQuery, params.Page); err != nil {
-			return nil, err
-		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-			return nil, err
-		} else {
-			for k, v := range parsed {
-				for _, v2 := range v {
-					queryValues.Add(k, v2)
+		if params.Page != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "page", runtime.ParamLocationQuery, *params.Page); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
 				}
 			}
+
 		}
 
 		queryURL.RawQuery = queryValues.Encode()
@@ -3569,16 +3576,20 @@ func NewGetBubbleboxRequest(server string, params *GetBubbleboxParams) (*http.Re
 	if params != nil {
 		queryValues := queryURL.Query()
 
-		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "page", runtime.ParamLocationQuery, params.Page); err != nil {
-			return nil, err
-		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-			return nil, err
-		} else {
-			for k, v := range parsed {
-				for _, v2 := range v {
-					queryValues.Add(k, v2)
+		if params.Page != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "page", runtime.ParamLocationQuery, *params.Page); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
 				}
 			}
+
 		}
 
 		queryURL.RawQuery = queryValues.Encode()
@@ -4330,28 +4341,36 @@ func NewGetCalendarRecordingsRequest(server string, calendarId int64, params *Ge
 	if params != nil {
 		queryValues := queryURL.Query()
 
-		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "starts_on", runtime.ParamLocationQuery, params.StartsOn); err != nil {
-			return nil, err
-		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-			return nil, err
-		} else {
-			for k, v := range parsed {
-				for _, v2 := range v {
-					queryValues.Add(k, v2)
+		if params.StartsOn != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "starts_on", runtime.ParamLocationQuery, *params.StartsOn); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
 				}
 			}
+
 		}
 
-		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "ends_on", runtime.ParamLocationQuery, params.EndsOn); err != nil {
-			return nil, err
-		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-			return nil, err
-		} else {
-			for k, v := range parsed {
-				for _, v2 := range v {
-					queryValues.Add(k, v2)
+		if params.EndsOn != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "ends_on", runtime.ParamLocationQuery, *params.EndsOn); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
 				}
 			}
+
 		}
 
 		queryURL.RawQuery = queryValues.Encode()
@@ -4488,28 +4507,36 @@ func NewListContactsRequest(server string, params *ListContactsParams) (*http.Re
 	if params != nil {
 		queryValues := queryURL.Query()
 
-		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "page", runtime.ParamLocationQuery, params.Page); err != nil {
-			return nil, err
-		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-			return nil, err
-		} else {
-			for k, v := range parsed {
-				for _, v2 := range v {
-					queryValues.Add(k, v2)
+		if params.Page != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "page", runtime.ParamLocationQuery, *params.Page); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
 				}
 			}
+
 		}
 
-		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "q", runtime.ParamLocationQuery, params.Q); err != nil {
-			return nil, err
-		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-			return nil, err
-		} else {
-			for k, v := range parsed {
-				for _, v2 := range v {
-					queryValues.Add(k, v2)
+		if params.Q != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "q", runtime.ParamLocationQuery, *params.Q); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
 				}
 			}
+
 		}
 
 		queryURL.RawQuery = queryValues.Encode()
@@ -4694,16 +4721,20 @@ func NewListDraftsRequest(server string, params *ListDraftsParams) (*http.Reques
 	if params != nil {
 		queryValues := queryURL.Query()
 
-		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "page", runtime.ParamLocationQuery, params.Page); err != nil {
-			return nil, err
-		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-			return nil, err
-		} else {
-			for k, v := range parsed {
-				for _, v2 := range v {
-					queryValues.Add(k, v2)
+		if params.Page != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "page", runtime.ParamLocationQuery, *params.Page); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
 				}
 			}
+
 		}
 
 		queryURL.RawQuery = queryValues.Encode()
@@ -4854,16 +4885,20 @@ func NewGetFeedboxRequest(server string, params *GetFeedboxParams) (*http.Reques
 	if params != nil {
 		queryValues := queryURL.Query()
 
-		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "page", runtime.ParamLocationQuery, params.Page); err != nil {
-			return nil, err
-		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-			return nil, err
-		} else {
-			for k, v := range parsed {
-				for _, v2 := range v {
-					queryValues.Add(k, v2)
+		if params.Page != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "page", runtime.ParamLocationQuery, *params.Page); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
 				}
 			}
+
 		}
 
 		queryURL.RawQuery = queryValues.Encode()
@@ -4906,16 +4941,20 @@ func NewGetFolderRequest(server string, folderId int64, params *GetFolderParams)
 	if params != nil {
 		queryValues := queryURL.Query()
 
-		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "page", runtime.ParamLocationQuery, params.Page); err != nil {
-			return nil, err
-		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-			return nil, err
-		} else {
-			for k, v := range parsed {
-				for _, v2 := range v {
-					queryValues.Add(k, v2)
+		if params.Page != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "page", runtime.ParamLocationQuery, *params.Page); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
 				}
 			}
+
 		}
 
 		queryURL.RawQuery = queryValues.Encode()
@@ -4978,16 +5017,20 @@ func NewGetImboxRequest(server string, params *GetImboxParams) (*http.Request, e
 	if params != nil {
 		queryValues := queryURL.Query()
 
-		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "page", runtime.ParamLocationQuery, params.Page); err != nil {
-			return nil, err
-		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-			return nil, err
-		} else {
-			for k, v := range parsed {
-				for _, v2 := range v {
-					queryValues.Add(k, v2)
+		if params.Page != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "page", runtime.ParamLocationQuery, *params.Page); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
 				}
 			}
+
 		}
 
 		queryURL.RawQuery = queryValues.Encode()
@@ -5124,16 +5167,20 @@ func NewGetTrailboxRequest(server string, params *GetTrailboxParams) (*http.Requ
 	if params != nil {
 		queryValues := queryURL.Query()
 
-		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "page", runtime.ParamLocationQuery, params.Page); err != nil {
-			return nil, err
-		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-			return nil, err
-		} else {
-			for k, v := range parsed {
-				for _, v2 := range v {
-					queryValues.Add(k, v2)
+		if params.Page != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "page", runtime.ParamLocationQuery, *params.Page); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
 				}
 			}
+
 		}
 
 		queryURL.RawQuery = queryValues.Encode()
@@ -5351,16 +5398,20 @@ func NewUnfilePostingsRequest(server string, params *UnfilePostingsParams) (*htt
 			}
 		}
 
-		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "folder_id", runtime.ParamLocationQuery, params.FolderId); err != nil {
-			return nil, err
-		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-			return nil, err
-		} else {
-			for k, v := range parsed {
-				for _, v2 := range v {
-					queryValues.Add(k, v2)
+		if params.FolderId != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "folder_id", runtime.ParamLocationQuery, *params.FolderId); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
 				}
 			}
+
 		}
 
 		queryURL.RawQuery = queryValues.Encode()
@@ -5761,16 +5812,20 @@ func NewGetLaterboxRequest(server string, params *GetLaterboxParams) (*http.Requ
 	if params != nil {
 		queryValues := queryURL.Query()
 
-		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "page", runtime.ParamLocationQuery, params.Page); err != nil {
-			return nil, err
-		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-			return nil, err
-		} else {
-			for k, v := range parsed {
-				for _, v2 := range v {
-					queryValues.Add(k, v2)
+		if params.Page != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "page", runtime.ParamLocationQuery, *params.Page); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
 				}
 			}
+
 		}
 
 		queryURL.RawQuery = queryValues.Encode()
@@ -5806,16 +5861,20 @@ func NewGetAsideboxRequest(server string, params *GetAsideboxParams) (*http.Requ
 	if params != nil {
 		queryValues := queryURL.Query()
 
-		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "page", runtime.ParamLocationQuery, params.Page); err != nil {
-			return nil, err
-		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-			return nil, err
-		} else {
-			for k, v := range parsed {
-				for _, v2 := range v {
-					queryValues.Add(k, v2)
+		if params.Page != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "page", runtime.ParamLocationQuery, *params.Page); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
 				}
 			}
+
 		}
 
 		queryURL.RawQuery = queryValues.Encode()
@@ -5851,16 +5910,20 @@ func NewListStickiesRequest(server string, params *ListStickiesParams) (*http.Re
 	if params != nil {
 		queryValues := queryURL.Query()
 
-		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "limit", runtime.ParamLocationQuery, params.Limit); err != nil {
-			return nil, err
-		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-			return nil, err
-		} else {
-			for k, v := range parsed {
-				for _, v2 := range v {
-					queryValues.Add(k, v2)
+		if params.Limit != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "limit", runtime.ParamLocationQuery, *params.Limit); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
 				}
 			}
+
 		}
 
 		queryURL.RawQuery = queryValues.Encode()
@@ -6057,16 +6120,20 @@ func NewGetEverythingTopicsRequest(server string, params *GetEverythingTopicsPar
 	if params != nil {
 		queryValues := queryURL.Query()
 
-		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "page", runtime.ParamLocationQuery, params.Page); err != nil {
-			return nil, err
-		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-			return nil, err
-		} else {
-			for k, v := range parsed {
-				for _, v2 := range v {
-					queryValues.Add(k, v2)
+		if params.Page != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "page", runtime.ParamLocationQuery, *params.Page); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
 				}
 			}
+
 		}
 
 		queryURL.RawQuery = queryValues.Encode()
@@ -6102,16 +6169,20 @@ func NewGetSentTopicsRequest(server string, params *GetSentTopicsParams) (*http.
 	if params != nil {
 		queryValues := queryURL.Query()
 
-		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "page", runtime.ParamLocationQuery, params.Page); err != nil {
-			return nil, err
-		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-			return nil, err
-		} else {
-			for k, v := range parsed {
-				for _, v2 := range v {
-					queryValues.Add(k, v2)
+		if params.Page != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "page", runtime.ParamLocationQuery, *params.Page); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
 				}
 			}
+
 		}
 
 		queryURL.RawQuery = queryValues.Encode()
@@ -6147,16 +6218,20 @@ func NewGetSpamTopicsRequest(server string, params *GetSpamTopicsParams) (*http.
 	if params != nil {
 		queryValues := queryURL.Query()
 
-		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "page", runtime.ParamLocationQuery, params.Page); err != nil {
-			return nil, err
-		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-			return nil, err
-		} else {
-			for k, v := range parsed {
-				for _, v2 := range v {
-					queryValues.Add(k, v2)
+		if params.Page != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "page", runtime.ParamLocationQuery, *params.Page); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
 				}
 			}
+
 		}
 
 		queryURL.RawQuery = queryValues.Encode()
@@ -6219,16 +6294,20 @@ func NewGetTrashTopicsRequest(server string, params *GetTrashTopicsParams) (*htt
 	if params != nil {
 		queryValues := queryURL.Query()
 
-		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "page", runtime.ParamLocationQuery, params.Page); err != nil {
-			return nil, err
-		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-			return nil, err
-		} else {
-			for k, v := range parsed {
-				for _, v2 := range v {
-					queryValues.Add(k, v2)
+		if params.Page != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "page", runtime.ParamLocationQuery, *params.Page); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
 				}
 			}
+
 		}
 
 		queryURL.RawQuery = queryValues.Encode()
@@ -6332,16 +6411,20 @@ func NewGetTopicEntriesRequest(server string, topicId int64, params *GetTopicEnt
 	if params != nil {
 		queryValues := queryURL.Query()
 
-		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "page", runtime.ParamLocationQuery, params.Page); err != nil {
-			return nil, err
-		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-			return nil, err
-		} else {
-			for k, v := range parsed {
-				for _, v2 := range v {
-					queryValues.Add(k, v2)
+		if params.Page != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "page", runtime.ParamLocationQuery, *params.Page); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
 				}
 			}
+
 		}
 
 		queryURL.RawQuery = queryValues.Encode()
@@ -6499,16 +6582,20 @@ func NewTrashTopicRequest(server string, topicId int64, params *TrashTopicParams
 	if params != nil {
 		queryValues := queryURL.Query()
 
-		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "confirm_destroy", runtime.ParamLocationQuery, params.ConfirmDestroy); err != nil {
-			return nil, err
-		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-			return nil, err
-		} else {
-			for k, v := range parsed {
-				for _, v2 := range v {
-					queryValues.Add(k, v2)
+		if params.ConfirmDestroy != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "confirm_destroy", runtime.ParamLocationQuery, *params.ConfirmDestroy); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
 				}
 			}
+
 		}
 
 		queryURL.RawQuery = queryValues.Encode()
@@ -9108,6 +9195,8 @@ func (r DeleteHabitResponse) ContentType() string {
 type UpdateHabitResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
+	// JSON200 the response for an HTTP 200 `application/json` response
+	JSON200 *UpdateHabitResponseContent
 	// JSON401 the response for an HTTP 401 `application/json` response
 	JSON401 *UnauthorizedErrorResponseContent
 	// JSON404 the response for an HTTP 404 `application/json` response
@@ -9118,6 +9207,11 @@ type UpdateHabitResponse struct {
 	JSON500 *InternalServerErrorResponseContent
 	// JSON503 the response for an HTTP 503 `application/json` response
 	JSON503 *ServiceUnavailableErrorResponseContent
+}
+
+// GetJSON200 returns the response for an HTTP 200 `application/json` response
+func (r UpdateHabitResponse) GetJSON200() *UpdateHabitResponseContent {
+	return r.JSON200
 }
 
 // GetJSON401 returns the response for an HTTP 401 `application/json` response
@@ -15712,8 +15806,12 @@ func ParseUpdateHabitResponse(rsp *http.Response) (*UpdateHabitResponse, error) 
 	}
 
 	switch {
-	case rsp.StatusCode == 200:
-		break // No content-type
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest UpdateHabitResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
 		var dest UnauthorizedErrorResponseContent

--- a/go/pkg/hey/boxes.go
+++ b/go/pkg/hey/boxes.go
@@ -2,7 +2,6 @@ package hey
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/basecamp/hey-sdk/go/pkg/generated"
@@ -278,8 +277,11 @@ func (s *BoxesService) DeleteGroup(ctx context.Context, boxID int64, groupID int
 	}
 
 	return s.client.instrument(ctx, op, func(ctx context.Context) error {
-		_, err := s.client.Delete(ctx, fmt.Sprintf("/boxes/%d/groups/%d.json", boxID, groupID))
-		return err
+		resp, err := s.client.genClient().DeleteBoxGroupWithResponse(ctx, boxID, groupID)
+		if err != nil {
+			return err
+		}
+		return CheckResponse(resp.HTTPResponse)
 	})
 }
 

--- a/go/pkg/hey/calendar_events.go
+++ b/go/pkg/hey/calendar_events.go
@@ -131,16 +131,6 @@ func recordingFromFormResponse(resp *FormResponse) (*generated.Recording, error)
 	return &generated.Recording{Id: id}, nil
 }
 
-// recordingFromData reads the recording a JSON write answers with. A server without the JSON
-// branch redirects to an HTML page instead, which leaves nothing to hand back.
-func recordingFromData(data []byte) *generated.Recording {
-	recording := &generated.Recording{}
-	if err := json.Unmarshal(data, recording); err != nil || recording.Id == 0 {
-		return nil
-	}
-	return recording
-}
-
 // Update updates an existing calendar event and returns it as a recording.
 //
 // A server carrying the JSON update branch answers 200 with the whole recording. An older

--- a/go/pkg/hey/calendar_todos.go
+++ b/go/pkg/hey/calendar_todos.go
@@ -1,8 +1,9 @@
 package hey
 
 import (
+	"bytes"
 	"context"
-	"fmt"
+	"encoding/json"
 	"time"
 
 	"github.com/basecamp/hey-sdk/go/pkg/generated"
@@ -40,22 +41,29 @@ func (s *CalendarTodosService) Create(ctx context.Context, title string, startsA
 		startsAt = time.Now().Format("2006-01-02")
 	}
 
+	// starts_at goes on the wire as a bare date (YYYY-MM-DD): the server casts it
+	// in the user's time zone, whereas an RFC 3339 instant at UTC midnight could
+	// land on the previous day. The generated payload types it as time.Time, so
+	// send the exact body through the generated route instead.
 	body := map[string]any{
 		"calendar_todo": map[string]any{
 			"title":     title,
 			"starts_at": startsAt,
 		},
 	}
-
-	resp, err := s.client.Post(ctx, "/calendar/todos.json", body)
+	payload, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
-	var recording generated.Recording
-	if err = resp.UnmarshalData(&recording); err != nil {
-		return nil, fmt.Errorf("failed to decode todo response: %w", err)
+
+	resp, err := s.client.genClient().CreateCalendarTodoWithBodyWithResponse(ctx, "application/json", bytes.NewReader(payload))
+	if err != nil {
+		return nil, err
 	}
-	return &recording, nil
+	if err = CheckResponse(resp.HTTPResponse); err != nil {
+		return nil, err
+	}
+	return resp.JSON200, nil
 }
 
 // Complete marks a calendar todo as complete.

--- a/go/pkg/hey/client.go
+++ b/go/pkg/hey/client.go
@@ -221,6 +221,8 @@ func (c *Client) initGeneratedClient() {
 				req.Header.Set("Content-Type", "application/json")
 			}
 			req.Header.Set("Accept", "application/json")
+			req.URL.Path = withJSONExtension(req.URL.Path)
+			req.URL.RawPath = ""
 			return nil
 		}
 		gen, err := generated.NewClientWithResponses(serverURL,
@@ -231,6 +233,21 @@ func (c *Client) initGeneratedClient() {
 		}
 		c.gen = gen
 	})
+}
+
+// withJSONExtension appends ".json" to a request path whose last segment has no
+// extension. HEY routes all take an optional format, and every generated operation
+// speaks JSON, but Smithy cannot express "{label}.json" inside one URI segment, so
+// operations that end in a path parameter are modelled without it and get it here.
+func withJSONExtension(path string) string {
+	if path == "" || strings.HasSuffix(path, "/") {
+		return path
+	}
+	last := path[strings.LastIndex(path, "/")+1:]
+	if strings.Contains(last, ".") {
+		return path
+	}
+	return path + ".json"
 }
 
 // discardHandler is a slog.Handler that discards all log records.

--- a/go/pkg/hey/client_test.go
+++ b/go/pkg/hey/client_test.go
@@ -469,3 +469,20 @@ func TestClient_GatewayErrors(t *testing.T) {
 		})
 	}
 }
+
+func TestWithJSONExtension(t *testing.T) {
+	cases := map[string]string{
+		"/boxes.json":                        "/boxes.json",
+		"/stickies/12":                       "/stickies/12.json",
+		"/calendar/days/2026-08-16/habits/7": "/calendar/days/2026-08-16/habits/7.json",
+		"/topics/1/status/trashed.json":      "/topics/1/status/trashed.json",
+		"/world/lists/a@b.com":               "/world/lists/a@b.com", // has a dot: left alone
+		"/":                                  "/",
+		"":                                   "",
+	}
+	for in, want := range cases {
+		if got := withJSONExtension(in); got != want {
+			t.Errorf("withJSONExtension(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/go/pkg/hey/collections.go
+++ b/go/pkg/hey/collections.go
@@ -64,17 +64,15 @@ func (s *CollectionsService) Update(ctx context.Context, collectionID int64, par
 	}
 
 	return s.client.instrument(ctx, op, func(ctx context.Context) error {
-		body := map[string]any{"collection": map[string]any{}}
-		collection := body["collection"].(map[string]any)
-		if params.Name != "" {
-			collection["name"] = params.Name
+		// Empty strings are omitted by the payload's omitempty tags, so unset
+		// fields are left alone server-side.
+		resp, err := s.client.genClient().UpdateCollectionWithResponse(ctx, collectionID, generated.UpdateCollectionRequestContent{
+			Collection: generated.CollectionPayload{Name: params.Name, Summary: params.Summary},
+		})
+		if err != nil {
+			return err
 		}
-		if params.Summary != "" {
-			collection["summary"] = params.Summary
-		}
-
-		_, err := s.client.PatchMutation(ctx, fmt.Sprintf("/collections/%d.json", collectionID), body)
-		return err
+		return CheckResponse(resp.HTTPResponse)
 	})
 }
 

--- a/go/pkg/hey/designations.go
+++ b/go/pkg/hey/designations.go
@@ -2,7 +2,6 @@ package hey
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/basecamp/hey-sdk/go/pkg/generated"
 )
@@ -45,7 +44,10 @@ func (s *DesignationsService) Destroy(ctx context.Context, boxID int64, designat
 	}
 
 	return s.client.instrument(ctx, op, func(ctx context.Context) error {
-		_, err := s.client.Delete(ctx, fmt.Sprintf("/boxes/%d/designations/%d.json", boxID, designationID))
-		return err
+		resp, err := s.client.genClient().DeleteBoxDesignationWithResponse(ctx, boxID, designationID)
+		if err != nil {
+			return err
+		}
+		return CheckResponse(resp.HTTPResponse)
 	})
 }

--- a/go/pkg/hey/habits.go
+++ b/go/pkg/hey/habits.go
@@ -2,7 +2,6 @@ package hey
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/basecamp/hey-sdk/go/pkg/generated"
@@ -114,11 +113,14 @@ func (s *HabitsService) Update(ctx context.Context, habitID int64, params HabitP
 	}
 
 	err = s.client.instrument(ctx, op, func(ctx context.Context) error {
-		resp, rerr := s.client.Patch(ctx, fmt.Sprintf("/calendar/habits/%d.json", habitID), habitBody(params))
+		resp, rerr := s.client.genClient().UpdateHabitWithResponse(ctx, habitID, habitBody(params))
 		if rerr != nil {
 			return rerr
 		}
-		recording = recordingFromData(resp.Data)
+		if cerr := CheckResponse(resp.HTTPResponse); cerr != nil {
+			return cerr
+		}
+		recording = resp.JSON200
 		return nil
 	})
 	return recording, err
@@ -132,8 +134,11 @@ func (s *HabitsService) Delete(ctx context.Context, habitID int64) error {
 	}
 
 	return s.client.instrument(ctx, op, func(ctx context.Context) error {
-		_, err := s.client.Delete(ctx, fmt.Sprintf("/calendar/habits/%d.json", habitID))
-		return err
+		resp, err := s.client.genClient().DeleteHabitWithResponse(ctx, habitID)
+		if err != nil {
+			return err
+		}
+		return CheckResponse(resp.HTTPResponse)
 	})
 }
 

--- a/go/pkg/hey/postings.go
+++ b/go/pkg/hey/postings.go
@@ -3,8 +3,6 @@ package hey
 import (
 	"context"
 	"fmt"
-	"net/url"
-	"strconv"
 	"time"
 
 	"github.com/basecamp/hey-sdk/go/pkg/generated"
@@ -212,15 +210,17 @@ func (s *PostingsService) File(ctx context.Context, folderID int64, postingIDs .
 // Unfile removes a label from one or more postings. A folderID of 0 removes every label.
 func (s *PostingsService) Unfile(ctx context.Context, folderID int64, postingIDs ...int64) (err error) {
 	return s.bulkAction(ctx, "UnfilePostings", postingIDs, func(ctx context.Context, ids []int64) error {
-		// Hand-rolled rather than generated: the generated client always writes folder_id
-		// into the query, and folder_id=0 is a lookup for a folder that does not exist.
-		query := url.Values{"posting_ids": {joinIDs(ids)}}
+		// folder_id is only sent when set: 0 is not "all folders" to the server,
+		// it is a lookup for a folder that does not exist.
+		params := generated.UnfilePostingsParams{PostingIds: joinIDs(ids)}
 		if folderID != 0 {
-			query.Set("folder_id", strconv.FormatInt(folderID, 10))
+			params.FolderId = &folderID
 		}
-
-		_, err := s.client.Delete(ctx, "/postings/filings.json?"+query.Encode())
-		return err
+		resp, err := s.genClient().UnfilePostingsWithResponse(ctx, &params)
+		if err != nil {
+			return err
+		}
+		return CheckResponse(resp.HTTPResponse)
 	})
 }
 

--- a/go/pkg/hey/services_test.go
+++ b/go/pkg/hey/services_test.go
@@ -368,7 +368,7 @@ func TestTopicsService_Get(t *testing.T) {
 
 func TestTopicsService_GetEntries(t *testing.T) {
 	client := newServiceTestClient(t, map[string]string{
-		"/topics/%s/entries": `[{"id":1}]`,
+		"/topics/%s/entries.json": `[{"id":1}]`,
 	})
 
 	result, err := client.Topics().GetEntries(context.Background(), 42, nil)
@@ -629,7 +629,7 @@ func TestCalendarsService_List(t *testing.T) {
 
 func TestCalendarsService_GetRecordings(t *testing.T) {
 	client := newServiceTestClient(t, map[string]string{
-		"/calendars/%s/recordings": `{"events":[{"id":1}]}`,
+		"/calendars/%s/recordings.json": `{"events":[{"id":1}]}`,
 	})
 
 	result, err := client.Calendars().GetRecordings(context.Background(), 1, nil)
@@ -875,7 +875,7 @@ func TestTimeTracksService_Stop(t *testing.T) {
 
 func TestJournalService_Get(t *testing.T) {
 	client := newServiceTestClient(t, map[string]string{
-		"/calendar/days/%s/journal_entry": `{"id":1,"type":"JournalEntry"}`,
+		"/calendar/days/%s/journal_entry.json": `{"id":1,"type":"JournalEntry"}`,
 	})
 
 	result, err := client.Journal().Get(context.Background(), "2026-03-09")

--- a/go/pkg/hey/stickies.go
+++ b/go/pkg/hey/stickies.go
@@ -49,7 +49,8 @@ func (s *StickiesService) List(ctx context.Context, limit int) (result *generate
 			if limit > MaxStickiesLimit {
 				limit = MaxStickiesLimit
 			}
-			params = &generated.ListStickiesParams{Limit: int32(limit)}
+			l := int32(limit)
+			params = &generated.ListStickiesParams{Limit: &l}
 		}
 
 		resp, rerr := s.client.genClient().ListStickiesWithResponse(ctx, params)
@@ -96,24 +97,18 @@ func (s *StickiesService) Update(ctx context.Context, stickyID int64, body strin
 	}
 
 	err = s.client.instrument(ctx, op, func(ctx context.Context) error {
-		payload := map[string]any{}
-		if body != "" {
-			payload["body"] = body
-		}
-		if size != "" {
-			payload["size"] = size
-		}
-
-		resp, rerr := s.client.Patch(ctx, stickyPath(stickyID), map[string]any{"sticky": payload})
+		// Empty strings are omitted by the payload's omitempty tags, so unset
+		// fields are left alone server-side.
+		resp, rerr := s.client.genClient().UpdateStickyWithResponse(ctx, stickyID, generated.StickyRequestContent{
+			Sticky: generated.StickyPayload{Body: body, Size: size},
+		})
 		if rerr != nil {
 			return rerr
 		}
-
-		var sticky generated.Sticky
-		if derr := resp.UnmarshalData(&sticky); derr != nil {
-			return derr
+		if cerr := CheckResponse(resp.HTTPResponse); cerr != nil {
+			return cerr
 		}
-		result = &sticky
+		result = resp.JSON200
 		return nil
 	})
 	return result, err
@@ -127,8 +122,11 @@ func (s *StickiesService) Delete(ctx context.Context, stickyID int64) error {
 	}
 
 	return s.client.instrument(ctx, op, func(ctx context.Context) error {
-		_, err := s.client.Delete(ctx, stickyPath(stickyID))
-		return err
+		resp, err := s.client.genClient().DeleteStickyWithResponse(ctx, stickyID)
+		if err != nil {
+			return err
+		}
+		return CheckResponse(resp.HTTPResponse)
 	})
 }
 
@@ -154,10 +152,4 @@ func (s *StickiesService) Move(ctx context.Context, stickyID int64, position int
 		}
 		return CheckResponse(resp.HTTPResponse)
 	})
-}
-
-// stickyPath builds the .json path Smithy cannot model, because a URI label may not carry a
-// literal suffix.
-func stickyPath(stickyID int64) string {
-	return fmt.Sprintf("/stickies/%d.json", stickyID)
 }

--- a/go/pkg/hey/time_tracks.go
+++ b/go/pkg/hey/time_tracks.go
@@ -71,15 +71,14 @@ func (s *TimeTracksService) Start(ctx context.Context, body generated.StartTimeT
 	ctx = s.client.hooks.OnOperationStart(ctx, op)
 	defer func() { s.client.hooks.OnOperationEnd(ctx, op, err, time.Since(start)) }()
 
-	resp, err := s.client.Post(ctx, "/calendar/ongoing_time_track.json", body)
+	resp, err := s.client.genClient().StartTimeTrackWithResponse(ctx, body)
 	if err != nil {
 		return nil, err
 	}
-	var recording generated.Recording
-	if err = resp.UnmarshalData(&recording); err != nil {
-		return nil, fmt.Errorf("failed to decode time track response: %w", err)
+	if err = CheckResponse(resp.HTTPResponse); err != nil {
+		return nil, err
 	}
-	return &recording, nil
+	return resp.JSON200, nil
 }
 
 // Update updates an existing time track.
@@ -99,15 +98,14 @@ func (s *TimeTracksService) Update(ctx context.Context, timeTrackID int64, body 
 	ctx = s.client.hooks.OnOperationStart(ctx, op)
 	defer func() { s.client.hooks.OnOperationEnd(ctx, op, err, time.Since(start)) }()
 
-	resp, err := s.client.Put(ctx, fmt.Sprintf("/calendar/time_tracks/%d.json", timeTrackID), body)
+	resp, err := s.client.genClient().UpdateTimeTrackWithResponse(ctx, timeTrackID, body)
 	if err != nil {
 		return nil, err
 	}
-	var recording generated.Recording
-	if err = resp.UnmarshalData(&recording); err != nil {
-		return nil, fmt.Errorf("failed to decode time track response: %w", err)
+	if err = CheckResponse(resp.HTTPResponse); err != nil {
+		return nil, err
 	}
-	return &recording, nil
+	return resp.JSON200, nil
 }
 
 // Stop stops an ongoing time track by setting ends_at to the current time.
@@ -150,8 +148,11 @@ func (s *TimeTracksService) Delete(ctx context.Context, timeTrackID int64) error
 	}
 
 	return s.client.instrument(ctx, op, func(ctx context.Context) error {
-		_, err := s.client.Delete(ctx, fmt.Sprintf("/calendar/time_tracks/%d.json", timeTrackID))
-		return err
+		resp, err := s.client.genClient().DeleteTimeTrackWithResponse(ctx, timeTrackID)
+		if err != nil {
+			return err
+		}
+		return CheckResponse(resp.HTTPResponse)
 	})
 }
 

--- a/go/pkg/hey/topics.go
+++ b/go/pkg/hey/topics.go
@@ -2,7 +2,6 @@ package hey
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/basecamp/hey-sdk/go/pkg/generated"
@@ -187,15 +186,18 @@ func (s *TopicsService) Trash(ctx context.Context, topicID int64, confirmDestroy
 	}
 
 	return s.client.instrument(ctx, op, func(ctx context.Context) error {
-		// Hand-rolled rather than generated: the generated client always writes
-		// confirm_destroy into the query, and an empty value reads as truthy on the server.
-		path := fmt.Sprintf("/topics/%d/status/trashed.json", topicID)
+		// confirm_destroy is only sent when set: an empty value would read as
+		// truthy on the server and skip the shared-topic confirmation.
+		var params generated.TrashTopicParams
 		if confirmDestroy {
-			path += "?confirm_destroy=1"
+			one := "1"
+			params.ConfirmDestroy = &one
 		}
-
-		_, err := s.client.Put(ctx, path, map[string]any{})
-		return err
+		resp, err := s.client.genClient().TrashTopicWithResponse(ctx, topicID, &params)
+		if err != nil {
+			return err
+		}
+		return CheckResponse(resp.HTTPResponse)
 	})
 }
 

--- a/openapi.json
+++ b/openapi.json
@@ -156,7 +156,8 @@
             "name": "page",
             "in": "query",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "x-go-type-skip-optional-pointer": false
             }
           }
         ],
@@ -739,7 +740,8 @@
             "name": "page",
             "in": "query",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "x-go-type-skip-optional-pointer": false
             }
           }
         ],
@@ -1328,7 +1330,14 @@
         ],
         "responses": {
           "200": {
-            "description": "UpdateHabit 200 response"
+            "description": "UpdateHabit 200 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateHabitResponseContent"
+                }
+              }
+            }
           },
           "401": {
             "description": "UnauthorizedError 401 response",
@@ -2341,14 +2350,16 @@
             "name": "starts_on",
             "in": "query",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "x-go-type-skip-optional-pointer": false
             }
           },
           {
             "name": "ends_on",
             "in": "query",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "x-go-type-skip-optional-pointer": false
             }
           }
         ],
@@ -2644,14 +2655,16 @@
             "name": "page",
             "in": "query",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "x-go-type-skip-optional-pointer": false
             }
           },
           {
             "name": "q",
             "in": "query",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "x-go-type-skip-optional-pointer": false
             }
           }
         ],
@@ -3055,7 +3068,8 @@
             "name": "page",
             "in": "query",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "x-go-type-skip-optional-pointer": false
             }
           }
         ],
@@ -3377,7 +3391,8 @@
             "name": "page",
             "in": "query",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "x-go-type-skip-optional-pointer": false
             }
           }
         ],
@@ -3455,7 +3470,8 @@
             "name": "page",
             "in": "query",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "x-go-type-skip-optional-pointer": false
             }
           }
         ],
@@ -3598,7 +3614,8 @@
             "name": "page",
             "in": "query",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "x-go-type-skip-optional-pointer": false
             }
           }
         ],
@@ -3881,7 +3898,8 @@
             "name": "page",
             "in": "query",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "x-go-type-skip-optional-pointer": false
             }
           }
         ],
@@ -4245,7 +4263,8 @@
             "in": "query",
             "schema": {
               "type": "integer",
-              "format": "int64"
+              "format": "int64",
+              "x-go-type-skip-optional-pointer": false
             }
           }
         ],
@@ -4962,7 +4981,8 @@
             "name": "page",
             "in": "query",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "x-go-type-skip-optional-pointer": false
             }
           }
         ],
@@ -5031,7 +5051,8 @@
             "name": "page",
             "in": "query",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "x-go-type-skip-optional-pointer": false
             }
           }
         ],
@@ -5103,7 +5124,8 @@
             "schema": {
               "type": "integer",
               "description": "Clamped server-side to 1..100",
-              "format": "int32"
+              "format": "int32",
+              "x-go-type-skip-optional-pointer": false
             }
           }
         ],
@@ -5496,7 +5518,8 @@
             "name": "page",
             "in": "query",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "x-go-type-skip-optional-pointer": false
             }
           }
         ],
@@ -5569,7 +5592,8 @@
             "name": "page",
             "in": "query",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "x-go-type-skip-optional-pointer": false
             }
           }
         ],
@@ -5642,7 +5666,8 @@
             "name": "page",
             "in": "query",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "x-go-type-skip-optional-pointer": false
             }
           }
         ],
@@ -5768,7 +5793,8 @@
             "name": "page",
             "in": "query",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "x-go-type-skip-optional-pointer": false
             }
           }
         ],
@@ -5984,7 +6010,8 @@
             "name": "page",
             "in": "query",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "x-go-type-skip-optional-pointer": false
             }
           }
         ],
@@ -6308,7 +6335,8 @@
             "name": "confirm_destroy",
             "in": "query",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "x-go-type-skip-optional-pointer": false
             }
           }
         ],
@@ -8832,6 +8860,9 @@
         "required": [
           "status"
         ]
+      },
+      "UpdateHabitResponseContent": {
+        "$ref": "#/components/schemas/Recording"
       },
       "UpdateJournalEntryRequestContent": {
         "type": "object",

--- a/scripts/enhance-openapi-go-types.sh
+++ b/scripts/enhance-openapi-go-types.sh
@@ -78,6 +78,27 @@ jq '
     )
 ' "$OPENAPI_FILE" > "${OPENAPI_FILE}.tmp" && mv "${OPENAPI_FILE}.tmp" "$OPENAPI_FILE"
 
+# Pass 4: Optional query parameters → pointers
+# oapi-codegen emits every non-pointer query field unconditionally, so an optional
+# param the caller did not set still goes on the wire as its zero value: page=,
+# limit=0, folder_id=0, confirm_destroy=. The last two are not harmless (unfile from
+# folder 0; skip the shared-topic trash confirmation). Pointers are omitted when nil.
+jq '
+  .paths |= with_entries(
+    .value |= with_entries(
+      if (.key | test("^(get|post|put|patch|delete)$")) and (((.value.parameters // []) | length) > 0) then
+        .value.parameters |= map(
+          if .in == "query" and ((.required // false) | not) then
+            .schema += {"x-go-type-skip-optional-pointer": false}
+          else .
+          end
+        )
+      else .
+      end
+    )
+  )
+' "$OPENAPI_FILE" > "${OPENAPI_FILE}.tmp" && mv "${OPENAPI_FILE}.tmp" "$OPENAPI_FILE"
+
 # Pass 3: Nothing here — self-referential types are fixed via post-codegen sed
 # in go/Makefile (oapi-codegen ignores type overrides on bare $ref properties).
 

--- a/spec/hey.smithy
+++ b/spec/hey.smithy
@@ -1668,9 +1668,10 @@ structure StartTimeTrackOutput {
 
 /// Update a time track (stop by setting ends_at to current time)
 @idempotent
-// NOTE: Live API path is /calendar/time_tracks/{id}.json but Smithy
-// forbids literals after labels in URI segments. The Go SDK uses a
-// hardcoded path; generated clients append .json via middleware.
+// NOTE: The live path is /calendar/time_tracks/{id}.json, but Smithy forbids a
+// literal after a label inside one segment. The generated client appends .json to
+// extension-less paths at request time (see initGeneratedClient), so URIs that end
+// in a label are written without it here.
 @http(method: "PUT", uri: "/calendar/time_tracks/{timeTrackId}")
 @tags(["Calendar Time Tracks"])
 @heyRetry(maxAttempts: 3, baseDelayMs: 1000, backoff: "exponential", retryOn: [429, 503])
@@ -2760,7 +2761,14 @@ structure HabitPayload {
 @heyRetry(maxAttempts: 2, baseDelayMs: 1000, backoff: "exponential", retryOn: [429, 503])
 operation UpdateHabit {
     input: UpdateHabitInput
+    output: UpdateHabitOutput
     errors: [UnauthorizedError, NotFoundError, UnprocessableEntityError, InternalServerError, ServiceUnavailableError]
+}
+
+/// The edited habit as a recording (haystack renders calendar/recordings/_recording).
+structure UpdateHabitOutput {
+    @required
+    recording: Recording
 }
 
 structure UpdateHabitInput {

--- a/spec/shape-fingerprint.json
+++ b/spec/shape-fingerprint.json
@@ -40,6 +40,7 @@
   "StartTimeTrack": "631c6e31e91d56c667db4f53df609e0006de3787de580f1f52366f8da283ec91",
   "UncompleteCalendarTodo": "2034f18325d4021bdf67313966275d25c100b11e77bcacfbcddfd3f2ab551783",
   "UncompleteHabit": "d6cbfd918a4f869bf812a29ebc40aeeb203fe88736c424701274b15c94041c43",
+  "UpdateHabit": "abdae94f7cb43bfa8d8fc2db6ead534ae9911b6f73d71a5d9bb212d876802444",
   "UpdateSticky": "59bd8472ed21daeff7a1c0e91ba53dff8821810a7badd9d1d05cf0e3f8bac339",
   "UpdateTimeTrack": "eb9135887276c0f3262eb6b4c74c5f9a533499d66d9b10d5965f791850fc496b"
 }


### PR DESCRIPTION
Stacked on #65 — review that first; this retargets to `main` when it merges. First step of the "#64 review follow-ups" card.

Thirteen wrappers hand-built paths for operations that *are* generated (Update/DeleteSticky, Update/DeleteHabit, UpdateCollection, DeleteBoxGroup, DeleteBoxDesignation, DeleteTimeTrack, Start/UpdateTimeTrack, CreateCalendarTodo, TrashTopic, UnfilePostings). Two things forced that, both fixed in the pipeline rather than by hand:

- **Smithy can't say `{label}.json`** inside one segment, so ops ending in a path parameter were modelled without the extension and wrappers re-added it. The generated client now appends `.json` to any extension-less path at request time (`withJSONExtension`, in the request editor). HEY routes all take an optional format, every generated op speaks JSON, and the URL router already strips `.json` when matching. The spec's old NOTE claiming this middleware existed is now true.
- **Optional query params were always sent** as their zero value: `folder_id=0` (unfile from a folder that doesn't exist) and `confirm_destroy=` (truthy on the server — skips the shared-topic trash confirmation). `enhance-openapi-go-types.sh` now makes optional query parameters pointers; the generated request only sends them when set.

Also: `UpdateHabit` gets its output (haystack returns the recording); `CreateCalendarTodo` sends its exact date-only body through the generated route because the payload types `starts_at` as an instant.

`check-service-drift` now reports **82/83** wrapped. The one holdout is `UpdateJournalEntry` — haystack's `journal_entries#update` has no JSON branch, so a generated call would 406; that's an `[API]` item, noted on the JSON-views card.

## Verified
- `make check` green (127 conformance).
- Live, read-only, against prod through the new editor: `ListBoxes`, `GetCalendarRecordings` (`.json` appended + pointer params), `ListStickies`, `GetJournalEntry` — all 200.
- Existing tests already assert `confirm_destroy` / `folder_id` are omitted when unset; new test for `withJSONExtension`.

Note for the CLI bump: `GetCalendarRecordingsParams.StartsOn/EndsOn` are now `*string` (hey-cli constructs these in three places).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes 13 hand-built SDK wrappers through the generated client to remove bespoke URLs and stop zero-value query strings from changing server behavior. Previously wrappers re-added “.json” and always sent optional query params; now the generator appends “.json” at request time and omits unset query params.

- Generated client middleware appends “.json” to extension-less paths; wrappers for Update/DeleteSticky, Update/DeleteHabit, UpdateCollection, DeleteBoxGroup, DeleteBoxDesignation, DeleteTimeTrack, Start/UpdateTimeTrack, CreateCalendarTodo, TrashTopic, and UnfilePostings now call the generated routes.
- Optional query params are pointers via `scripts/enhance-openapi-go-types.sh`; they are not sent unless set. This prevents folder_id=0 on UnfilePostings and confirm_destroy= on TrashTopic; also applies to page, limit, and q.
- `UpdateHabit` parses and returns the `Recording` on 200 JSON; `CreateCalendarTodo` sends a date-only `starts_at` body via the generated route to avoid timezone drift.
- Added a unit test for the “.json” appender; conformance is green; live read-only smoke tests returned 200s.

**Migration**
- Optional query params are now pointer fields. Update callers to pass pointers where they previously passed values; e.g., `GetCalendarRecordingsParams.StartsOn`/`EndsOn` are `*string` (affects `hey-cli`), and `ListStickiesParams.Limit`, `UnfilePostingsParams.FolderId`, and `TrashTopicParams.ConfirmDestroy` are now pointers.

<sup>Written for commit ea6a891fe50b091509d09b697205ed0f19f19ecc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-sdk/pull/66?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

