### PR TITLE
Make optional request objects pointers; restore StopTimeTrack and the 403 scope hint

### DIFF
--- a/conformance/runner/go/main.go
+++ b/conformance/runner/go/main.go
@@ -843,8 +843,7 @@ func executeOperation(client *generated.Client, ctx context.Context, tc TestCase
 	case "GetOngoingTimeTrack":
 		return client.GetOngoingTimeTrack(ctx)
 	case "StartTimeTrack":
-		body := generated.StartTimeTrackJSONRequestBody{}
-		return client.StartTimeTrack(ctx, body)
+		return client.StartTimeTrack(ctx)
 	case "UpdateTimeTrack":
 		timeTrackId := getInt64Param(tc.PathParams, "timeTrackId")
 		body := generated.UpdateTimeTrackJSONRequestBody{

--- a/go/pkg/generated/client.gen.go
+++ b/go/pkg/generated/client.gen.go
@@ -212,6 +212,12 @@ type CompleteCalendarTodoResponseContent = Recording
 // CompleteHabitResponseContent Recording — polymorphic by `type` (CalendarEvent, CalendarTodo, etc.)
 type CompleteHabitResponseContent = Recording
 
+// ConflictErrorResponseContent The request conflicts with current state, e.g. starting a time track while one
+// is already ongoing (haystack answers {"error": "..."} with 409).
+type ConflictErrorResponseContent struct {
+	Error string `json:"error"`
+}
+
 // Contact Contact — the identity of someone in HEY
 type Contact struct {
 	AccountId             int64  `json:"account_id,omitempty"`
@@ -284,16 +290,19 @@ type CreateHabitResponseContent = Recording
 
 // CreateMessageRequestContent Wire format: {acting_sender_id, message: {subject, content}, entry: {addressed: {directly: "..."}}}
 type CreateMessageRequestContent struct {
-	ActingSenderId int64               `json:"acting_sender_id"`
-	Entry          MessageEntryPayload `json:"entry,omitempty"`
-	Message        MessagePayload      `json:"message"`
+	ActingSenderId int64                `json:"acting_sender_id"`
+	Entry          *MessageEntryPayload `json:"entry,omitempty"`
+	Message        MessagePayload       `json:"message"`
 }
 
 // CreateReplyRequestContent Wire format: {acting_sender_id, message: {content}, entry: {addressed: {directly: [...]}}}
+// entry.addressed is optional on the wire but a reply posted without it is saved as a
+// draft rather than delivered — HEY does not reply-all for the caller. Resolve the
+// thread's recipients first and always send them.
 type CreateReplyRequestContent struct {
-	ActingSenderId int64               `json:"acting_sender_id"`
-	Entry          MessageEntryPayload `json:"entry,omitempty"`
-	Message        ReplyMessagePayload `json:"message"`
+	ActingSenderId int64                `json:"acting_sender_id"`
+	Entry          *MessageEntryPayload `json:"entry,omitempty"`
+	Message        ReplyMessagePayload  `json:"message"`
 }
 
 // CreateStickyResponseContent Sticky — a note on the stickies board
@@ -631,7 +640,7 @@ type MessageEntryPayload struct {
 	// Addressed Recipients per kind, each a list of email addresses.
 	// haystack applies Array() to each kind, so a JSON array is the correct wire format
 	// (a bare string would be treated as a single address, not split on commas).
-	Addressed MessageAddressed `json:"addressed,omitempty"`
+	Addressed *MessageAddressed `json:"addressed,omitempty"`
 }
 
 // MessagePayload defines model for MessagePayload.
@@ -890,18 +899,6 @@ type Sender struct {
 // ServiceUnavailableErrorResponseContent defines model for ServiceUnavailableErrorResponseContent.
 type ServiceUnavailableErrorResponseContent struct {
 	Message string `json:"message"`
-}
-
-// StartTimeTrackPayload defines model for StartTimeTrackPayload.
-type StartTimeTrackPayload struct {
-	Category string `json:"category,omitempty"`
-	Notes    string `json:"notes,omitempty"`
-	Title    string `json:"title,omitempty"`
-}
-
-// StartTimeTrackRequestContent Wire format: {calendar_time_track: {title, notes, category}}
-type StartTimeTrackRequestContent struct {
-	CalendarTimeTrack StartTimeTrackPayload `json:"calendar_time_track,omitempty"`
 }
 
 // StartTimeTrackResponseContent Recording — polymorphic by `type` (CalendarEvent, CalendarTodo, etc.)
@@ -1225,9 +1222,6 @@ type CreateHabitJSONRequestBody = HabitRequestContent
 
 // UpdateHabitJSONRequestBody defines body for UpdateHabit for application/json ContentType.
 type UpdateHabitJSONRequestBody = HabitRequestContent
-
-// StartTimeTrackJSONRequestBody defines body for StartTimeTrack for application/json ContentType.
-type StartTimeTrackJSONRequestBody = StartTimeTrackRequestContent
 
 // CreateTimeTrackJSONRequestBody defines body for CreateTimeTrack for application/json ContentType.
 type CreateTimeTrackJSONRequestBody = TimeTrackRequestContent
@@ -1590,10 +1584,8 @@ type ClientInterface interface {
 	// GetOngoingTimeTrack request
 	GetOngoingTimeTrack(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// StartTimeTrackWithBody request with any body
-	StartTimeTrackWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
-
-	StartTimeTrack(ctx context.Context, body StartTimeTrackJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// StartTimeTrack request
+	StartTimeTrack(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// CreateTimeTrackWithBody request with any body
 	CreateTimeTrackWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -2136,25 +2128,11 @@ func (c *Client) GetOngoingTimeTrack(ctx context.Context, reqEditors ...RequestE
 
 }
 
-// StartTimeTrackWithBody executes the StartTimeTrack operation.
+// StartTimeTrack executes the StartTimeTrack operation.
 
-func (c *Client) StartTimeTrackWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+func (c *Client) StartTimeTrack(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
 
-	req, err := NewStartTimeTrackRequestWithBody(c.Server, contentType, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
-}
-
-func (c *Client) StartTimeTrack(ctx context.Context, body StartTimeTrackJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewStartTimeTrackRequest(c.Server, body)
+	req, err := NewStartTimeTrackRequest(c.Server)
 	if err != nil {
 		return nil, err
 	}
@@ -3982,19 +3960,8 @@ func NewGetOngoingTimeTrackRequest(server string) (*http.Request, error) {
 	return req, nil
 }
 
-// NewStartTimeTrackRequest calls the generic StartTimeTrack builder with application/json body
-func NewStartTimeTrackRequest(server string, body StartTimeTrackJSONRequestBody) (*http.Request, error) {
-	var bodyReader io.Reader
-	buf, err := json.Marshal(body)
-	if err != nil {
-		return nil, err
-	}
-	bodyReader = bytes.NewReader(buf)
-	return NewStartTimeTrackRequestWithBody(server, "application/json", bodyReader)
-}
-
-// NewStartTimeTrackRequestWithBody generates requests for StartTimeTrack with any type of body
-func NewStartTimeTrackRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+// NewStartTimeTrackRequest generates requests for StartTimeTrack
+func NewStartTimeTrackRequest(server string) (*http.Request, error) {
 	var err error
 
 	serverURL, err := url.Parse(server)
@@ -4012,12 +3979,10 @@ func NewStartTimeTrackRequestWithBody(server string, contentType string, body io
 		return nil, err
 	}
 
-	req, err := http.NewRequest("POST", queryURL.String(), body)
+	req, err := http.NewRequest("POST", queryURL.String(), nil)
 	if err != nil {
 		return nil, err
 	}
-
-	req.Header.Add("Content-Type", contentType)
 
 	return req, nil
 }
@@ -7505,19 +7470,14 @@ type ClientWithResponsesInterface interface {
 	// Returns a wrapper object for the known response body format(s).
 	GetOngoingTimeTrackWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetOngoingTimeTrackResponse, error)
 
-	// StartTimeTrackWithBodyWithResponse performs a POST /calendar/ongoing_time_track.json (the `StartTimeTrack` operationId) request,
-	// with any type of body and a specified content type.
+	// StartTimeTrackWithResponse performs a POST /calendar/ongoing_time_track.json (the `StartTimeTrack` operationId) request.
 	//
-	// Start a new time track.
+	// Start a new time track. Takes no body: haystack's
+	// Calendar::OngoingTimeTracksController#create ignores request parameters and
+	// starts a track with defaults; use UpdateTimeTrack to set title/notes/category.
 	//
 	// Returns a wrapper object for the known response body format(s).
-	StartTimeTrackWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*StartTimeTrackResponse, error)
-
-	// StartTimeTrackWithResponse performs a POST /calendar/ongoing_time_track.json (the `StartTimeTrack` operationId) request.
-	// Takes a body of the `application/json` content type, and returns a wrapper object for the known response body format(s).
-	//
-	// Start a new time track.
-	StartTimeTrackWithResponse(ctx context.Context, body StartTimeTrackJSONRequestBody, reqEditors ...RequestEditorFn) (*StartTimeTrackResponse, error)
+	StartTimeTrackWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*StartTimeTrackResponse, error)
 
 	// CreateTimeTrackWithBodyWithResponse performs a POST /calendar/time_tracks.json (the `CreateTimeTrack` operationId) request,
 	// with any type of body and a specified content type.
@@ -9461,6 +9421,8 @@ type StartTimeTrackResponse struct {
 	JSON200 *StartTimeTrackResponseContent
 	// JSON401 the response for an HTTP 401 `application/json` response
 	JSON401 *UnauthorizedErrorResponseContent
+	// JSON409 the response for an HTTP 409 `application/json` response
+	JSON409 *ConflictErrorResponseContent
 	// JSON422 the response for an HTTP 422 `application/json` response
 	JSON422 *UnprocessableEntityErrorResponseContent
 	// JSON500 the response for an HTTP 500 `application/json` response
@@ -9477,6 +9439,11 @@ func (r StartTimeTrackResponse) GetJSON200() *StartTimeTrackResponseContent {
 // GetJSON401 returns the response for an HTTP 401 `application/json` response
 func (r StartTimeTrackResponse) GetJSON401() *UnauthorizedErrorResponseContent {
 	return r.JSON401
+}
+
+// GetJSON409 returns the response for an HTTP 409 `application/json` response
+func (r StartTimeTrackResponse) GetJSON409() *ConflictErrorResponseContent {
+	return r.JSON409
 }
 
 // GetJSON422 returns the response for an HTTP 422 `application/json` response
@@ -13818,26 +13785,15 @@ func (c *ClientWithResponses) GetOngoingTimeTrackWithResponse(ctx context.Contex
 	return ParseGetOngoingTimeTrackResponse(rsp)
 }
 
-// StartTimeTrackWithBodyWithResponse performs a POST /calendar/ongoing_time_track.json (the `StartTimeTrack` operationId) request,
-// with any type of body and a specified content type.
+// StartTimeTrackWithResponse performs a POST /calendar/ongoing_time_track.json (the `StartTimeTrack` operationId) request.
 //
-// Start a new time track.
+// Start a new time track. Takes no body: haystack's
+// Calendar::OngoingTimeTracksController#create ignores request parameters and
+// starts a track with defaults; use UpdateTimeTrack to set title/notes/category.
 //
 // Returns a wrapper object for the known response body format(s).
-func (c *ClientWithResponses) StartTimeTrackWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*StartTimeTrackResponse, error) {
-	rsp, err := c.StartTimeTrackWithBody(ctx, contentType, body, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseStartTimeTrackResponse(rsp)
-}
-
-// StartTimeTrackWithResponse performs a POST /calendar/ongoing_time_track.json (the `StartTimeTrack` operationId) request.
-// Takes a body of the `application/json` content type, and returns a wrapper object for the known response body format(s).
-//
-// Start a new time track.
-func (c *ClientWithResponses) StartTimeTrackWithResponse(ctx context.Context, body StartTimeTrackJSONRequestBody, reqEditors ...RequestEditorFn) (*StartTimeTrackResponse, error) {
-	rsp, err := c.StartTimeTrack(ctx, body, reqEditors...)
+func (c *ClientWithResponses) StartTimeTrackWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*StartTimeTrackResponse, error) {
+	rsp, err := c.StartTimeTrack(ctx, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -16027,6 +15983,13 @@ func ParseStartTimeTrackResponse(rsp *http.Response) (*StartTimeTrackResponse, e
 			return nil, err
 		}
 		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 409:
+		var dest ConflictErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON409 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
 		var dest UnprocessableEntityErrorResponseContent

--- a/go/pkg/hey/entries.go
+++ b/go/pkg/hey/entries.go
@@ -1,9 +1,7 @@
 package hey
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"time"
 
 	"github.com/basecamp/hey-sdk/go/pkg/generated"
@@ -48,10 +46,14 @@ func (s *EntriesService) ListDrafts(ctx context.Context, params *generated.ListD
 // CreateReply replies to an entry (POST /entries/{entryId}/replies.json) and delivers it.
 // The acting sender ID is automatically resolved.
 //
-// If to/cc/bcc are all empty the "entry" key is omitted so HEY falls back to the
-// thread's existing recipients (reply-all). Sending an empty addressed hash would
-// clear the recipient list, because Entry#enter_reply treats {} as an explicit choice.
+// Recipients are required. HEY does not reply-all on the caller's behalf: a reply
+// posted without entry.addressed is saved as a draft (the server answers with a
+// redirect to the thread with the draft expanded) rather than delivered. Callers
+// resolve the thread's recipients first — hey-cli reads them from the topic page.
 func (s *EntriesService) CreateReply(ctx context.Context, entryID int64, content string, to, cc, bcc []string) (err error) {
+	if len(to)+len(cc)+len(bcc) == 0 {
+		return ErrUsage("a reply needs at least one recipient (to, cc or bcc); HEY saves an unaddressed reply as a draft")
+	}
 	op := OperationInfo{
 		Service: "Entries", Operation: "CreateReply",
 		ResourceType: "reply", IsMutation: true, ResourceID: entryID,
@@ -70,22 +72,13 @@ func (s *EntriesService) CreateReply(ctx context.Context, entryID int64, content
 		return err
 	}
 
-	body := map[string]any{
-		"acting_sender_id": senderID,
-		"message": map[string]any{
-			"content": content,
-		},
-	}
-	if addressed := addressedPayload(to, cc, bcc); len(addressed) > 0 {
-		body["entry"] = map[string]any{"addressed": addressed}
-	}
-	payload, err := json.Marshal(body)
-	if err != nil {
-		return err
+	body := generated.CreateReplyRequestContent{
+		ActingSenderId: senderID,
+		Message:        generated.ReplyMessagePayload{Content: content},
+		Entry:          entryPayload(to, cc, bcc),
 	}
 
-	s.client.initGeneratedClient()
-	resp, err := s.client.gen.CreateReplyWithBodyWithResponse(ctx, entryID, "application/json", bytes.NewReader(payload))
+	resp, err := s.client.genClient().CreateReplyWithResponse(ctx, entryID, body)
 	if err != nil {
 		return err
 	}

--- a/go/pkg/hey/errors.go
+++ b/go/pkg/hey/errors.go
@@ -26,6 +26,7 @@ const (
 	CodeAPI        = "api_error"
 	CodeValidation = "validation"
 	CodeAmbiguous  = "ambiguous"
+	CodeConflict   = "conflict"
 )
 
 // Exit codes for CLI tools.
@@ -92,6 +93,8 @@ func ExitCodeFor(code string) int {
 		return ExitValidation
 	case CodeAmbiguous:
 		return ExitAmbiguous
+	case CodeConflict:
+		return ExitValidation
 	default:
 		return ExitAPI
 	}
@@ -183,6 +186,16 @@ func ErrAPI(status int, msg string) *Error {
 		Code:       CodeAPI,
 		Message:    msg,
 		HTTPStatus: status,
+	}
+}
+
+// ErrConflict signals that the request conflicts with current server state
+// (HTTP 409), carrying the server's own message.
+func ErrConflict(msg string) *Error {
+	return &Error{
+		Code:       CodeConflict,
+		Message:    msg,
+		HTTPStatus: 409,
 	}
 }
 

--- a/go/pkg/hey/helpers.go
+++ b/go/pkg/hey/helpers.go
@@ -27,6 +27,13 @@ func CheckResponse(resp *http.Response) error {
 	case http.StatusUnauthorized:
 		return &Error{Code: CodeAuth, Message: "authentication required", HTTPStatus: 401, RequestID: requestID}
 	case http.StatusForbidden:
+		// A read-only OAuth token can GET but not mutate: tell the caller why,
+		// the same way the raw request path does (see doRequest).
+		if resp.Request != nil && resp.Request.Method != http.MethodGet {
+			e := ErrForbiddenScope()
+			e.RequestID = requestID
+			return e
+		}
 		return &Error{Code: CodeForbidden, Message: "access denied", HTTPStatus: 403, RequestID: requestID}
 	case http.StatusNotFound:
 		return &Error{Code: CodeNotFound, Message: "resource not found", HTTPStatus: 404, RequestID: requestID}

--- a/go/pkg/hey/messages.go
+++ b/go/pkg/hey/messages.go
@@ -1,9 +1,7 @@
 package hey
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"time"
 
 	"github.com/basecamp/hey-sdk/go/pkg/generated"
@@ -52,6 +50,9 @@ func (s *MessagesService) Get(ctx context.Context, messageID int64) (result *gen
 // entry: {addressed: {directly: [...], copied: [...], blindcopied: [...]}}}.
 // Recipient lists are JSON arrays; haystack applies Array() to each kind.
 func (s *MessagesService) Create(ctx context.Context, subject, content string, to, cc, bcc []string) (err error) {
+	if len(to)+len(cc)+len(bcc) == 0 {
+		return ErrUsage("a message needs at least one recipient (to, cc or bcc)")
+	}
 	op := OperationInfo{
 		Service: "Messages", Operation: "CreateMessage",
 		ResourceType: "message", IsMutation: true,
@@ -70,40 +71,27 @@ func (s *MessagesService) Create(ctx context.Context, subject, content string, t
 		return err
 	}
 
-	body := map[string]any{
-		"acting_sender_id": senderID,
-		"message": map[string]any{
-			"subject": subject,
-			"content": content,
-		},
-		"entry": map[string]any{
-			"addressed": addressedPayload(to, cc, bcc),
-		},
-	}
-	payload, err := json.Marshal(body)
-	if err != nil {
-		return err
+	body := generated.CreateMessageRequestContent{
+		ActingSenderId: senderID,
+		Message:        generated.MessagePayload{Subject: subject, Content: content},
+		Entry:          entryPayload(to, cc, bcc),
 	}
 
-	s.client.initGeneratedClient()
-	resp, err := s.client.gen.CreateMessageWithBodyWithResponse(ctx, "application/json", bytes.NewReader(payload))
+	resp, err := s.client.genClient().CreateMessageWithResponse(ctx, body)
 	if err != nil {
 		return err
 	}
 	return CheckResponse(resp.HTTPResponse)
 }
 
-// addressedPayload builds the entry.addressed map, omitting empty kinds.
-func addressedPayload(to, cc, bcc []string) map[string]any {
-	addressed := map[string]any{}
-	if len(to) > 0 {
-		addressed["directly"] = to
+// entryPayload builds entry.addressed for a message or reply. Callers guarantee at
+// least one recipient; it still returns nil for none so the "entry" key is omitted
+// rather than sent as an empty hash.
+func entryPayload(to, cc, bcc []string) *generated.MessageEntryPayload {
+	if len(to)+len(cc)+len(bcc) == 0 {
+		return nil
 	}
-	if len(cc) > 0 {
-		addressed["copied"] = cc
+	return &generated.MessageEntryPayload{
+		Addressed: &generated.MessageAddressed{Directly: to, Copied: cc, Blindcopied: bcc},
 	}
-	if len(bcc) > 0 {
-		addressed["blindcopied"] = bcc
-	}
-	return addressed
 }

--- a/go/pkg/hey/postings_test.go
+++ b/go/pkg/hey/postings_test.go
@@ -230,3 +230,18 @@ func TestCheckResponse_ForbiddenMutationIsScopeError(t *testing.T) {
 		t.Errorf("read 403 should be a plain forbidden, got %#v", err)
 	}
 }
+
+func TestTimeTracksService_StartConflict(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusConflict)
+		_, _ = w.Write([]byte(`{"error":"Ongoing time track already in progress"}`))
+	}))
+	t.Cleanup(srv.Close)
+	c := NewClient(&Config{BaseURL: srv.URL}, &StaticTokenProvider{Token: "t"}, WithMaxRetries(0))
+	_, err := c.TimeTracks().Start(context.Background())
+	e := AsError(err)
+	if e == nil || e.Code != CodeConflict || e.HTTPStatus != 409 || e.Message != "Ongoing time track already in progress" {
+		t.Fatalf("expected a conflict error carrying the server message, got %#v", err)
+	}
+}

--- a/go/pkg/hey/postings_test.go
+++ b/go/pkg/hey/postings_test.go
@@ -186,3 +186,47 @@ func TestPostingsService_ServerErrorSurfaced(t *testing.T) {
 		t.Fatal("expected error on 500")
 	}
 }
+
+// opRecorder captures the operation names announced to hooks.
+type opRecorder struct {
+	NoopHooks
+	ops []string
+}
+
+func (r *opRecorder) OnOperationStart(ctx context.Context, op OperationInfo) context.Context {
+	r.ops = append(r.ops, op.Operation)
+	return ctx
+}
+
+func TestTimeTracksService_StopAnnouncesItself(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":1,"type":"TimeTrack"}`))
+	}))
+	t.Cleanup(srv.Close)
+	rec := &opRecorder{}
+	c := NewClient(&Config{BaseURL: srv.URL}, &StaticTokenProvider{Token: "t"}, WithMaxRetries(0), WithHooks(rec))
+	if err := c.TimeTracks().Stop(context.Background(), 1); err != nil {
+		t.Fatal(err)
+	}
+	if len(rec.ops) != 1 || rec.ops[0] != "StopTimeTrack" {
+		t.Errorf("hooks saw %v, want exactly [StopTimeTrack] (not UpdateTimeTrack, and not both)", rec.ops)
+	}
+}
+
+func TestCheckResponse_ForbiddenMutationIsScopeError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	t.Cleanup(srv.Close)
+	c := NewClient(&Config{BaseURL: srv.URL}, &StaticTokenProvider{Token: "t"}, WithMaxRetries(0))
+
+	err := c.Postings().Mute(context.Background(), 1) // POST through the generated client
+	if e := AsError(err); e == nil || e.Code != CodeForbidden || e.Hint == "" {
+		t.Errorf("mutation 403 should carry the scope hint, got %#v", err)
+	}
+	_, err = c.Boxes().List(context.Background()) // GET
+	if e := AsError(err); e == nil || e.Code != CodeForbidden || e.Hint != "" {
+		t.Errorf("read 403 should be a plain forbidden, got %#v", err)
+	}
+}

--- a/go/pkg/hey/services_test.go
+++ b/go/pkg/hey/services_test.go
@@ -538,21 +538,20 @@ func TestEntriesService_CreateReply(t *testing.T) {
 	}
 }
 
-func TestEntriesService_CreateReply_OmitsEntryWithoutRecipients(t *testing.T) {
+func TestEntriesService_CreateReply_RequiresRecipients(t *testing.T) {
+	// HEY saves an unaddressed reply as a draft instead of delivering it, so the
+	// SDK refuses before making a request.
 	client := newMutationTestClientWithValidation(t, "POST", "/entries/%s/replies.json",
-		func(t *testing.T, body map[string]any) {
-			t.Helper()
-			// An empty entry.addressed would clear the recipient list server-side
-			// (Entry#enter_reply treats {} as explicit), so it must be omitted.
-			if _, present := body["entry"]; present {
-				t.Errorf("entry must be omitted when no recipients are given, got %v", body["entry"])
-			}
-		},
+		func(t *testing.T, _ map[string]any) { t.Helper(); t.Error("no request should be sent") },
 		`{"notice":"sent"}`,
 	)
-
-	if err := client.Entries().CreateReply(context.Background(), 10, "Reply-all", nil, nil, nil); err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	err := client.Entries().CreateReply(context.Background(), 10, "hello", nil, nil, nil)
+	if e := AsError(err); e == nil || e.Code != CodeUsage {
+		t.Fatalf("expected a usage error, got %#v", err)
+	}
+	err = client.Messages().Create(context.Background(), "s", "b", nil, nil, nil)
+	if e := AsError(err); e == nil || e.Code != CodeUsage {
+		t.Fatalf("expected a usage error for a message with no recipients, got %#v", err)
 	}
 }
 
@@ -802,18 +801,13 @@ func TestTimeTracksService_GetOngoing_NotFound(t *testing.T) {
 }
 
 func TestTimeTracksService_Start(t *testing.T) {
+	// The server ignores any body on start, so the SDK sends none.
 	client := newMutationTestClientWithValidation(t, "POST", "/calendar/ongoing_time_track.json",
-		func(t *testing.T, body map[string]any) {
-			t.Helper()
-			if _, ok := body["calendar_time_track"]; !ok {
-				t.Fatal("missing calendar_time_track wrapper")
-			}
-		},
+		nil,
 		`{"id":1,"type":"TimeTrack"}`,
 	)
 
-	body := generated.StartTimeTrackJSONRequestBody{}
-	result, err := client.TimeTracks().Start(context.Background(), body)
+	result, err := client.TimeTracks().Start(context.Background())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/go/pkg/hey/time_tracks.go
+++ b/go/pkg/hey/time_tracks.go
@@ -54,10 +54,12 @@ func (s *TimeTracksService) GetOngoing(ctx context.Context) (result *generated.R
 	return resp.JSON200, nil
 }
 
-// Start starts a new time track.
+// Start starts a new time track and returns it as a recording.
 //
-// The body already carries the {calendar_time_track: {...}} wrapper the API expects.
-func (s *TimeTracksService) Start(ctx context.Context, body generated.StartTimeTrackJSONRequestBody) (result *generated.Recording, err error) {
+// It takes no parameters: haystack ignores the request body here and starts a
+// track with defaults. Set title/notes/category afterwards with Update. A 409
+// means a track is already ongoing.
+func (s *TimeTracksService) Start(ctx context.Context) (result *generated.Recording, err error) {
 	op := OperationInfo{
 		Service: "TimeTracks", Operation: "StartTimeTrack",
 		ResourceType: "time_track", IsMutation: true,
@@ -71,7 +73,7 @@ func (s *TimeTracksService) Start(ctx context.Context, body generated.StartTimeT
 	ctx = s.client.hooks.OnOperationStart(ctx, op)
 	defer func() { s.client.hooks.OnOperationEnd(ctx, op, err, time.Since(start)) }()
 
-	resp, err := s.client.genClient().StartTimeTrackWithResponse(ctx, body)
+	resp, err := s.client.genClient().StartTimeTrackWithResponse(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -109,12 +111,23 @@ func (s *TimeTracksService) Update(ctx context.Context, timeTrackID int64, body 
 }
 
 // Stop stops an ongoing time track by setting ends_at to the current time.
+// It reports itself to hooks as StopTimeTrack, distinct from UpdateTimeTrack,
+// so a gating policy can allow one without the other.
 func (s *TimeTracksService) Stop(ctx context.Context, timeTrackID int64) error {
-	now := time.Now().UTC()
-	_, err := s.Update(ctx, timeTrackID, generated.UpdateTimeTrackJSONRequestBody{
-		CalendarTimeTrack: generated.UpdateTimeTrackPayload{EndsAt: &now},
+	op := OperationInfo{
+		Service: "TimeTracks", Operation: "StopTimeTrack",
+		ResourceType: "time_track", IsMutation: true, ResourceID: timeTrackID,
+	}
+	return s.client.instrument(ctx, op, func(ctx context.Context) error {
+		now := time.Now().UTC()
+		resp, err := s.client.genClient().UpdateTimeTrackWithResponse(ctx, timeTrackID, generated.UpdateTimeTrackJSONRequestBody{
+			CalendarTimeTrack: generated.UpdateTimeTrackPayload{EndsAt: &now},
+		})
+		if err != nil {
+			return err
+		}
+		return CheckResponse(resp.HTTPResponse)
 	})
-	return err
 }
 
 // Create records a stretch of time that has already finished.

--- a/go/pkg/hey/time_tracks.go
+++ b/go/pkg/hey/time_tracks.go
@@ -77,6 +77,11 @@ func (s *TimeTracksService) Start(ctx context.Context) (result *generated.Record
 	if err != nil {
 		return nil, err
 	}
+	if resp.JSON409 != nil {
+		// A track is already running; hand back the server's message so the
+		// caller can branch on CodeConflict rather than parse a generic error.
+		return nil, ErrConflict(resp.JSON409.Error)
+	}
 	if err = CheckResponse(resp.HTTPResponse); err != nil {
 		return nil, err
 	}
@@ -91,15 +96,34 @@ func (s *TimeTracksService) Update(ctx context.Context, timeTrackID int64, body 
 		Service: "TimeTracks", Operation: "UpdateTimeTrack",
 		ResourceType: "time_track", IsMutation: true, ResourceID: timeTrackID,
 	}
-	if gater, ok := s.client.hooks.(GatingHooks); ok {
-		if ctx, err = gater.OnOperationGate(ctx, op); err != nil {
-			return
-		}
-	}
-	start := time.Now()
-	ctx = s.client.hooks.OnOperationStart(ctx, op)
-	defer func() { s.client.hooks.OnOperationEnd(ctx, op, err, time.Since(start)) }()
+	err = s.client.instrument(ctx, op, func(ctx context.Context) error {
+		result, err = s.update(ctx, timeTrackID, body)
+		return err
+	})
+	return result, err
+}
 
+// Stop stops an ongoing time track by setting ends_at to the current time.
+// It reports itself to hooks as StopTimeTrack, distinct from UpdateTimeTrack,
+// so a gating policy can allow one without the other; the request itself is
+// the same PUT that Update sends.
+func (s *TimeTracksService) Stop(ctx context.Context, timeTrackID int64) error {
+	op := OperationInfo{
+		Service: "TimeTracks", Operation: "StopTimeTrack",
+		ResourceType: "time_track", IsMutation: true, ResourceID: timeTrackID,
+	}
+	return s.client.instrument(ctx, op, func(ctx context.Context) error {
+		now := time.Now().UTC()
+		_, err := s.update(ctx, timeTrackID, generated.UpdateTimeTrackJSONRequestBody{
+			CalendarTimeTrack: generated.UpdateTimeTrackPayload{EndsAt: &now},
+		})
+		return err
+	})
+}
+
+// update is the shared PUT for Update and Stop: same request, same response
+// handling; only the announced operation differs.
+func (s *TimeTracksService) update(ctx context.Context, timeTrackID int64, body generated.UpdateTimeTrackJSONRequestBody) (*generated.Recording, error) {
 	resp, err := s.client.genClient().UpdateTimeTrackWithResponse(ctx, timeTrackID, body)
 	if err != nil {
 		return nil, err
@@ -108,26 +132,6 @@ func (s *TimeTracksService) Update(ctx context.Context, timeTrackID int64, body 
 		return nil, err
 	}
 	return resp.JSON200, nil
-}
-
-// Stop stops an ongoing time track by setting ends_at to the current time.
-// It reports itself to hooks as StopTimeTrack, distinct from UpdateTimeTrack,
-// so a gating policy can allow one without the other.
-func (s *TimeTracksService) Stop(ctx context.Context, timeTrackID int64) error {
-	op := OperationInfo{
-		Service: "TimeTracks", Operation: "StopTimeTrack",
-		ResourceType: "time_track", IsMutation: true, ResourceID: timeTrackID,
-	}
-	return s.client.instrument(ctx, op, func(ctx context.Context) error {
-		now := time.Now().UTC()
-		resp, err := s.client.genClient().UpdateTimeTrackWithResponse(ctx, timeTrackID, generated.UpdateTimeTrackJSONRequestBody{
-			CalendarTimeTrack: generated.UpdateTimeTrackPayload{EndsAt: &now},
-		})
-		if err != nil {
-			return err
-		}
-		return CheckResponse(resp.HTTPResponse)
-	})
 }
 
 // Create records a stretch of time that has already finished.

--- a/openapi.json
+++ b/openapi.json
@@ -1615,17 +1615,8 @@
         }
       },
       "post": {
-        "description": "Start a new time track",
+        "description": "Start a new time track. Takes no body: haystack's\nCalendar::OngoingTimeTracksController#create ignores request parameters and\nstarts a track with defaults; use UpdateTimeTrack to set title/notes/category.",
         "operationId": "StartTimeTrack",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/StartTimeTrackRequestContent"
-              }
-            }
-          }
-        },
         "responses": {
           "200": {
             "description": "StartTimeTrack 200 response",
@@ -1643,6 +1634,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/UnauthorizedErrorResponseContent"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "ConflictError 409 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConflictErrorResponseContent"
                 }
               }
             }
@@ -6926,6 +6927,18 @@
       "CompleteHabitResponseContent": {
         "$ref": "#/components/schemas/Recording"
       },
+      "ConflictErrorResponseContent": {
+        "type": "object",
+        "description": "The request conflicts with current state, e.g. starting a time track while one\nis already ongoing (haystack answers {\"error\": \"...\"} with 409).",
+        "properties": {
+          "error": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "error"
+        ]
+      },
       "Contact": {
         "type": "object",
         "description": "Contact — the identity of someone in HEY",
@@ -7121,7 +7134,8 @@
             "$ref": "#/components/schemas/MessagePayload"
           },
           "entry": {
-            "$ref": "#/components/schemas/MessageEntryPayload"
+            "$ref": "#/components/schemas/MessageEntryPayload",
+            "x-go-type-skip-optional-pointer": false
           }
         },
         "required": [
@@ -7131,7 +7145,7 @@
       },
       "CreateReplyRequestContent": {
         "type": "object",
-        "description": "Wire format: {acting_sender_id, message: {content}, entry: {addressed: {directly: [...]}}}",
+        "description": "Wire format: {acting_sender_id, message: {content}, entry: {addressed: {directly: [...]}}}\nentry.addressed is optional on the wire but a reply posted without it is saved as a\ndraft rather than delivered — HEY does not reply-all for the caller. Resolve the\nthread's recipients first and always send them.",
         "properties": {
           "acting_sender_id": {
             "type": "integer",
@@ -7141,7 +7155,8 @@
             "$ref": "#/components/schemas/ReplyMessagePayload"
           },
           "entry": {
-            "$ref": "#/components/schemas/MessageEntryPayload"
+            "$ref": "#/components/schemas/MessageEntryPayload",
+            "x-go-type-skip-optional-pointer": false
           }
         },
         "required": [
@@ -7822,7 +7837,8 @@
         "type": "object",
         "properties": {
           "addressed": {
-            "$ref": "#/components/schemas/MessageAddressed"
+            "$ref": "#/components/schemas/MessageAddressed",
+            "x-go-type-skip-optional-pointer": false
           }
         }
       },
@@ -8574,29 +8590,6 @@
         "required": [
           "message"
         ]
-      },
-      "StartTimeTrackPayload": {
-        "type": "object",
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "notes": {
-            "type": "string"
-          },
-          "category": {
-            "type": "string"
-          }
-        }
-      },
-      "StartTimeTrackRequestContent": {
-        "type": "object",
-        "description": "Wire format: {calendar_time_track: {title, notes, category}}",
-        "properties": {
-          "calendar_time_track": {
-            "$ref": "#/components/schemas/StartTimeTrackPayload"
-          }
-        }
       },
       "StartTimeTrackResponseContent": {
         "$ref": "#/components/schemas/Recording"

--- a/scripts/enhance-openapi-go-types.sh
+++ b/scripts/enhance-openapi-go-types.sh
@@ -99,6 +99,43 @@ jq '
   )
 ' "$OPENAPI_FILE" > "${OPENAPI_FILE}.tmp" && mv "${OPENAPI_FILE}.tmp" "$OPENAPI_FILE"
 
+# Pass 4: Optional object references in request schemas → pointers
+# A value-typed struct field is never omitted by omitempty, so an optional nested
+# object the caller left unset still goes on the wire as {} — for
+# CreateReplyRequestContent.entry that is {"addressed":{}}, which the server reads as
+# an explicit empty recipient list and drops reply-all. Same request-reachable set as
+# pass 2; only non-required properties whose schema is a bare $ref to an object.
+jq '
+  def refname: sub("^#/components/schemas/"; "");
+  . as $root
+  | [ .paths[] | .[] | objects | .requestBody? // empty | .. | .["$ref"]? // empty | refname ] | unique as $seeds
+  | def expand($set):
+      ($set + [ $set[] | $root.components.schemas[.] | .. | .["$ref"]? // empty | refname ] | unique) as $n
+      | if ($n | length) == ($set | length) then $set else expand($n) end;
+    expand($seeds) as $request_schemas
+  | $root
+  | (.components.schemas // {}) |= with_entries(
+      if (.key as $k | $request_schemas | index($k)) then
+        .value |= (
+          if .properties then
+            (.required // []) as $req
+            | .properties |= with_entries(
+                if (.value["$ref"]? // "" | test("^#/components/schemas/"))
+                   and ((.key as $p | $req | index($p)) | not)
+                   and (($root.components.schemas[(.value["$ref"] | refname)].type // "object") == "object")
+                then
+                  .value += {"x-go-type-skip-optional-pointer": false}
+                else .
+                end
+              )
+          else .
+          end
+        )
+      else .
+      end
+    )
+' "$OPENAPI_FILE" > "${OPENAPI_FILE}.tmp" && mv "${OPENAPI_FILE}.tmp" "$OPENAPI_FILE"
+
 # Self-referential types are fixed via post-codegen sed in go/Makefile.
 
 echo "Enhanced $OPENAPI_FILE with Go type annotations"

--- a/spec/hey.smithy
+++ b/spec/hey.smithy
@@ -231,6 +231,15 @@ structure UnprocessableEntityError {
     message: String
 }
 
+/// The request conflicts with current state, e.g. starting a time track while one
+/// is already ongoing (haystack answers {"error": "..."} with 409).
+@error("client")
+@httpError(409)
+structure ConflictError {
+    @required
+    error: String
+}
+
 @error("client")
 @httpError(429)
 @retryable(throttling: true)
@@ -1352,6 +1361,9 @@ structure CreateReplyInput {
 }
 
 /// Wire format: {acting_sender_id, message: {content}, entry: {addressed: {directly: [...]}}}
+/// entry.addressed is optional on the wire but a reply posted without it is saved as a
+/// draft rather than delivered — HEY does not reply-all for the caller. Resolve the
+/// thread's recipients first and always send them.
 structure CreateReplyRequestContent {
     @required
     acting_sender_id: Long
@@ -1635,30 +1647,15 @@ structure GetOngoingTimeTrackOutput {
     recording: Recording
 }
 
-/// Start a new time track
+/// Start a new time track. Takes no body: haystack's
+/// Calendar::OngoingTimeTracksController#create ignores request parameters and
+/// starts a track with defaults; use UpdateTimeTrack to set title/notes/category.
 @http(method: "POST", uri: "/calendar/ongoing_time_track.json")
 @tags(["Calendar Time Tracks"])
 @heyRetry(maxAttempts: 2, baseDelayMs: 1000, backoff: "exponential", retryOn: [429, 503])
 operation StartTimeTrack {
-    input: StartTimeTrackInput
     output: StartTimeTrackOutput
-    errors: [UnauthorizedError, UnprocessableEntityError, InternalServerError, ServiceUnavailableError]
-}
-
-structure StartTimeTrackInput {
-    @httpPayload
-    body: StartTimeTrackRequestContent
-}
-
-/// Wire format: {calendar_time_track: {title, notes, category}}
-structure StartTimeTrackRequestContent {
-    calendar_time_track: StartTimeTrackPayload
-}
-
-structure StartTimeTrackPayload {
-    title: String
-    notes: String
-    category: String
+    errors: [UnauthorizedError, ConflictError, UnprocessableEntityError, InternalServerError, ServiceUnavailableError]
 }
 
 structure StartTimeTrackOutput {


### PR DESCRIPTION
Stacked on #67 — review that first. Last of the shape-changing items to land before v0.4.0.

## What changed

- **Optional `$ref` objects in request bodies are pointers** (`enhance-openapi-go-types.sh` pass 3): `CreateMessage`/`CreateReply` `.entry`, `MessageEntryPayload.addressed`, `StartTimeTrackRequestContent`. A value struct is never omitted by `omitempty`, so typed callers were sending `entry:{addressed:{}}`. `Messages.Create` and `Entries.CreateReply` now use the typed generated ops instead of hand-marshalled maps.
- **Recipients are required on `Create` and `CreateReply`.** Verified live: a reply posted without `entry.addressed` is saved as a *draft* (302 to the thread with `expanded_draft`), not delivered — HEY does not reply-all for the caller. The SDK now refuses with a usage error before sending. My earlier note in #61 that an omitted `entry` preserved reply-all was wrong; this is what hey-cli discovered too (its `reply` scrapes recipients for this reason).
- **`StartTimeTrack` takes no body.** haystack's `OngoingTimeTracksController#create` ignores request params, so the `{calendar_time_track:{title,notes,category}}` payload was fiction. `Start(ctx)`; the 409 for "already running" is modelled.
- **`TimeTracks().Stop` announces `StopTimeTrack`** to hooks again (it had become `UpdateTimeTrack` by delegation), so a gating policy can allow one without the other.
- **403 on a mutation → `ErrForbiddenScope`** in `CheckResponse`, matching what the raw request path always did; every generated-client wrapper had lost the "re-authenticate with full scope" hint.

## Verified
- `make check` green (127 conformance).
- Live on prod: typed `CreateReply` with a recipient delivers (thread 2101291513 now has 3 entries); without one, the server drafts — hence the guard.

## For the CLI bump
`TimeTracks().Start(ctx)` (no body); `Messages.Create`/`CreateReply` reject empty recipients (the CLI already resolves them).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes optional request-body objects pointers and removes the `StartTimeTrack` body to stop sending empty `{}` payloads, enforce recipients, and surface conflict and scope errors. Old: `{entry:{addressed:{}}}` cleared recipients and unaddressed replies were drafted; `StartTimeTrack` accepted a fictional payload and hid 409s; `Stop` announced as `Update`; 403 mutations lacked the “insufficient scope” hint. New: SDK omits unset objects, requires recipients, sends no body on start, returns a 409 conflict with the server message, restores `StopTimeTrack` announcements, and maps 403 mutations to `ErrForbiddenScope` (GETs remain plain forbidden).

- Optional `.entry` and `.entry.addressed` are pointers in generated request types; `Messages.Create`/`Entries.CreateReply` use typed ops, preventing `{entry:{addressed:{}}}` on the wire.
- `Create`/`CreateReply` now require recipients and return a usage error if none are provided (HEY drafts unaddressed replies instead of delivering).
- `TimeTracks.Start` takes no body; a running track yields a conflict error carrying the server’s message. `Update` and `Stop` share one request helper; `Stop` announces `StopTimeTrack` to hooks.
- `CheckResponse` maps 403 on non-GETs to `ErrForbiddenScope`.

**Migration**
- Replace `TimeTracks().Start(ctx, body)` with `TimeTracks().Start(ctx)`.
- Provide at least one recipient to `Messages.Create` and `Entries.CreateReply`.

<sup>Written for commit f13a8ed0bea67e4c9e26b8414fb45aebcf57fe27. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-sdk/pull/68?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

