### PR TITLE
Add topic Bubble Up operations

### DIFF
--- a/behavior-model.json
+++ b/behavior-model.json
@@ -44,6 +44,13 @@
         ]
       }
     },
+    "BubbleUpTopicNow": {
+      "idempotent": false,
+      "readonly": false,
+      "retry": {
+        "max": 0
+      }
+    },
     "BundleContact": {
       "idempotent": false,
       "readonly": false,
@@ -58,6 +65,19 @@
       }
     },
     "CancelPostingsBubbleUp": {
+      "idempotent": true,
+      "readonly": false,
+      "retry": {
+        "backoff": "exponential",
+        "base_delay_ms": 1000,
+        "max": 2,
+        "retry_on": [
+          429,
+          503
+        ]
+      }
+    },
+    "CancelTopicBubbleUp": {
       "idempotent": true,
       "readonly": false,
       "retry": {
@@ -1120,6 +1140,13 @@
           429,
           503
         ]
+      }
+    },
+    "ScheduleTopicBubbleUp": {
+      "idempotent": false,
+      "readonly": false,
+      "retry": {
+        "max": 0
       }
     },
     "StartTimeTrack": {

--- a/conformance/runner/go/main.go
+++ b/conformance/runner/go/main.go
@@ -565,6 +565,34 @@ func checkAssertion(testName string, a Assertion, s checkState) TestResult {
 			}
 		}
 
+	case "requestForm":
+		// expected: {"field": value, "absent": null}. Validate every recorded
+		// request so retry cases also prove that the form body was rebuilt.
+		expected, ok := a.Expected.(map[string]interface{})
+		if !ok {
+			return fail(testName, "requestForm: expected an object, got %T", a.Expected)
+		}
+		if len(s.requestBodies) == 0 {
+			return fail(testName, "Expected a request, but none were recorded")
+		}
+		for attempt, rawBody := range s.requestBodies {
+			form, err := url.ParseQuery(string(rawBody))
+			if err != nil {
+				return fail(testName, "requestForm: attempt %d is not valid URL-encoded form data: %v", attempt+1, err)
+			}
+			for key, want := range expected {
+				if want == nil {
+					if form.Has(key) {
+						return fail(testName, "Expected form field %q to be absent on attempt %d, got %q", key, attempt+1, form.Get(key))
+					}
+					continue
+				}
+				if got := form.Get(key); got != fmt.Sprint(want) {
+					return fail(testName, "Expected form field %s=%v on attempt %d, got %q", key, want, attempt+1, got)
+				}
+			}
+		}
+
 	case "headerPresent":
 		headerName := a.Path
 		if len(s.requestHeaders) == 0 {
@@ -1113,6 +1141,28 @@ func executeOperation(client *generated.Client, ctx context.Context, tc TestCase
 	case "RestoreTopic":
 		topicId := getInt64Param(tc.PathParams, "topicId")
 		return client.RestoreTopic(ctx, topicId)
+	case "ScheduleTopicBubbleUp":
+		topicId := getInt64Param(tc.PathParams, "topicId")
+		params := &generated.ScheduleTopicBubbleUpParams{
+			Slot: getStringParam(tc.QueryParams, "slot"),
+		}
+		if waitingOn, ok := tc.QueryParams["waiting_on"].(bool); ok {
+			params.WaitingOn = &waitingOn
+		}
+		form := url.Values{"date": {getStringParam(tc.RequestBody, "date")}}
+		return client.ScheduleTopicBubbleUpWithBody(
+			ctx,
+			topicId,
+			params,
+			"application/x-www-form-urlencoded",
+			strings.NewReader(form.Encode()),
+		)
+	case "CancelTopicBubbleUp":
+		topicId := getInt64Param(tc.PathParams, "topicId")
+		return client.CancelTopicBubbleUp(ctx, topicId)
+	case "BubbleUpTopicNow":
+		topicId := getInt64Param(tc.PathParams, "topicId")
+		return client.BubbleUpTopicNow(ctx, topicId)
 	case "MarkTopicHam":
 		topicId := getInt64Param(tc.PathParams, "topicId")
 		return client.MarkTopicHam(ctx, topicId)

--- a/conformance/tests/paths.json
+++ b/conformance/tests/paths.json
@@ -3452,5 +3452,112 @@
       "boxes",
       "sync"
     ]
+  },
+  {
+    "name": "ScheduleTopicBubbleUp uses /topics/{topicId}/bubble_up path",
+    "description": "Verifies that ScheduleTopicBubbleUp constructs the custom-date Bubble Up request",
+    "operation": "ScheduleTopicBubbleUp",
+    "method": "POST",
+    "path": "/topics/{topicId}/bubble_up",
+    "pathParams": {
+      "topicId": 456
+    },
+    "queryParams": {
+      "slot": "custom",
+      "waiting_on": true
+    },
+    "requestBody": {
+      "date": "2026-08-20"
+    },
+    "mockResponses": [
+      {
+        "status": 204,
+        "body": {}
+      }
+    ],
+    "assertions": [
+      {
+        "type": "requestPath",
+        "expected": "/topics/456/bubble_up"
+      },
+      {
+        "type": "requestQuery",
+        "expected": {
+          "slot": "custom",
+          "waiting_on": true
+        }
+      },
+      {
+        "type": "requestForm",
+        "expected": {
+          "date": "2026-08-20"
+        }
+      },
+      {
+        "type": "noError"
+      }
+    ],
+    "tags": [
+      "path",
+      "topics"
+    ]
+  },
+  {
+    "name": "CancelTopicBubbleUp uses /topics/{topicId}/bubble_up path",
+    "description": "Verifies that CancelTopicBubbleUp constructs the topic Bubble Up path",
+    "operation": "CancelTopicBubbleUp",
+    "method": "DELETE",
+    "path": "/topics/{topicId}/bubble_up",
+    "pathParams": {
+      "topicId": 456
+    },
+    "mockResponses": [
+      {
+        "status": 204,
+        "body": {}
+      }
+    ],
+    "assertions": [
+      {
+        "type": "requestPath",
+        "expected": "/topics/456/bubble_up"
+      },
+      {
+        "type": "noError"
+      }
+    ],
+    "tags": [
+      "path",
+      "topics"
+    ]
+  },
+  {
+    "name": "BubbleUpTopicNow uses /topics/{topicId}/bubble_up_now path",
+    "description": "Verifies that BubbleUpTopicNow constructs the immediate Bubble Up path",
+    "operation": "BubbleUpTopicNow",
+    "method": "POST",
+    "path": "/topics/{topicId}/bubble_up_now",
+    "pathParams": {
+      "topicId": 456
+    },
+    "mockResponses": [
+      {
+        "status": 204,
+        "body": {}
+      }
+    ],
+    "assertions": [
+      {
+        "type": "requestPath",
+        "expected": "/topics/456/bubble_up_now"
+      },
+      {
+        "type": "noError"
+      }
+    ],
+    "tags": [
+      "path",
+      "topics"
+    ]
   }
 ]

--- a/go/pkg/generated/client.gen.go
+++ b/go/pkg/generated/client.gen.go
@@ -1073,6 +1073,9 @@ type ReplyMessagePayload struct {
 // RevealContactResponseContent Contact — the identity of someone in HEY
 type RevealContactResponseContent = Contact
 
+// ScheduleTopicBubbleUpInputPayload defines model for ScheduleTopicBubbleUpInputPayload.
+type ScheduleTopicBubbleUpInputPayload = string
+
 // SearchFilterItem SearchFilterItem — one option offered by the advanced search refine form
 type SearchFilterItem struct {
 	Title string `json:"title,omitempty"`
@@ -1505,6 +1508,12 @@ type GetTrashTopicsParams struct {
 	Page *string `form:"page,omitempty" json:"page,omitempty"`
 }
 
+// ScheduleTopicBubbleUpParams defines parameters for ScheduleTopicBubbleUp.
+type ScheduleTopicBubbleUpParams struct {
+	Slot      string `form:"slot" json:"slot"`
+	WaitingOn *bool  `form:"waiting_on,omitempty" json:"waiting_on,omitempty"`
+}
+
 // GetTopicEntriesParams defines parameters for GetTopicEntries.
 type GetTopicEntriesParams struct {
 	Page *string `form:"page,omitempty" json:"page,omitempty"`
@@ -1604,6 +1613,9 @@ type MoveStickyJSONRequestBody = MoveStickyRequestContent
 
 // UpdateStickyJSONRequestBody defines body for UpdateSticky for application/json ContentType.
 type UpdateStickyJSONRequestBody = StickyRequestContent
+
+// ScheduleTopicBubbleUpFormdataRequestBody defines body for ScheduleTopicBubbleUp for application/x-www-form-urlencoded ContentType.
+type ScheduleTopicBubbleUpFormdataRequestBody = ScheduleTopicBubbleUpInputPayload
 
 // MoveTopicJSONRequestBody defines body for MoveTopic for application/json ContentType.
 type MoveTopicJSONRequestBody = MoveTopicRequestContent
@@ -2174,6 +2186,17 @@ type ClientInterface interface {
 
 	// GetTopic request
 	GetTopic(ctx context.Context, topicId int64, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// CancelTopicBubbleUp request
+	CancelTopicBubbleUp(ctx context.Context, topicId int64, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ScheduleTopicBubbleUpWithBody request with any body
+	ScheduleTopicBubbleUpWithBody(ctx context.Context, topicId int64, params *ScheduleTopicBubbleUpParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	ScheduleTopicBubbleUpWithFormdataBody(ctx context.Context, topicId int64, params *ScheduleTopicBubbleUpParams, body ScheduleTopicBubbleUpFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// BubbleUpTopicNow request
+	BubbleUpTopicNow(ctx context.Context, topicId int64, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetTopicEntries request
 	GetTopicEntries(ctx context.Context, topicId int64, params *GetTopicEntriesParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -3744,6 +3767,62 @@ func (c *Client) GetTopic(ctx context.Context, topicId int64, reqEditors ...Requ
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewGetTopicRequest(c.Server, topicId)
 	}, true, "GetTopic", reqEditors...)
+
+}
+
+// CancelTopicBubbleUp is marked as idempotent and will be retried on transient failures.
+
+func (c *Client) CancelTopicBubbleUp(ctx context.Context, topicId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
+
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		return NewCancelTopicBubbleUpRequest(c.Server, topicId)
+	}, true, "CancelTopicBubbleUp", reqEditors...)
+
+}
+
+// ScheduleTopicBubbleUpWithBody executes the ScheduleTopicBubbleUp operation.
+
+func (c *Client) ScheduleTopicBubbleUpWithBody(ctx context.Context, topicId int64, params *ScheduleTopicBubbleUpParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+
+	req, err := NewScheduleTopicBubbleUpRequestWithBody(c.Server, topicId, params, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+
+}
+
+func (c *Client) ScheduleTopicBubbleUpWithFormdataBody(ctx context.Context, topicId int64, params *ScheduleTopicBubbleUpParams, body ScheduleTopicBubbleUpFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+
+	req, err := NewScheduleTopicBubbleUpRequestWithFormdataBody(c.Server, topicId, params, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+
+}
+
+// BubbleUpTopicNow executes the BubbleUpTopicNow operation.
+
+func (c *Client) BubbleUpTopicNow(ctx context.Context, topicId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
+
+	req, err := NewBubbleUpTopicNowRequest(c.Server, topicId)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
 
 }
 
@@ -7845,6 +7924,155 @@ func NewGetTopicRequest(server string, topicId int64) (*http.Request, error) {
 	return req, nil
 }
 
+// NewCancelTopicBubbleUpRequest generates requests for CancelTopicBubbleUp
+func NewCancelTopicBubbleUpRequest(server string, topicId int64) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "topicId", runtime.ParamLocationPath, topicId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/topics/%s/bubble_up", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("DELETE", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewScheduleTopicBubbleUpRequestWithFormdataBody calls the generic ScheduleTopicBubbleUp builder with application/x-www-form-urlencoded body
+func NewScheduleTopicBubbleUpRequestWithFormdataBody(server string, topicId int64, params *ScheduleTopicBubbleUpParams, body ScheduleTopicBubbleUpFormdataRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	bodyStr, err := runtime.MarshalForm(body, nil)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = strings.NewReader(bodyStr.Encode())
+	return NewScheduleTopicBubbleUpRequestWithBody(server, topicId, params, "application/x-www-form-urlencoded", bodyReader)
+}
+
+// NewScheduleTopicBubbleUpRequestWithBody generates requests for ScheduleTopicBubbleUp with any type of body
+func NewScheduleTopicBubbleUpRequestWithBody(server string, topicId int64, params *ScheduleTopicBubbleUpParams, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "topicId", runtime.ParamLocationPath, topicId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/topics/%s/bubble_up", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "slot", runtime.ParamLocationQuery, params.Slot); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+		if params.WaitingOn != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "waiting_on", runtime.ParamLocationQuery, *params.WaitingOn); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewBubbleUpTopicNowRequest generates requests for BubbleUpTopicNow
+func NewBubbleUpTopicNowRequest(server string, topicId int64) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "topicId", runtime.ParamLocationPath, topicId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/topics/%s/bubble_up_now", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewGetTopicEntriesRequest generates requests for GetTopicEntries
 func NewGetTopicEntriesRequest(server string, topicId int64, params *GetTopicEntriesParams) (*http.Request, error) {
 	var err error
@@ -8259,6 +8487,9 @@ var operationMetadata = map[string]OperationMetadata{
 	"GetTrashTopics":             {Idempotent: true, HasSensitiveParams: false},
 	"EmptyTrash":                 {Idempotent: true, HasSensitiveParams: false},
 	"GetTopic":                   {Idempotent: true, HasSensitiveParams: false},
+	"CancelTopicBubbleUp":        {Idempotent: true, HasSensitiveParams: false},
+	"ScheduleTopicBubbleUp":      {Idempotent: false, HasSensitiveParams: false},
+	"BubbleUpTopicNow":           {Idempotent: false, HasSensitiveParams: false},
 	"GetTopicEntries":            {Idempotent: true, HasSensitiveParams: false},
 	"MoveTopic":                  {Idempotent: false, HasSensitiveParams: false},
 	"GetTopicPublication":        {Idempotent: true, HasSensitiveParams: false},
@@ -9791,6 +10022,34 @@ type ClientWithResponsesInterface interface {
 	//
 	// Returns a wrapper object for the known response body format(s).
 	GetTopicWithResponse(ctx context.Context, topicId int64, reqEditors ...RequestEditorFn) (*GetTopicResponse, error)
+
+	// CancelTopicBubbleUpWithResponse performs a DELETE /topics/{topicId}/bubble_up (the `CancelTopicBubbleUp` operationId) request.
+	//
+	// Cancel a scheduled Bubble Up.
+	//
+	// Returns a wrapper object for the known response body format(s).
+	CancelTopicBubbleUpWithResponse(ctx context.Context, topicId int64, reqEditors ...RequestEditorFn) (*CancelTopicBubbleUpResponse, error)
+
+	// ScheduleTopicBubbleUpWithBodyWithResponse performs a POST /topics/{topicId}/bubble_up (the `ScheduleTopicBubbleUp` operationId) request,
+	// with any type of body and a specified content type.
+	//
+	// Schedule a topic to Bubble Up on a custom date.
+	//
+	// Returns a wrapper object for the known response body format(s).
+	ScheduleTopicBubbleUpWithBodyWithResponse(ctx context.Context, topicId int64, params *ScheduleTopicBubbleUpParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*ScheduleTopicBubbleUpResponse, error)
+
+	// ScheduleTopicBubbleUpWithFormdataBodyWithResponse performs a POST /topics/{topicId}/bubble_up (the `ScheduleTopicBubbleUp` operationId) request.
+	// Takes a body of the `application/x-www-form-urlencoded` content type, and returns a wrapper object for the known response body format(s).
+	//
+	// Schedule a topic to Bubble Up on a custom date.
+	ScheduleTopicBubbleUpWithFormdataBodyWithResponse(ctx context.Context, topicId int64, params *ScheduleTopicBubbleUpParams, body ScheduleTopicBubbleUpFormdataRequestBody, reqEditors ...RequestEditorFn) (*ScheduleTopicBubbleUpResponse, error)
+
+	// BubbleUpTopicNowWithResponse performs a POST /topics/{topicId}/bubble_up_now (the `BubbleUpTopicNow` operationId) request.
+	//
+	// Bubble a topic up immediately.
+	//
+	// Returns a wrapper object for the known response body format(s).
+	BubbleUpTopicNowWithResponse(ctx context.Context, topicId int64, reqEditors ...RequestEditorFn) (*BubbleUpTopicNowResponse, error)
 
 	// GetTopicEntriesWithResponse performs a GET /topics/{topicId}/entries (the `GetTopicEntries` operationId) request.
 	//
@@ -15930,6 +16189,199 @@ func (r GetTopicResponse) ContentType() string {
 	return ""
 }
 
+type CancelTopicBubbleUpResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	// JSON401 the response for an HTTP 401 `application/json` response
+	JSON401 *UnauthorizedErrorResponseContent
+	// JSON404 the response for an HTTP 404 `application/json` response
+	JSON404 *NotFoundErrorResponseContent
+	// JSON500 the response for an HTTP 500 `application/json` response
+	JSON500 *InternalServerErrorResponseContent
+	// JSON503 the response for an HTTP 503 `application/json` response
+	JSON503 *ServiceUnavailableErrorResponseContent
+}
+
+// GetJSON401 returns the response for an HTTP 401 `application/json` response
+func (r CancelTopicBubbleUpResponse) GetJSON401() *UnauthorizedErrorResponseContent {
+	return r.JSON401
+}
+
+// GetJSON404 returns the response for an HTTP 404 `application/json` response
+func (r CancelTopicBubbleUpResponse) GetJSON404() *NotFoundErrorResponseContent {
+	return r.JSON404
+}
+
+// GetJSON500 returns the response for an HTTP 500 `application/json` response
+func (r CancelTopicBubbleUpResponse) GetJSON500() *InternalServerErrorResponseContent {
+	return r.JSON500
+}
+
+// GetJSON503 returns the response for an HTTP 503 `application/json` response
+func (r CancelTopicBubbleUpResponse) GetJSON503() *ServiceUnavailableErrorResponseContent {
+	return r.JSON503
+}
+
+// GetBody returns the raw response body bytes
+func (r CancelTopicBubbleUpResponse) GetBody() []byte {
+	return r.Body
+}
+
+// Status returns HTTPResponse.Status
+func (r CancelTopicBubbleUpResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r CancelTopicBubbleUpResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r CancelTopicBubbleUpResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type ScheduleTopicBubbleUpResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	// JSON401 the response for an HTTP 401 `application/json` response
+	JSON401 *UnauthorizedErrorResponseContent
+	// JSON404 the response for an HTTP 404 `application/json` response
+	JSON404 *NotFoundErrorResponseContent
+	// JSON422 the response for an HTTP 422 `application/json` response
+	JSON422 *UnprocessableEntityErrorResponseContent
+	// JSON500 the response for an HTTP 500 `application/json` response
+	JSON500 *InternalServerErrorResponseContent
+	// JSON503 the response for an HTTP 503 `application/json` response
+	JSON503 *ServiceUnavailableErrorResponseContent
+}
+
+// GetJSON401 returns the response for an HTTP 401 `application/json` response
+func (r ScheduleTopicBubbleUpResponse) GetJSON401() *UnauthorizedErrorResponseContent {
+	return r.JSON401
+}
+
+// GetJSON404 returns the response for an HTTP 404 `application/json` response
+func (r ScheduleTopicBubbleUpResponse) GetJSON404() *NotFoundErrorResponseContent {
+	return r.JSON404
+}
+
+// GetJSON422 returns the response for an HTTP 422 `application/json` response
+func (r ScheduleTopicBubbleUpResponse) GetJSON422() *UnprocessableEntityErrorResponseContent {
+	return r.JSON422
+}
+
+// GetJSON500 returns the response for an HTTP 500 `application/json` response
+func (r ScheduleTopicBubbleUpResponse) GetJSON500() *InternalServerErrorResponseContent {
+	return r.JSON500
+}
+
+// GetJSON503 returns the response for an HTTP 503 `application/json` response
+func (r ScheduleTopicBubbleUpResponse) GetJSON503() *ServiceUnavailableErrorResponseContent {
+	return r.JSON503
+}
+
+// GetBody returns the raw response body bytes
+func (r ScheduleTopicBubbleUpResponse) GetBody() []byte {
+	return r.Body
+}
+
+// Status returns HTTPResponse.Status
+func (r ScheduleTopicBubbleUpResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ScheduleTopicBubbleUpResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r ScheduleTopicBubbleUpResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type BubbleUpTopicNowResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	// JSON401 the response for an HTTP 401 `application/json` response
+	JSON401 *UnauthorizedErrorResponseContent
+	// JSON404 the response for an HTTP 404 `application/json` response
+	JSON404 *NotFoundErrorResponseContent
+	// JSON500 the response for an HTTP 500 `application/json` response
+	JSON500 *InternalServerErrorResponseContent
+	// JSON503 the response for an HTTP 503 `application/json` response
+	JSON503 *ServiceUnavailableErrorResponseContent
+}
+
+// GetJSON401 returns the response for an HTTP 401 `application/json` response
+func (r BubbleUpTopicNowResponse) GetJSON401() *UnauthorizedErrorResponseContent {
+	return r.JSON401
+}
+
+// GetJSON404 returns the response for an HTTP 404 `application/json` response
+func (r BubbleUpTopicNowResponse) GetJSON404() *NotFoundErrorResponseContent {
+	return r.JSON404
+}
+
+// GetJSON500 returns the response for an HTTP 500 `application/json` response
+func (r BubbleUpTopicNowResponse) GetJSON500() *InternalServerErrorResponseContent {
+	return r.JSON500
+}
+
+// GetJSON503 returns the response for an HTTP 503 `application/json` response
+func (r BubbleUpTopicNowResponse) GetJSON503() *ServiceUnavailableErrorResponseContent {
+	return r.JSON503
+}
+
+// GetBody returns the raw response body bytes
+func (r BubbleUpTopicNowResponse) GetBody() []byte {
+	return r.Body
+}
+
+// Status returns HTTPResponse.Status
+func (r BubbleUpTopicNowResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r BubbleUpTopicNowResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r BubbleUpTopicNowResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
 type GetTopicEntriesResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -18049,6 +18501,58 @@ func (c *ClientWithResponses) GetTopicWithResponse(ctx context.Context, topicId 
 		return nil, err
 	}
 	return ParseGetTopicResponse(rsp)
+}
+
+// CancelTopicBubbleUpWithResponse performs a DELETE /topics/{topicId}/bubble_up (the `CancelTopicBubbleUp` operationId) request.
+//
+// Cancel a scheduled Bubble Up.
+//
+// Returns a wrapper object for the known response body format(s).
+func (c *ClientWithResponses) CancelTopicBubbleUpWithResponse(ctx context.Context, topicId int64, reqEditors ...RequestEditorFn) (*CancelTopicBubbleUpResponse, error) {
+	rsp, err := c.CancelTopicBubbleUp(ctx, topicId, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCancelTopicBubbleUpResponse(rsp)
+}
+
+// ScheduleTopicBubbleUpWithBodyWithResponse performs a POST /topics/{topicId}/bubble_up (the `ScheduleTopicBubbleUp` operationId) request,
+// with any type of body and a specified content type.
+//
+// Schedule a topic to Bubble Up on a custom date.
+//
+// Returns a wrapper object for the known response body format(s).
+func (c *ClientWithResponses) ScheduleTopicBubbleUpWithBodyWithResponse(ctx context.Context, topicId int64, params *ScheduleTopicBubbleUpParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*ScheduleTopicBubbleUpResponse, error) {
+	rsp, err := c.ScheduleTopicBubbleUpWithBody(ctx, topicId, params, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseScheduleTopicBubbleUpResponse(rsp)
+}
+
+// ScheduleTopicBubbleUpWithFormdataBodyWithResponse performs a POST /topics/{topicId}/bubble_up (the `ScheduleTopicBubbleUp` operationId) request.
+// Takes a body of the `application/x-www-form-urlencoded` content type, and returns a wrapper object for the known response body format(s).
+//
+// Schedule a topic to Bubble Up on a custom date.
+func (c *ClientWithResponses) ScheduleTopicBubbleUpWithFormdataBodyWithResponse(ctx context.Context, topicId int64, params *ScheduleTopicBubbleUpParams, body ScheduleTopicBubbleUpFormdataRequestBody, reqEditors ...RequestEditorFn) (*ScheduleTopicBubbleUpResponse, error) {
+	rsp, err := c.ScheduleTopicBubbleUpWithFormdataBody(ctx, topicId, params, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseScheduleTopicBubbleUpResponse(rsp)
+}
+
+// BubbleUpTopicNowWithResponse performs a POST /topics/{topicId}/bubble_up_now (the `BubbleUpTopicNow` operationId) request.
+//
+// Bubble a topic up immediately.
+//
+// Returns a wrapper object for the known response body format(s).
+func (c *ClientWithResponses) BubbleUpTopicNowWithResponse(ctx context.Context, topicId int64, reqEditors ...RequestEditorFn) (*BubbleUpTopicNowResponse, error) {
+	rsp, err := c.BubbleUpTopicNow(ctx, topicId, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseBubbleUpTopicNowResponse(rsp)
 }
 
 // GetTopicEntriesWithResponse performs a GET /topics/{topicId}/entries (the `GetTopicEntries` operationId) request.
@@ -22915,6 +23419,163 @@ func ParseGetTopicResponse(rsp *http.Response) (*GetTopicResponse, error) {
 			return nil, err
 		}
 		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest UnauthorizedErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFoundErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalServerErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 503:
+		var dest ServiceUnavailableErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON503 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseCancelTopicBubbleUpResponse parses an HTTP response from a CancelTopicBubbleUpWithResponse call
+func ParseCancelTopicBubbleUpResponse(rsp *http.Response) (*CancelTopicBubbleUpResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &CancelTopicBubbleUpResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case rsp.StatusCode == 200:
+		break // No content-type
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest UnauthorizedErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFoundErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalServerErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 503:
+		var dest ServiceUnavailableErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON503 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseScheduleTopicBubbleUpResponse parses an HTTP response from a ScheduleTopicBubbleUpWithResponse call
+func ParseScheduleTopicBubbleUpResponse(rsp *http.Response) (*ScheduleTopicBubbleUpResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ScheduleTopicBubbleUpResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case rsp.StatusCode == 200:
+		break // No content-type
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest UnauthorizedErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFoundErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest UnprocessableEntityErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalServerErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 503:
+		var dest ServiceUnavailableErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON503 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseBubbleUpTopicNowResponse parses an HTTP response from a BubbleUpTopicNowWithResponse call
+func ParseBubbleUpTopicNowResponse(rsp *http.Response) (*BubbleUpTopicNowResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &BubbleUpTopicNowResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case rsp.StatusCode == 200:
+		break // No content-type
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
 		var dest UnauthorizedErrorResponseContent

--- a/go/pkg/hey/client.go
+++ b/go/pkg/hey/client.go
@@ -218,14 +218,17 @@ func (c *Client) initGeneratedClient() {
 			if err := c.authStrategy.Authenticate(ctx, req); err != nil {
 				return err
 			}
+			accept := acceptFromContext(ctx)
 			req.Header.Set("User-Agent", c.userAgent)
-			if req.Header.Get("Content-Type") == "" {
+			if req.Header.Get("Content-Type") == "" && accept == "application/json" {
 				req.Header.Set("Content-Type", "application/json")
 			}
-			req.Header.Set("Accept", "application/json")
-			req.URL.Path = withJSONExtension(req.URL.Path)
-			if req.URL.RawPath != "" {
-				req.URL.RawPath = withJSONExtension(req.URL.RawPath)
+			req.Header.Set("Accept", accept)
+			if accept == "application/json" {
+				req.URL.Path = withJSONExtension(req.URL.Path)
+				if req.URL.RawPath != "" {
+					req.URL.RawPath = withJSONExtension(req.URL.RawPath)
+				}
 			}
 			return nil
 		}

--- a/go/pkg/hey/topic_bubble_up_test.go
+++ b/go/pkg/hey/topic_bubble_up_test.go
@@ -1,0 +1,135 @@
+package hey
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func TestTopicsService_ScheduleBubbleUp(t *testing.T) {
+	tests := []struct {
+		name          string
+		waitingOn     bool
+		wantWaitingOn string
+	}{
+		{name: "custom date"},
+		{name: "waiting on someone", waitingOn: true, wantWaitingOn: "true"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := newRequestTestClient(t, http.MethodPost, "/topics/%s/bubble_up", func(t *testing.T, r *http.Request) {
+				t.Helper()
+				if got := r.URL.Query().Get("slot"); got != "custom" {
+					t.Errorf("slot = %q, want custom", got)
+				}
+				if got := r.URL.Query().Get("waiting_on"); got != tt.wantWaitingOn {
+					t.Errorf("waiting_on = %q, want %q", got, tt.wantWaitingOn)
+				}
+				if got := r.Header.Get("Content-Type"); got != "application/x-www-form-urlencoded" {
+					t.Errorf("Content-Type = %q, want application/x-www-form-urlencoded", got)
+				}
+				if got := r.Header.Get("Accept"); got != "*/*" {
+					t.Errorf("Accept = %q, want */*", got)
+				}
+				if err := r.ParseForm(); err != nil {
+					t.Fatalf("ParseForm: %v", err)
+				}
+				if got := r.PostForm.Get("date"); got != "2026-08-20" {
+					t.Errorf("date = %q, want 2026-08-20", got)
+				}
+			}, http.StatusNoContent, "")
+
+			if err := client.Topics().ScheduleBubbleUp(context.Background(), 123, "2026-08-20", tt.waitingOn); err != nil {
+				t.Fatalf("ScheduleBubbleUp: %v", err)
+			}
+		})
+	}
+}
+
+func TestTopicsService_CancelAndBubbleUpNow(t *testing.T) {
+	tests := []struct {
+		name   string
+		method string
+		path   string
+		call   func(*Client) error
+	}{
+		{
+			name:   "cancel",
+			method: http.MethodDelete,
+			path:   "/topics/%s/bubble_up",
+			call: func(client *Client) error {
+				return client.Topics().CancelBubbleUp(context.Background(), 123)
+			},
+		},
+		{
+			name:   "now",
+			method: http.MethodPost,
+			path:   "/topics/%s/bubble_up_now",
+			call: func(client *Client) error {
+				return client.Topics().BubbleUpNow(context.Background(), 123)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := newRequestTestClient(t, tt.method, tt.path, nil, http.StatusNoContent, "")
+			if err := tt.call(client); err != nil {
+				t.Fatalf("%s: %v", tt.name, err)
+			}
+		})
+	}
+}
+
+func TestTopicsService_BubbleUpRejectsInvalidInputBeforeRequest(t *testing.T) {
+	var requests atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(server.Close)
+
+	client := NewClient(
+		&Config{BaseURL: server.URL},
+		&StaticTokenProvider{Token: "test-token"},
+		WithMaxRetries(0),
+	)
+	tests := []struct {
+		name string
+		call func() error
+		want string
+	}{
+		{name: "schedule topic ID", call: func() error {
+			return client.Topics().ScheduleBubbleUp(context.Background(), 0, "2026-08-20", false)
+		}, want: "topic ID must be positive"},
+		{name: "schedule date", call: func() error {
+			return client.Topics().ScheduleBubbleUp(context.Background(), 123, "August 20", false)
+		}, want: "YYYY-MM-DD"},
+		{name: "cancel topic ID", call: func() error {
+			return client.Topics().CancelBubbleUp(context.Background(), 0)
+		}, want: "topic ID must be positive"},
+		{name: "now topic ID", call: func() error {
+			return client.Topics().BubbleUpNow(context.Background(), 0)
+		}, want: "topic ID must be positive"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.call()
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("error = %v, want %q", err, tt.want)
+			}
+			if AsError(err).Code != CodeUsage {
+				t.Errorf("error code = %q, want %q", AsError(err).Code, CodeUsage)
+			}
+		})
+	}
+
+	if got := requests.Load(); got != 0 {
+		t.Fatalf("requests = %d, want 0", got)
+	}
+}

--- a/go/pkg/hey/topics.go
+++ b/go/pkg/hey/topics.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
+	"strings"
 	"time"
 
 	"github.com/basecamp/hey-sdk/go/pkg/generated"
@@ -173,6 +175,81 @@ func (s *TopicsService) GetEverything(ctx context.Context, params *generated.Get
 		return nil, err
 	}
 	return resp.JSON200, nil
+}
+
+// ScheduleBubbleUp schedules a topic to bubble up on a custom date.
+func (s *TopicsService) ScheduleBubbleUp(ctx context.Context, topicID int64, date string, waitingOn bool) error {
+	if topicID <= 0 {
+		return ErrUsage("topic ID must be positive")
+	}
+	if _, err := time.Parse("2006-01-02", date); err != nil {
+		return ErrUsage("bubble up date must use YYYY-MM-DD")
+	}
+
+	op := OperationInfo{
+		Service: "Topics", Operation: "ScheduleTopicBubbleUp",
+		ResourceType: "topic", IsMutation: true, ResourceID: topicID,
+	}
+
+	return s.client.instrument(ctx, op, func(ctx context.Context) error {
+		params := &generated.ScheduleTopicBubbleUpParams{Slot: "custom"}
+		if waitingOn {
+			params.WaitingOn = &waitingOn
+		}
+		values := url.Values{"date": {date}}
+
+		resp, err := s.client.genClient().ScheduleTopicBubbleUpWithBodyWithResponse(
+			contextWithAccept(ctx, "*/*"),
+			topicID,
+			params,
+			"application/x-www-form-urlencoded",
+			strings.NewReader(values.Encode()),
+		)
+		if err != nil {
+			return err
+		}
+		return CheckResponse(resp.HTTPResponse)
+	})
+}
+
+// CancelBubbleUp removes a topic's scheduled Bubble Up.
+func (s *TopicsService) CancelBubbleUp(ctx context.Context, topicID int64) error {
+	if topicID <= 0 {
+		return ErrUsage("topic ID must be positive")
+	}
+
+	op := OperationInfo{
+		Service: "Topics", Operation: "CancelTopicBubbleUp",
+		ResourceType: "topic", IsMutation: true, ResourceID: topicID,
+	}
+
+	return s.client.instrument(ctx, op, func(ctx context.Context) error {
+		resp, err := s.client.genClient().CancelTopicBubbleUpWithResponse(contextWithAccept(ctx, "*/*"), topicID)
+		if err != nil {
+			return err
+		}
+		return CheckResponse(resp.HTTPResponse)
+	})
+}
+
+// BubbleUpNow moves a topic to the top of the Imbox immediately.
+func (s *TopicsService) BubbleUpNow(ctx context.Context, topicID int64) error {
+	if topicID <= 0 {
+		return ErrUsage("topic ID must be positive")
+	}
+
+	op := OperationInfo{
+		Service: "Topics", Operation: "BubbleUpTopicNow",
+		ResourceType: "topic", IsMutation: true, ResourceID: topicID,
+	}
+
+	return s.client.instrument(ctx, op, func(ctx context.Context) error {
+		resp, err := s.client.genClient().BubbleUpTopicNowWithResponse(contextWithAccept(ctx, "*/*"), topicID)
+		if err != nil {
+			return err
+		}
+		return CheckResponse(resp.HTTPResponse)
+	})
 }
 
 // --- Status and moves ---

--- a/go/pkg/hey/url-routes.json
+++ b/go/pkg/hey/url-routes.json
@@ -767,6 +767,33 @@
       }
     },
     {
+      "pattern": "/topics/{topicId}/bubble_up",
+      "resource": "Topics",
+      "operations": {
+        "DELETE": "CancelTopicBubbleUp",
+        "POST": "ScheduleTopicBubbleUp"
+      },
+      "params": {
+        "topicId": {
+          "role": "parent",
+          "type": "int64"
+        }
+      }
+    },
+    {
+      "pattern": "/topics/{topicId}/bubble_up_now",
+      "resource": "Topics",
+      "operations": {
+        "POST": "BubbleUpTopicNow"
+      },
+      "params": {
+        "topicId": {
+          "role": "parent",
+          "type": "int64"
+        }
+      }
+    },
+    {
       "pattern": "/topics/{topicId}/entries",
       "resource": "Topics",
       "operations": {

--- a/openapi.json
+++ b/openapi.json
@@ -7320,6 +7320,244 @@
         }
       }
     },
+    "/topics/{topicId}/bubble_up": {
+      "delete": {
+        "description": "Cancel a scheduled Bubble Up.",
+        "operationId": "CancelTopicBubbleUp",
+        "parameters": [
+          {
+            "name": "topicId",
+            "in": "path",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "CancelTopicBubbleUp 200 response"
+          },
+          "401": {
+            "description": "UnauthorizedError 401 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedErrorResponseContent"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFoundError 404 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundErrorResponseContent"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "InternalServerError 500 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerErrorResponseContent"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "ServiceUnavailableError 503 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceUnavailableErrorResponseContent"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Topics"
+        ],
+        "x-hey-retry": {
+          "maxAttempts": 2,
+          "baseDelayMs": 1000,
+          "backoff": "exponential",
+          "retryOn": [
+            429,
+            503
+          ]
+        }
+      },
+      "post": {
+        "description": "Schedule a topic to Bubble Up on a custom date.",
+        "operationId": "ScheduleTopicBubbleUp",
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/ScheduleTopicBubbleUpInputPayload"
+              }
+            }
+          },
+          "required": true
+        },
+        "parameters": [
+          {
+            "name": "topicId",
+            "in": "path",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "required": true
+          },
+          {
+            "name": "slot",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "name": "waiting_on",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "x-go-type-skip-optional-pointer": false
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ScheduleTopicBubbleUp 200 response"
+          },
+          "401": {
+            "description": "UnauthorizedError 401 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedErrorResponseContent"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFoundError 404 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundErrorResponseContent"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "UnprocessableEntityError 422 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnprocessableEntityErrorResponseContent"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "InternalServerError 500 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerErrorResponseContent"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "ServiceUnavailableError 503 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceUnavailableErrorResponseContent"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Topics"
+        ]
+      }
+    },
+    "/topics/{topicId}/bubble_up_now": {
+      "post": {
+        "description": "Bubble a topic up immediately.",
+        "operationId": "BubbleUpTopicNow",
+        "parameters": [
+          {
+            "name": "topicId",
+            "in": "path",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "BubbleUpTopicNow 200 response"
+          },
+          "401": {
+            "description": "UnauthorizedError 401 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedErrorResponseContent"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFoundError 404 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundErrorResponseContent"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "InternalServerError 500 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerErrorResponseContent"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "ServiceUnavailableError 503 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceUnavailableErrorResponseContent"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Topics"
+        ]
+      }
+    },
     "/topics/{topicId}/entries": {
       "get": {
         "description": "Get entries for a topic",
@@ -10483,6 +10721,9 @@
       },
       "RevealContactResponseContent": {
         "$ref": "#/components/schemas/Contact"
+      },
+      "ScheduleTopicBubbleUpInputPayload": {
+        "type": "string"
       },
       "SearchFilterItem": {
         "type": "object",

--- a/spec/excluded-routes.json
+++ b/spec/excluded-routes.json
@@ -3250,16 +3250,6 @@
     "reason": "phase-2: topic breakout threads"
   },
   {
-    "method": "DELETE",
-    "path": "/topics/{topic_id}/bubble_up",
-    "reason": "phase-2: topic bubble up"
-  },
-  {
-    "method": "POST",
-    "path": "/topics/{topic_id}/bubble_up",
-    "reason": "phase-2: topic bubble up"
-  },
-  {
     "method": "GET",
     "path": "/topics/{topic_id}/bubble_up/menu",
     "reason": "phase-2: topic bubble up"
@@ -3276,11 +3266,6 @@
   },
   {
     "method": "PATCH",
-    "path": "/topics/{topic_id}/bubble_up_now",
-    "reason": "phase-2: topic bubble up"
-  },
-  {
-    "method": "POST",
     "path": "/topics/{topic_id}/bubble_up_now",
     "reason": "phase-2: topic bubble up"
   },

--- a/spec/hey.smithy
+++ b/spec/hey.smithy
@@ -39,6 +39,7 @@ use smithy.api#readonly
 use smithy.api#idempotent
 use smithy.api#error
 use smithy.api#httpError
+use smithy.api#mediaType
 use smithy.api#retryable
 use smithy.api#sensitive
 use smithy.api#tags
@@ -157,6 +158,9 @@ service HEY {
         EmptyTrash
         EmptySpam
         MoveTopic
+        ScheduleTopicBubbleUp
+        CancelTopicBubbleUp
+        BubbleUpTopicNow
 
         // Entries
         MarkEntrySpam
@@ -2538,6 +2542,52 @@ structure TrashTopicInput {
 @tags(["Topics"])
 @heyRetry(maxAttempts: 2, baseDelayMs: 1000, backoff: "exponential", retryOn: [429, 503])
 operation RestoreTopic {
+    input: TopicStatusInput
+    errors: [UnauthorizedError, NotFoundError, InternalServerError, ServiceUnavailableError]
+}
+
+@mediaType("application/x-www-form-urlencoded")
+string BubbleUpFormDocument
+
+/// Schedule a topic to Bubble Up on a custom date.
+@http(method: "POST", uri: "/topics/{topicId}/bubble_up")
+@tags(["Topics"])
+operation ScheduleTopicBubbleUp {
+    input: ScheduleTopicBubbleUpInput
+    errors: [UnauthorizedError, NotFoundError, UnprocessableEntityError, InternalServerError, ServiceUnavailableError]
+}
+
+structure ScheduleTopicBubbleUpInput {
+    @httpLabel
+    @required
+    topicId: Long
+
+    @httpQuery("slot")
+    @required
+    slot: String
+
+    @httpQuery("waiting_on")
+    waiting_on: Boolean
+
+    @httpPayload
+    @required
+    body: BubbleUpFormDocument
+}
+
+/// Cancel a scheduled Bubble Up.
+@idempotent
+@http(method: "DELETE", uri: "/topics/{topicId}/bubble_up")
+@tags(["Topics"])
+@heyRetry(maxAttempts: 2, baseDelayMs: 1000, backoff: "exponential", retryOn: [429, 503])
+operation CancelTopicBubbleUp {
+    input: TopicStatusInput
+    errors: [UnauthorizedError, NotFoundError, InternalServerError, ServiceUnavailableError]
+}
+
+/// Bubble a topic up immediately.
+@http(method: "POST", uri: "/topics/{topicId}/bubble_up_now")
+@tags(["Topics"])
+operation BubbleUpTopicNow {
     input: TopicStatusInput
     errors: [UnauthorizedError, NotFoundError, InternalServerError, ServiceUnavailableError]
 }

--- a/spec/route-coverage.json
+++ b/spec/route-coverage.json
@@ -16,6 +16,11 @@
   },
   {
     "method": "POST",
+    "operationId": "BubbleUpTopicNow",
+    "path": "/topics/{topicId}/bubble_up_now"
+  },
+  {
+    "method": "POST",
     "operationId": "BundleContact",
     "path": "/contacts/{contactId}/bundle.json"
   },
@@ -23,6 +28,11 @@
     "method": "DELETE",
     "operationId": "CancelPostingsBubbleUp",
     "path": "/postings/bubble_up.json"
+  },
+  {
+    "method": "DELETE",
+    "operationId": "CancelTopicBubbleUp",
+    "path": "/topics/{topicId}/bubble_up"
   },
   {
     "method": "POST",
@@ -413,6 +423,11 @@
     "method": "POST",
     "operationId": "RevealContact",
     "path": "/contacts/{contactId}/reveal.json"
+  },
+  {
+    "method": "POST",
+    "operationId": "ScheduleTopicBubbleUp",
+    "path": "/topics/{topicId}/bubble_up"
   },
   {
     "method": "POST",


### PR DESCRIPTION
HEY has topic-level Bubble Up routes, but the SDK only covered the bulk posting versions. This adds the missing topic operations for scheduling a custom date, canceling a scheduled Bubble Up, and bubbling a topic up now.

The schedule request matches the form HEY expects:

- `slot=custom` in the query
- `date=YYYY-MM-DD` in the form body
- `waiting_on=true` only when requested

The service wrapper rejects invalid topic IDs and dates before making a request. The Smithy model, generated client, route coverage, behavior model, service tests, and conformance suite are updated together.

Tested against live HEY behavior for schedule, cancel, and Bubble Up now. `make check` passes with 130 conformance cases.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds topic-level Bubble Up operations to `TopicsService` so callers can schedule, cancel, or run Bubble Up immediately. Previously only bulk routes were supported; this adds topic routes with validation and correct form wire format.

- Adds `ScheduleBubbleUp(ctx, topicID, date, waitingOn)`, `CancelBubbleUp(ctx, topicID)`, and `BubbleUpNow(ctx, topicID)`. Schedule uses `slot=custom`, optional `waiting_on`, and an `application/x-www-form-urlencoded` body `date=YYYY-MM-DD`.
- Validates `topicID > 0` and date format; returns a usage error without sending a request on invalid input.
- Adjusts client header/path behavior: only append `.json` and set JSON headers when `Accept` is `application/json`; these endpoints set `Accept: */*` and send form bodies to avoid `.json`.
- Retry policy: cancel is idempotent and retries on 429/503 with exponential backoff; schedule and now do not auto-retry.
- Updates Smithy and `openapi.json` with `/topics/{topicId}/bubble_up` and `/topics/{topicId}/bubble_up_now`, regenerates the client, adds conformance tests (including form-body assertions). No breaking changes to existing bulk Bubble Up APIs.

<sup>Written for commit d382685c548d007f61a0e7cf08c928dd2d8c295e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-sdk/pull/70?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

