### PR TITLE
Fix four behaviours flagged in the #64 review

### DIFF
--- a/go/pkg/hey/contacts.go
+++ b/go/pkg/hey/contacts.go
@@ -189,7 +189,9 @@ func (s *ContactsService) Create(ctx context.Context, params ContactParams) (id 
 //
 // HEY's update is a full replacement (Contact::Ingress::Revise rewrites name, email and
 // removes any alias not submitted), so the current contact is read first and unset
-// fields are filled in from it before the form is sent.
+// fields are filled in from it before the form is sent. That read-then-write is not
+// atomic: a change made to the contact between the two requests is overwritten with
+// what was read. Pass every field explicitly when that matters.
 func (s *ContactsService) Update(ctx context.Context, contactID int64, params ContactParams) error {
 	op := OperationInfo{
 		Service: "Contacts", Operation: "UpdateContact",

--- a/go/pkg/hey/contacts.go
+++ b/go/pkg/hey/contacts.go
@@ -51,17 +51,16 @@ func (s *ContactsService) Get(ctx context.Context, contactID int64) (result *gen
 		Service: "Contacts", Operation: "GetContact",
 		ResourceType: "contact", IsMutation: false, ResourceID: contactID,
 	}
-	if gater, ok := s.client.hooks.(GatingHooks); ok {
-		if ctx, err = gater.OnOperationGate(ctx, op); err != nil {
-			return
-		}
-	}
-	start := time.Now()
-	ctx = s.client.hooks.OnOperationStart(ctx, op)
-	defer func() { s.client.hooks.OnOperationEnd(ctx, op, err, time.Since(start)) }()
+	err = s.client.instrument(ctx, op, func(ctx context.Context) error {
+		result, err = s.get(ctx, contactID)
+		return err
+	})
+	return result, err
+}
 
-	s.client.initGeneratedClient()
-	resp, err := s.client.gen.GetContactWithResponse(ctx, contactID)
+// get is the un-instrumented read shared by Get and Update.
+func (s *ContactsService) get(ctx context.Context, contactID int64) (*generated.ContactDetail, error) {
+	resp, err := s.client.genClient().GetContactWithResponse(ctx, contactID)
 	if err != nil {
 		return nil, err
 	}
@@ -187,6 +186,10 @@ func (s *ContactsService) Create(ctx context.Context, params ContactParams) (id 
 
 // Update edits a contact. Empty fields are left alone, except AliasEmailAddresses, which
 // replaces the whole list when it is non-nil.
+//
+// HEY's update is a full replacement (Contact::Ingress::Revise rewrites name, email and
+// removes any alias not submitted), so the current contact is read first and unset
+// fields are filled in from it before the form is sent.
 func (s *ContactsService) Update(ctx context.Context, contactID int64, params ContactParams) error {
 	op := OperationInfo{
 		Service: "Contacts", Operation: "UpdateContact",
@@ -194,7 +197,23 @@ func (s *ContactsService) Update(ctx context.Context, contactID int64, params Co
 	}
 
 	return s.client.instrument(ctx, op, func(ctx context.Context) error {
-		_, err := s.client.PatchForm(ctx, fmt.Sprintf("/contacts/%d", contactID), contactForm(params))
+		current, err := s.get(ctx, contactID)
+		if err != nil {
+			return err
+		}
+		merged := params
+		if merged.Name == "" {
+			merged.Name = current.Name
+		}
+		if merged.EmailAddress == "" {
+			merged.EmailAddress = current.EmailAddress
+		}
+		if merged.AliasEmailAddresses == nil {
+			for _, alias := range current.Aliases {
+				merged.AliasEmailAddresses = append(merged.AliasEmailAddresses, alias.EmailAddress)
+			}
+		}
+		_, err = s.client.PatchForm(ctx, fmt.Sprintf("/contacts/%d", contactID), contactForm(merged))
 		return err
 	})
 }

--- a/go/pkg/hey/habits.go
+++ b/go/pkg/hey/habits.go
@@ -71,9 +71,10 @@ func (s *HabitsService) Uncomplete(ctx context.Context, day string, habitID int6
 
 // --- Habit CRUD ---
 //
-// Create and Update answer the written habit as a recording on servers that carry the JSON
-// branches. Servers that don't redirect to the habits page instead; the write still reads as
-// a success here, just without a recording to hand back.
+// Create and Update answer the written habit as a recording (HEY renders it as JSON on
+// create and update; verified against production 2026-08-17). There is no redirect
+// fallback: a non-2xx answer is an error, so a caller never sees a "success" that
+// wrote nothing.
 
 // HabitParams describes a habit. Days are 0 for Sunday through 6 for Saturday.
 type HabitParams struct {

--- a/go/pkg/hey/habits.go
+++ b/go/pkg/hey/habits.go
@@ -71,8 +71,8 @@ func (s *HabitsService) Uncomplete(ctx context.Context, day string, habitID int6
 
 // --- Habit CRUD ---
 //
-// Create and Update answer the written habit as a recording (HEY renders it as JSON on
-// create and update; verified against production 2026-08-17). There is no redirect
+// Create and Update answer the written habit as a recording: HEY renders it as JSON on
+// create and update (the JSON branches added in haystack #8623). There is no redirect
 // fallback: a non-2xx answer is an error, so a caller never sees a "success" that
 // wrote nothing.
 

--- a/go/pkg/hey/postings_test.go
+++ b/go/pkg/hey/postings_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -243,5 +244,109 @@ func TestTimeTracksService_StartConflict(t *testing.T) {
 	e := AsError(err)
 	if e == nil || e.Code != CodeConflict || e.HTTPStatus != 409 || e.Message != "Ongoing time track already in progress" {
 		t.Fatalf("expected a conflict error carrying the server message, got %#v", err)
+	}
+}
+
+// --- Behaviour fixes from the #64 review ---
+
+func TestContactsService_UpdateMergesUnsetFields(t *testing.T) {
+	var form url.Values
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/contacts/7.json":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":7,"name":"Jane Dawson","email_address":"jane@x.com","aliases":[{"id":8,"email_address":"jd@x.com"},{"id":9,"email_address":"jane.d@x.com"}]}`))
+		case r.Method == http.MethodPatch && r.URL.Path == "/contacts/7":
+			_ = r.ParseForm()
+			form = r.PostForm
+			w.Header().Set("Location", srv0URL(r)+"/contacts/7")
+			w.WriteHeader(http.StatusFound)
+		default:
+			w.WriteHeader(404)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	c := NewClient(&Config{BaseURL: srv.URL}, &StaticTokenProvider{Token: "t"}, WithMaxRetries(0))
+
+	// Only the email changes: name and both aliases must be carried over.
+	if err := c.Contacts().Update(context.Background(), 7, ContactParams{EmailAddress: "new@x.com"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := form.Get("contact[name]"); got != "Jane Dawson" {
+		t.Errorf("name should be preserved, got %q", got)
+	}
+	if got := form.Get("contact[email_address]"); got != "new@x.com" {
+		t.Errorf("email should be updated, got %q", got)
+	}
+	if got := form["contact[alias_email_addresses][]"]; len(got) != 2 || got[0] != "jd@x.com" {
+		t.Errorf("aliases should be preserved, got %v", got)
+	}
+
+	// An explicit empty alias list clears them.
+	if err := c.Contacts().Update(context.Background(), 7, ContactParams{AliasEmailAddresses: []string{}}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := form["contact[alias_email_addresses][]"]; len(got) != 0 {
+		t.Errorf("explicit empty aliases should clear them, got %v", got)
+	}
+	if got := form.Get("contact[name]"); got != "Jane Dawson" {
+		t.Errorf("name should still be preserved, got %q", got)
+	}
+}
+
+func srv0URL(r *http.Request) string { return "http://" + r.Host }
+
+func TestPublicationsService_CreateIsOneOperation(t *testing.T) {
+	page := `<turbo-frame id="edit_topic_publication">
+		<span class="copy-to-clipboard__text" data-copy-to-clipboard-target="copyable">https://public.hey.com/p/abc123</span>
+	</turbo-frame>`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/topics/5/publication":
+			w.Header().Set("Location", "http://"+r.Host+"/topics/5")
+			w.WriteHeader(http.StatusFound)
+		case r.Method == http.MethodGet && r.URL.Path == "/topics/5/publication/edit":
+			w.Header().Set("Content-Type", "text/html")
+			_, _ = w.Write([]byte(page))
+		default:
+			w.WriteHeader(404)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	rec := &opRecorder{}
+	c := NewClient(&Config{BaseURL: srv.URL}, &StaticTokenProvider{Token: "t"}, WithMaxRetries(0), WithHooks(rec))
+
+	pub, err := c.Publications().Create(context.Background(), 5)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !pub.Published || pub.URL != "https://public.hey.com/p/abc123" {
+		t.Errorf("expected the public link back, got %#v", pub)
+	}
+	if len(rec.ops) != 1 || rec.ops[0] != "CreateTopicPublication" {
+		t.Errorf("hooks saw %v, want exactly [CreateTopicPublication] — Get must not be a nested operation", rec.ops)
+	}
+}
+
+func TestTopicsService_TrashSharedTopicNeedsConfirmation(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPut && r.URL.Path == "/topics/9/status/trashed.json":
+			// A shared topic without confirm_destroy: HEY redirects to the confirmation page.
+			w.Header().Set("Location", "http://"+r.Host+"/topics/9/removal/new")
+			w.WriteHeader(http.StatusFound)
+		case r.URL.Path == "/topics/9/removal/new":
+			w.WriteHeader(http.StatusNotAcceptable) // HTML page asked for as JSON
+		default:
+			w.WriteHeader(404)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	c := NewClient(&Config{BaseURL: srv.URL}, &StaticTokenProvider{Token: "t"}, WithMaxRetries(0))
+
+	err := c.Topics().Trash(context.Background(), 9, false)
+	e := AsError(err)
+	if e == nil || e.Code != CodeUsage || e.Hint == "" {
+		t.Fatalf("expected a usage error telling the caller to confirm, got %#v", err)
 	}
 }

--- a/go/pkg/hey/publications.go
+++ b/go/pkg/hey/publications.go
@@ -36,16 +36,20 @@ func (s *PublicationsService) Get(ctx context.Context, topicID int64) (result *P
 	}
 
 	err = s.client.instrument(ctx, op, func(ctx context.Context) error {
-		resp, rerr := s.client.GetHTML(ctx, fmt.Sprintf("/topics/%d/publication/edit", topicID))
-		if rerr != nil {
-			return rerr
-		}
-
-		publicURL := parsePublicationURLHTML(string(resp.Data))
-		result = &Publication{Published: publicURL != "", URL: publicURL}
-		return nil
+		result, err = s.get(ctx, topicID)
+		return err
 	})
 	return result, err
+}
+
+// get is the un-instrumented read shared by Get and Create.
+func (s *PublicationsService) get(ctx context.Context, topicID int64) (*Publication, error) {
+	resp, err := s.client.GetHTML(ctx, fmt.Sprintf("/topics/%d/publication/edit", topicID))
+	if err != nil {
+		return nil, err
+	}
+	publicURL := parsePublicationURLHTML(string(resp.Data))
+	return &Publication{Published: publicURL != "", URL: publicURL}, nil
 }
 
 // Create publishes a thread and returns its public link.
@@ -62,8 +66,9 @@ func (s *PublicationsService) Create(ctx context.Context, topicID int64) (result
 			return perr
 		}
 
-		// The redirect lands on the sharing panel rather than carrying the link, so read it back.
-		publication, gerr := s.Get(ctx, topicID)
+		// The redirect lands on the sharing panel rather than carrying the link, so read it
+		// back — inside this same operation, not as a second instrumented Get.
+		publication, gerr := s.get(ctx, topicID)
 		if gerr != nil {
 			return gerr
 		}

--- a/go/pkg/hey/topics.go
+++ b/go/pkg/hey/topics.go
@@ -2,6 +2,9 @@ package hey
 
 import (
 	"context"
+	"fmt"
+	"net/http"
+	"strings"
 	"time"
 
 	"github.com/basecamp/hey-sdk/go/pkg/generated"
@@ -197,8 +200,24 @@ func (s *TopicsService) Trash(ctx context.Context, topicID int64, confirmDestroy
 		if err != nil {
 			return err
 		}
+		if awaitingRemovalConfirmation(resp.HTTPResponse) {
+			return ErrUsageHint(
+				fmt.Sprintf("topic %d is shared; HEY wants confirmation before trashing it", topicID),
+				"Call Trash with confirmDestroy=true to trash it and remove your access")
+		}
 		return CheckResponse(resp.HTTPResponse)
 	})
+}
+
+// awaitingRemovalConfirmation reports whether HEY answered a trash request by
+// redirecting to the shared-topic removal confirmation page (/topics/:id/removal/new).
+// The client follows the redirect, so it shows up as a non-2xx response whose final
+// request URL is that page.
+func awaitingRemovalConfirmation(resp *http.Response) bool {
+	if resp == nil || resp.Request == nil || resp.Request.URL == nil {
+		return false
+	}
+	return resp.StatusCode >= 300 && strings.HasSuffix(resp.Request.URL.Path, "/removal/new")
 }
 
 // Restore brings a topic back from the trash or the catch-all.

--- a/go/pkg/hey/topics.go
+++ b/go/pkg/hey/topics.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/basecamp/hey-sdk/go/pkg/generated"
@@ -200,7 +199,7 @@ func (s *TopicsService) Trash(ctx context.Context, topicID int64, confirmDestroy
 		if err != nil {
 			return err
 		}
-		if awaitingRemovalConfirmation(resp.HTTPResponse) {
+		if awaitingRemovalConfirmation(resp.HTTPResponse, topicID) {
 			return ErrUsageHint(
 				fmt.Sprintf("topic %d is shared; HEY wants confirmation before trashing it", topicID),
 				"Call Trash with confirmDestroy=true to trash it and remove your access")
@@ -210,14 +209,14 @@ func (s *TopicsService) Trash(ctx context.Context, topicID int64, confirmDestroy
 }
 
 // awaitingRemovalConfirmation reports whether HEY answered a trash request by
-// redirecting to the shared-topic removal confirmation page (/topics/:id/removal/new).
-// The client follows the redirect, so it shows up as a non-2xx response whose final
-// request URL is that page.
-func awaitingRemovalConfirmation(resp *http.Response) bool {
+// redirecting to the shared-topic removal confirmation page for that topic
+// (/topics/:id/removal/new). The client follows the redirect, so it shows up as a
+// non-2xx response whose final request URL is that page.
+func awaitingRemovalConfirmation(resp *http.Response, topicID int64) bool {
 	if resp == nil || resp.Request == nil || resp.Request.URL == nil {
 		return false
 	}
-	return resp.StatusCode >= 300 && strings.HasSuffix(resp.Request.URL.Path, "/removal/new")
+	return resp.StatusCode >= 300 && resp.Request.URL.Path == fmt.Sprintf("/topics/%d/removal/new", topicID)
 }
 
 // Restore brings a topic back from the trash or the catch-all.


### PR DESCRIPTION
Four small correctness fixes, each with a test. No spec changes.

- **`Contacts.Update` merges instead of replacing.** HEY's update is a full replacement (`Contact::Ingress::Revise` rewrites name/email and drops any alias not submitted), so `Update(id, {EmailAddress: x})` used to blank the name and remove every alias. It now reads the contact first and fills unset fields from it: `nil` aliases keeps them, an empty slice clears them. Doc was already promising this; now it's true.
- **`Publications.Create` is one operation.** It read the public link back via `Get`, nesting a second instrumented op inside the first — hooks saw two, and a read-denying gate could fail a publish after the thread was already public. Shared un-instrumented `get()` now.
- **`Topics.Trash` on a shared topic says what it wants.** Without `confirmDestroy`, HEY redirects to `/topics/:id/removal/new`; the client followed it into a 406. Now detected and returned as a usage error with the hint to pass `confirmDestroy=true`.
- **Habits Create/Update verified**, no fallback needed. Round-tripped create → rename → delete on the current server and on production (201/200/204; #8623 is deployed). Doc no longer describes a redirect fallback that doesn't exist.

`make check` green (127 conformance).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes four SDK behaviors to match HEY and reduce instrumentation noise, preventing destructive contact updates, double-counted publish operations, opaque 406s on shared-topic trash, and stale habit docs.

- `Contacts.Update` now merges unset fields instead of replacing. Old: updating one field blanked Name and dropped aliases. New: reads the contact first and fills missing Name/EmailAddress; nil `AliasEmailAddresses` preserves aliases, an empty slice clears them. Side effect: the read-then-write is not atomic and can overwrite intervening changes. Migration: send all fields explicitly if you need a full replacement.
- `Publications.Create` is a single instrumented operation. Old: nested a `Get`, so hooks saw two ops and a read-denying gate could fail after publishing. New: reads the public link via a shared un-instrumented `get`, so only CreateTopicPublication is recorded.
- `Topics.Trash` on shared topics returns a usage error that explains the redirect to removal confirmation; detection matches the exact `/topics/:id/removal/new` path. Migration: pass `confirmDestroy=true` to trash a shared topic.
- `Habits.Create`/`Update` return a JSON recording on success; docs remove the nonexistent redirect fallback. Migration: none.

<sup>Written for commit e161604a9779f5691246be1cba14db7757ea2253. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-sdk/pull/71?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

