### PR TITLE
Conformance asserts method, query and body; tests for the untested workflow writes

### DIFF
--- a/conformance/runner/go/main.go
+++ b/conformance/runner/go/main.go
@@ -144,6 +144,7 @@ func runTest(tc TestCase) TestResult {
 	var requestMethods []string
 	var requestQueries []url.Values
 	var requestBodies [][]byte
+	var requestReadErr error
 	var requestHeaders []http.Header
 	var responseStatuses []int
 
@@ -156,7 +157,10 @@ func runTest(tc TestCase) TestResult {
 		requestPaths = append(requestPaths, r.URL.Path)
 		requestMethods = append(requestMethods, r.Method)
 		requestQueries = append(requestQueries, r.URL.Query())
-		body, _ := io.ReadAll(r.Body)
+		body, readErr := io.ReadAll(r.Body)
+		if readErr != nil && requestReadErr == nil {
+			requestReadErr = fmt.Errorf("reading request body: %w", readErr)
+		}
 		requestBodies = append(requestBodies, body)
 		requestHeaders = append(requestHeaders, r.Header.Clone())
 		idx := responseIndex
@@ -263,6 +267,14 @@ func runTest(tc TestCase) TestResult {
 	// If we have a successful response, use its status
 	if sdkResp != nil && sdkResp.StatusCode > 0 {
 		lastStatus = sdkResp.StatusCode
+	}
+
+	// A request body that failed to read would make body assertions lie, so fail
+	// the case outright rather than assert against a partial body.
+	if requestReadErr != nil {
+		result := fail(tc.Name, "%v", requestReadErr)
+		fmt.Printf("  FAIL: %s\n        %s\n", tc.Name, result.Message)
+		return result
 	}
 
 	// Run assertions
@@ -744,7 +756,6 @@ func fail(testName, format string, args ...interface{}) TestResult {
 	}
 }
 
-// toInt safely converts an interface{} (typically from JSON) to int.
 // lookupJSONPath walks a decoded JSON value by a dot-separated path, using
 // integer segments as array indexes. It reports whether the path resolved.
 func lookupJSONPath(v interface{}, path string) (interface{}, bool) {
@@ -770,6 +781,7 @@ func lookupJSONPath(v interface{}, path string) (interface{}, bool) {
 	return cur, true
 }
 
+// toInt safely converts an interface{} (typically from JSON) to int.
 func toInt(v interface{}) (int, error) {
 	switch n := v.(type) {
 	case float64:

--- a/conformance/runner/go/main.go
+++ b/conformance/runner/go/main.go
@@ -141,6 +141,9 @@ func runTest(tc TestCase) TestResult {
 	var requestCount int
 	var requestTimes []time.Time
 	var requestPaths []string
+	var requestMethods []string
+	var requestQueries []url.Values
+	var requestBodies [][]byte
 	var requestHeaders []http.Header
 	var responseStatuses []int
 
@@ -151,6 +154,10 @@ func runTest(tc TestCase) TestResult {
 		requestCount++
 		requestTimes = append(requestTimes, time.Now())
 		requestPaths = append(requestPaths, r.URL.Path)
+		requestMethods = append(requestMethods, r.Method)
+		requestQueries = append(requestQueries, r.URL.Query())
+		body, _ := io.ReadAll(r.Body)
+		requestBodies = append(requestBodies, body)
 		requestHeaders = append(requestHeaders, r.Header.Clone())
 		idx := responseIndex
 		responseIndex++
@@ -265,6 +272,9 @@ func runTest(tc TestCase) TestResult {
 			requestCount:      requestCount,
 			requestTimes:      requestTimes,
 			requestPaths:      requestPaths,
+			requestMethods:    requestMethods,
+			requestQueries:    requestQueries,
+			requestBodies:     requestBodies,
 			requestHeaders:    requestHeaders,
 			lastStatus:        lastStatus,
 			sdkErr:            sdkErr,
@@ -351,6 +361,9 @@ type checkState struct {
 	requestCount      int
 	requestTimes      []time.Time
 	requestPaths      []string
+	requestMethods    []string
+	requestQueries    []url.Values
+	requestBodies     [][]byte
 	requestHeaders    []http.Header
 	lastStatus        int
 	sdkErr            error
@@ -471,6 +484,73 @@ func checkAssertion(testName string, a Assertion, s checkState) TestResult {
 		}
 		if s.requestPaths[0] != expected {
 			return fail(testName, "Expected request path %q, got %q", expected, s.requestPaths[0])
+		}
+
+	case "requestMethod":
+		expected, ok := a.Expected.(string)
+		if !ok {
+			return fail(testName, "requestMethod: expected a string value, got %T", a.Expected)
+		}
+		if len(s.requestMethods) == 0 {
+			return fail(testName, "Expected a request, but none were recorded")
+		}
+		if s.requestMethods[0] != expected {
+			return fail(testName, "Expected request method %q, got %q", expected, s.requestMethods[0])
+		}
+
+	case "requestQuery":
+		// expected: {"param": "value", "absent": null} — a null value asserts the
+		// parameter is NOT sent (guards optional params that must be omitted).
+		expected, ok := a.Expected.(map[string]interface{})
+		if !ok {
+			return fail(testName, "requestQuery: expected an object, got %T", a.Expected)
+		}
+		if len(s.requestQueries) == 0 {
+			return fail(testName, "Expected a request, but none were recorded")
+		}
+		q := s.requestQueries[0]
+		for k, v := range expected {
+			if v == nil {
+				if q.Has(k) {
+					return fail(testName, "Expected query param %q to be absent, got %q", k, q.Get(k))
+				}
+				continue
+			}
+			if got := q.Get(k); got != fmt.Sprint(v) {
+				return fail(testName, "Expected query param %s=%v, got %q", k, v, got)
+			}
+		}
+
+	case "requestBody":
+		// expected: {"json.path": value, ...}; a null value asserts the key is absent.
+		// Paths are dot-separated; array elements by index (e.g. "posting_ids.0").
+		expected, ok := a.Expected.(map[string]interface{})
+		if !ok {
+			return fail(testName, "requestBody: expected an object, got %T", a.Expected)
+		}
+		if len(s.requestBodies) == 0 {
+			return fail(testName, "Expected a request, but none were recorded")
+		}
+		var body interface{}
+		if len(s.requestBodies[0]) > 0 {
+			if err := json.Unmarshal(s.requestBodies[0], &body); err != nil {
+				return fail(testName, "requestBody: request body is not JSON: %v", err)
+			}
+		}
+		for path, want := range expected {
+			got, present := lookupJSONPath(body, path)
+			if want == nil {
+				if present {
+					return fail(testName, "Expected body key %q to be absent, got %v", path, got)
+				}
+				continue
+			}
+			if !present {
+				return fail(testName, "Expected body key %q = %v, but it is absent", path, want)
+			}
+			if fmt.Sprint(got) != fmt.Sprint(want) {
+				return fail(testName, "Expected body key %q = %v, got %v", path, want, got)
+			}
 		}
 
 	case "headerPresent":
@@ -665,6 +745,31 @@ func fail(testName, format string, args ...interface{}) TestResult {
 }
 
 // toInt safely converts an interface{} (typically from JSON) to int.
+// lookupJSONPath walks a decoded JSON value by a dot-separated path, using
+// integer segments as array indexes. It reports whether the path resolved.
+func lookupJSONPath(v interface{}, path string) (interface{}, bool) {
+	cur := v
+	for _, seg := range strings.Split(path, ".") {
+		switch node := cur.(type) {
+		case map[string]interface{}:
+			next, ok := node[seg]
+			if !ok {
+				return nil, false
+			}
+			cur = next
+		case []interface{}:
+			idx, err := strconv.Atoi(seg)
+			if err != nil || idx < 0 || idx >= len(node) {
+				return nil, false
+			}
+			cur = node[idx]
+		default:
+			return nil, false
+		}
+	}
+	return cur, true
+}
+
 func toInt(v interface{}) (int, error) {
 	switch n := v.(type) {
 	case float64:

--- a/conformance/tests/paths.json
+++ b/conformance/tests/paths.json
@@ -116,6 +116,17 @@
       },
       {
         "type": "noError"
+      },
+      {
+        "type": "requestMethod",
+        "expected": "POST"
+      },
+      {
+        "type": "requestBody",
+        "expected": {
+          "message.subject": "Test",
+          "message.content": "Hello"
+        }
       }
     ],
     "tags": [
@@ -151,6 +162,17 @@
       },
       {
         "type": "noError"
+      },
+      {
+        "type": "requestMethod",
+        "expected": "POST"
+      },
+      {
+        "type": "requestBody",
+        "expected": {
+          "message.content": "Reply text",
+          "entry": null
+        }
       }
     ],
     "tags": [
@@ -179,6 +201,10 @@
       },
       {
         "type": "noError"
+      },
+      {
+        "type": "requestMethod",
+        "expected": "DELETE"
       }
     ],
     "tags": [
@@ -896,6 +922,10 @@
       },
       {
         "type": "noError"
+      },
+      {
+        "type": "requestMethod",
+        "expected": "POST"
       }
     ],
     "tags": [
@@ -925,6 +955,10 @@
       },
       {
         "type": "noError"
+      },
+      {
+        "type": "requestMethod",
+        "expected": "DELETE"
       }
     ],
     "tags": [
@@ -955,6 +989,10 @@
       },
       {
         "type": "noError"
+      },
+      {
+        "type": "requestMethod",
+        "expected": "DELETE"
       }
     ],
     "tags": [
@@ -1024,6 +1062,10 @@
       },
       {
         "type": "noError"
+      },
+      {
+        "type": "requestMethod",
+        "expected": "PUT"
       }
     ],
     "tags": [
@@ -1056,6 +1098,17 @@
       },
       {
         "type": "noError"
+      },
+      {
+        "type": "requestMethod",
+        "expected": "POST"
+      },
+      {
+        "type": "requestBody",
+        "expected": {
+          "posting_ids.0": 1,
+          "posting_ids.1": 2
+        }
       }
     ],
     "tags": [
@@ -1088,6 +1141,17 @@
       },
       {
         "type": "noError"
+      },
+      {
+        "type": "requestMethod",
+        "expected": "POST"
+      },
+      {
+        "type": "requestBody",
+        "expected": {
+          "posting_ids.0": 1,
+          "posting_ids.1": 2
+        }
       }
     ],
     "tags": [
@@ -1121,6 +1185,18 @@
       },
       {
         "type": "noError"
+      },
+      {
+        "type": "requestMethod",
+        "expected": "POST"
+      },
+      {
+        "type": "requestBody",
+        "expected": {
+          "posting_ids.0": 1,
+          "posting_ids.1": 2,
+          "box_id": 24089
+        }
       }
     ],
     "tags": [
@@ -1153,6 +1229,17 @@
       },
       {
         "type": "noError"
+      },
+      {
+        "type": "requestMethod",
+        "expected": "POST"
+      },
+      {
+        "type": "requestBody",
+        "expected": {
+          "posting_ids.0": 1,
+          "posting_ids.1": 2
+        }
       }
     ],
     "tags": [
@@ -1185,6 +1272,17 @@
       },
       {
         "type": "noError"
+      },
+      {
+        "type": "requestMethod",
+        "expected": "POST"
+      },
+      {
+        "type": "requestBody",
+        "expected": {
+          "posting_ids.0": 1,
+          "posting_ids.1": 2
+        }
       }
     ],
     "tags": [
@@ -1214,6 +1312,16 @@
       },
       {
         "type": "noError"
+      },
+      {
+        "type": "requestMethod",
+        "expected": "DELETE"
+      },
+      {
+        "type": "requestQuery",
+        "expected": {
+          "posting_ids": "1,2"
+        }
       }
     ],
     "tags": [
@@ -1246,6 +1354,17 @@
       },
       {
         "type": "noError"
+      },
+      {
+        "type": "requestMethod",
+        "expected": "POST"
+      },
+      {
+        "type": "requestBody",
+        "expected": {
+          "posting_ids.0": 1,
+          "posting_ids.1": 2
+        }
       }
     ],
     "tags": [
@@ -1280,6 +1399,18 @@
       },
       {
         "type": "noError"
+      },
+      {
+        "type": "requestMethod",
+        "expected": "POST"
+      },
+      {
+        "type": "requestBody",
+        "expected": {
+          "posting_ids.0": 1,
+          "box_id": 24090,
+          "box_group_id": 9
+        }
       }
     ],
     "tags": [
@@ -1309,6 +1440,16 @@
       },
       {
         "type": "noError"
+      },
+      {
+        "type": "requestMethod",
+        "expected": "DELETE"
+      },
+      {
+        "type": "requestQuery",
+        "expected": {
+          "posting_ids": "1,2"
+        }
       }
     ],
     "tags": [
@@ -1342,6 +1483,17 @@
       },
       {
         "type": "noError"
+      },
+      {
+        "type": "requestMethod",
+        "expected": "POST"
+      },
+      {
+        "type": "requestBody",
+        "expected": {
+          "posting_ids.0": 1,
+          "folder_id": 12
+        }
       }
     ],
     "tags": [
@@ -1372,6 +1524,17 @@
       },
       {
         "type": "noError"
+      },
+      {
+        "type": "requestMethod",
+        "expected": "DELETE"
+      },
+      {
+        "type": "requestQuery",
+        "expected": {
+          "posting_ids": "1,2",
+          "folder_id": "12"
+        }
       }
     ],
     "tags": [
@@ -1405,6 +1568,17 @@
       },
       {
         "type": "noError"
+      },
+      {
+        "type": "requestMethod",
+        "expected": "POST"
+      },
+      {
+        "type": "requestBody",
+        "expected": {
+          "posting_ids.0": 1,
+          "folder.name": "Receipts"
+        }
       }
     ],
     "tags": [
@@ -1434,6 +1608,16 @@
       },
       {
         "type": "noError"
+      },
+      {
+        "type": "requestMethod",
+        "expected": "DELETE"
+      },
+      {
+        "type": "requestQuery",
+        "expected": {
+          "posting_ids": "1,2"
+        }
       }
     ],
     "tags": [
@@ -1466,6 +1650,17 @@
       },
       {
         "type": "noError"
+      },
+      {
+        "type": "requestMethod",
+        "expected": "POST"
+      },
+      {
+        "type": "requestBody",
+        "expected": {
+          "posting_ids.0": 1,
+          "posting_ids.1": 2
+        }
       }
     ],
     "tags": [
@@ -1498,6 +1693,16 @@
       },
       {
         "type": "noError"
+      },
+      {
+        "type": "requestMethod",
+        "expected": "PUT"
+      },
+      {
+        "type": "requestQuery",
+        "expected": {
+          "confirm_destroy": "true"
+        }
       }
     ],
     "tags": [
@@ -1640,6 +1845,16 @@
       },
       {
         "type": "noError"
+      },
+      {
+        "type": "requestMethod",
+        "expected": "POST"
+      },
+      {
+        "type": "requestBody",
+        "expected": {
+          "box_id": 24089
+        }
       }
     ],
     "tags": [
@@ -1979,6 +2194,10 @@
       },
       {
         "type": "noError"
+      },
+      {
+        "type": "requestMethod",
+        "expected": "DELETE"
       }
     ],
     "tags": [
@@ -2128,6 +2347,16 @@
       },
       {
         "type": "noError"
+      },
+      {
+        "type": "requestMethod",
+        "expected": "GET"
+      },
+      {
+        "type": "requestQuery",
+        "expected": {
+          "limit": "25"
+        }
       }
     ],
     "tags": [
@@ -2162,6 +2391,17 @@
       },
       {
         "type": "noError"
+      },
+      {
+        "type": "requestMethod",
+        "expected": "POST"
+      },
+      {
+        "type": "requestBody",
+        "expected": {
+          "sticky.body": "Call the plumber",
+          "sticky.size": "medium"
+        }
       }
     ],
     "tags": [
@@ -2199,6 +2439,17 @@
       },
       {
         "type": "noError"
+      },
+      {
+        "type": "requestMethod",
+        "expected": "PATCH"
+      },
+      {
+        "type": "requestBody",
+        "expected": {
+          "sticky.body": "Call the electrician",
+          "sticky.size": "large"
+        }
       }
     ],
     "tags": [
@@ -2228,6 +2479,10 @@
       },
       {
         "type": "noError"
+      },
+      {
+        "type": "requestMethod",
+        "expected": "DELETE"
       }
     ],
     "tags": [
@@ -2258,6 +2513,17 @@
       },
       {
         "type": "noError"
+      },
+      {
+        "type": "requestMethod",
+        "expected": "POST"
+      },
+      {
+        "type": "requestBody",
+        "expected": {
+          "id": 1,
+          "position": 2
+        }
       }
     ],
     "tags": [
@@ -2321,6 +2587,10 @@
       },
       {
         "type": "noError"
+      },
+      {
+        "type": "requestMethod",
+        "expected": "DELETE"
       }
     ],
     "tags": [
@@ -2360,6 +2630,17 @@
       },
       {
         "type": "noError"
+      },
+      {
+        "type": "requestMethod",
+        "expected": "POST"
+      },
+      {
+        "type": "requestBody",
+        "expected": {
+          "calendar_habit.name": "Morning run",
+          "calendar_habit.days.0": 1
+        }
       }
     ],
     "tags": [

--- a/go/pkg/hey/services_test.go
+++ b/go/pkg/hey/services_test.go
@@ -2347,6 +2347,47 @@ func TestWorkflowsService_Writes(t *testing.T) {
 	}
 }
 
+func TestWorkflowsService_UpdateAndDelete(t *testing.T) {
+	renamer := newFormTestClient(t, "PATCH", "/workflows/%s", func(t *testing.T, values url.Values) {
+		t.Helper()
+		if values.Get("workflow[name]") != "Recruiting" {
+			t.Errorf("expected the workflow name, got %q", values.Get("workflow[name]"))
+		}
+	}, "/workflows/8801")
+	if err := renamer.Workflows().Update(context.Background(), 8801, "Recruiting"); err != nil {
+		t.Fatalf("unexpected error renaming: %v", err)
+	}
+
+	deleter := newFormTestClient(t, "DELETE", "/workflows/%s", nil, "/workflows")
+	if err := deleter.Workflows().Delete(context.Background(), 8801); err != nil {
+		t.Fatalf("unexpected error deleting: %v", err)
+	}
+
+	stageDeleter := newFormTestClient(t, "DELETE", "/workflows/%s/stages/%s", nil, "/workflows/8801")
+	if err := stageDeleter.Workflows().DeleteStage(context.Background(), 8801, 5512); err != nil {
+		t.Fatalf("unexpected error deleting a stage: %v", err)
+	}
+
+	unfiler := newFormTestClient(t, "DELETE", "/topics/%s/workflows/%s/stagings", nil, "/topics/4471829")
+	if err := unfiler.Workflows().UnstageTopic(context.Background(), 4471829, 8801); err != nil {
+		t.Fatalf("unexpected error unstaging a topic: %v", err)
+	}
+}
+
+func TestWorkflowsService_WriteErrorsSurface(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	t.Cleanup(srv.Close)
+	c := NewClient(&Config{BaseURL: srv.URL}, &StaticTokenProvider{Token: "t"}, WithMaxRetries(0))
+	if err := c.Workflows().Delete(context.Background(), 8801); err == nil {
+		t.Fatal("expected a 403 to surface as an error")
+	}
+	if err := c.Workflows().UnstageTopic(context.Background(), 4471829, 8801); err == nil {
+		t.Fatal("expected a 403 to surface as an error")
+	}
+}
+
 // --- Publications ---
 
 func TestPublicationsService_GetPublished(t *testing.T) {


### PR DESCRIPTION
Closes the last two test-debt items from the #64 review.

**Conformance runner.** Cases could only assert the request *path*, so the bulk postings ops, the DELETE-with-query ops (`UnmutePostings`, `UnfilePostings`, `CancelPostingsBubbleUp`, `RemovePostingsFromBoxGroup`) and `TrashTopic` were covered in name only — a wrong verb, a dropped query param or a mis-shaped body still passed. Three new assertion types:
- `requestMethod`
- `requestQuery` — `{"param": "value"}`; a `null` value asserts the parameter is **absent** (guards the optional params that must be omitted)
- `requestBody` — dot-paths into the JSON (`"posting_ids.0"`, `"sticky.body"`); `null` asserts the key is absent

Applied across the postings, topics, stickies, habits, time-track, todo and message cases: **220 assertions over 127 cases**, up from path-only. `CreateReply` now asserts `entry` is absent when no recipients are passed, so the reply-all fix from #68 is pinned on the wire.

**Unit tests** for `Workflows.Update/Delete/DeleteStage/UnstageTopic` — form method, path and fields, and that a 403 surfaces. (`Publications.Create` and `Contacts.Update` got theirs in #71.)

`make check` green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Asserts HTTP method, query, and JSON body in conformance (not just path) and fails a case if the request body cannot be read. This blocks wrong verbs, dropped/extra query params, and mis-shaped bodies; adds tests for workflows writes and ensures 403s surface.

**Review notes**
- Runner captures method, query, and body; supports dot-path JSON lookup and array indexes; `null` asserts absence; a failed body read now fails the case outright.
- Applied across message, postings, topics, stickies, habits, time-track, and todo cases; `CreateReply` asserts `entry` is absent when no recipients are provided. Tests cover `Workflows.Update`, `Workflows.Delete`, `Workflows.DeleteStage`, and `Workflows.UnstageTopic` (form method/path/fields; 403 surfaces).

**Migration**
- SDKs must use the correct HTTP verb, omit optional params when unset, and match the expected JSON/form shape to pass conformance.

<sup>Written for commit 1a5c92d424e5a04e39be0c9d27f88384ef64997c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-sdk/pull/72?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

