### PR TITLE
README: describe the SDK as it is

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,9 +4,8 @@
 
 - Smithy CLI
 - Go 1.26+
-- Node.js 20+
-- Ruby 3.2+
 - Make
+- jq
 
 ## Development Workflow
 
@@ -20,11 +19,15 @@
 ## Adding a New API Operation
 
 1. Add the operation to the Smithy spec in `spec/`
-2. Run `make smithy-build` to regenerate OpenAPI
-3. Run `make {lang}-generate-services` for each language
+2. Run `make smithy-build` to regenerate OpenAPI, then refresh the derived files
+   (`make url-routes`, `./scripts/generate-shape-fingerprint`, `./scripts/generate-route-coverage`)
+3. Run `make go-generate` to regenerate the Go client, then add or update the hand-written
+   service in `go/pkg/hey`
 4. Add unit tests
 5. Add conformance tests if the operation has behavioral requirements
 6. Run `make check`
+
+The full step-by-step, including how the drift gates work, is in [AGENTS.md](AGENTS.md).
 
 ## Release Process
 

--- a/README.md
+++ b/README.md
@@ -1,42 +1,112 @@
 # HEY SDK
 
-Official SDK for the HEY API. Multi-language support for Go, TypeScript, Ruby, Swift, and Kotlin.
+The Go SDK for the [HEY](https://www.hey.com) API. It is the library behind
+[hey-cli](https://github.com/basecamp/hey-cli), and it is generated from a Smithy model of
+the API in `spec/`, so what the SDK offers is what HEY actually serves.
 
-## Quick Start
+**Go only.** This repository ships a single Go module, `github.com/basecamp/hey-sdk/go`.
+The Makefile still carries `ts-`, `rb-`, `swift-` and `kt-` targets inherited from a shared
+SDK template; there are no such SDKs here and those targets fail immediately.
 
-### Go
-
-```go
-import "github.com/basecamp/hey-sdk/go/pkg/hey"
-
-client := hey.NewClient(&hey.Config{}, &hey.StaticTokenProvider{Token: "your-token"})
-boxes, err := client.Boxes().List(ctx)
-```
-
-### TypeScript
-
-```typescript
-import { HEYClient } from '@basecamp/hey-sdk'
-
-const client = new HEYClient({ token: 'your-token' })
-const boxes = await client.boxes.list()
-```
-
-### Ruby
-
-```ruby
-require 'hey-sdk'
-
-client = HEY::Client.new(token: 'your-token')
-boxes = client.boxes.list
-```
-
-## Development
+## Install
 
 ```bash
-make check          # Run all checks
-make {lang}-test    # Run tests for one language
-make conformance    # Run cross-language conformance tests
+go get github.com/basecamp/hey-sdk/go@latest
 ```
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for full development workflow.
+Requires Go 1.26 or newer.
+
+## Authenticate
+
+Static token (scripts, agents, anything that already holds a token):
+
+```go
+import hey "github.com/basecamp/hey-sdk/go/pkg/hey"
+
+cfg := hey.DefaultConfig() // https://app.hey.com
+client := hey.NewClient(cfg, &hey.StaticTokenProvider{Token: os.Getenv("HEY_TOKEN")})
+```
+
+OAuth 2.0 with PKCE (user-facing apps): `hey.NewAuthManager` handles the token lifecycle
+and refresh, and the `oauth` subpackage provides discovery, PKCE and the code exchange.
+Anything else can plug in with `hey.WithAuthStrategy`, which sets headers on each request —
+hey-cli uses this to bridge its own credential store.
+
+## Use it
+
+```go
+ctx := context.Background()
+
+boxes, _ := client.Boxes().List(ctx)          // Imbox, The Feed, Paper Trail, ...
+imbox, _ := client.Boxes().GetImbox(ctx, nil)   // postings in the Imbox
+
+// Sending: recipients are required — HEY saves an unaddressed reply as a draft.
+_ = client.Messages().Create(ctx, "Subject", "Body", []string{"someone@example.com"}, nil, nil)
+_ = client.Entries().CreateReply(ctx, entryID, "Reply body", []string{"someone@example.com"}, nil, nil)
+
+// Postings are bulk operations, as they are in HEY.
+_ = client.Postings().MoveToSetAside(ctx, postingID)
+_ = client.Postings().MarkSeen(ctx, []int64{a, b})
+
+// Calendar
+rec, _ := client.TimeTracks().Start(ctx)
+_ = client.TimeTracks().Stop(ctx, rec.Id)
+```
+
+Services on the client: `Identity`, `Boxes`, `Postings`, `Topics`, `Messages`, `Entries`,
+`Contacts`, `Calendars`, `CalendarTodos`, `CalendarEvents`, `Habits`, `TimeTracks`,
+`Journal`, `Search`, `Folders`, `Collections`, `Stickies`, `Clips`, `Snippets`, `Workflows`,
+`Publications`, `Designations`, `Extenzions`, `World`.
+
+Every call reports itself to the client's `Hooks` (`hey.WithHooks`) as a named operation —
+`Postings.MovePostings`, `TimeTracks.StopTimeTrack` — and a `GatingHooks` implementation
+can refuse an operation before it runs. Retries, circuit breaking, bulkheads and rate limits
+are configured with `WithResilience`, `WithCircuitBreaker`, `WithBulkhead` and
+`WithRateLimit`; HTTP caching with `WithCache`.
+
+### Errors
+
+Calls return `*hey.Error` with a stable `Code` (`hey.CodeNotFound`, `hey.CodeAuth`,
+`hey.CodeForbidden`, `hey.CodeRateLimit`, `hey.CodeConflict`, `hey.CodeUsage`, ...), the
+HTTP status, and — for auth and scope problems — a hint. `hey.AsError(err)` unwraps it.
+
+### Pagination
+
+Paged reads follow HEY's `Link` headers automatically, up to `WithMaxPages`.
+
+## How the SDK is built
+
+```
+spec/hey.smithy ──► openapi.json ──► oapi-codegen ──► go/pkg/generated/client.gen.go
+                                                                │
+                              hand-written services in go/pkg/hey call into it
+```
+
+The Smithy model is the source of truth for routes and payloads. `openapi.json`,
+`behavior-model.json`, `client.gen.go`, `go/pkg/hey/url-routes.json` and the files under
+`spec/` that describe coverage are all regenerated from it — editing them by hand is lost on
+the next build. The services in `go/pkg/hey` are written by hand and add the things a
+generated client cannot know: which recipients a reply needs, that HEY answers a shared
+topic's trash request with a confirmation page, that starting a time track takes no body.
+
+`make check` verifies the model against a snapshot of HEY's own routes
+(`spec/route-snapshot.json`, pinned in `spec/api-provenance.json`): every modelled route
+must exist in HEY, and every JSON-capable HEY route must be either modelled or listed in
+`spec/excluded-routes.json` with a reason. Generated ops that HEY does not serve cannot get
+in unnoticed.
+
+A handful of services (`Clips`, `Snippets`, `Workflows`, `Publications`, `World`,
+`Extenzions`, `CalendarEvents`, and parts of `Contacts` and `Search`) still talk to HEY the
+way the web UI does — form posts, and for a few reads, the HTML page — because those
+endpoints have no JSON yet. They are marked as such in the code and are being replaced as
+HEY grows JSON for them.
+
+## Develop
+
+```bash
+make check      # Smithy validate/build, drift gates, Go vet/lint/tests, conformance
+```
+
+`make check` is the gate; see [AGENTS.md](AGENTS.md) for the pipeline, the exact steps for
+adding an operation, and the hard rules (never hand-write an API path; every operation needs
+tests). [CONTRIBUTING.md](CONTRIBUTING.md) covers the workflow and releases.

--- a/README.md
+++ b/README.md
@@ -4,9 +4,11 @@ The Go SDK for the [HEY](https://www.hey.com) API. It is the library behind
 [hey-cli](https://github.com/basecamp/hey-cli), and it is generated from a Smithy model of
 the API in `spec/`, so what the SDK offers is what HEY actually serves.
 
-**Go only.** This repository ships a single Go module, `github.com/basecamp/hey-sdk/go`.
-The Makefile still carries `ts-`, `rb-`, `swift-` and `kt-` targets inherited from a shared
-SDK template; there are no such SDKs here and those targets fail immediately.
+Today the repository ships a single Go module, `github.com/basecamp/hey-sdk/go`.
+
+TypeScript, Ruby, Swift and Kotlin SDKs will be added in future updates, generated from the
+same Smithy model; the Makefile already reserves targets for them (`ts-`, `rb-`, `swift-`,
+`kt-`), which fail until those SDKs exist.
 
 ## Install
 

--- a/go/pkg/hey/doc.go
+++ b/go/pkg/hey/doc.go
@@ -30,18 +30,18 @@
 // The SDK provides typed services for each HEY resource:
 //
 //   - [Client.Identity] - Current user identity and navigation
-//   - [Client.Boxes] - Mailboxes (imbox, feedbox, etc.) and box groups
+//   - [Client.Boxes] - Mailboxes (the Imbox, The Feed, Paper Trail, ...) and box groups
 //   - [Client.Postings] - Bulk posting actions: seen, move, trash, spam, mute, file, bubble up
 //   - [Client.Topics] - Topics and views (sent, spam, trash, everything), status and moves
 //   - [Client.Messages] - Individual messages
 //   - [Client.Entries] - Drafts, replies and forwards
 //   - [Client.Contacts] - Contacts, notes, screening and bundling
 //   - [Client.Calendars] - Calendar views and recordings
-//   - [Client.CalendarTodos], [Client.CalendarEvents], [Client.Habits], [Client.TimeTracks], [Client.Journal]
+//   - [Client.CalendarTodos], [Client.CalendarEvents], [Client.Habits], [Client.TimeTracks], [Client.Journal] - What a calendar records
 //   - [Client.Search] - Search
-//   - [Client.Folders], [Client.Collections], [Client.Stickies], [Client.Clips], [Client.Snippets], [Client.Workflows]
+//   - [Client.Folders], [Client.Collections], [Client.Stickies], [Client.Clips], [Client.Snippets], [Client.Workflows] - Filing mail, and text kept to reuse
 //   - [Client.Publications] - Public links for threads
-//   - [Client.Designations], [Client.Extenzions], [Client.World]
+//   - [Client.Designations], [Client.Extenzions], [Client.World] - Where mail lands, extra addresses, and HEY World
 //
 // # Working with Boxes
 //

--- a/go/pkg/hey/doc.go
+++ b/go/pkg/hey/doc.go
@@ -30,17 +30,18 @@
 // The SDK provides typed services for each HEY resource:
 //
 //   - [Client.Identity] - Current user identity and navigation
-//   - [Client.Boxes] - Mailboxes (imbox, feedbox, etc.)
-//   - [Client.Topics] - Email topics and views (sent, spam, trash, everything)
+//   - [Client.Boxes] - Mailboxes (imbox, feedbox, etc.) and box groups
+//   - [Client.Postings] - Bulk posting actions: seen, move, trash, spam, mute, file, bubble up
+//   - [Client.Topics] - Topics and views (sent, spam, trash, everything), status and moves
 //   - [Client.Messages] - Individual messages
-//   - [Client.Entries] - Drafts and replies
-//   - [Client.Contacts] - Contact management
+//   - [Client.Entries] - Drafts, replies and forwards
+//   - [Client.Contacts] - Contacts, notes, screening and bundling
 //   - [Client.Calendars] - Calendar views and recordings
-//   - [Client.CalendarTodos] - Calendar todo items
-//   - [Client.Habits] - Habit tracking
-//   - [Client.TimeTracks] - Time tracking
-//   - [Client.Journal] - Journal entries
-//   - [Client.Search] - Full-text search
+//   - [Client.CalendarTodos], [Client.CalendarEvents], [Client.Habits], [Client.TimeTracks], [Client.Journal]
+//   - [Client.Search] - Search
+//   - [Client.Folders], [Client.Collections], [Client.Stickies], [Client.Clips], [Client.Snippets], [Client.Workflows]
+//   - [Client.Publications] - Public links for threads
+//   - [Client.Designations], [Client.Extenzions], [Client.World]
 //
 // # Working with Boxes
 //


### PR DESCRIPTION
The README advertised TypeScript, Ruby, Swift and Kotlin quick starts and a cross-language `make conformance` — none of which exist in this repository. Rewritten around what the repo actually is. Documentation only; no code changes.

**README** now covers: Go-only (and why the Makefile still has other-language targets), install, the three ways to authenticate (`StaticTokenProvider`, `AuthManager` + `oauth`, `WithAuthStrategy`), a short usage sample that reflects real behaviour (recipients required on send; postings are bulk; `Start(ctx)`), the 24 services, hooks/gating and resilience options, errors and pagination, how the Smithy → OpenAPI → oapi-codegen pipeline and the drift gates work, and which services still talk to HEY the way the web UI does (form posts / HTML) pending JSON.

**CONTRIBUTING**: prerequisites without Node/Ruby, and the add-an-operation steps match AGENTS.md (no `make {lang}-generate-services`).

**doc.go**: the service list was 12 of 24; now complete.

Every symbol named in the README was checked against `go/pkg/hey`.

One thing to know while reading: the paragraph listing services that still talk to HEY the way the web UI does describes main as it stands today. It shrinks as #76, #78 and #79 land — Contacts drops off that list entirely — and I will trim it then rather than describe a state the repo has not reached.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rewrites README to accurately present this repo as a Go-only SDK generated from the Smithy model, fixes CONTRIBUTING to match, and refreshes service docs; no API or runtime changes.

- README: adds module `github.com/basecamp/hey-sdk/go`, install, and auth options (`StaticTokenProvider`, `AuthManager` + `oauth`, `WithAuthStrategy`); corrects usage (recipients required, postings are bulk, `TimeTracks.Start`); enumerates services and client facilities (`WithHooks`, `WithResilience`, `WithCircuitBreaker`, `WithBulkhead`, `WithRateLimit`, `WithCache`); documents error codes and pagination (`WithMaxPages`); explains Smithy → OpenAPI → `oapi-codegen` and drift gates; notes remaining HTML/form-backed services; clarifies that TypeScript/Ruby/Swift/Kotlin SDKs are planned and Make targets are reserved (currently fail).
- CONTRIBUTING: removes Node/Ruby, adds `jq`; updates “add an operation” flow to `make smithy-build` then refresh derived files, run `make go-generate`, and update hand-written services in `go/pkg/hey`; links to `AGENTS.md` for the full gate flow.
- `go/pkg/hey/doc.go`: completes and groups the service list with brief descriptions (e.g., calendar-related services together), adds `Postings`, and fixes “Imbox” spelling.

<sup>Written for commit a82519fc4cf6ce3e7efdbe69ab0ca5f133b5934a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-sdk/pull/73?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

