### PR TITLE
Add attachment direct upload operation

### DIFF
--- a/behavior-model.json
+++ b/behavior-model.json
@@ -119,6 +119,13 @@
         ]
       }
     },
+    "CreateDirectUpload": {
+      "idempotent": false,
+      "readonly": false,
+      "retry": {
+        "max": 0
+      }
+    },
     "CreateFolderForPostings": {
       "idempotent": false,
       "readonly": false,

--- a/conformance/runner/go/main.go
+++ b/conformance/runner/go/main.go
@@ -903,6 +903,16 @@ func executeOperation(client *generated.Client, ctx context.Context, tc TestCase
 			},
 		}
 		return client.CreateMessage(ctx, body)
+	case "CreateDirectUpload":
+		body := generated.CreateDirectUploadJSONRequestBody{
+			Blob: generated.DirectUploadBlob{
+				Filename:    getStringParam(tc.RequestBody, "filename"),
+				ByteSize:    getInt64Param(tc.RequestBody, "byte_size"),
+				Checksum:    getStringParam(tc.RequestBody, "checksum"),
+				ContentType: getStringParam(tc.RequestBody, "content_type"),
+			},
+		}
+		return client.CreateDirectUpload(ctx, body)
 	case "ListDrafts":
 		return client.ListDrafts(ctx, nil)
 	case "CreateReply":

--- a/conformance/tests/paths.json
+++ b/conformance/tests/paths.json
@@ -91,6 +91,60 @@
     ]
   },
   {
+    "name": "CreateDirectUpload uses /rails/active_storage/direct_uploads.json path",
+    "description": "Verifies that CreateDirectUpload sends Active Storage blob metadata to the direct upload endpoint",
+    "operation": "CreateDirectUpload",
+    "method": "POST",
+    "path": "/rails/active_storage/direct_uploads.json",
+    "requestBody": {
+      "filename": "quarterly-report.pdf",
+      "byte_size": 128,
+      "checksum": "YWJjZA==",
+      "content_type": "application/pdf"
+    },
+    "mockResponses": [
+      {
+        "status": 200,
+        "body": {
+          "signed_id": "signed-123",
+          "attachable_sgid": "sgid-456",
+          "direct_upload": {
+            "url": "https://uploads.example.com/blob",
+            "headers": {
+              "Content-Type": "application/pdf"
+            }
+          }
+        }
+      }
+    ],
+    "assertions": [
+      {
+        "type": "requestPath",
+        "expected": "/rails/active_storage/direct_uploads.json"
+      },
+      {
+        "type": "requestMethod",
+        "expected": "POST"
+      },
+      {
+        "type": "requestBody",
+        "expected": {
+          "blob.filename": "quarterly-report.pdf",
+          "blob.byte_size": 128,
+          "blob.checksum": "YWJjZA==",
+          "blob.content_type": "application/pdf"
+        }
+      },
+      {
+        "type": "noError"
+      }
+    ],
+    "tags": [
+      "path",
+      "attachments"
+    ]
+  },
+  {
     "name": "CreateMessage uses /messages.json path",
     "description": "Verifies that CreateMessage constructs the URL path /messages.json",
     "operation": "CreateMessage",

--- a/go/pkg/generated/client.gen.go
+++ b/go/pkg/generated/client.gen.go
@@ -279,6 +279,14 @@ type CreateCalendarTodoRequestContent struct {
 // CreateCalendarTodoResponseContent Recording — polymorphic by `type` (CalendarEvent, CalendarTodo, etc.)
 type CreateCalendarTodoResponseContent = Recording
 
+// CreateDirectUploadRequestContent defines model for CreateDirectUploadRequestContent.
+type CreateDirectUploadRequestContent struct {
+	Blob DirectUploadBlob `json:"blob"`
+}
+
+// CreateDirectUploadResponseContent defines model for CreateDirectUploadResponseContent.
+type CreateDirectUploadResponseContent = DirectUpload
+
 // CreateFolderForPostingsRequestContent Wire format: {posting_ids: [...], folder: {name, status}}
 type CreateFolderForPostingsRequestContent struct {
 	Folder     FolderPayload `json:"folder"`
@@ -310,6 +318,30 @@ type CreateStickyResponseContent = Sticky
 
 // CreateTimeTrackResponseContent Recording — polymorphic by `type` (CalendarEvent, CalendarTodo, etc.)
 type CreateTimeTrackResponseContent = Recording
+
+// DirectUpload defines model for DirectUpload.
+type DirectUpload struct {
+	AttachableSgid string             `json:"attachable_sgid"`
+	DirectUpload   DirectUploadTarget `json:"direct_upload"`
+	SignedId       string             `json:"signed_id"`
+}
+
+// DirectUploadBlob defines model for DirectUploadBlob.
+type DirectUploadBlob struct {
+	ByteSize    int64  `json:"byte_size"`
+	Checksum    string `json:"checksum"`
+	ContentType string `json:"content_type"`
+	Filename    string `json:"filename"`
+}
+
+// DirectUploadHeaders defines model for DirectUploadHeaders.
+type DirectUploadHeaders map[string]string
+
+// DirectUploadTarget defines model for DirectUploadTarget.
+type DirectUploadTarget struct {
+	Headers DirectUploadHeaders `json:"headers,omitempty"`
+	Url     string              `json:"url"`
+}
 
 // Domain Domain — email domain
 type Domain struct {
@@ -1274,6 +1306,9 @@ type TrashPostingsJSONRequestBody = TrashPostingsRequestContent
 // MarkPostingsUnseenJSONRequestBody defines body for MarkPostingsUnseen for application/json ContentType.
 type MarkPostingsUnseenJSONRequestBody = MarkPostingsRequestContent
 
+// CreateDirectUploadJSONRequestBody defines body for CreateDirectUpload for application/json ContentType.
+type CreateDirectUploadJSONRequestBody = CreateDirectUploadRequestContent
+
 // CreateStickyJSONRequestBody defines body for CreateSticky for application/json ContentType.
 type CreateStickyJSONRequestBody = StickyRequestContent
 
@@ -1749,6 +1784,11 @@ type ClientInterface interface {
 	MarkPostingsUnseenWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	MarkPostingsUnseen(ctx context.Context, body MarkPostingsUnseenJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// CreateDirectUploadWithBody request with any body
+	CreateDirectUploadWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	CreateDirectUpload(ctx context.Context, body CreateDirectUploadJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetLaterbox request
 	GetLaterbox(ctx context.Context, params *GetLaterboxParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -2897,6 +2937,36 @@ func (c *Client) MarkPostingsUnseenWithBody(ctx context.Context, contentType str
 func (c *Client) MarkPostingsUnseen(ctx context.Context, body MarkPostingsUnseenJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 
 	req, err := NewMarkPostingsUnseenRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+
+}
+
+// CreateDirectUploadWithBody executes the CreateDirectUpload operation.
+
+func (c *Client) CreateDirectUploadWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+
+	req, err := NewCreateDirectUploadRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+
+}
+
+func (c *Client) CreateDirectUpload(ctx context.Context, body CreateDirectUploadJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+
+	req, err := NewCreateDirectUploadRequest(c.Server, body)
 	if err != nil {
 		return nil, err
 	}
@@ -5755,6 +5825,46 @@ func NewMarkPostingsUnseenRequestWithBody(server string, contentType string, bod
 	return req, nil
 }
 
+// NewCreateDirectUploadRequest calls the generic CreateDirectUpload builder with application/json body
+func NewCreateDirectUploadRequest(server string, body CreateDirectUploadJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewCreateDirectUploadRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewCreateDirectUploadRequestWithBody generates requests for CreateDirectUpload with any type of body
+func NewCreateDirectUploadRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/rails/active_storage/direct_uploads.json")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
 // NewGetLaterboxRequest generates requests for GetLaterbox
 func NewGetLaterboxRequest(server string, params *GetLaterboxParams) (*http.Request, error) {
 	var err error
@@ -6664,6 +6774,7 @@ var operationMetadata = map[string]OperationMetadata{
 	"MarkPostingsSpam":           {Idempotent: false, HasSensitiveParams: false},
 	"TrashPostings":              {Idempotent: false, HasSensitiveParams: false},
 	"MarkPostingsUnseen":         {Idempotent: false, HasSensitiveParams: false},
+	"CreateDirectUpload":         {Idempotent: false, HasSensitiveParams: false},
 	"GetLaterbox":                {Idempotent: true, HasSensitiveParams: false},
 	"GetAsidebox":                {Idempotent: true, HasSensitiveParams: false},
 	"ListStickies":               {Idempotent: true, HasSensitiveParams: false},
@@ -7927,6 +8038,22 @@ type ClientWithResponsesInterface interface {
 	//
 	// Mark postings as unseen.
 	MarkPostingsUnseenWithResponse(ctx context.Context, body MarkPostingsUnseenJSONRequestBody, reqEditors ...RequestEditorFn) (*MarkPostingsUnseenResponse, error)
+
+	// CreateDirectUploadWithBodyWithResponse performs a POST /rails/active_storage/direct_uploads.json (the `CreateDirectUpload` operationId) request,
+	// with any type of body and a specified content type.
+	//
+	// Create an Active Storage direct upload for an outgoing attachment.
+	// The returned URL is self-authenticating and accepts the raw file bytes via PUT.
+	//
+	// Returns a wrapper object for the known response body format(s).
+	CreateDirectUploadWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateDirectUploadResponse, error)
+
+	// CreateDirectUploadWithResponse performs a POST /rails/active_storage/direct_uploads.json (the `CreateDirectUpload` operationId) request.
+	// Takes a body of the `application/json` content type, and returns a wrapper object for the known response body format(s).
+	//
+	// Create an Active Storage direct upload for an outgoing attachment.
+	// The returned URL is self-authenticating and accepts the raw file bytes via PUT.
+	CreateDirectUploadWithResponse(ctx context.Context, body CreateDirectUploadJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateDirectUploadResponse, error)
 
 	// GetLaterboxWithResponse performs a GET /reply_later.json (the `GetLaterbox` operationId) request.
 	//
@@ -12254,6 +12381,75 @@ func (r MarkPostingsUnseenResponse) ContentType() string {
 	return ""
 }
 
+type CreateDirectUploadResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	// JSON200 the response for an HTTP 200 `application/json` response
+	JSON200 *CreateDirectUploadResponseContent
+	// JSON401 the response for an HTTP 401 `application/json` response
+	JSON401 *UnauthorizedErrorResponseContent
+	// JSON422 the response for an HTTP 422 `application/json` response
+	JSON422 *UnprocessableEntityErrorResponseContent
+	// JSON500 the response for an HTTP 500 `application/json` response
+	JSON500 *InternalServerErrorResponseContent
+	// JSON503 the response for an HTTP 503 `application/json` response
+	JSON503 *ServiceUnavailableErrorResponseContent
+}
+
+// GetJSON200 returns the response for an HTTP 200 `application/json` response
+func (r CreateDirectUploadResponse) GetJSON200() *CreateDirectUploadResponseContent {
+	return r.JSON200
+}
+
+// GetJSON401 returns the response for an HTTP 401 `application/json` response
+func (r CreateDirectUploadResponse) GetJSON401() *UnauthorizedErrorResponseContent {
+	return r.JSON401
+}
+
+// GetJSON422 returns the response for an HTTP 422 `application/json` response
+func (r CreateDirectUploadResponse) GetJSON422() *UnprocessableEntityErrorResponseContent {
+	return r.JSON422
+}
+
+// GetJSON500 returns the response for an HTTP 500 `application/json` response
+func (r CreateDirectUploadResponse) GetJSON500() *InternalServerErrorResponseContent {
+	return r.JSON500
+}
+
+// GetJSON503 returns the response for an HTTP 503 `application/json` response
+func (r CreateDirectUploadResponse) GetJSON503() *ServiceUnavailableErrorResponseContent {
+	return r.JSON503
+}
+
+// GetBody returns the raw response body bytes
+func (r CreateDirectUploadResponse) GetBody() []byte {
+	return r.Body
+}
+
+// Status returns HTTPResponse.Status
+func (r CreateDirectUploadResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r CreateDirectUploadResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r CreateDirectUploadResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
 type GetLaterboxResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -14607,6 +14803,34 @@ func (c *ClientWithResponses) MarkPostingsUnseenWithResponse(ctx context.Context
 		return nil, err
 	}
 	return ParseMarkPostingsUnseenResponse(rsp)
+}
+
+// CreateDirectUploadWithBodyWithResponse performs a POST /rails/active_storage/direct_uploads.json (the `CreateDirectUpload` operationId) request,
+// with any type of body and a specified content type.
+//
+// Create an Active Storage direct upload for an outgoing attachment.
+// The returned URL is self-authenticating and accepts the raw file bytes via PUT.
+//
+// Returns a wrapper object for the known response body format(s).
+func (c *ClientWithResponses) CreateDirectUploadWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateDirectUploadResponse, error) {
+	rsp, err := c.CreateDirectUploadWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateDirectUploadResponse(rsp)
+}
+
+// CreateDirectUploadWithResponse performs a POST /rails/active_storage/direct_uploads.json (the `CreateDirectUpload` operationId) request.
+// Takes a body of the `application/json` content type, and returns a wrapper object for the known response body format(s).
+//
+// Create an Active Storage direct upload for an outgoing attachment.
+// The returned URL is self-authenticating and accepts the raw file bytes via PUT.
+func (c *ClientWithResponses) CreateDirectUploadWithResponse(ctx context.Context, body CreateDirectUploadJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateDirectUploadResponse, error) {
+	rsp, err := c.CreateDirectUpload(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateDirectUploadResponse(rsp)
 }
 
 // GetLaterboxWithResponse performs a GET /reply_later.json (the `GetLaterbox` operationId) request.
@@ -18185,6 +18409,60 @@ func ParseMarkPostingsUnseenResponse(rsp *http.Response) (*MarkPostingsUnseenRes
 			return nil, err
 		}
 		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalServerErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 503:
+		var dest ServiceUnavailableErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON503 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseCreateDirectUploadResponse parses an HTTP response from a CreateDirectUploadWithResponse call
+func ParseCreateDirectUploadResponse(rsp *http.Response) (*CreateDirectUploadResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &CreateDirectUploadResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest CreateDirectUploadResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest UnauthorizedErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest UnprocessableEntityErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest InternalServerErrorResponseContent

--- a/go/pkg/hey/attachments.go
+++ b/go/pkg/hey/attachments.go
@@ -1,0 +1,40 @@
+package hey
+
+import (
+	"context"
+
+	"github.com/basecamp/hey-sdk/go/pkg/generated"
+)
+
+// AttachmentsService handles outgoing attachment uploads.
+type AttachmentsService struct {
+	client *Client
+}
+
+// NewAttachmentsService creates an AttachmentsService.
+func NewAttachmentsService(client *Client) *AttachmentsService {
+	return &AttachmentsService{client: client}
+}
+
+// CreateDirectUpload creates an Active Storage blob and returns the target for
+// uploading its bytes. The target URL is self-authenticating and must be used
+// with the exact headers returned by HEY.
+func (s *AttachmentsService) CreateDirectUpload(ctx context.Context, body generated.CreateDirectUploadJSONRequestBody) (result *generated.DirectUpload, err error) {
+	op := OperationInfo{
+		Service: "Attachments", Operation: "CreateDirectUpload",
+		ResourceType: "attachment", IsMutation: true,
+	}
+
+	err = s.client.instrument(ctx, op, func(ctx context.Context) error {
+		resp, requestErr := s.client.genClient().CreateDirectUploadWithResponse(ctx, body)
+		if requestErr != nil {
+			return requestErr
+		}
+		if responseErr := CheckResponse(resp.HTTPResponse); responseErr != nil {
+			return responseErr
+		}
+		result = resp.JSON200
+		return nil
+	})
+	return result, err
+}

--- a/go/pkg/hey/attachments_test.go
+++ b/go/pkg/hey/attachments_test.go
@@ -1,0 +1,72 @@
+package hey
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/basecamp/hey-sdk/go/pkg/generated"
+)
+
+func TestAttachmentsCreateDirectUpload(t *testing.T) {
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/rails/active_storage/direct_uploads.json" {
+			t.Errorf("path = %s, want /rails/active_storage/direct_uploads.json", r.URL.Path)
+		}
+
+		var body generated.CreateDirectUploadRequestContent
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		if body.Blob.Filename != "quarterly-report.pdf" {
+			t.Errorf("filename = %q", body.Blob.Filename)
+		}
+		if body.Blob.ByteSize != 128 {
+			t.Errorf("byte size = %d", body.Blob.ByteSize)
+		}
+		if body.Blob.Checksum != "YWJjZA==" {
+			t.Errorf("checksum = %q", body.Blob.Checksum)
+		}
+		if body.Blob.ContentType != "application/pdf" {
+			t.Errorf("content type = %q", body.Blob.ContentType)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"signed_id":"signed-123",
+			"attachable_sgid":"sgid-456",
+			"direct_upload":{
+				"url":"https://uploads.example.com/blob",
+				"headers":{"Content-Type":"application/pdf","Content-MD5":"YWJjZA=="}
+			}
+		}`))
+	})
+
+	result, err := client.Attachments().CreateDirectUpload(context.Background(), generated.CreateDirectUploadRequestContent{
+		Blob: generated.DirectUploadBlob{
+			Filename:    "quarterly-report.pdf",
+			ByteSize:    128,
+			Checksum:    "YWJjZA==",
+			ContentType: "application/pdf",
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateDirectUpload: %v", err)
+	}
+	if result.SignedId != "signed-123" {
+		t.Errorf("signed ID = %q", result.SignedId)
+	}
+	if result.AttachableSgid != "sgid-456" {
+		t.Errorf("attachable SGID = %q", result.AttachableSgid)
+	}
+	if result.DirectUpload.Url != "https://uploads.example.com/blob" {
+		t.Errorf("upload URL = %q", result.DirectUpload.Url)
+	}
+	if result.DirectUpload.Headers["Content-MD5"] != "YWJjZA==" {
+		t.Errorf("upload headers = %v", result.DirectUpload.Headers)
+	}
+}

--- a/go/pkg/hey/client.go
+++ b/go/pkg/hey/client.go
@@ -57,6 +57,7 @@ type Client struct {
 	postings       *PostingsService
 	topics         *TopicsService
 	messages       *MessagesService
+	attachments    *AttachmentsService
 	entries        *EntriesService
 	contacts       *ContactsService
 	calendars      *CalendarsService
@@ -792,6 +793,16 @@ func (c *Client) Messages() *MessagesService {
 		c.messages = NewMessagesService(c)
 	}
 	return c.messages
+}
+
+// Attachments returns the attachment service.
+func (c *Client) Attachments() *AttachmentsService {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.attachments == nil {
+		c.attachments = NewAttachmentsService(c)
+	}
+	return c.attachments
 }
 
 // Entries returns the EntriesService.

--- a/go/pkg/hey/client_test.go
+++ b/go/pkg/hey/client_test.go
@@ -267,6 +267,9 @@ func TestClient_ServiceAccessors(t *testing.T) {
 	if c.Messages() == nil {
 		t.Fatal("expected non-nil MessagesService")
 	}
+	if c.Attachments() == nil {
+		t.Fatal("expected non-nil AttachmentsService")
+	}
 	if c.Entries() == nil {
 		t.Fatal("expected non-nil EntriesService")
 	}

--- a/go/pkg/hey/doc.go
+++ b/go/pkg/hey/doc.go
@@ -33,6 +33,7 @@
 //   - [Client.Boxes] - Mailboxes (imbox, feedbox, etc.)
 //   - [Client.Topics] - Email topics and views (sent, spam, trash, everything)
 //   - [Client.Messages] - Individual messages
+//   - [Client.Attachments] - Active Storage direct uploads for outgoing attachments
 //   - [Client.Entries] - Drafts and replies
 //   - [Client.Contacts] - Contact management
 //   - [Client.Calendars] - Calendar views and recordings

--- a/go/pkg/hey/url-routes.json
+++ b/go/pkg/hey/url-routes.json
@@ -559,6 +559,14 @@
       "params": {}
     },
     {
+      "pattern": "/rails/active_storage/direct_uploads",
+      "resource": "Attachments",
+      "operations": {
+        "POST": "CreateDirectUpload"
+      },
+      "params": {}
+    },
+    {
       "pattern": "/reply_later",
       "resource": "Boxes",
       "operations": {

--- a/openapi.json
+++ b/openapi.json
@@ -4973,6 +4973,77 @@
         }
       }
     },
+    "/rails/active_storage/direct_uploads.json": {
+      "post": {
+        "description": "Create an Active Storage direct upload for an outgoing attachment.\nThe returned URL is self-authenticating and accepts the raw file bytes via PUT.",
+        "operationId": "CreateDirectUpload",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateDirectUploadRequestContent"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "CreateDirectUpload 200 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateDirectUploadResponseContent"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "UnauthorizedError 401 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedErrorResponseContent"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "UnprocessableEntityError 422 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnprocessableEntityErrorResponseContent"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "InternalServerError 500 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerErrorResponseContent"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "ServiceUnavailableError 503 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceUnavailableErrorResponseContent"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Attachments"
+        ]
+      }
+    },
     "/reply_later.json": {
       "get": {
         "description": "Get the Reply Later box",
@@ -7099,6 +7170,20 @@
       "CreateCalendarTodoResponseContent": {
         "$ref": "#/components/schemas/Recording"
       },
+      "CreateDirectUploadRequestContent": {
+        "type": "object",
+        "properties": {
+          "blob": {
+            "$ref": "#/components/schemas/DirectUploadBlob"
+          }
+        },
+        "required": [
+          "blob"
+        ]
+      },
+      "CreateDirectUploadResponseContent": {
+        "$ref": "#/components/schemas/DirectUpload"
+      },
       "CreateFolderForPostingsRequestContent": {
         "type": "object",
         "description": "Wire format: {posting_ids: [...], folder: {name, status}}",
@@ -7169,6 +7254,72 @@
       },
       "CreateTimeTrackResponseContent": {
         "$ref": "#/components/schemas/Recording"
+      },
+      "DirectUpload": {
+        "type": "object",
+        "properties": {
+          "signed_id": {
+            "type": "string"
+          },
+          "attachable_sgid": {
+            "type": "string"
+          },
+          "direct_upload": {
+            "$ref": "#/components/schemas/DirectUploadTarget"
+          }
+        },
+        "required": [
+          "attachable_sgid",
+          "direct_upload",
+          "signed_id"
+        ]
+      },
+      "DirectUploadBlob": {
+        "type": "object",
+        "properties": {
+          "filename": {
+            "type": "string"
+          },
+          "byte_size": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "checksum": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "byte_size",
+          "checksum",
+          "content_type",
+          "filename"
+        ]
+      },
+      "DirectUploadHeaders": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "string"
+        },
+        "propertyNames": {
+          "type": "string"
+        }
+      },
+      "DirectUploadTarget": {
+        "type": "object",
+        "properties": {
+          "url": {
+            "type": "string"
+          },
+          "headers": {
+            "$ref": "#/components/schemas/DirectUploadHeaders"
+          }
+        },
+        "required": [
+          "url"
+        ]
       },
       "Domain": {
         "type": "object",

--- a/spec/hey.smithy
+++ b/spec/hey.smithy
@@ -87,6 +87,9 @@ service HEY {
         GetMessage
         CreateMessage
 
+        // Attachments
+        CreateDirectUpload
+
         // Entries (2 MVP)
         ListDrafts
         CreateReply
@@ -1301,6 +1304,73 @@ structure MessagePayload {
 
     @required
     content: String
+}
+
+// =============================================================================
+// ATTACHMENT OPERATIONS
+// =============================================================================
+
+/// Create an Active Storage direct upload for an outgoing attachment.
+/// The returned URL is self-authenticating and accepts the raw file bytes via PUT.
+@http(method: "POST", uri: "/rails/active_storage/direct_uploads.json")
+@tags(["Attachments"])
+operation CreateDirectUpload {
+    input: CreateDirectUploadInput
+    output: CreateDirectUploadOutput
+    errors: [UnauthorizedError, UnprocessableEntityError, InternalServerError, ServiceUnavailableError]
+}
+
+structure CreateDirectUploadInput {
+    @httpPayload
+    @required
+    body: CreateDirectUploadRequestContent
+}
+
+structure CreateDirectUploadRequestContent {
+    @required
+    blob: DirectUploadBlob
+}
+
+structure DirectUploadBlob {
+    @required
+    filename: String
+
+    @required
+    byte_size: Long
+
+    @required
+    checksum: String
+
+    @required
+    content_type: String
+}
+
+map DirectUploadHeaders {
+    key: String
+    value: String
+}
+
+structure DirectUploadTarget {
+    @required
+    url: String
+
+    headers: DirectUploadHeaders
+}
+
+structure DirectUpload {
+    @required
+    signed_id: String
+
+    @required
+    attachable_sgid: String
+
+    @required
+    direct_upload: DirectUploadTarget
+}
+
+structure CreateDirectUploadOutput {
+    @required
+    upload: DirectUpload
 }
 
 structure MessageEntryPayload {

--- a/spec/route-coverage.json
+++ b/spec/route-coverage.json
@@ -46,6 +46,11 @@
   },
   {
     "method": "POST",
+    "operationId": "CreateDirectUpload",
+    "path": "/rails/active_storage/direct_uploads.json"
+  },
+  {
+    "method": "POST",
     "operationId": "CreateFolderForPostings",
     "path": "/postings/folders.json"
   },

--- a/spec/shape-fingerprint.json
+++ b/spec/shape-fingerprint.json
@@ -3,6 +3,7 @@
   "CompleteHabit": "9bb7a50c07c31309731cb6ae3289aab6c496d65b4458c13ac535ba6919e69bc5",
   "CreateBoxGroup": "d04089956551c379f18238cfef578d7241682aa98b660a5292deb551ce891ed4",
   "CreateCalendarTodo": "3e3226f5123ba16c946207e7c94c4eb179a6dfeaa4f3329b54ffeda0c7b8e585",
+  "CreateDirectUpload": "76da4e9cf90916cb4713ca59665dcb56fb172f7759a93cfbb497309eed40adac",
   "CreateHabit": "545c7bf2eddaf0b71a68ae839ac12e31d4e3d75c6dc70027a250cf89a7c9ac75",
   "CreateSticky": "109e08efe54f16e8275188b672d9387a55a02fefb69b15dae548e0965f5421f9",
   "CreateTimeTrack": "099983ea35840ec326931119b6bc4feecaee4500dc4f42b8a6259f138b632fd4",


### PR DESCRIPTION
## Summary

Model HEY's Active Storage direct-upload endpoint and expose it through `client.Attachments().CreateDirectUpload(...)`.

The request carries the filename, byte size, checksum, and content type. The response returns the signed blob ID, attachable SGID, upload URL, and the exact headers required for the file PUT. The caller still sends the file bytes to that self-authenticating URL.

This is the SDK dependency for basecamp/hey-cli#117.

The generated OpenAPI, Go client, behavior model, route metadata, and shape fingerprints are refreshed. A path conformance case covers the new operation.

## Validation

- `env GOWORK=off mise x -- make check`
- 128 of 128 conformance cases passed


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Active Storage direct-upload support for outgoing attachments via `Client.Attachments().CreateDirectUpload(...)`, letting callers obtain a self-authenticating PUT URL and required headers. This enables uploads without proxying file bytes through HEY.

**API and review notes**
- New accessor `Client.Attachments()` with `CreateDirectUpload(ctx, { blob: { filename, byte_size, checksum, content_type } })` returning `*generated.DirectUpload` (`signed_id`, `attachable_sgid`, `direct_upload.url`, `direct_upload.headers`).
- Sends POST to `/rails/active_storage/direct_uploads.json`; callers must PUT the file bytes to the returned URL with the exact headers.
- Operation is non-idempotent and not retried by the generated client.
- OpenAPI/Smithy specs, generated Go client, routes, and conformance tests updated; unit tests cover path, request body, and response. Additive change; no migration required.

<sup>Written for commit abeb583b1bc762e01b099990d0d24e8c4a006977. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-sdk/pull/74?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

