### PR TITLE
Add binary download helper

### DIFF
--- a/go/pkg/hey/client.go
+++ b/go/pkg/hey/client.go
@@ -271,6 +271,23 @@ func (c *Client) GetHTML(ctx context.Context, path string) (*Response, error) {
 	return c.doRequest(contextWithAccept(ctx, "text/html"), "GET", path, nil)
 }
 
+// GetBlob performs a same-origin GET request for binary content and bypasses
+// the response cache. Redirects may leave the HEY origin, but the HTTP client
+// strips authorization before following them.
+func (c *Client) GetBlob(ctx context.Context, path string) (*Response, error) {
+	resolvedURL, err := c.buildURL(path)
+	if err != nil {
+		return nil, err
+	}
+	if !isSameOrigin(c.cfg.BaseURL, resolvedURL) {
+		return nil, fmt.Errorf("blob URL points to different origin: %s", resolvedURL)
+	}
+
+	ctx = contextWithAccept(ctx, "*/*")
+	ctx = contextWithoutCache(ctx)
+	return c.doRequestURL(ctx, "GET", resolvedURL, nil)
+}
+
 // GetCSV performs a GET request with Accept: text/csv, returning the raw CSV bytes.
 // Use this for the export endpoints, which stream a file rather than a document.
 func (c *Client) GetCSV(ctx context.Context, path string) (*Response, error) {
@@ -452,6 +469,17 @@ func acceptFromContext(ctx context.Context) string {
 	return "application/json"
 }
 
+type contextKeyNoCache struct{}
+
+func contextWithoutCache(ctx context.Context) context.Context {
+	return context.WithValue(ctx, contextKeyNoCache{}, true)
+}
+
+func noCacheFromContext(ctx context.Context) bool {
+	v, _ := ctx.Value(contextKeyNoCache{}).(bool)
+	return v
+}
+
 func (c *Client) doRequest(ctx context.Context, method, path string, body any) (*Response, error) {
 	url, err := c.buildURL(path)
 	if err != nil {
@@ -546,7 +574,7 @@ func (c *Client) singleRequest(ctx context.Context, method, url string, body any
 	req.Header.Set("Accept", acceptFromContext(ctx))
 
 	var cacheKey string
-	if method == "GET" && c.cache != nil {
+	if method == "GET" && c.cache != nil && !noCacheFromContext(ctx) {
 		cacheKey = c.cache.Key(url, req.Header.Get("Authorization"))
 		if etag := c.cache.GetETag(cacheKey); etag != "" {
 			req.Header.Set("If-None-Match", etag)

--- a/go/pkg/hey/client_test.go
+++ b/go/pkg/hey/client_test.go
@@ -1,6 +1,7 @@
 package hey
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"net/http"
@@ -90,6 +91,101 @@ func TestClient_Get(t *testing.T) {
 	}
 	if resp.StatusCode != 200 {
 		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+}
+
+func TestClient_GetBlob(t *testing.T) {
+	binary := []byte{0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0xff, 0xfe}
+	var requests atomic.Int64
+	var lastIfNoneMatch atomic.Value
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		lastIfNoneMatch.Store(r.Header.Get("If-None-Match"))
+		if got := r.Header.Get("Accept"); got != "*/*" {
+			t.Errorf("Accept = %q, want %q", got, "*/*")
+		}
+		w.Header().Set("Content-Type", "image/png")
+		w.Header().Set("ETag", `"abc"`)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(binary)
+	}))
+	t.Cleanup(server.Close)
+
+	client := NewClient(
+		&Config{BaseURL: server.URL},
+		&StaticTokenProvider{Token: "test-token"},
+		WithMaxRetries(0),
+		WithBaseDelay(time.Millisecond),
+		WithMaxJitter(time.Millisecond),
+		WithCache(NewCache(t.TempDir())),
+	)
+
+	for i := 0; i < 2; i++ {
+		resp, err := client.GetBlob(context.Background(), "/rails/blobs/abc/image.png")
+		if err != nil {
+			t.Fatalf("request %d: %v", i+1, err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("request %d status = %d, want %d", i+1, resp.StatusCode, http.StatusOK)
+		}
+		if !bytes.Equal(resp.Data, binary) {
+			t.Fatalf("request %d body = %d bytes, want %d", i+1, len(resp.Data), len(binary))
+		}
+		if resp.FromCache {
+			t.Errorf("request %d unexpectedly came from cache", i+1)
+		}
+		if value, _ := lastIfNoneMatch.Load().(string); value != "" {
+			t.Errorf("request %d If-None-Match = %q, want empty", i+1, value)
+		}
+	}
+	if requests.Load() != 2 {
+		t.Errorf("requests = %d, want 2", requests.Load())
+	}
+}
+
+func TestClient_GetBlobRejectsCrossOriginURL(t *testing.T) {
+	client := newTestClient(t, func(http.ResponseWriter, *http.Request) {
+		t.Error("cross-origin blob URL should be rejected before making a request")
+	})
+
+	_, err := client.GetBlob(context.Background(), "https://files.example.org/report.pdf")
+	if err == nil {
+		t.Fatal("expected cross-origin URL error")
+	}
+}
+
+func TestClient_GetBlobStripsAuthorizationOnCrossOriginRedirect(t *testing.T) {
+	binary := []byte{0x00, 0xff, 0x01, 0xfe}
+	var targetAuthorization atomic.Value
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		targetAuthorization.Store(r.Header.Get("Authorization"))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(binary)
+	}))
+	t.Cleanup(target.Close)
+
+	source := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			t.Errorf("source Authorization = %q, want Bearer token", got)
+		}
+		http.Redirect(w, r, target.URL+"/download/file.bin", http.StatusFound)
+	}))
+	t.Cleanup(source.Close)
+
+	client := NewClient(
+		&Config{BaseURL: source.URL},
+		&StaticTokenProvider{Token: "test-token"},
+		WithMaxRetries(0),
+	)
+	resp, err := client.GetBlob(context.Background(), "/rails/active_storage/blobs/redirect/abc/file.bin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(resp.Data, binary) {
+		t.Fatalf("body = %v, want %v", resp.Data, binary)
+	}
+	if got, _ := targetAuthorization.Load().(string); got != "" {
+		t.Errorf("target Authorization = %q, want empty", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

Add `Client.GetBlob` for binary downloads such as Active Storage attachment URLs.

The helper accepts only a same-origin starting URL, requests `*/*`, and bypasses the response cache. Redirects can point to another origin, but the client removes the Authorization header before following them.

This is the SDK piece needed to add attachment downloads to `hey-cli`.

## Validation

- `env GOWORK=off mise x -- make check`
- 127 of 127 conformance cases passed
- Unit coverage confirms cache bypass, same-origin enforcement, and authorization stripping on cross-origin redirects


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Client.GetBlob to download binary attachments safely and predictably. Previously callers used generic GET (Accept: application/json, cached); now downloads request */*, bypass the cache, require a same-origin start URL, and strip Authorization on cross-origin redirects.

- Enforces same-origin for the initial URL; returns an error if the start URL differs from the client origin.
- Bypasses the response cache for these GETs (no ETag sent, never serves FromCache).
- Sends Accept: */* and preserves server-provided content types.
- Allows redirects to other origins but removes Authorization before following them.
- Cache behavior for existing methods is unchanged; only GetBlob opts out of caching.

<sup>Written for commit bb71d7d55300d241f8c8429af18e0cee8998b8b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-sdk/pull/75?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

