### PR TITLE
Journal reads and writes go through the API; topics carry their entries

### DIFF
--- a/conformance/tests/paths.json
+++ b/conformance/tests/paths.json
@@ -1027,6 +1027,16 @@
       },
       {
         "type": "noError"
+      },
+      {
+        "type": "requestMethod",
+        "expected": "PATCH"
+      },
+      {
+        "type": "requestBody",
+        "expected": {
+          "calendar_journal_entry.content": "Updated content"
+        }
       }
     ],
     "tags": [

--- a/go/pkg/generated/client.gen.go
+++ b/go/pkg/generated/client.gen.go
@@ -790,6 +790,10 @@ type Recording struct {
 	CompletedAt time.Time `json:"completed_at,omitempty"`
 	Content     string    `json:"content,omitempty"`
 
+	// ContentHtml Full rich-text HTML of a journal entry (GetJournalEntry / UpdateJournalEntry only;
+	// listings carry a truncated plain-text `content` instead).
+	ContentHtml string `json:"content_html,omitempty"`
+
 	// CreatedAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
 	CreatedAt   time.Time `json:"created_at,omitempty"`
 	Days        []int32   `json:"days,omitempty"`
@@ -950,7 +954,11 @@ type Topic struct {
 	CreatedAt time.Time `json:"created_at,omitempty"`
 
 	// Creator Contact — the identity of someone in HEY
-	Creator        Contact     `json:"creator,omitempty"`
+	Creator Contact `json:"creator,omitempty"`
+
+	// Entries The topic's first page of entries (summaries, no bodies). Present on GetTopic; use
+	// GetTopicEntries for the rest and GetMessage for a body.
+	Entries        []Entry     `json:"entries,omitempty"`
 	Extenzions     []Extenzion `json:"extenzions,omitempty"`
 	Id             int64       `json:"id"`
 	IsForgedSender bool        `json:"is_forged_sender,omitempty"`
@@ -1013,6 +1021,9 @@ type UpdateHabitResponseContent = Recording
 type UpdateJournalEntryRequestContent struct {
 	CalendarJournalEntry JournalEntryPayload `json:"calendar_journal_entry"`
 }
+
+// UpdateJournalEntryResponseContent Recording — polymorphic by `type` (CalendarEvent, CalendarTodo, etc.)
+type UpdateJournalEntryResponseContent = Recording
 
 // UpdateStickyResponseContent Sticky — a note on the stickies board
 type UpdateStickyResponseContent = Sticky
@@ -7403,7 +7414,8 @@ type ClientWithResponsesInterface interface {
 	// UpdateJournalEntryWithBodyWithResponse performs a PATCH /calendar/days/{day}/journal_entry (the `UpdateJournalEntry` operationId) request,
 	// with any type of body and a specified content type.
 	//
-	// Update journal entry for a day.
+	// Update the journal entry for a day: writes (or creates) it and answers the entry as a
+	// recording, or 204 when empty content removes it.
 	//
 	// Returns a wrapper object for the known response body format(s).
 	UpdateJournalEntryWithBodyWithResponse(ctx context.Context, day string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateJournalEntryResponse, error)
@@ -7411,7 +7423,8 @@ type ClientWithResponsesInterface interface {
 	// UpdateJournalEntryWithResponse performs a PATCH /calendar/days/{day}/journal_entry (the `UpdateJournalEntry` operationId) request.
 	// Takes a body of the `application/json` content type, and returns a wrapper object for the known response body format(s).
 	//
-	// Update journal entry for a day.
+	// Update the journal entry for a day: writes (or creates) it and answers the entry as a
+	// recording, or 204 when empty content removes it.
 	UpdateJournalEntryWithResponse(ctx context.Context, day string, body UpdateJournalEntryJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateJournalEntryResponse, error)
 
 	// CreateHabitWithBodyWithResponse performs a POST /calendar/habits.json (the `CreateHabit` operationId) request,
@@ -8955,6 +8968,8 @@ func (r GetJournalEntryResponse) ContentType() string {
 type UpdateJournalEntryResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
+	// JSON200 the response for an HTTP 200 `application/json` response
+	JSON200 *UpdateJournalEntryResponseContent
 	// JSON401 the response for an HTTP 401 `application/json` response
 	JSON401 *UnauthorizedErrorResponseContent
 	// JSON404 the response for an HTTP 404 `application/json` response
@@ -8965,6 +8980,11 @@ type UpdateJournalEntryResponse struct {
 	JSON500 *InternalServerErrorResponseContent
 	// JSON503 the response for an HTTP 503 `application/json` response
 	JSON503 *ServiceUnavailableErrorResponseContent
+}
+
+// GetJSON200 returns the response for an HTTP 200 `application/json` response
+func (r UpdateJournalEntryResponse) GetJSON200() *UpdateJournalEntryResponseContent {
+	return r.JSON200
 }
 
 // GetJSON401 returns the response for an HTTP 401 `application/json` response
@@ -13658,7 +13678,8 @@ func (c *ClientWithResponses) GetJournalEntryWithResponse(ctx context.Context, d
 // UpdateJournalEntryWithBodyWithResponse performs a PATCH /calendar/days/{day}/journal_entry (the `UpdateJournalEntry` operationId) request,
 // with any type of body and a specified content type.
 //
-// Update journal entry for a day.
+// Update the journal entry for a day: writes (or creates) it and answers the entry as a
+// recording, or 204 when empty content removes it.
 //
 // Returns a wrapper object for the known response body format(s).
 func (c *ClientWithResponses) UpdateJournalEntryWithBodyWithResponse(ctx context.Context, day string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateJournalEntryResponse, error) {
@@ -13672,7 +13693,8 @@ func (c *ClientWithResponses) UpdateJournalEntryWithBodyWithResponse(ctx context
 // UpdateJournalEntryWithResponse performs a PATCH /calendar/days/{day}/journal_entry (the `UpdateJournalEntry` operationId) request.
 // Takes a body of the `application/json` content type, and returns a wrapper object for the known response body format(s).
 //
-// Update journal entry for a day.
+// Update the journal entry for a day: writes (or creates) it and answers the entry as a
+// recording, or 204 when empty content removes it.
 func (c *ClientWithResponses) UpdateJournalEntryWithResponse(ctx context.Context, day string, body UpdateJournalEntryJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateJournalEntryResponse, error) {
 	rsp, err := c.UpdateJournalEntry(ctx, day, body, reqEditors...)
 	if err != nil {
@@ -15601,8 +15623,12 @@ func ParseUpdateJournalEntryResponse(rsp *http.Response) (*UpdateJournalEntryRes
 	}
 
 	switch {
-	case rsp.StatusCode == 200:
-		break // No content-type
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest UpdateJournalEntryResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
 		var dest UnauthorizedErrorResponseContent

--- a/go/pkg/hey/journal.go
+++ b/go/pkg/hey/journal.go
@@ -1,18 +1,16 @@
 package hey
 
 import (
-	"bytes"
 	"context"
-	"fmt"
-	"strings"
-	"time"
-
-	"golang.org/x/net/html"
 
 	"github.com/basecamp/hey-sdk/go/pkg/generated"
 )
 
 // JournalService handles journal entry operations.
+//
+// A day has at most one journal entry. HEY answers the entry as a calendar recording
+// carrying the full text (`content`) and the rich-text HTML (`content_html`); a day with
+// no entry answers 204, which the SDK reports as a nil recording.
 type JournalService struct {
 	client *Client
 }
@@ -22,127 +20,72 @@ func NewJournalService(client *Client) *JournalService {
 	return &JournalService{client: client}
 }
 
-// Get returns a journal entry for a specific day (YYYY-MM-DD format).
+// Get returns the journal entry for a day (YYYY-MM-DD), or nil when the day has none.
 func (s *JournalService) Get(ctx context.Context, day string) (result *generated.Recording, err error) {
 	op := OperationInfo{
 		Service: "Journal", Operation: "GetJournalEntry",
 		ResourceType: "journal_entry", IsMutation: false,
 	}
-	if gater, ok := s.client.hooks.(GatingHooks); ok {
-		if ctx, err = gater.OnOperationGate(ctx, op); err != nil {
-			return
-		}
-	}
-	start := time.Now()
-	ctx = s.client.hooks.OnOperationStart(ctx, op)
-	defer func() { s.client.hooks.OnOperationEnd(ctx, op, err, time.Since(start)) }()
-
-	s.client.initGeneratedClient()
-	resp, err := s.client.gen.GetJournalEntryWithResponse(ctx, day)
-	if err != nil {
-		return nil, err
-	}
-	if err = CheckResponse(resp.HTTPResponse); err != nil {
-		return nil, err
-	}
-	return resp.JSON200, nil
+	err = s.client.instrument(ctx, op, func(ctx context.Context) error {
+		result, err = s.get(ctx, day)
+		return err
+	})
+	return result, err
 }
 
-// GetContent returns the HTML content of a journal entry for a specific day.
-// It tries the JSON API first; if that returns 204 (no content), it falls back
-// to scraping the edit page for the Trix editor content.
+// GetContent returns the rich-text HTML of the day's journal entry, or "" when there is none.
 func (s *JournalService) GetContent(ctx context.Context, day string) (content string, err error) {
 	op := OperationInfo{
 		Service: "Journal", Operation: "GetJournalContent",
 		ResourceType: "journal_entry", IsMutation: false,
 	}
-	if gater, ok := s.client.hooks.(GatingHooks); ok {
-		if ctx, err = gater.OnOperationGate(ctx, op); err != nil {
-			return
+	err = s.client.instrument(ctx, op, func(ctx context.Context) error {
+		recording, err := s.get(ctx, day)
+		if err != nil || recording == nil {
+			return err
 		}
-	}
-	start := time.Now()
-	ctx = s.client.hooks.OnOperationStart(ctx, op)
-	defer func() { s.client.hooks.OnOperationEnd(ctx, op, err, time.Since(start)) }()
-
-	// Try JSON API first.
-	s.client.initGeneratedClient()
-	resp, err := s.client.gen.GetJournalEntryWithResponse(ctx, day)
-	if err != nil {
-		return "", err
-	}
-	if err = CheckResponse(resp.HTTPResponse); err != nil {
-		return "", err
-	}
-	if resp.JSON200 != nil && resp.JSON200.Content != "" {
-		return resp.JSON200.Content, nil
-	}
-
-	// JSON API returned 204 or empty content — scrape the edit page.
-	htmlResp, err := s.client.GetHTML(ctx, fmt.Sprintf("/calendar/days/%s/journal_entry/edit", day))
-	if err != nil {
-		return "", nil // not fatal — just no content
-	}
-	return extractTrixContent(htmlResp.Data)
+		content = recording.ContentHtml
+		if content == "" {
+			content = recording.Content
+		}
+		return nil
+	})
+	return content, err
 }
 
-// extractTrixContent extracts journal content from the edit page HTML.
-// The content is stored in a Trix editor hidden input element.
-func extractTrixContent(data []byte) (string, error) {
-	doc, err := html.Parse(bytes.NewReader(data))
-	if err != nil {
-		return "", err
-	}
-	return findTrixInput(doc), nil
-}
-
-func findTrixInput(n *html.Node) string {
-	if n.Type == html.ElementNode && n.Data == "input" {
-		isTarget := false
-		value := ""
-		for _, a := range n.Attr {
-			if a.Key == "id" && strings.Contains(a.Val, "journal") && strings.HasSuffix(a.Val, "trix_input") {
-				isTarget = true
-			}
-			if a.Key == "value" {
-				value = a.Val
-			}
-		}
-		if isTarget && value != "" {
-			return value
-		}
-	}
-	for c := n.FirstChild; c != nil; c = c.NextSibling {
-		if v := findTrixInput(c); v != "" {
-			return v
-		}
-	}
-	return ""
-}
-
-// Update updates a journal entry for a specific day.
+// Update writes the day's journal entry (creating it if needed) and returns it as a
+// recording. Empty content removes the entry, in which case the result is nil.
 //
 // The HEY API expects the body wrapped as {calendar_journal_entry: {content: "..."}}.
-func (s *JournalService) Update(ctx context.Context, day string, content string) (err error) {
+func (s *JournalService) Update(ctx context.Context, day string, content string) (result *generated.Recording, err error) {
 	op := OperationInfo{
 		Service: "Journal", Operation: "UpdateJournalEntry",
 		ResourceType: "journal_entry", IsMutation: true,
 	}
-	if gater, ok := s.client.hooks.(GatingHooks); ok {
-		if ctx, err = gater.OnOperationGate(ctx, op); err != nil {
-			return
+	err = s.client.instrument(ctx, op, func(ctx context.Context) error {
+		resp, err := s.client.genClient().UpdateJournalEntryWithResponse(ctx, day, generated.UpdateJournalEntryRequestContent{
+			CalendarJournalEntry: generated.JournalEntryPayload{Content: content},
+		})
+		if err != nil {
+			return err
 		}
-	}
-	start := time.Now()
-	ctx = s.client.hooks.OnOperationStart(ctx, op)
-	defer func() { s.client.hooks.OnOperationEnd(ctx, op, err, time.Since(start)) }()
+		if err = CheckResponse(resp.HTTPResponse); err != nil {
+			return err
+		}
+		result = resp.JSON200 // nil on 204: empty content removed the entry
+		return nil
+	})
+	return result, err
+}
 
-	body := map[string]any{
-		"calendar_journal_entry": map[string]any{
-			"content": content,
-		},
+// get is the un-instrumented read shared by Get and GetContent.
+func (s *JournalService) get(ctx context.Context, day string) (*generated.Recording, error) {
+	resp, err := s.client.genClient().GetJournalEntryWithResponse(ctx, day)
+	if err != nil {
+		return nil, err
 	}
-
-	_, err = s.client.PatchMutation(ctx, fmt.Sprintf("/calendar/days/%s/journal_entry", day), body)
-	return err
+	if err = CheckResponse(resp.HTTPResponse); err != nil {
+		return nil, err
+	}
+	return resp.JSON200, nil // nil on 204: no entry that day
 }

--- a/go/pkg/hey/services_test.go
+++ b/go/pkg/hey/services_test.go
@@ -882,7 +882,7 @@ func TestJournalService_Get(t *testing.T) {
 }
 
 func TestJournalService_Update(t *testing.T) {
-	client := newMutationTestClientWithValidation(t, "PATCH", "/calendar/days/%s/journal_entry",
+	client := newMutationTestClientWithValidation(t, "PATCH", "/calendar/days/%s/journal_entry.json",
 		func(t *testing.T, body map[string]any) {
 			t.Helper()
 			entry, ok := body["calendar_journal_entry"].(map[string]any)
@@ -893,12 +893,63 @@ func TestJournalService_Update(t *testing.T) {
 				t.Errorf("expected content 'Today was great', got %v", entry["content"])
 			}
 		},
-		`{"id":1,"type":"JournalEntry"}`,
+		`{"id":1,"type":"Calendar::JournalEntry","content":"Today was great","content_html":"<div class=\"trix-content\">Today was great</div>"}`,
 	)
 
-	err := client.Journal().Update(context.Background(), "2026-03-09", "Today was great")
+	recording, err := client.Journal().Update(context.Background(), "2026-03-09", "Today was great")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+	if recording == nil || recording.Content != "Today was great" || recording.ContentHtml == "" {
+		t.Fatalf("expected the written entry back, got %#v", recording)
+	}
+}
+
+func TestJournalService_UpdateEmptyContentRemovesEntry(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(srv.Close)
+	client := NewClient(&Config{BaseURL: srv.URL}, &StaticTokenProvider{Token: "t"}, WithMaxRetries(0))
+
+	recording, err := client.Journal().Update(context.Background(), "2026-03-09", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if recording != nil {
+		t.Errorf("expected nil when the entry was removed, got %#v", recording)
+	}
+}
+
+func TestJournalService_GetContentPrefersHTMLAndNoLongerScrapes(t *testing.T) {
+	var paths []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path)
+		switch r.URL.Path {
+		case "/calendar/days/2026-03-09/journal_entry.json":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":1,"type":"Calendar::JournalEntry","content":"plain","content_html":"<div class=\"trix-content\"><strong>rich</strong></div>"}`))
+		case "/calendar/days/2026-03-10/journal_entry.json":
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			w.WriteHeader(404)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	client := NewClient(&Config{BaseURL: srv.URL}, &StaticTokenProvider{Token: "t"}, WithMaxRetries(0))
+
+	content, err := client.Journal().GetContent(context.Background(), "2026-03-09")
+	if err != nil || !strings.Contains(content, "<strong>rich</strong>") {
+		t.Fatalf("expected the HTML content, got %q err=%v", content, err)
+	}
+	content, err = client.Journal().GetContent(context.Background(), "2026-03-10")
+	if err != nil || content != "" {
+		t.Fatalf("expected empty content for a day without an entry, got %q err=%v", content, err)
+	}
+	for _, p := range paths {
+		if strings.HasSuffix(p, "/edit") {
+			t.Errorf("edit page must not be fetched any more, got %s", p)
+		}
 	}
 }
 

--- a/openapi.json
+++ b/openapi.json
@@ -1060,7 +1060,7 @@
         }
       },
       "patch": {
-        "description": "Update journal entry for a day",
+        "description": "Update the journal entry for a day: writes (or creates) it and answers the entry as a\nrecording, or 204 when empty content removes it.",
         "operationId": "UpdateJournalEntry",
         "requestBody": {
           "content": {
@@ -1084,7 +1084,14 @@
         ],
         "responses": {
           "200": {
-            "description": "UpdateJournalEntry 200 response"
+            "description": "UpdateJournalEntry 200 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateJournalEntryResponseContent"
+                }
+              }
+            }
           },
           "401": {
             "description": "UnauthorizedError 401 response",
@@ -8354,6 +8361,10 @@
           "content": {
             "type": "string"
           },
+          "content_html": {
+            "type": "string",
+            "description": "Full rich-text HTML of a journal entry (GetJournalEntry / UpdateJournalEntry only;\nlistings carry a truncated plain-text `content` instead)."
+          },
           "color": {
             "type": "string"
           },
@@ -8759,6 +8770,13 @@
           },
           "latest_entry": {
             "$ref": "#/components/schemas/Entry"
+          },
+          "entries": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Entry"
+            },
+            "description": "The topic's first page of entries (summaries, no bodies). Present on GetTopic; use\nGetTopicEntries for the rest and GetMessage for a body."
           }
         },
         "required": [
@@ -8868,6 +8886,9 @@
         "required": [
           "calendar_journal_entry"
         ]
+      },
+      "UpdateJournalEntryResponseContent": {
+        "$ref": "#/components/schemas/Recording"
       },
       "UpdateStickyResponseContent": {
         "$ref": "#/components/schemas/Sticky"

--- a/spec/hey.smithy
+++ b/spec/hey.smithy
@@ -602,6 +602,10 @@ structure Topic {
     collections: CollectionList
     is_forged_sender: Boolean
     latest_entry: Entry
+
+    /// The topic's first page of entries (summaries, no bodies). Present on GetTopic; use
+    /// GetTopicEntries for the rest and GetMessage for a body.
+    entries: EntryList
 }
 
 list TopicList {
@@ -839,6 +843,9 @@ structure Recording {
 
     // CalendarJournalEntry fields
     content: String
+    /// Full rich-text HTML of a journal entry (GetJournalEntry / UpdateJournalEntry only;
+    /// listings carry a truncated plain-text `content` instead).
+    content_html: String
 
     // CalendarHabit fields
     color: String
@@ -1733,13 +1740,20 @@ structure GetJournalEntryOutput {
     recording: Recording
 }
 
-/// Update journal entry for a day
+/// Update the journal entry for a day: writes (or creates) it and answers the entry as a
+/// recording, or 204 when empty content removes it.
 @http(method: "PATCH", uri: "/calendar/days/{day}/journal_entry")
 @tags(["Calendar Journal"])
 @heyRetry(maxAttempts: 2, baseDelayMs: 1000, backoff: "exponential", retryOn: [429, 503])
 operation UpdateJournalEntry {
     input: UpdateJournalEntryInput
+    output: UpdateJournalEntryOutput
     errors: [UnauthorizedError, NotFoundError, UnprocessableEntityError, InternalServerError, ServiceUnavailableError]
+}
+
+structure UpdateJournalEntryOutput {
+    @required
+    recording: Recording
 }
 
 structure UpdateJournalEntryInput {

--- a/spec/shape-fingerprint.json
+++ b/spec/shape-fingerprint.json
@@ -41,6 +41,7 @@
   "UncompleteCalendarTodo": "2034f18325d4021bdf67313966275d25c100b11e77bcacfbcddfd3f2ab551783",
   "UncompleteHabit": "d6cbfd918a4f869bf812a29ebc40aeeb203fe88736c424701274b15c94041c43",
   "UpdateHabit": "abdae94f7cb43bfa8d8fc2db6ead534ae9911b6f73d71a5d9bb212d876802444",
+  "UpdateJournalEntry": "c28bc6186595cfc9bb61c3e90f3735fb90e50c81a78a60e45c08189713db9004",
   "UpdateSticky": "59bd8472ed21daeff7a1c0e91ba53dff8821810a7badd9d1d05cf0e3f8bac339",
   "UpdateTimeTrack": "eb9135887276c0f3262eb6b4c74c5f9a533499d66d9b10d5965f791850fc496b"
 }


### PR DESCRIPTION
SDK side of haystack#8624 (JSON for the CLI's read endpoints), which is now merged — this is what consumes those shapes.

- **`GetJournalEntry`** answers the entry as a recording with the full text and the rich-text HTML (`content_html`). `Journal.GetContent` reads that; the edit-page scraper (`extractTrixContent`) is deleted. A day with no entry → nil recording (HEY answers 204).
- **`UpdateJournalEntry`** answers the written entry (or 204 when empty content removes it). `Journal.Update` now returns `*Recording` and goes through the generated operation — it was the last hand-built request in the service layer, so **`check-service-drift` reports 83/83**.
- **`Topic`** gains `entries` (its first page, summaries only), which `GetTopic` now returns; `GetTopicEntries` and `ListContacts` were already modelled correctly and simply stop 406-ing once the server side lands.

Verified against a dev server running the haystack branch: journal write → read as HTML → missing day → removal, `Topics.Get` with entries, `Topics.GetEntries`. Tests updated (typed update returns the entry; 204 → nil; no `/edit` fetch); conformance asserts the journal PATCH's method and body. `make check` green.

For the CLI bump: `Journal().Update` now returns `(*Recording, error)`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Journal reads and writes now use the generated JSON API. Entries return as `Recording` with `content` and `content_html`; days without entries return 204 and map to a nil recording. `Topic` now includes its first page of `entries` (summaries).

**Migration**
- Callers of `Journal().Update` must handle `(*Recording, error)` and a nil recording when empty content removes the entry.
- Stop fetching `/edit`; use `Journal().GetContent` which reads `content_html` and returns an empty string when there is no entry.

**Review notes**
- Journal operations route through generated endpoints; `UpdateJournalEntry` 200 returns a JSON `Recording`. Specs add `recording.content_html` and `topic.entries`; conformance asserts PATCH and body.

<sup>Written for commit 7f46b510751c3aadf5ea5dfd9b3a7dbe766f0861. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-sdk/pull/76?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


