### PR TITLE
Add paginated Screener clearance operations

### DIFF
--- a/behavior-model.json
+++ b/behavior-model.json
@@ -811,6 +811,19 @@
         ]
       }
     },
+    "ListClearances": {
+      "idempotent": false,
+      "readonly": true,
+      "retry": {
+        "backoff": "exponential",
+        "base_delay_ms": 1000,
+        "max": 3,
+        "retry_on": [
+          429,
+          503
+        ]
+      }
+    },
     "ListClips": {
       "idempotent": false,
       "pagination": {
@@ -1227,6 +1240,19 @@
       }
     },
     "UnmutePostings": {
+      "idempotent": true,
+      "readonly": false,
+      "retry": {
+        "backoff": "exponential",
+        "base_delay_ms": 1000,
+        "max": 2,
+        "retry_on": [
+          429,
+          503
+        ]
+      }
+    },
+    "UpdateClearance": {
       "idempotent": true,
       "readonly": false,
       "retry": {

--- a/conformance/runner/go/main.go
+++ b/conformance/runner/go/main.go
@@ -209,12 +209,6 @@ func runTest(tc TestCase) TestResult {
 
 	// Create generated client pointing to mock server with auth header
 	client, err := generated.NewClient(server.URL,
-		generated.WithRetryConfig(generated.RetryConfig{
-			MaxRetries: 3,
-			BaseDelay:  1 * time.Second,
-			MaxDelay:   30 * time.Second,
-			Multiplier: 2.0,
-		}),
 		generated.WithRequestEditorFn(func(_ context.Context, req *http.Request) error {
 			req.Header.Set("Authorization", "Bearer conformance-test-token")
 			req.Header.Set("User-Agent", "hey-sdk-go/conformance")

--- a/conformance/runner/go/main.go
+++ b/conformance/runner/go/main.go
@@ -993,6 +993,17 @@ func executeOperation(client *generated.Client, ctx context.Context, tc TestCase
 		contactId := getInt64Param(tc.PathParams, "contactId")
 		return client.GetContact(ctx, contactId)
 
+	// Clearances
+	case "ListClearances":
+		return client.ListClearances(ctx)
+	case "UpdateClearance":
+		clearanceId := getInt64Param(tc.PathParams, "clearanceId")
+		values := url.Values{"status": {getStringParam(tc.RequestBody, "status")}}
+		if designationBoxID := getInt64Param(tc.RequestBody, "designation_box_id"); designationBoxID > 0 {
+			values.Set("designation_box_id", strconv.FormatInt(designationBoxID, 10))
+		}
+		return client.UpdateClearanceWithBody(ctx, clearanceId, "application/x-www-form-urlencoded", strings.NewReader(values.Encode()))
+
 	// Calendars
 	case "ListCalendars":
 		return client.ListCalendars(ctx)

--- a/conformance/tests/paths.json
+++ b/conformance/tests/paths.json
@@ -2474,6 +2474,76 @@
     ]
   },
   {
+    "name": "ListClearances uses /clearances path",
+    "description": "Verifies that ListClearances constructs the URL path /clearances",
+    "operation": "ListClearances",
+    "method": "GET",
+    "path": "/clearances",
+    "mockResponses": [
+      {
+        "status": 200,
+        "headers": {
+          "Content-Type": "text/html"
+        },
+        "body": "<html></html>"
+      }
+    ],
+    "assertions": [
+      {
+        "type": "requestPath",
+        "expected": "/clearances"
+      },
+      {
+        "type": "noError"
+      },
+      {
+        "type": "requestMethod",
+        "expected": "GET"
+      }
+    ],
+    "tags": [
+      "path",
+      "clearances"
+    ]
+  },
+  {
+    "name": "UpdateClearance uses /clearances/{clearanceId} path",
+    "description": "Verifies that UpdateClearance constructs the URL path /clearances/{clearanceId}",
+    "operation": "UpdateClearance",
+    "method": "PATCH",
+    "path": "/clearances/{clearanceId}",
+    "pathParams": {
+      "clearanceId": 789
+    },
+    "requestBody": {
+      "status": "approved",
+      "designation_box_id": 456
+    },
+    "mockResponses": [
+      {
+        "status": 204,
+        "body": null
+      }
+    ],
+    "assertions": [
+      {
+        "type": "requestPath",
+        "expected": "/clearances/789"
+      },
+      {
+        "type": "noError"
+      },
+      {
+        "type": "requestMethod",
+        "expected": "PATCH"
+      }
+    ],
+    "tags": [
+      "path",
+      "clearances"
+    ]
+  },
+  {
     "name": "CreateBoxDesignation uses /boxes/{boxId}/designations.json path",
     "description": "Verifies that CreateBoxDesignation constructs the URL path /boxes/{boxId}/designations.json",
     "operation": "CreateBoxDesignation",

--- a/conformance/tests/retry.json
+++ b/conformance/tests/retry.json
@@ -36,6 +36,43 @@
     "tags": ["retry", "429", "rate-limit"]
   },
   {
+    "name": "Operation retry policy limits UpdateClearance to two attempts",
+    "description": "Verifies that UpdateClearance follows its maxAttempts contract instead of the generated client's global default",
+    "operation": "UpdateClearance",
+    "method": "PATCH",
+    "path": "/clearances/{clearanceId}",
+    "pathParams": {"clearanceId": 12345},
+    "requestBody": {"status": "denied"},
+    "mockResponses": [
+      {"status": 503},
+      {"status": 503},
+      {"status": 204}
+    ],
+    "assertions": [
+      {"type": "requestCount", "expected": 2},
+      {"type": "statusCode", "expected": 503}
+    ],
+    "tags": ["retry", "operation-policy", "max-attempts"]
+  },
+  {
+    "name": "Operation retry policy excludes undeclared statuses",
+    "description": "Verifies that UpdateClearance does not retry a 500 response when its retryOn contract lists only 429 and 503",
+    "operation": "UpdateClearance",
+    "method": "PATCH",
+    "path": "/clearances/{clearanceId}",
+    "pathParams": {"clearanceId": 12345},
+    "requestBody": {"status": "denied"},
+    "mockResponses": [
+      {"status": 500},
+      {"status": 204}
+    ],
+    "assertions": [
+      {"type": "requestCount", "expected": 1},
+      {"type": "statusCode", "expected": 500}
+    ],
+    "tags": ["retry", "operation-policy", "retry-on"]
+  },
+  {
     "name": "POST operation does NOT retry (not idempotent)",
     "description": "Verifies that POST operations do NOT retry since they are not idempotent",
     "operation": "CreateMessage",

--- a/go/pkg/generated/client.gen.go
+++ b/go/pkg/generated/client.gen.go
@@ -1627,11 +1627,12 @@ type HttpRequestDoer interface {
 	Do(req *http.Request) (*http.Response, error)
 }
 
-// RetryConfig configures retry behavior for idempotent operations.
+// RetryConfig configures client-level retry overrides for idempotent operations.
+// Retryable status codes always come from each operation's API contract.
 type RetryConfig struct {
-	// MaxRetries is the maximum number of retry attempts (default: 3)
+	// MaxRetries overrides the operation's maximum attempts when explicitly configured.
 	MaxRetries int
-	// BaseDelay is the initial delay between retries (default: 1s)
+	// BaseDelay overrides the operation's initial delay when explicitly configured.
 	BaseDelay time.Duration
 	// MaxDelay is the maximum delay between retries (default: 30s)
 	MaxDelay time.Duration
@@ -1647,6 +1648,221 @@ func DefaultRetryConfig() RetryConfig {
 		MaxDelay:   30 * time.Second,
 		Multiplier: 2.0,
 	}
+}
+
+type retryPolicy struct {
+	MaxAttempts       int
+	BaseDelay         time.Duration
+	Backoff           string
+	RetryableStatuses []int
+}
+
+var operationRetryPolicies = map[string]retryPolicy{
+
+	"AdvancedSearch": {MaxAttempts: 3, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"GetAdvancedSearchFilters": {MaxAttempts: 3, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"ListBoxes": {MaxAttempts: 3, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"GetBox": {MaxAttempts: 3, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"CreateBoxDesignation": {MaxAttempts: 2, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"DeleteBoxDesignation": {MaxAttempts: 2, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"ListBoxGroups": {MaxAttempts: 3, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"CreateBoxGroup": {MaxAttempts: 2, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"DeleteBoxGroup": {MaxAttempts: 2, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"MarkBoxSeen": {MaxAttempts: 2, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"GetBoxPostingChanges": {MaxAttempts: 3, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"GetBubblebox": {MaxAttempts: 3, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"NewBulkReply": {MaxAttempts: 3, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"UncompleteHabit": {MaxAttempts: 3, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"CompleteHabit": {MaxAttempts: 3, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"GetJournalEntry": {MaxAttempts: 3, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"UpdateJournalEntry": {MaxAttempts: 2, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"CreateHabit": {MaxAttempts: 2, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"DeleteHabit": {MaxAttempts: 2, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"UpdateHabit": {MaxAttempts: 2, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"ResumeHabit": {MaxAttempts: 2, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"StopHabit": {MaxAttempts: 2, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"GetOngoingTimeTrack": {MaxAttempts: 3, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"StartTimeTrack": {MaxAttempts: 2, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"CreateTimeTrack": {MaxAttempts: 2, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"ListTimeTrackCategories": {MaxAttempts: 3, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"DeleteTimeTrack": {MaxAttempts: 2, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"UpdateTimeTrack": {MaxAttempts: 3, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"CreateCalendarTodo": {MaxAttempts: 2, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"DeleteCalendarTodo": {MaxAttempts: 3, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"UncompleteCalendarTodo": {MaxAttempts: 3, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"CompleteCalendarTodo": {MaxAttempts: 3, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"ListCalendars": {MaxAttempts: 3, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"GetCalendarRecordings": {MaxAttempts: 3, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"ListClearances": {MaxAttempts: 3, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"GetClearances": {MaxAttempts: 3, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"UpdateClearance": {MaxAttempts: 2, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"ListClips": {MaxAttempts: 3, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"ListCollections": {MaxAttempts: 3, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"UpdateCollection": {MaxAttempts: 2, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"ListContacts": {MaxAttempts: 3, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"CreateContact": {MaxAttempts: 2, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"HideContact": {MaxAttempts: 2, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"GetContact": {MaxAttempts: 3, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"UpdateContact": {MaxAttempts: 2, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"UnbundleContact": {MaxAttempts: 2, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"BundleContact": {MaxAttempts: 2, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"UpdateContactClearance": {MaxAttempts: 2, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"DeleteContactNote": {MaxAttempts: 2, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"GetContactNote": {MaxAttempts: 3, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"UpdateContactNote": {MaxAttempts: 2, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"RevealContact": {MaxAttempts: 2, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"ListDrafts": {MaxAttempts: 3, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"NewEntryForward": {MaxAttempts: 3, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"CreateReply": {MaxAttempts: 2, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"MarkEntrySpam": {MaxAttempts: 2, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"GetFeedbox": {MaxAttempts: 3, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"GetFolder": {MaxAttempts: 3, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"GetIdentity": {MaxAttempts: 3, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"GetImbox": {MaxAttempts: 3, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"CreateMessage": {MaxAttempts: 2, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"GetMessage": {MaxAttempts: 3, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"GetNavigation": {MaxAttempts: 3, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"GetTrailbox": {MaxAttempts: 3, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"RemovePostingsFromBoxGroup": {MaxAttempts: 2, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"AddPostingsToBoxGroup": {MaxAttempts: 2, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"CancelPostingsBubbleUp": {MaxAttempts: 2, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"BubbleUpPostingsNow": {MaxAttempts: 2, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"UnfilePostings": {MaxAttempts: 2, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"FilePostings": {MaxAttempts: 2, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"CreateFolderForPostings": {MaxAttempts: 2, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"MovePostings": {MaxAttempts: 2, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"UnmutePostings": {MaxAttempts: 2, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"MutePostings": {MaxAttempts: 2, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"MarkPostingsSeen": {MaxAttempts: 2, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"MarkPostingsSpam": {MaxAttempts: 2, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"TrashPostings": {MaxAttempts: 2, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"MarkPostingsUnseen": {MaxAttempts: 2, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"GetLaterbox": {MaxAttempts: 3, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"GetAsidebox": {MaxAttempts: 3, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"ListSnippets": {MaxAttempts: 3, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"ListStickies": {MaxAttempts: 3, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"CreateSticky": {MaxAttempts: 2, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"MoveSticky": {MaxAttempts: 2, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"DeleteSticky": {MaxAttempts: 2, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"UpdateSticky": {MaxAttempts: 2, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"GetEverythingTopics": {MaxAttempts: 3, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"GetSentTopics": {MaxAttempts: 3, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"GetSpamTopics": {MaxAttempts: 3, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"EmptySpam": {MaxAttempts: 2, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"GetTrashTopics": {MaxAttempts: 3, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"EmptyTrash": {MaxAttempts: 2, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"GetTopic": {MaxAttempts: 3, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"GetTopicEntries": {MaxAttempts: 3, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"MoveTopic": {MaxAttempts: 2, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"GetTopicPublication": {MaxAttempts: 3, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"RestoreTopic": {MaxAttempts: 2, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"MarkTopicHam": {MaxAttempts: 2, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"TrashTopic": {MaxAttempts: 2, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+
+	"GetWorkflow": {MaxAttempts: 3, BaseDelay: time.Duration(1000) * time.Millisecond, Backoff: "exponential", RetryableStatuses: []int{429, 503}},
+}
+
+type retryOverrides struct {
+	MaxRetries bool
+	BaseDelay  bool
 }
 
 // Client which conforms to the OpenAPI3 specification for this service.
@@ -1666,7 +1882,8 @@ type Client struct {
 	RequestEditors []RequestEditorFn
 
 	// RetryConfig for idempotent operations
-	RetryConfig RetryConfig
+	RetryConfig    RetryConfig
+	retryOverrides retryOverrides
 
 	// Logger for debug output (optional)
 	Logger *slog.Logger
@@ -1717,10 +1934,31 @@ func WithRequestEditorFn(fn RequestEditorFn) ClientOption {
 	}
 }
 
-// WithRetryConfig allows setting custom retry configuration for idempotent operations.
+// WithRetryConfig overrides operation-specific attempt and delay defaults.
+// Retryable status codes remain operation-defined.
 func WithRetryConfig(cfg RetryConfig) ClientOption {
 	return func(c *Client) error {
 		c.RetryConfig = cfg
+		c.retryOverrides.MaxRetries = true
+		c.retryOverrides.BaseDelay = true
+		return nil
+	}
+}
+
+// WithMaxRetries overrides the maximum retries for idempotent operations.
+func WithMaxRetries(maxRetries int) ClientOption {
+	return func(c *Client) error {
+		c.RetryConfig.MaxRetries = maxRetries
+		c.retryOverrides.MaxRetries = true
+		return nil
+	}
+}
+
+// WithBaseDelay overrides the initial delay for idempotent operations.
+func WithBaseDelay(baseDelay time.Duration) ClientOption {
+	return func(c *Client) error {
+		c.RetryConfig.BaseDelay = baseDelay
+		c.retryOverrides.BaseDelay = true
 		return nil
 	}
 }
@@ -1733,30 +1971,58 @@ func WithLogger(logger *slog.Logger) ClientOption {
 	}
 }
 
-// isRetryableStatus returns true if the HTTP status code indicates a retryable error.
-func isRetryableStatus(statusCode int) bool {
-	switch statusCode {
-	case http.StatusTooManyRequests, // 429
-		http.StatusInternalServerError, // 500
-		http.StatusBadGateway,          // 502
-		http.StatusServiceUnavailable,  // 503
-		http.StatusGatewayTimeout:      // 504
-		return true
-	default:
-		return false
+func (p retryPolicy) retriesStatus(statusCode int) bool {
+	for _, retryableStatus := range p.RetryableStatuses {
+		if statusCode == retryableStatus {
+			return true
+		}
 	}
+	return false
 }
 
-// doWithRetry executes a request with retry logic for idempotent operations.
+func (p retryPolicy) nextDelay(current, maxDelay time.Duration, multiplier float64) time.Duration {
+	switch p.Backoff {
+	case "constant":
+		current = p.BaseDelay
+	case "linear":
+		current += p.BaseDelay
+	default:
+		current = time.Duration(float64(current) * multiplier)
+	}
+	if current > maxDelay {
+		return maxDelay
+	}
+	return current
+}
+
+func (c *Client) retryPolicy(operationId string) retryPolicy {
+	policy, ok := operationRetryPolicies[operationId]
+	if !ok {
+		return retryPolicy{MaxAttempts: 1}
+	}
+	if c.retryOverrides.MaxRetries {
+		policy.MaxAttempts = c.RetryConfig.MaxRetries + 1
+	}
+	if c.retryOverrides.BaseDelay {
+		policy.BaseDelay = c.RetryConfig.BaseDelay
+	}
+	if policy.MaxAttempts < 1 {
+		policy.MaxAttempts = 1
+	}
+	return policy
+}
+
+// doWithRetry executes a request using the operation's declared retry policy.
 func (c *Client) doWithRetry(ctx context.Context, buildRequest func() (*http.Request, error), isIdempotent bool, operationId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	policy := c.retryPolicy(operationId)
 	maxAttempts := 1
 	if isIdempotent {
-		maxAttempts = c.RetryConfig.MaxRetries + 1
+		maxAttempts = policy.MaxAttempts
 	}
 
 	var lastResp *http.Response
 	var lastErr error
-	delay := c.RetryConfig.BaseDelay
+	delay := policy.BaseDelay
 
 	for attempt := 1; attempt <= maxAttempts; attempt++ {
 		req, err := buildRequest()
@@ -1785,17 +2051,14 @@ func (c *Client) doWithRetry(ctx context.Context, buildRequest func() (*http.Req
 					return nil, ctx.Err()
 				case <-time.After(delay + time.Duration(rand.Int63n(int64(100*time.Millisecond)))):
 				}
-				delay = time.Duration(float64(delay) * c.RetryConfig.Multiplier)
-				if delay > c.RetryConfig.MaxDelay {
-					delay = c.RetryConfig.MaxDelay
-				}
+				delay = policy.nextDelay(delay, c.RetryConfig.MaxDelay, c.RetryConfig.Multiplier)
 				continue
 			}
 			return nil, err
 		}
 
 		// Success or non-retryable status
-		if !isRetryableStatus(resp.StatusCode) {
+		if !policy.retriesStatus(resp.StatusCode) {
 			return resp, nil
 		}
 
@@ -1831,10 +2094,7 @@ func (c *Client) doWithRetry(ctx context.Context, buildRequest func() (*http.Req
 			return nil, ctx.Err()
 		case <-time.After(retryDelay + time.Duration(rand.Int63n(int64(100*time.Millisecond)))):
 		}
-		delay = time.Duration(float64(delay) * c.RetryConfig.Multiplier)
-		if delay > c.RetryConfig.MaxDelay {
-			delay = c.RetryConfig.MaxDelay
-		}
+		delay = policy.nextDelay(delay, c.RetryConfig.MaxDelay, c.RetryConfig.Multiplier)
 	}
 
 	if lastErr != nil {
@@ -2216,7 +2476,7 @@ type ClientInterface interface {
 	GetWorkflow(ctx context.Context, workflowId int64, reqEditors ...RequestEditorFn) (*http.Response, error)
 }
 
-// AdvancedSearch is marked as idempotent and will be retried on transient failures.
+// AdvancedSearch is marked as idempotent and follows its operation retry policy.
 
 func (c *Client) AdvancedSearch(ctx context.Context, params *AdvancedSearchParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 
@@ -2226,7 +2486,7 @@ func (c *Client) AdvancedSearch(ctx context.Context, params *AdvancedSearchParam
 
 }
 
-// GetAdvancedSearchFilters is marked as idempotent and will be retried on transient failures.
+// GetAdvancedSearchFilters is marked as idempotent and follows its operation retry policy.
 
 func (c *Client) GetAdvancedSearchFilters(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
 
@@ -2236,7 +2496,7 @@ func (c *Client) GetAdvancedSearchFilters(ctx context.Context, reqEditors ...Req
 
 }
 
-// ListBoxes is marked as idempotent and will be retried on transient failures.
+// ListBoxes is marked as idempotent and follows its operation retry policy.
 
 func (c *Client) ListBoxes(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
 
@@ -2246,7 +2506,7 @@ func (c *Client) ListBoxes(ctx context.Context, reqEditors ...RequestEditorFn) (
 
 }
 
-// GetBox is marked as idempotent and will be retried on transient failures.
+// GetBox is marked as idempotent and follows its operation retry policy.
 
 func (c *Client) GetBox(ctx context.Context, boxId int64, params *GetBoxParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 
@@ -2286,7 +2546,7 @@ func (c *Client) CreateBoxDesignation(ctx context.Context, boxId int64, body Cre
 
 }
 
-// DeleteBoxDesignation is marked as idempotent and will be retried on transient failures.
+// DeleteBoxDesignation is marked as idempotent and follows its operation retry policy.
 
 func (c *Client) DeleteBoxDesignation(ctx context.Context, boxId int64, designationId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
 
@@ -2296,7 +2556,7 @@ func (c *Client) DeleteBoxDesignation(ctx context.Context, boxId int64, designat
 
 }
 
-// ListBoxGroups is marked as idempotent and will be retried on transient failures.
+// ListBoxGroups is marked as idempotent and follows its operation retry policy.
 
 func (c *Client) ListBoxGroups(ctx context.Context, boxId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
 
@@ -2336,7 +2596,7 @@ func (c *Client) CreateBoxGroup(ctx context.Context, boxId int64, body CreateBox
 
 }
 
-// DeleteBoxGroup is marked as idempotent and will be retried on transient failures.
+// DeleteBoxGroup is marked as idempotent and follows its operation retry policy.
 
 func (c *Client) DeleteBoxGroup(ctx context.Context, boxId int64, groupId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
 
@@ -2362,7 +2622,7 @@ func (c *Client) MarkBoxSeen(ctx context.Context, boxId int64, reqEditors ...Req
 
 }
 
-// GetBoxPostingChanges is marked as idempotent and will be retried on transient failures.
+// GetBoxPostingChanges is marked as idempotent and follows its operation retry policy.
 
 func (c *Client) GetBoxPostingChanges(ctx context.Context, boxId int64, params *GetBoxPostingChangesParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 
@@ -2372,7 +2632,7 @@ func (c *Client) GetBoxPostingChanges(ctx context.Context, boxId int64, params *
 
 }
 
-// GetBubblebox is marked as idempotent and will be retried on transient failures.
+// GetBubblebox is marked as idempotent and follows its operation retry policy.
 
 func (c *Client) GetBubblebox(ctx context.Context, params *GetBubbleboxParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 
@@ -2412,7 +2672,7 @@ func (c *Client) CreateBulkReply(ctx context.Context, body CreateBulkReplyJSONRe
 
 }
 
-// NewBulkReply is marked as idempotent and will be retried on transient failures.
+// NewBulkReply is marked as idempotent and follows its operation retry policy.
 
 func (c *Client) NewBulkReply(ctx context.Context, params *NewBulkReplyParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 
@@ -2422,7 +2682,7 @@ func (c *Client) NewBulkReply(ctx context.Context, params *NewBulkReplyParams, r
 
 }
 
-// UncompleteHabit is marked as idempotent and will be retried on transient failures.
+// UncompleteHabit is marked as idempotent and follows its operation retry policy.
 
 func (c *Client) UncompleteHabit(ctx context.Context, day string, habitId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
 
@@ -2432,7 +2692,7 @@ func (c *Client) UncompleteHabit(ctx context.Context, day string, habitId int64,
 
 }
 
-// CompleteHabit is marked as idempotent and will be retried on transient failures.
+// CompleteHabit is marked as idempotent and follows its operation retry policy.
 
 func (c *Client) CompleteHabit(ctx context.Context, day string, habitId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
 
@@ -2442,7 +2702,7 @@ func (c *Client) CompleteHabit(ctx context.Context, day string, habitId int64, r
 
 }
 
-// GetJournalEntry is marked as idempotent and will be retried on transient failures.
+// GetJournalEntry is marked as idempotent and follows its operation retry policy.
 
 func (c *Client) GetJournalEntry(ctx context.Context, day string, reqEditors ...RequestEditorFn) (*http.Response, error) {
 
@@ -2512,7 +2772,7 @@ func (c *Client) CreateHabit(ctx context.Context, body CreateHabitJSONRequestBod
 
 }
 
-// DeleteHabit is marked as idempotent and will be retried on transient failures.
+// DeleteHabit is marked as idempotent and follows its operation retry policy.
 
 func (c *Client) DeleteHabit(ctx context.Context, habitId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
 
@@ -2552,7 +2812,7 @@ func (c *Client) UpdateHabit(ctx context.Context, habitId int64, body UpdateHabi
 
 }
 
-// ResumeHabit is marked as idempotent and will be retried on transient failures.
+// ResumeHabit is marked as idempotent and follows its operation retry policy.
 
 func (c *Client) ResumeHabit(ctx context.Context, habitId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
 
@@ -2578,7 +2838,7 @@ func (c *Client) StopHabit(ctx context.Context, habitId int64, reqEditors ...Req
 
 }
 
-// GetOngoingTimeTrack is marked as idempotent and will be retried on transient failures.
+// GetOngoingTimeTrack is marked as idempotent and follows its operation retry policy.
 
 func (c *Client) GetOngoingTimeTrack(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
 
@@ -2634,7 +2894,7 @@ func (c *Client) CreateTimeTrack(ctx context.Context, body CreateTimeTrackJSONRe
 
 }
 
-// ListTimeTrackCategories is marked as idempotent and will be retried on transient failures.
+// ListTimeTrackCategories is marked as idempotent and follows its operation retry policy.
 
 func (c *Client) ListTimeTrackCategories(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
 
@@ -2644,7 +2904,7 @@ func (c *Client) ListTimeTrackCategories(ctx context.Context, reqEditors ...Requ
 
 }
 
-// DeleteTimeTrack is marked as idempotent and will be retried on transient failures.
+// DeleteTimeTrack is marked as idempotent and follows its operation retry policy.
 
 func (c *Client) DeleteTimeTrack(ctx context.Context, timeTrackId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
 
@@ -2654,7 +2914,7 @@ func (c *Client) DeleteTimeTrack(ctx context.Context, timeTrackId int64, reqEdit
 
 }
 
-// UpdateTimeTrackWithBody is marked as idempotent and will be retried on transient failures.
+// UpdateTimeTrackWithBody is marked as idempotent and follows its operation retry policy.
 
 func (c *Client) UpdateTimeTrackWithBody(ctx context.Context, timeTrackId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
 
@@ -2710,7 +2970,7 @@ func (c *Client) CreateCalendarTodo(ctx context.Context, body CreateCalendarTodo
 
 }
 
-// DeleteCalendarTodo is marked as idempotent and will be retried on transient failures.
+// DeleteCalendarTodo is marked as idempotent and follows its operation retry policy.
 
 func (c *Client) DeleteCalendarTodo(ctx context.Context, todoId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
 
@@ -2720,7 +2980,7 @@ func (c *Client) DeleteCalendarTodo(ctx context.Context, todoId int64, reqEditor
 
 }
 
-// UncompleteCalendarTodo is marked as idempotent and will be retried on transient failures.
+// UncompleteCalendarTodo is marked as idempotent and follows its operation retry policy.
 
 func (c *Client) UncompleteCalendarTodo(ctx context.Context, todoId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
 
@@ -2730,7 +2990,7 @@ func (c *Client) UncompleteCalendarTodo(ctx context.Context, todoId int64, reqEd
 
 }
 
-// CompleteCalendarTodo is marked as idempotent and will be retried on transient failures.
+// CompleteCalendarTodo is marked as idempotent and follows its operation retry policy.
 
 func (c *Client) CompleteCalendarTodo(ctx context.Context, todoId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
 
@@ -2740,7 +3000,7 @@ func (c *Client) CompleteCalendarTodo(ctx context.Context, todoId int64, reqEdit
 
 }
 
-// ListCalendars is marked as idempotent and will be retried on transient failures.
+// ListCalendars is marked as idempotent and follows its operation retry policy.
 
 func (c *Client) ListCalendars(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
 
@@ -2750,7 +3010,7 @@ func (c *Client) ListCalendars(ctx context.Context, reqEditors ...RequestEditorF
 
 }
 
-// GetCalendarRecordings is marked as idempotent and will be retried on transient failures.
+// GetCalendarRecordings is marked as idempotent and follows its operation retry policy.
 
 func (c *Client) GetCalendarRecordings(ctx context.Context, calendarId int64, params *GetCalendarRecordingsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 
@@ -2760,7 +3020,7 @@ func (c *Client) GetCalendarRecordings(ctx context.Context, calendarId int64, pa
 
 }
 
-// ListClearances is marked as idempotent and will be retried on transient failures.
+// ListClearances is marked as idempotent and follows its operation retry policy.
 
 func (c *Client) ListClearances(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
 
@@ -2770,7 +3030,7 @@ func (c *Client) ListClearances(ctx context.Context, reqEditors ...RequestEditor
 
 }
 
-// GetClearances is marked as idempotent and will be retried on transient failures.
+// GetClearances is marked as idempotent and follows its operation retry policy.
 
 func (c *Client) GetClearances(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
 
@@ -2780,7 +3040,7 @@ func (c *Client) GetClearances(ctx context.Context, reqEditors ...RequestEditorF
 
 }
 
-// UpdateClearanceWithBody is marked as idempotent and will be retried on transient failures.
+// UpdateClearanceWithBody is marked as idempotent and follows its operation retry policy.
 
 func (c *Client) UpdateClearanceWithBody(ctx context.Context, clearanceId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
 
@@ -2806,7 +3066,7 @@ func (c *Client) UpdateClearanceWithFormdataBody(ctx context.Context, clearanceI
 
 }
 
-// ListClips is marked as idempotent and will be retried on transient failures.
+// ListClips is marked as idempotent and follows its operation retry policy.
 
 func (c *Client) ListClips(ctx context.Context, params *ListClipsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 
@@ -2816,7 +3076,7 @@ func (c *Client) ListClips(ctx context.Context, params *ListClipsParams, reqEdit
 
 }
 
-// ListCollections is marked as idempotent and will be retried on transient failures.
+// ListCollections is marked as idempotent and follows its operation retry policy.
 
 func (c *Client) ListCollections(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
 
@@ -2856,7 +3116,7 @@ func (c *Client) UpdateCollection(ctx context.Context, collectionId int64, body 
 
 }
 
-// ListContacts is marked as idempotent and will be retried on transient failures.
+// ListContacts is marked as idempotent and follows its operation retry policy.
 
 func (c *Client) ListContacts(ctx context.Context, params *ListContactsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 
@@ -2896,7 +3156,7 @@ func (c *Client) CreateContact(ctx context.Context, body CreateContactJSONReques
 
 }
 
-// HideContact is marked as idempotent and will be retried on transient failures.
+// HideContact is marked as idempotent and follows its operation retry policy.
 
 func (c *Client) HideContact(ctx context.Context, contactId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
 
@@ -2906,7 +3166,7 @@ func (c *Client) HideContact(ctx context.Context, contactId int64, reqEditors ..
 
 }
 
-// GetContact is marked as idempotent and will be retried on transient failures.
+// GetContact is marked as idempotent and follows its operation retry policy.
 
 func (c *Client) GetContact(ctx context.Context, contactId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
 
@@ -2946,7 +3206,7 @@ func (c *Client) UpdateContact(ctx context.Context, contactId int64, body Update
 
 }
 
-// UnbundleContact is marked as idempotent and will be retried on transient failures.
+// UnbundleContact is marked as idempotent and follows its operation retry policy.
 
 func (c *Client) UnbundleContact(ctx context.Context, contactId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
 
@@ -3002,7 +3262,7 @@ func (c *Client) UpdateContactClearance(ctx context.Context, contactId int64, bo
 
 }
 
-// DeleteContactNote is marked as idempotent and will be retried on transient failures.
+// DeleteContactNote is marked as idempotent and follows its operation retry policy.
 
 func (c *Client) DeleteContactNote(ctx context.Context, contactId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
 
@@ -3012,7 +3272,7 @@ func (c *Client) DeleteContactNote(ctx context.Context, contactId int64, reqEdit
 
 }
 
-// GetContactNote is marked as idempotent and will be retried on transient failures.
+// GetContactNote is marked as idempotent and follows its operation retry policy.
 
 func (c *Client) GetContactNote(ctx context.Context, contactId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
 
@@ -3068,7 +3328,7 @@ func (c *Client) RevealContact(ctx context.Context, contactId int64, reqEditors 
 
 }
 
-// ListDrafts is marked as idempotent and will be retried on transient failures.
+// ListDrafts is marked as idempotent and follows its operation retry policy.
 
 func (c *Client) ListDrafts(ctx context.Context, params *ListDraftsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 
@@ -3078,7 +3338,7 @@ func (c *Client) ListDrafts(ctx context.Context, params *ListDraftsParams, reqEd
 
 }
 
-// NewEntryForward is marked as idempotent and will be retried on transient failures.
+// NewEntryForward is marked as idempotent and follows its operation retry policy.
 
 func (c *Client) NewEntryForward(ctx context.Context, entryId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
 
@@ -3118,7 +3378,7 @@ func (c *Client) CreateReply(ctx context.Context, entryId int64, body CreateRepl
 
 }
 
-// MarkEntrySpam is marked as idempotent and will be retried on transient failures.
+// MarkEntrySpam is marked as idempotent and follows its operation retry policy.
 
 func (c *Client) MarkEntrySpam(ctx context.Context, entryId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
 
@@ -3128,7 +3388,7 @@ func (c *Client) MarkEntrySpam(ctx context.Context, entryId int64, reqEditors ..
 
 }
 
-// GetFeedbox is marked as idempotent and will be retried on transient failures.
+// GetFeedbox is marked as idempotent and follows its operation retry policy.
 
 func (c *Client) GetFeedbox(ctx context.Context, params *GetFeedboxParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 
@@ -3138,7 +3398,7 @@ func (c *Client) GetFeedbox(ctx context.Context, params *GetFeedboxParams, reqEd
 
 }
 
-// GetFolder is marked as idempotent and will be retried on transient failures.
+// GetFolder is marked as idempotent and follows its operation retry policy.
 
 func (c *Client) GetFolder(ctx context.Context, folderId int64, params *GetFolderParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 
@@ -3148,7 +3408,7 @@ func (c *Client) GetFolder(ctx context.Context, folderId int64, params *GetFolde
 
 }
 
-// GetIdentity is marked as idempotent and will be retried on transient failures.
+// GetIdentity is marked as idempotent and follows its operation retry policy.
 
 func (c *Client) GetIdentity(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
 
@@ -3158,7 +3418,7 @@ func (c *Client) GetIdentity(ctx context.Context, reqEditors ...RequestEditorFn)
 
 }
 
-// GetImbox is marked as idempotent and will be retried on transient failures.
+// GetImbox is marked as idempotent and follows its operation retry policy.
 
 func (c *Client) GetImbox(ctx context.Context, params *GetImboxParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 
@@ -3198,7 +3458,7 @@ func (c *Client) CreateMessage(ctx context.Context, body CreateMessageJSONReques
 
 }
 
-// GetMessage is marked as idempotent and will be retried on transient failures.
+// GetMessage is marked as idempotent and follows its operation retry policy.
 
 func (c *Client) GetMessage(ctx context.Context, messageId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
 
@@ -3208,7 +3468,7 @@ func (c *Client) GetMessage(ctx context.Context, messageId int64, reqEditors ...
 
 }
 
-// GetNavigation is marked as idempotent and will be retried on transient failures.
+// GetNavigation is marked as idempotent and follows its operation retry policy.
 
 func (c *Client) GetNavigation(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
 
@@ -3218,7 +3478,7 @@ func (c *Client) GetNavigation(ctx context.Context, reqEditors ...RequestEditorF
 
 }
 
-// GetTrailbox is marked as idempotent and will be retried on transient failures.
+// GetTrailbox is marked as idempotent and follows its operation retry policy.
 
 func (c *Client) GetTrailbox(ctx context.Context, params *GetTrailboxParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 
@@ -3228,7 +3488,7 @@ func (c *Client) GetTrailbox(ctx context.Context, params *GetTrailboxParams, req
 
 }
 
-// RemovePostingsFromBoxGroup is marked as idempotent and will be retried on transient failures.
+// RemovePostingsFromBoxGroup is marked as idempotent and follows its operation retry policy.
 
 func (c *Client) RemovePostingsFromBoxGroup(ctx context.Context, params *RemovePostingsFromBoxGroupParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 
@@ -3268,7 +3528,7 @@ func (c *Client) AddPostingsToBoxGroup(ctx context.Context, body AddPostingsToBo
 
 }
 
-// CancelPostingsBubbleUp is marked as idempotent and will be retried on transient failures.
+// CancelPostingsBubbleUp is marked as idempotent and follows its operation retry policy.
 
 func (c *Client) CancelPostingsBubbleUp(ctx context.Context, params *CancelPostingsBubbleUpParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 
@@ -3308,7 +3568,7 @@ func (c *Client) BubbleUpPostingsNow(ctx context.Context, body BubbleUpPostingsN
 
 }
 
-// UnfilePostings is marked as idempotent and will be retried on transient failures.
+// UnfilePostings is marked as idempotent and follows its operation retry policy.
 
 func (c *Client) UnfilePostings(ctx context.Context, params *UnfilePostingsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 
@@ -3408,7 +3668,7 @@ func (c *Client) MovePostings(ctx context.Context, body MovePostingsJSONRequestB
 
 }
 
-// UnmutePostings is marked as idempotent and will be retried on transient failures.
+// UnmutePostings is marked as idempotent and follows its operation retry policy.
 
 func (c *Client) UnmutePostings(ctx context.Context, params *UnmutePostingsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 
@@ -3598,7 +3858,7 @@ func (c *Client) CreateDirectUpload(ctx context.Context, body CreateDirectUpload
 
 }
 
-// GetLaterbox is marked as idempotent and will be retried on transient failures.
+// GetLaterbox is marked as idempotent and follows its operation retry policy.
 
 func (c *Client) GetLaterbox(ctx context.Context, params *GetLaterboxParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 
@@ -3608,7 +3868,7 @@ func (c *Client) GetLaterbox(ctx context.Context, params *GetLaterboxParams, req
 
 }
 
-// GetAsidebox is marked as idempotent and will be retried on transient failures.
+// GetAsidebox is marked as idempotent and follows its operation retry policy.
 
 func (c *Client) GetAsidebox(ctx context.Context, params *GetAsideboxParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 
@@ -3618,7 +3878,7 @@ func (c *Client) GetAsidebox(ctx context.Context, params *GetAsideboxParams, req
 
 }
 
-// ListSnippets is marked as idempotent and will be retried on transient failures.
+// ListSnippets is marked as idempotent and follows its operation retry policy.
 
 func (c *Client) ListSnippets(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
 
@@ -3628,7 +3888,7 @@ func (c *Client) ListSnippets(ctx context.Context, reqEditors ...RequestEditorFn
 
 }
 
-// ListStickies is marked as idempotent and will be retried on transient failures.
+// ListStickies is marked as idempotent and follows its operation retry policy.
 
 func (c *Client) ListStickies(ctx context.Context, params *ListStickiesParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 
@@ -3698,7 +3958,7 @@ func (c *Client) MoveSticky(ctx context.Context, body MoveStickyJSONRequestBody,
 
 }
 
-// DeleteSticky is marked as idempotent and will be retried on transient failures.
+// DeleteSticky is marked as idempotent and follows its operation retry policy.
 
 func (c *Client) DeleteSticky(ctx context.Context, stickyId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
 
@@ -3738,7 +3998,7 @@ func (c *Client) UpdateSticky(ctx context.Context, stickyId int64, body UpdateSt
 
 }
 
-// GetEverythingTopics is marked as idempotent and will be retried on transient failures.
+// GetEverythingTopics is marked as idempotent and follows its operation retry policy.
 
 func (c *Client) GetEverythingTopics(ctx context.Context, params *GetEverythingTopicsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 
@@ -3748,7 +4008,7 @@ func (c *Client) GetEverythingTopics(ctx context.Context, params *GetEverythingT
 
 }
 
-// GetSentTopics is marked as idempotent and will be retried on transient failures.
+// GetSentTopics is marked as idempotent and follows its operation retry policy.
 
 func (c *Client) GetSentTopics(ctx context.Context, params *GetSentTopicsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 
@@ -3758,7 +4018,7 @@ func (c *Client) GetSentTopics(ctx context.Context, params *GetSentTopicsParams,
 
 }
 
-// GetSpamTopics is marked as idempotent and will be retried on transient failures.
+// GetSpamTopics is marked as idempotent and follows its operation retry policy.
 
 func (c *Client) GetSpamTopics(ctx context.Context, params *GetSpamTopicsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 
@@ -3768,7 +4028,7 @@ func (c *Client) GetSpamTopics(ctx context.Context, params *GetSpamTopicsParams,
 
 }
 
-// EmptySpam is marked as idempotent and will be retried on transient failures.
+// EmptySpam is marked as idempotent and follows its operation retry policy.
 
 func (c *Client) EmptySpam(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
 
@@ -3778,7 +4038,7 @@ func (c *Client) EmptySpam(ctx context.Context, reqEditors ...RequestEditorFn) (
 
 }
 
-// GetTrashTopics is marked as idempotent and will be retried on transient failures.
+// GetTrashTopics is marked as idempotent and follows its operation retry policy.
 
 func (c *Client) GetTrashTopics(ctx context.Context, params *GetTrashTopicsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 
@@ -3788,7 +4048,7 @@ func (c *Client) GetTrashTopics(ctx context.Context, params *GetTrashTopicsParam
 
 }
 
-// EmptyTrash is marked as idempotent and will be retried on transient failures.
+// EmptyTrash is marked as idempotent and follows its operation retry policy.
 
 func (c *Client) EmptyTrash(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
 
@@ -3798,7 +4058,7 @@ func (c *Client) EmptyTrash(ctx context.Context, reqEditors ...RequestEditorFn) 
 
 }
 
-// GetTopic is marked as idempotent and will be retried on transient failures.
+// GetTopic is marked as idempotent and follows its operation retry policy.
 
 func (c *Client) GetTopic(ctx context.Context, topicId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
 
@@ -3808,7 +4068,7 @@ func (c *Client) GetTopic(ctx context.Context, topicId int64, reqEditors ...Requ
 
 }
 
-// GetTopicEntries is marked as idempotent and will be retried on transient failures.
+// GetTopicEntries is marked as idempotent and follows its operation retry policy.
 
 func (c *Client) GetTopicEntries(ctx context.Context, topicId int64, params *GetTopicEntriesParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 
@@ -3848,7 +4108,7 @@ func (c *Client) MoveTopic(ctx context.Context, topicId int64, body MoveTopicJSO
 
 }
 
-// GetTopicPublication is marked as idempotent and will be retried on transient failures.
+// GetTopicPublication is marked as idempotent and follows its operation retry policy.
 
 func (c *Client) GetTopicPublication(ctx context.Context, topicId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
 
@@ -3858,7 +4118,7 @@ func (c *Client) GetTopicPublication(ctx context.Context, topicId int64, reqEdit
 
 }
 
-// RestoreTopic is marked as idempotent and will be retried on transient failures.
+// RestoreTopic is marked as idempotent and follows its operation retry policy.
 
 func (c *Client) RestoreTopic(ctx context.Context, topicId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
 
@@ -3868,7 +4128,7 @@ func (c *Client) RestoreTopic(ctx context.Context, topicId int64, reqEditors ...
 
 }
 
-// MarkTopicHam is marked as idempotent and will be retried on transient failures.
+// MarkTopicHam is marked as idempotent and follows its operation retry policy.
 
 func (c *Client) MarkTopicHam(ctx context.Context, topicId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
 
@@ -3878,7 +4138,7 @@ func (c *Client) MarkTopicHam(ctx context.Context, topicId int64, reqEditors ...
 
 }
 
-// TrashTopic is marked as idempotent and will be retried on transient failures.
+// TrashTopic is marked as idempotent and follows its operation retry policy.
 
 func (c *Client) TrashTopic(ctx context.Context, topicId int64, params *TrashTopicParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 
@@ -3888,7 +4148,7 @@ func (c *Client) TrashTopic(ctx context.Context, topicId int64, params *TrashTop
 
 }
 
-// GetWorkflow is marked as idempotent and will be retried on transient failures.
+// GetWorkflow is marked as idempotent and follows its operation retry policy.
 
 func (c *Client) GetWorkflow(ctx context.Context, workflowId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
 

--- a/go/pkg/generated/client.gen.go
+++ b/go/pkg/generated/client.gen.go
@@ -737,6 +737,9 @@ type ListBoxesResponseContent = []Box
 // ListCalendarsResponseContent CalendarListPayload
 type ListCalendarsResponseContent = CalendarListPayload
 
+// ListClearancesOutputPayload defines model for ListClearancesOutputPayload.
+type ListClearancesOutputPayload = string
+
 // ListClipsResponseContent defines model for ListClipsResponseContent.
 type ListClipsResponseContent = []Clip
 
@@ -1244,6 +1247,9 @@ type UnprocessableEntityErrorResponseContent struct {
 	Message string   `json:"message,omitempty"`
 }
 
+// UpdateClearanceInputPayload defines model for UpdateClearanceInputPayload.
+type UpdateClearanceInputPayload = string
+
 // UpdateCollectionRequestContent Wire format: {collection: {name, summary}}
 type UpdateCollectionRequestContent struct {
 	Collection CollectionPayload `json:"collection"`
@@ -1541,6 +1547,9 @@ type UpdateTimeTrackJSONRequestBody = UpdateTimeTrackRequestContent
 
 // CreateCalendarTodoJSONRequestBody defines body for CreateCalendarTodo for application/json ContentType.
 type CreateCalendarTodoJSONRequestBody = CreateCalendarTodoRequestContent
+
+// UpdateClearanceFormdataRequestBody defines body for UpdateClearance for application/x-www-form-urlencoded ContentType.
+type UpdateClearanceFormdataRequestBody = UpdateClearanceInputPayload
 
 // UpdateCollectionJSONRequestBody defines body for UpdateCollection for application/json ContentType.
 type UpdateCollectionJSONRequestBody = UpdateCollectionRequestContent
@@ -1959,8 +1968,16 @@ type ClientInterface interface {
 	// GetCalendarRecordings request
 	GetCalendarRecordings(ctx context.Context, calendarId int64, params *GetCalendarRecordingsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// ListClearances request
+	ListClearances(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// GetClearances request
 	GetClearances(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UpdateClearanceWithBody request with any body
+	UpdateClearanceWithBody(ctx context.Context, clearanceId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	UpdateClearanceWithFormdataBody(ctx context.Context, clearanceId int64, body UpdateClearanceFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// ListClips request
 	ListClips(ctx context.Context, params *ListClipsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -2641,8 +2658,16 @@ func (c *Client) DeleteTimeTrack(ctx context.Context, timeTrackId int64, reqEdit
 
 func (c *Client) UpdateTimeTrackWithBody(ctx context.Context, timeTrackId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
 
+	var bodyBytes []byte
+	if body != nil {
+		var err error
+		bodyBytes, err = io.ReadAll(body)
+		if err != nil {
+			return nil, err
+		}
+	}
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
-		return NewUpdateTimeTrackRequestWithBody(c.Server, timeTrackId, contentType, body)
+		return NewUpdateTimeTrackRequestWithBody(c.Server, timeTrackId, contentType, bytes.NewReader(bodyBytes))
 	}, true, "UpdateTimeTrack", reqEditors...)
 
 }
@@ -2735,6 +2760,16 @@ func (c *Client) GetCalendarRecordings(ctx context.Context, calendarId int64, pa
 
 }
 
+// ListClearances is marked as idempotent and will be retried on transient failures.
+
+func (c *Client) ListClearances(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		return NewListClearancesRequest(c.Server)
+	}, true, "ListClearances", reqEditors...)
+
+}
+
 // GetClearances is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) GetClearances(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
@@ -2742,6 +2777,32 @@ func (c *Client) GetClearances(ctx context.Context, reqEditors ...RequestEditorF
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewGetClearancesRequest(c.Server)
 	}, true, "GetClearances", reqEditors...)
+
+}
+
+// UpdateClearanceWithBody is marked as idempotent and will be retried on transient failures.
+
+func (c *Client) UpdateClearanceWithBody(ctx context.Context, clearanceId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+
+	var bodyBytes []byte
+	if body != nil {
+		var err error
+		bodyBytes, err = io.ReadAll(body)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		return NewUpdateClearanceRequestWithBody(c.Server, clearanceId, contentType, bytes.NewReader(bodyBytes))
+	}, true, "UpdateClearance", reqEditors...)
+
+}
+
+func (c *Client) UpdateClearanceWithFormdataBody(ctx context.Context, clearanceId int64, body UpdateClearanceFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		return NewUpdateClearanceRequestWithFormdataBody(c.Server, clearanceId, body)
+	}, true, "UpdateClearance", reqEditors...)
 
 }
 
@@ -5461,6 +5522,33 @@ func NewGetCalendarRecordingsRequest(server string, calendarId int64, params *Ge
 	return req, nil
 }
 
+// NewListClearancesRequest generates requests for ListClearances
+func NewListClearancesRequest(server string) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/clearances")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewGetClearancesRequest generates requests for GetClearances
 func NewGetClearancesRequest(server string) (*http.Request, error) {
 	var err error
@@ -5484,6 +5572,53 @@ func NewGetClearancesRequest(server string) (*http.Request, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	return req, nil
+}
+
+// NewUpdateClearanceRequestWithFormdataBody calls the generic UpdateClearance builder with application/x-www-form-urlencoded body
+func NewUpdateClearanceRequestWithFormdataBody(server string, clearanceId int64, body UpdateClearanceFormdataRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	bodyStr, err := runtime.MarshalForm(body, nil)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = strings.NewReader(bodyStr.Encode())
+	return NewUpdateClearanceRequestWithBody(server, clearanceId, "application/x-www-form-urlencoded", bodyReader)
+}
+
+// NewUpdateClearanceRequestWithBody generates requests for UpdateClearance with any type of body
+func NewUpdateClearanceRequestWithBody(server string, clearanceId int64, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "clearanceId", runtime.ParamLocationPath, clearanceId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/clearances/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("PATCH", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
 
 	return req, nil
 }
@@ -8201,7 +8336,9 @@ var operationMetadata = map[string]OperationMetadata{
 	"CompleteCalendarTodo":       {Idempotent: true, HasSensitiveParams: false},
 	"ListCalendars":              {Idempotent: true, HasSensitiveParams: false},
 	"GetCalendarRecordings":      {Idempotent: true, HasSensitiveParams: false},
+	"ListClearances":             {Idempotent: true, HasSensitiveParams: false},
 	"GetClearances":              {Idempotent: true, HasSensitiveParams: false},
+	"UpdateClearance":            {Idempotent: true, HasSensitiveParams: false},
 	"ListClips":                  {Idempotent: true, HasSensitiveParams: false},
 	"ListCollections":            {Idempotent: true, HasSensitiveParams: false},
 	"UpdateCollection":           {Idempotent: false, HasSensitiveParams: false},
@@ -9208,12 +9345,33 @@ type ClientWithResponsesInterface interface {
 	// Returns a wrapper object for the known response body format(s).
 	GetCalendarRecordingsWithResponse(ctx context.Context, calendarId int64, params *GetCalendarRecordingsParams, reqEditors ...RequestEditorFn) (*GetCalendarRecordingsResponse, error)
 
+	// ListClearancesWithResponse performs a GET /clearances (the `ListClearances` operationId) request.
+	//
+	// List the senders waiting in the Screener. HEY serves this collection as HTML.
+	//
+	// Returns a wrapper object for the known response body format(s).
+	ListClearancesWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListClearancesResponse, error)
+
 	// GetClearancesWithResponse performs a GET /clearances.json (the `GetClearances` operationId) request.
 	//
 	// Get the screener summary — how many senders are waiting to be screened.
 	//
 	// Returns a wrapper object for the known response body format(s).
 	GetClearancesWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetClearancesResponse, error)
+
+	// UpdateClearanceWithBodyWithResponse performs a PATCH /clearances/{clearanceId} (the `UpdateClearance` operationId) request,
+	// with any type of body and a specified content type.
+	//
+	// Approve or deny a pending Screener clearance.
+	//
+	// Returns a wrapper object for the known response body format(s).
+	UpdateClearanceWithBodyWithResponse(ctx context.Context, clearanceId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateClearanceResponse, error)
+
+	// UpdateClearanceWithFormdataBodyWithResponse performs a PATCH /clearances/{clearanceId} (the `UpdateClearance` operationId) request.
+	// Takes a body of the `application/x-www-form-urlencoded` content type, and returns a wrapper object for the known response body format(s).
+	//
+	// Approve or deny a pending Screener clearance.
+	UpdateClearanceWithFormdataBodyWithResponse(ctx context.Context, clearanceId int64, body UpdateClearanceFormdataRequestBody, reqEditors ...RequestEditorFn) (*UpdateClearanceResponse, error)
 
 	// ListClipsWithResponse performs a GET /clips.json (the `ListClips` operationId) request.
 	//
@@ -12208,6 +12366,61 @@ func (r GetCalendarRecordingsResponse) ContentType() string {
 	return ""
 }
 
+type ListClearancesResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	// JSON401 the response for an HTTP 401 `application/json` response
+	JSON401 *UnauthorizedErrorResponseContent
+	// JSON500 the response for an HTTP 500 `application/json` response
+	JSON500 *InternalServerErrorResponseContent
+	// JSON503 the response for an HTTP 503 `application/json` response
+	JSON503 *ServiceUnavailableErrorResponseContent
+}
+
+// GetJSON401 returns the response for an HTTP 401 `application/json` response
+func (r ListClearancesResponse) GetJSON401() *UnauthorizedErrorResponseContent {
+	return r.JSON401
+}
+
+// GetJSON500 returns the response for an HTTP 500 `application/json` response
+func (r ListClearancesResponse) GetJSON500() *InternalServerErrorResponseContent {
+	return r.JSON500
+}
+
+// GetJSON503 returns the response for an HTTP 503 `application/json` response
+func (r ListClearancesResponse) GetJSON503() *ServiceUnavailableErrorResponseContent {
+	return r.JSON503
+}
+
+// GetBody returns the raw response body bytes
+func (r ListClearancesResponse) GetBody() []byte {
+	return r.Body
+}
+
+// Status returns HTTPResponse.Status
+func (r ListClearancesResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListClearancesResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r ListClearancesResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
 type GetClearancesResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -12264,6 +12477,75 @@ func (r GetClearancesResponse) StatusCode() int {
 
 // ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
 func (r GetClearancesResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type UpdateClearanceResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	// JSON401 the response for an HTTP 401 `application/json` response
+	JSON401 *UnauthorizedErrorResponseContent
+	// JSON404 the response for an HTTP 404 `application/json` response
+	JSON404 *NotFoundErrorResponseContent
+	// JSON422 the response for an HTTP 422 `application/json` response
+	JSON422 *UnprocessableEntityErrorResponseContent
+	// JSON500 the response for an HTTP 500 `application/json` response
+	JSON500 *InternalServerErrorResponseContent
+	// JSON503 the response for an HTTP 503 `application/json` response
+	JSON503 *ServiceUnavailableErrorResponseContent
+}
+
+// GetJSON401 returns the response for an HTTP 401 `application/json` response
+func (r UpdateClearanceResponse) GetJSON401() *UnauthorizedErrorResponseContent {
+	return r.JSON401
+}
+
+// GetJSON404 returns the response for an HTTP 404 `application/json` response
+func (r UpdateClearanceResponse) GetJSON404() *NotFoundErrorResponseContent {
+	return r.JSON404
+}
+
+// GetJSON422 returns the response for an HTTP 422 `application/json` response
+func (r UpdateClearanceResponse) GetJSON422() *UnprocessableEntityErrorResponseContent {
+	return r.JSON422
+}
+
+// GetJSON500 returns the response for an HTTP 500 `application/json` response
+func (r UpdateClearanceResponse) GetJSON500() *InternalServerErrorResponseContent {
+	return r.JSON500
+}
+
+// GetJSON503 returns the response for an HTTP 503 `application/json` response
+func (r UpdateClearanceResponse) GetJSON503() *ServiceUnavailableErrorResponseContent {
+	return r.JSON503
+}
+
+// GetBody returns the raw response body bytes
+func (r UpdateClearanceResponse) GetBody() []byte {
+	return r.Body
+}
+
+// Status returns HTTPResponse.Status
+func (r UpdateClearanceResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UpdateClearanceResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r UpdateClearanceResponse) ContentType() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Header.Get("Content-Type")
 	}
@@ -16993,6 +17275,19 @@ func (c *ClientWithResponses) GetCalendarRecordingsWithResponse(ctx context.Cont
 	return ParseGetCalendarRecordingsResponse(rsp)
 }
 
+// ListClearancesWithResponse performs a GET /clearances (the `ListClearances` operationId) request.
+//
+// List the senders waiting in the Screener. HEY serves this collection as HTML.
+//
+// Returns a wrapper object for the known response body format(s).
+func (c *ClientWithResponses) ListClearancesWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListClearancesResponse, error) {
+	rsp, err := c.ListClearances(ctx, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListClearancesResponse(rsp)
+}
+
 // GetClearancesWithResponse performs a GET /clearances.json (the `GetClearances` operationId) request.
 //
 // Get the screener summary — how many senders are waiting to be screened.
@@ -17004,6 +17299,32 @@ func (c *ClientWithResponses) GetClearancesWithResponse(ctx context.Context, req
 		return nil, err
 	}
 	return ParseGetClearancesResponse(rsp)
+}
+
+// UpdateClearanceWithBodyWithResponse performs a PATCH /clearances/{clearanceId} (the `UpdateClearance` operationId) request,
+// with any type of body and a specified content type.
+//
+// Approve or deny a pending Screener clearance.
+//
+// Returns a wrapper object for the known response body format(s).
+func (c *ClientWithResponses) UpdateClearanceWithBodyWithResponse(ctx context.Context, clearanceId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateClearanceResponse, error) {
+	rsp, err := c.UpdateClearanceWithBody(ctx, clearanceId, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateClearanceResponse(rsp)
+}
+
+// UpdateClearanceWithFormdataBodyWithResponse performs a PATCH /clearances/{clearanceId} (the `UpdateClearance` operationId) request.
+// Takes a body of the `application/x-www-form-urlencoded` content type, and returns a wrapper object for the known response body format(s).
+//
+// Approve or deny a pending Screener clearance.
+func (c *ClientWithResponses) UpdateClearanceWithFormdataBodyWithResponse(ctx context.Context, clearanceId int64, body UpdateClearanceFormdataRequestBody, reqEditors ...RequestEditorFn) (*UpdateClearanceResponse, error) {
+	rsp, err := c.UpdateClearanceWithFormdataBody(ctx, clearanceId, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateClearanceResponse(rsp)
 }
 
 // ListClipsWithResponse performs a GET /clips.json (the `ListClips` operationId) request.
@@ -20016,6 +20337,46 @@ func ParseGetCalendarRecordingsResponse(rsp *http.Response) (*GetCalendarRecordi
 	return response, nil
 }
 
+// ParseListClearancesResponse parses an HTTP response from a ListClearancesWithResponse call
+func ParseListClearancesResponse(rsp *http.Response) (*ListClearancesResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListClearancesResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest UnauthorizedErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalServerErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 503:
+		var dest ServiceUnavailableErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON503 = &dest
+
+	}
+
+	return response, nil
+}
+
 // ParseGetClearancesResponse parses an HTTP response from a GetClearancesWithResponse call
 func ParseGetClearancesResponse(rsp *http.Response) (*GetClearancesResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
@@ -20043,6 +20404,63 @@ func ParseGetClearancesResponse(rsp *http.Response) (*GetClearancesResponse, err
 			return nil, err
 		}
 		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalServerErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 503:
+		var dest ServiceUnavailableErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON503 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUpdateClearanceResponse parses an HTTP response from a UpdateClearanceWithResponse call
+func ParseUpdateClearanceResponse(rsp *http.Response) (*UpdateClearanceResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UpdateClearanceResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case rsp.StatusCode == 200:
+		break // No content-type
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest UnauthorizedErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFoundErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest UnprocessableEntityErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest InternalServerErrorResponseContent

--- a/go/pkg/hey/clearances.go
+++ b/go/pkg/hey/clearances.go
@@ -1,0 +1,298 @@
+package hey
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"golang.org/x/net/html"
+)
+
+// ClearancesService handles HEY Screener operations.
+type ClearancesService struct {
+	client *Client
+}
+
+// NewClearancesService creates a new ClearancesService.
+func NewClearancesService(client *Client) *ClearancesService {
+	return &ClearancesService{client: client}
+}
+
+// PendingClearance is an email sender awaiting a Screener decision.
+type PendingClearance struct {
+	ID           int64  `json:"id"`
+	EntryID      int64  `json:"entry_id,omitempty"`
+	TopicID      int64  `json:"topic_id,omitempty"`
+	Name         string `json:"name,omitempty"`
+	EmailAddress string `json:"email_address,omitempty"`
+	Subject      string `json:"subject,omitempty"`
+	FeedBoxID    int64  `json:"feed_box_id,omitempty"`
+	TrailBoxID   int64  `json:"trail_box_id,omitempty"`
+}
+
+// List returns all pending Screener clearances.
+func (s *ClearancesService) List(ctx context.Context) ([]PendingClearance, error) {
+	return s.ListWithLimit(ctx, 0)
+}
+
+// ListWithLimit returns pending Screener clearances up to limit. A zero limit
+// follows every cursor page.
+func (s *ClearancesService) ListWithLimit(ctx context.Context, limit int) (result []PendingClearance, err error) {
+	if limit < 0 {
+		return nil, fmt.Errorf("clearance limit must not be negative")
+	}
+	result = make([]PendingClearance, 0)
+
+	op := OperationInfo{
+		Service: "Clearances", Operation: "ListClearances",
+		ResourceType: "clearance", IsMutation: false,
+	}
+
+	err = s.client.instrument(ctx, op, func(ctx context.Context) error {
+		resp, rerr := s.client.genClient().ListClearancesWithResponse(contextWithAccept(ctx, "text/html"))
+		if rerr != nil {
+			return rerr
+		}
+		if rerr = CheckResponse(resp.HTTPResponse); rerr != nil {
+			return rerr
+		}
+		if resp.HTTPResponse == nil || resp.HTTPResponse.Request == nil || resp.HTTPResponse.Request.URL == nil {
+			return fmt.Errorf("cannot follow clearance pagination: response has no request URL")
+		}
+
+		currentURL := resp.HTTPResponse.Request.URL.String()
+		originURL := s.client.cfg.BaseURL
+		if !isSameOrigin(originURL, currentURL) {
+			return fmt.Errorf("clearance list redirected to different origin")
+		}
+		page, rerr := parseClearancesPageHTML(string(resp.Body))
+		if rerr != nil {
+			return rerr
+		}
+
+		seenPages := map[string]struct{}{currentURL: {}}
+		seenClearances := make(map[int64]struct{})
+		for pageNumber := 1; ; pageNumber++ {
+			for _, clearance := range page.Clearances {
+				if _, seen := seenClearances[clearance.ID]; seen {
+					continue
+				}
+				seenClearances[clearance.ID] = struct{}{}
+				result = append(result, clearance)
+				if limit > 0 && len(result) >= limit {
+					return nil
+				}
+			}
+
+			if page.NextPage == "" {
+				return nil
+			}
+			if pageNumber >= s.client.httpOpts.MaxPages {
+				return fmt.Errorf("clearance pagination exceeded max pages (%d)", s.client.httpOpts.MaxPages)
+			}
+
+			nextURL := resolveURL(currentURL, page.NextPage)
+			if !isSameOrigin(originURL, nextURL) {
+				return fmt.Errorf("clearance pagination link points to different origin")
+			}
+			if _, seen := seenPages[nextURL]; seen {
+				return fmt.Errorf("clearance pagination loop detected")
+			}
+			seenPages[nextURL] = struct{}{}
+
+			nextResponse, rerr := s.client.GetHTML(ctx, nextURL)
+			if rerr != nil {
+				return rerr
+			}
+			page, rerr = parseClearancesPageHTML(string(nextResponse.Data))
+			if rerr != nil {
+				return rerr
+			}
+			currentURL = nextURL
+		}
+	})
+	return result, err
+}
+
+// Approve screens a sender in. A zero designationBoxID uses the Imbox.
+func (s *ClearancesService) Approve(ctx context.Context, clearanceID, designationBoxID int64) error {
+	if designationBoxID < 0 {
+		return fmt.Errorf("designation box ID must not be negative")
+	}
+	return s.update(ctx, clearanceID, "approved", designationBoxID)
+}
+
+// Deny screens a sender out.
+func (s *ClearancesService) Deny(ctx context.Context, clearanceID int64) error {
+	return s.update(ctx, clearanceID, "denied", 0)
+}
+
+func (s *ClearancesService) update(ctx context.Context, clearanceID int64, status string, designationBoxID int64) error {
+	if clearanceID <= 0 {
+		return fmt.Errorf("clearance ID must be positive")
+	}
+
+	op := OperationInfo{
+		Service: "Clearances", Operation: "UpdateClearance",
+		ResourceType: "clearance", IsMutation: true, ResourceID: clearanceID,
+	}
+
+	return s.client.instrument(ctx, op, func(ctx context.Context) error {
+		values := url.Values{"status": {status}}
+		if designationBoxID > 0 {
+			values.Set("designation_box_id", strconv.FormatInt(designationBoxID, 10))
+		}
+
+		resp, err := s.client.genClient().UpdateClearanceWithBodyWithResponse(
+			contextWithAccept(ctx, "*/*"),
+			clearanceID,
+			"application/x-www-form-urlencoded",
+			strings.NewReader(values.Encode()),
+		)
+		if err != nil {
+			return err
+		}
+		if resp.HTTPResponse != nil && (resp.HTTPResponse.StatusCode == http.StatusFound || resp.HTTPResponse.StatusCode == http.StatusSeeOther) {
+			return nil
+		}
+		return CheckResponse(resp.HTTPResponse)
+	})
+}
+
+var clearanceIDPattern = regexp.MustCompile(`^clearance_(\d+)$`)
+var clearanceEntryPathPattern = regexp.MustCompile(`^/clearances/entries/(\d+)$`)
+
+type clearancesPage struct {
+	Clearances []PendingClearance
+	NextPage   string
+}
+
+func parseClearancesPageHTML(pageHTML string) (clearancesPage, error) {
+	doc, err := html.Parse(strings.NewReader(pageHTML))
+	if err != nil {
+		return clearancesPage{}, fmt.Errorf("parse clearances HTML: %w", err)
+	}
+
+	var page clearancesPage
+	var walk func(*html.Node)
+	walk = func(node *html.Node) {
+		if node.Type == html.ElementNode && node.Data == "article" && clearanceHasClass(node, "clearance") {
+			if clearance, ok := parseClearanceNode(node); ok {
+				page.Clearances = append(page.Clearances, clearance)
+			}
+			return
+		}
+		if node.Type == html.ElementNode && node.Data == "a" && clearanceHasClass(node, "pagination-link") {
+			if nextPage := clearanceNodeAttr(node, "href"); nextPage != "" {
+				page.NextPage = nextPage
+			}
+		}
+		for child := node.FirstChild; child != nil; child = child.NextSibling {
+			walk(child)
+		}
+	}
+	walk(doc)
+	return page, nil
+}
+
+func parseClearanceNode(node *html.Node) (PendingClearance, bool) {
+	match := clearanceIDPattern.FindStringSubmatch(clearanceNodeAttr(node, "id"))
+	if match == nil {
+		return PendingClearance{}, false
+	}
+	id, err := strconv.ParseInt(match[1], 10, 64)
+	if err != nil {
+		return PendingClearance{}, false
+	}
+
+	clearance := PendingClearance{ID: id}
+	var walk func(*html.Node)
+	walk = func(current *html.Node) {
+		if current.Type == html.ElementNode {
+			currentID := clearanceNodeAttr(current, "id")
+			switch {
+			case currentID == fmt.Sprintf("name_clearance_%d", id):
+				clearance.Name = clearanceNodeText(current)
+			case currentID == fmt.Sprintf("email_clearance_%d", id):
+				clearance.EmailAddress = clearanceNodeText(current)
+			case clearanceHasClass(current, "clearance__subject"):
+				clearance.Subject = clearanceNodeText(current)
+			case current.Data == "turbo-frame":
+				if entryMatch := clearanceEntryPathPattern.FindStringSubmatch(clearanceNodeAttr(current, "src")); entryMatch != nil {
+					clearance.EntryID, _ = strconv.ParseInt(entryMatch[1], 10, 64)
+				}
+			case current.Data == "input" && clearanceNodeAttr(current, "name") == "reply_to_topic_id":
+				clearance.TopicID, _ = strconv.ParseInt(clearanceNodeAttr(current, "value"), 10, 64)
+			case current.Data == "form":
+				target, boxID := clearanceDesignation(current)
+				switch target {
+				case "feedboxButton":
+					clearance.FeedBoxID = boxID
+				case "trailboxButton":
+					clearance.TrailBoxID = boxID
+				}
+			}
+		}
+		for child := current.FirstChild; child != nil; child = child.NextSibling {
+			walk(child)
+		}
+	}
+	walk(node)
+	return clearance, true
+}
+
+func clearanceDesignation(form *html.Node) (target string, boxID int64) {
+	var walk func(*html.Node)
+	walk = func(node *html.Node) {
+		if node.Type == html.ElementNode {
+			if value := clearanceNodeAttr(node, "data-clearances-target"); value != "" {
+				target = value
+			}
+			if node.Data == "input" && clearanceNodeAttr(node, "name") == "designation_box_id" {
+				boxID, _ = strconv.ParseInt(clearanceNodeAttr(node, "value"), 10, 64)
+			}
+		}
+		for child := node.FirstChild; child != nil; child = child.NextSibling {
+			walk(child)
+		}
+	}
+	walk(form)
+	return target, boxID
+}
+
+func clearanceHasClass(node *html.Node, class string) bool {
+	for _, candidate := range strings.Fields(clearanceNodeAttr(node, "class")) {
+		if candidate == class {
+			return true
+		}
+	}
+	return false
+}
+
+func clearanceNodeAttr(node *html.Node, key string) string {
+	for _, attr := range node.Attr {
+		if attr.Key == key {
+			return attr.Val
+		}
+	}
+	return ""
+}
+
+func clearanceNodeText(node *html.Node) string {
+	var builder strings.Builder
+	var walk func(*html.Node)
+	walk = func(current *html.Node) {
+		if current.Type == html.TextNode {
+			builder.WriteString(current.Data)
+		}
+		for child := current.FirstChild; child != nil; child = child.NextSibling {
+			walk(child)
+		}
+	}
+	walk(node)
+	return strings.Join(strings.Fields(builder.String()), " ")
+}

--- a/go/pkg/hey/clearances_test.go
+++ b/go/pkg/hey/clearances_test.go
@@ -350,7 +350,7 @@ func TestClearancesServiceUpdateAcceptsRedirect(t *testing.T) {
 	}
 }
 
-func TestClearancesServiceUpdateRetriesWithCompleteBody(t *testing.T) {
+func TestClearancesServiceUpdateExplicitRetryOverrideReplaysCompleteBody(t *testing.T) {
 	var requests atomic.Int64
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		request := requests.Add(1)
@@ -363,7 +363,7 @@ func TestClearancesServiceUpdateRetriesWithCompleteBody(t *testing.T) {
 		if got := r.PostForm.Get("designation_box_id"); got != "215744" {
 			t.Errorf("request %d designation_box_id = %q, want 215744", request, got)
 		}
-		if request == 1 {
+		if request < 3 {
 			w.WriteHeader(http.StatusServiceUnavailable)
 			return
 		}
@@ -374,15 +374,49 @@ func TestClearancesServiceUpdateRetriesWithCompleteBody(t *testing.T) {
 	client := NewClient(
 		&Config{BaseURL: server.URL},
 		&StaticTokenProvider{Token: "test-token"},
-		WithMaxRetries(1),
+		WithMaxRetries(2),
 		WithBaseDelay(time.Millisecond),
 		WithMaxJitter(time.Millisecond),
 	)
 	if err := client.Clearances().Approve(context.Background(), 123, 215744); err != nil {
 		t.Fatalf("Approve: %v", err)
 	}
-	if requests.Load() != 2 {
-		t.Fatalf("requests = %d, want 2", requests.Load())
+	if requests.Load() != 3 {
+		t.Fatalf("requests = %d, want 3", requests.Load())
+	}
+}
+
+func TestClearancesServiceUpdateUsesOperationRetryPolicy(t *testing.T) {
+	tests := []struct {
+		name         string
+		status       int
+		wantRequests int64
+	}{
+		{name: "declared status", status: http.StatusServiceUnavailable, wantRequests: 2},
+		{name: "undeclared status", status: http.StatusInternalServerError, wantRequests: 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var requests atomic.Int64
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				requests.Add(1)
+				w.WriteHeader(tt.status)
+			}))
+			t.Cleanup(server.Close)
+
+			client := NewClient(
+				&Config{BaseURL: server.URL},
+				&StaticTokenProvider{Token: "test-token"},
+				WithBaseDelay(time.Nanosecond),
+			)
+			if err := client.Clearances().Deny(context.Background(), 123); err == nil {
+				t.Fatal("Deny returned nil, want API error")
+			}
+			if got := requests.Load(); got != tt.wantRequests {
+				t.Fatalf("requests = %d, want %d", got, tt.wantRequests)
+			}
+		})
 	}
 }
 

--- a/go/pkg/hey/clearances_test.go
+++ b/go/pkg/hey/clearances_test.go
@@ -1,0 +1,416 @@
+package hey
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestClearancesServiceList(t *testing.T) {
+	var requests atomic.Int64
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %s, want GET", r.Method)
+		}
+		if r.URL.Path != "/clearances" {
+			t.Errorf("path = %s, want /clearances", r.URL.Path)
+		}
+		if got := r.Header.Get("Accept"); got != "text/html" {
+			t.Errorf("Accept = %q, want text/html", got)
+		}
+		w.Header().Set("Content-Type", "text/html")
+		if page := r.URL.Query().Get("page"); page != "" {
+			if page != "cursor-2" {
+				t.Errorf("page = %q, want cursor-2", page)
+			}
+			_, _ = w.Write([]byte(`<!doctype html>
+<html><body>
+  <article class="clearance" id="clearance_321">
+    <span id="email_clearance_321">second@example.com</span>
+  </article>
+  <article class="clearance" id="clearance_654">
+    <span id="name_clearance_654">Third Sender</span>
+    <span id="email_clearance_654">third@example.org</span>
+  </article>
+</body></html>`))
+			return
+		}
+		_, _ = w.Write([]byte(`<!doctype html>
+<html><body>
+  <span id="email_clearance_999">navigation@example.com</span>
+  <article class="card clearance pending" id="clearance_123">
+    <span id="name_clearance_123"> Acme &amp; Co. </span>
+    <span id="email_clearance_123">sender@example.com</span>
+    <span class="clearance__subject">  A useful   subject </span>
+    <turbo-frame src="/clearances/entries/456"></turbo-frame>
+    <input type="hidden" name="reply_to_topic_id" value="789">
+    <form action="/clearances/123" method="post">
+      <input type="hidden" name="designation_box_id" value="215744">
+      <button data-clearances-target="feedboxButton">Feed</button>
+    </form>
+    <form action="/clearances/123" method="post">
+      <input type="hidden" name="designation_box_id" value="215747">
+      <button data-clearances-target="trailboxButton">Paper Trail</button>
+    </form>
+  </article>
+  <article class="clearance" id="clearance_321">
+    <span id="name_clearance_321">Second Sender</span>
+    <span id="email_clearance_321">second@example.com</span>
+    <span class="clearance__subject">Second subject</span>
+  </article>
+  <article class="clearance" id="not-a-clearance"></article>
+  <a class="pagination-link" href="/clearances?page=cursor-2">Next</a>
+</body></html>`))
+	})
+
+	got, err := client.Clearances().List(context.Background())
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("len(List) = %d, want 3", len(got))
+	}
+
+	wantFirst := PendingClearance{
+		ID:           123,
+		EntryID:      456,
+		TopicID:      789,
+		Name:         "Acme & Co.",
+		EmailAddress: "sender@example.com",
+		Subject:      "A useful subject",
+		FeedBoxID:    215744,
+		TrailBoxID:   215747,
+	}
+	if got[0] != wantFirst {
+		t.Errorf("first clearance = %#v, want %#v", got[0], wantFirst)
+	}
+	if got[1].ID != 321 || got[1].EmailAddress != "second@example.com" {
+		t.Errorf("second clearance = %#v", got[1])
+	}
+	if got[1].FeedBoxID != 0 || got[1].TrailBoxID != 0 {
+		t.Errorf("second clearance destinations = (%d, %d), want zero values", got[1].FeedBoxID, got[1].TrailBoxID)
+	}
+	if got[2].ID != 654 || got[2].EmailAddress != "third@example.org" {
+		t.Errorf("third clearance = %#v", got[2])
+	}
+	if requests.Load() != 2 {
+		t.Errorf("requests = %d, want 2", requests.Load())
+	}
+}
+
+func TestClearancesServiceListWithLimit(t *testing.T) {
+	var requests atomic.Int64
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		if r.URL.Query().Get("page") != "" {
+			t.Error("limit should stop before requesting another page")
+		}
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte(`<html><body>
+  <article class="clearance" id="clearance_123"></article>
+  <article class="clearance" id="clearance_321"></article>
+  <a class="pagination-link" href="/clearances?page=cursor-2">Next</a>
+</body></html>`))
+	})
+
+	got, err := client.Clearances().ListWithLimit(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("ListWithLimit: %v", err)
+	}
+	if len(got) != 1 || got[0].ID != 123 {
+		t.Fatalf("ListWithLimit = %#v, want only clearance 123", got)
+	}
+	if requests.Load() != 1 {
+		t.Errorf("requests = %d, want 1", requests.Load())
+	}
+
+	if _, err := client.Clearances().ListWithLimit(context.Background(), -1); err == nil || !strings.Contains(err.Error(), "must not be negative") {
+		t.Fatalf("negative limit error = %v, want validation error", err)
+	}
+	if requests.Load() != 1 {
+		t.Errorf("requests after invalid limit = %d, want 1", requests.Load())
+	}
+}
+
+func TestClearancesServiceListReturnsEmptySlice(t *testing.T) {
+	client := newTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte(`<html><body></body></html>`))
+	})
+
+	got, err := client.Clearances().List(context.Background())
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if got == nil {
+		t.Fatal("List returned nil, want an empty slice")
+	}
+	if len(got) != 0 {
+		t.Fatalf("len(List) = %d, want 0", len(got))
+	}
+}
+
+func TestClearancesServiceRejectsCrossOriginPagination(t *testing.T) {
+	var requests atomic.Int64
+	client := newTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte(`<html><body>
+  <article class="clearance" id="clearance_123"></article>
+  <a class="pagination-link" href="https://files.example.org/clearances?page=cursor-2">Next</a>
+</body></html>`))
+	})
+
+	_, err := client.Clearances().List(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "different origin") {
+		t.Fatalf("List error = %v, want cross-origin pagination error", err)
+	}
+	if requests.Load() != 1 {
+		t.Errorf("requests = %d, want 1", requests.Load())
+	}
+}
+
+func TestClearancesServiceRejectsCrossOriginInitialRedirect(t *testing.T) {
+	var originRequests atomic.Int64
+	var foreignRequests atomic.Int64
+	var foreignAuthorization atomic.Value
+
+	foreign := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		foreignRequests.Add(1)
+		foreignAuthorization.Store(r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte(`<html><body>
+  <article class="clearance" id="clearance_123"></article>
+  <a class="pagination-link" href="/clearances?page=cursor-2">Next</a>
+</body></html>`))
+	}))
+	t.Cleanup(foreign.Close)
+
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		originRequests.Add(1)
+		w.Header().Set("Location", foreign.URL+"/clearances")
+		w.WriteHeader(http.StatusFound)
+	}))
+	t.Cleanup(origin.Close)
+
+	client := NewClient(
+		&Config{BaseURL: origin.URL},
+		&StaticTokenProvider{Token: "test-token"},
+		WithMaxRetries(0),
+	)
+	_, err := client.Clearances().List(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "redirected to different origin") {
+		t.Fatalf("List error = %v, want initial redirect rejection", err)
+	}
+	if originRequests.Load() != 1 || foreignRequests.Load() != 1 {
+		t.Fatalf("requests = origin %d, foreign %d; want 1 and 1", originRequests.Load(), foreignRequests.Load())
+	}
+	if got, _ := foreignAuthorization.Load().(string); got != "" {
+		t.Fatalf("foreign redirect received Authorization header %q", got)
+	}
+}
+
+func TestClearancesServiceRejectsPaginationLoop(t *testing.T) {
+	var requests atomic.Int64
+	client := newTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte(`<html><body>
+  <article class="clearance" id="clearance_123"></article>
+  <a class="pagination-link" href="/clearances">Next</a>
+</body></html>`))
+	})
+
+	_, err := client.Clearances().List(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "loop detected") {
+		t.Fatalf("List error = %v, want pagination loop error", err)
+	}
+	if requests.Load() != 1 {
+		t.Errorf("requests = %d, want 1", requests.Load())
+	}
+}
+
+func TestClearancesServiceHonorsMaxPages(t *testing.T) {
+	var requests atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		page := requests.Add(1)
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = fmt.Fprintf(w, `<html><body>
+  <article class="clearance" id="clearance_%d"></article>
+  <a class="pagination-link" href="/clearances?page=cursor-%d">Next</a>
+</body></html>`, page, page+1)
+	}))
+	t.Cleanup(server.Close)
+
+	client := NewClient(
+		&Config{BaseURL: server.URL},
+		&StaticTokenProvider{Token: "test-token"},
+		WithMaxPages(2),
+		WithMaxRetries(0),
+		WithBaseDelay(time.Millisecond),
+		WithMaxJitter(time.Millisecond),
+	)
+
+	_, err := client.Clearances().List(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "exceeded max pages (2)") {
+		t.Fatalf("List error = %v, want max-pages error", err)
+	}
+	if requests.Load() != 2 {
+		t.Errorf("requests = %d, want 2", requests.Load())
+	}
+}
+
+func TestClearancesServiceUpdates(t *testing.T) {
+	tests := []struct {
+		name            string
+		call            func(*ClearancesService) error
+		wantStatus      string
+		wantDesignation string
+	}{
+		{
+			name:       "approve to Imbox",
+			call:       func(service *ClearancesService) error { return service.Approve(context.Background(), 123, 0) },
+			wantStatus: "approved",
+		},
+		{
+			name:            "approve to a designation box",
+			call:            func(service *ClearancesService) error { return service.Approve(context.Background(), 123, 215744) },
+			wantStatus:      "approved",
+			wantDesignation: "215744",
+		},
+		{
+			name:       "deny",
+			call:       func(service *ClearancesService) error { return service.Deny(context.Background(), 123) },
+			wantStatus: "denied",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodPatch {
+					t.Errorf("method = %s, want PATCH", r.Method)
+				}
+				if r.URL.Path != "/clearances/123" {
+					t.Errorf("path = %s, want /clearances/123", r.URL.Path)
+				}
+				if got := r.Header.Get("Content-Type"); got != "application/x-www-form-urlencoded" {
+					t.Errorf("Content-Type = %q, want application/x-www-form-urlencoded", got)
+				}
+				if got := r.Header.Get("Accept"); got != "*/*" {
+					t.Errorf("Accept = %q, want */*", got)
+				}
+				if err := r.ParseForm(); err != nil {
+					t.Fatalf("ParseForm: %v", err)
+				}
+				if got := r.PostForm.Get("status"); got != tt.wantStatus {
+					t.Errorf("status = %q, want %q", got, tt.wantStatus)
+				}
+				if got := r.PostForm.Get("designation_box_id"); got != tt.wantDesignation {
+					t.Errorf("designation_box_id = %q, want %q", got, tt.wantDesignation)
+				}
+				w.WriteHeader(http.StatusNoContent)
+			})
+
+			if err := tt.call(client.Clearances()); err != nil {
+				t.Fatalf("update: %v", err)
+			}
+		})
+	}
+}
+
+func TestClearancesServiceUpdateAcceptsRedirect(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Location", "/clearances")
+		w.WriteHeader(http.StatusFound)
+	}))
+	t.Cleanup(server.Close)
+
+	httpClient := server.Client()
+	httpClient.CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+	client := NewClient(
+		&Config{BaseURL: server.URL},
+		&StaticTokenProvider{Token: "test-token"},
+		WithHTTPClient(httpClient),
+		WithMaxRetries(0),
+		WithBaseDelay(time.Millisecond),
+		WithMaxJitter(time.Millisecond),
+	)
+
+	if err := client.Clearances().Deny(context.Background(), 123); err != nil {
+		t.Fatalf("Deny: %v", err)
+	}
+}
+
+func TestClearancesServiceUpdateRetriesWithCompleteBody(t *testing.T) {
+	var requests atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		request := requests.Add(1)
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm: %v", err)
+		}
+		if got := r.PostForm.Get("status"); got != "approved" {
+			t.Errorf("request %d status = %q, want approved", request, got)
+		}
+		if got := r.PostForm.Get("designation_box_id"); got != "215744" {
+			t.Errorf("request %d designation_box_id = %q, want 215744", request, got)
+		}
+		if request == 1 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(server.Close)
+
+	client := NewClient(
+		&Config{BaseURL: server.URL},
+		&StaticTokenProvider{Token: "test-token"},
+		WithMaxRetries(1),
+		WithBaseDelay(time.Millisecond),
+		WithMaxJitter(time.Millisecond),
+	)
+	if err := client.Clearances().Approve(context.Background(), 123, 215744); err != nil {
+		t.Fatalf("Approve: %v", err)
+	}
+	if requests.Load() != 2 {
+		t.Fatalf("requests = %d, want 2", requests.Load())
+	}
+}
+
+func TestClearancesServiceRejectsInvalidIDsBeforeRequest(t *testing.T) {
+	var requests atomic.Int64
+	client := newTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	if err := client.Clearances().Deny(context.Background(), 0); err == nil || !strings.Contains(err.Error(), "positive") {
+		t.Fatalf("Deny(0) error = %v, want positive ID error", err)
+	}
+	if err := client.Clearances().Approve(context.Background(), 123, -1); err == nil || !strings.Contains(err.Error(), "negative") {
+		t.Fatalf("Approve(-1) error = %v, want negative box ID error", err)
+	}
+	if got := requests.Load(); got != 0 {
+		t.Fatalf("requests = %d, want 0", got)
+	}
+}
+
+func TestClientClearancesReturnsCachedService(t *testing.T) {
+	client := newTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	first := client.Clearances()
+	second := client.Clearances()
+	if first == nil || first != second {
+		t.Fatalf("Clearances service pointers = (%p, %p), want same non-nil service", first, second)
+	}
+}

--- a/go/pkg/hey/client.go
+++ b/go/pkg/hey/client.go
@@ -32,6 +32,8 @@ type clientShared struct {
 	logger         *slog.Logger
 	httpOpts       HTTPOptions
 	hooks          Hooks
+	maxRetriesSet  bool
+	baseDelaySet   bool
 }
 
 // Client is an HTTP client for the HEY API. A root client represents the
@@ -228,9 +230,6 @@ func NewClient(cfg *Config, tokenProvider TokenProvider, opts ...ClientOption) *
 func (c *Client) initGeneratedClient() {
 	c.genOnce.Do(func() {
 		serverURL := strings.TrimSuffix(c.cfg.BaseURL, "/")
-		retryConfig := generated.DefaultRetryConfig()
-		retryConfig.MaxRetries = c.httpOpts.MaxRetries
-		retryConfig.BaseDelay = c.httpOpts.BaseDelay
 		authEditor := func(ctx context.Context, req *http.Request) error {
 			accept := acceptFromContext(ctx)
 			if accept == "application/json" {
@@ -248,10 +247,17 @@ func (c *Client) initGeneratedClient() {
 			req.Header.Set("Accept", accept)
 			return nil
 		}
-		gen, err := generated.NewClientWithResponses(serverURL,
+		options := []generated.ClientOption{
 			generated.WithHTTPClient(c.httpClient),
-			generated.WithRetryConfig(retryConfig),
-			generated.WithRequestEditorFn(authEditor))
+			generated.WithRequestEditorFn(authEditor),
+		}
+		if c.maxRetriesSet {
+			options = append(options, generated.WithMaxRetries(c.httpOpts.MaxRetries))
+		}
+		if c.baseDelaySet {
+			options = append(options, generated.WithBaseDelay(c.httpOpts.BaseDelay))
+		}
+		gen, err := generated.NewClientWithResponses(serverURL, options...)
 		if err != nil {
 			panic(fmt.Sprintf("hey: failed to create generated client: %v", err))
 		}

--- a/go/pkg/hey/client.go
+++ b/go/pkg/hey/client.go
@@ -73,6 +73,7 @@ type Client struct {
 	entries        *EntriesService
 	bulkReplies    *BulkRepliesService
 	contacts       *ContactsService
+	clearances     *ClearancesService
 	calendars      *CalendarsService
 	calendarTodos  *CalendarTodosService
 	calendarEvents *CalendarEventsService
@@ -227,22 +228,29 @@ func NewClient(cfg *Config, tokenProvider TokenProvider, opts ...ClientOption) *
 func (c *Client) initGeneratedClient() {
 	c.genOnce.Do(func() {
 		serverURL := strings.TrimSuffix(c.cfg.BaseURL, "/")
+		retryConfig := generated.DefaultRetryConfig()
+		retryConfig.MaxRetries = c.httpOpts.MaxRetries
+		retryConfig.BaseDelay = c.httpOpts.BaseDelay
 		authEditor := func(ctx context.Context, req *http.Request) error {
-			req.URL.Path = withJSONExtension(req.URL.Path)
-			if req.URL.RawPath != "" {
-				req.URL.RawPath = withJSONExtension(req.URL.RawPath)
+			accept := acceptFromContext(ctx)
+			if accept == "application/json" {
+				req.URL.Path = withJSONExtension(req.URL.Path)
+				if req.URL.RawPath != "" {
+					req.URL.RawPath = withJSONExtension(req.URL.RawPath)
+				}
 			}
 			if err := c.prepareAPIRequest(ctx, req); err != nil {
 				return err
 			}
-			if req.Header.Get("Content-Type") == "" {
+			if req.Header.Get("Content-Type") == "" && accept == "application/json" {
 				req.Header.Set("Content-Type", "application/json")
 			}
-			req.Header.Set("Accept", "application/json")
+			req.Header.Set("Accept", accept)
 			return nil
 		}
 		gen, err := generated.NewClientWithResponses(serverURL,
 			generated.WithHTTPClient(c.httpClient),
+			generated.WithRetryConfig(retryConfig),
 			generated.WithRequestEditorFn(authEditor))
 		if err != nil {
 			panic(fmt.Sprintf("hey: failed to create generated client: %v", err))
@@ -948,6 +956,16 @@ func (c *Client) Contacts() *ContactsService {
 		c.contacts = NewContactsService(c)
 	}
 	return c.contacts
+}
+
+// Clearances returns the ClearancesService.
+func (c *Client) Clearances() *ClearancesService {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.clearances == nil {
+		c.clearances = NewClearancesService(c)
+	}
+	return c.clearances
 }
 
 // Calendars returns the CalendarsService.

--- a/go/pkg/hey/http.go
+++ b/go/pkg/hey/http.go
@@ -59,6 +59,7 @@ func WithTimeout(d time.Duration) ClientOption {
 func WithMaxRetries(n int) ClientOption {
 	return func(c *Client) {
 		c.httpOpts.MaxRetries = n
+		c.maxRetriesSet = true
 	}
 }
 
@@ -66,6 +67,7 @@ func WithMaxRetries(n int) ClientOption {
 func WithBaseDelay(d time.Duration) ClientOption {
 	return func(c *Client) {
 		c.httpOpts.BaseDelay = d
+		c.baseDelaySet = true
 	}
 }
 

--- a/go/pkg/hey/http.go
+++ b/go/pkg/hey/http.go
@@ -20,7 +20,7 @@ type HTTPOptions struct {
 	// Timeout is the request timeout (default: 30s).
 	Timeout time.Duration
 
-	// MaxRetries is the maximum retry attempts for GET requests (default: 3).
+	// MaxRetries is the maximum retry attempts for idempotent requests (default: 3).
 	MaxRetries int
 
 	// BaseDelay is the initial backoff delay (default: 1s).
@@ -55,7 +55,7 @@ func WithTimeout(d time.Duration) ClientOption {
 	}
 }
 
-// WithMaxRetries sets the maximum number of retry attempts for GET requests.
+// WithMaxRetries sets the maximum number of retry attempts for idempotent requests.
 func WithMaxRetries(n int) ClientOption {
 	return func(c *Client) {
 		c.httpOpts.MaxRetries = n

--- a/go/pkg/hey/url-routes.json
+++ b/go/pkg/hey/url-routes.json
@@ -316,11 +316,32 @@
     },
     {
       "pattern": "/clearances",
+      "resource": "Clearances",
+      "operations": {
+        "GET": "ListClearances"
+      },
+      "params": {}
+    },
+    {
+      "pattern": "/clearances",
       "resource": "Contacts",
       "operations": {
         "GET": "GetClearances"
       },
       "params": {}
+    },
+    {
+      "pattern": "/clearances/{clearanceId}",
+      "resource": "Clearances",
+      "operations": {
+        "PATCH": "UpdateClearance"
+      },
+      "params": {
+        "clearanceId": {
+          "role": "recording",
+          "type": "int64"
+        }
+      }
     },
     {
       "pattern": "/clips",

--- a/go/templates/client.tmpl
+++ b/go/templates/client.tmpl
@@ -267,8 +267,18 @@ type ClientInterface interface {
 {{end}}
 func (c *{{ $clientTypeName }}) {{$opid}}{{if .HasBody}}WithBody{{end}}(ctx context.Context{{genParamArgs $pathParams}}{{if $hasParams}}, params *{{$opid}}Params{{end}}{{if .HasBody}}, contentType string, body io.Reader{{end}}, reqEditors... RequestEditorFn) (*http.Response, error) {
 {{if $isIdempotent}}
+    {{if .HasBody -}}
+    var bodyBytes []byte
+    if body != nil {
+        var err error
+        bodyBytes, err = io.ReadAll(body)
+        if err != nil {
+            return nil, err
+        }
+    }
+    {{end -}}
     return c.doWithRetry(ctx, func() (*http.Request, error) {
-        return New{{$opid}}Request{{if .HasBody}}WithBody{{end}}(c.Server{{genParamNames .PathParams}}{{if $hasParams}}, params{{end}}{{if .HasBody}}, contentType, body{{end}})
+        return New{{$opid}}Request{{if .HasBody}}WithBody{{end}}(c.Server{{genParamNames .PathParams}}{{if $hasParams}}, params{{end}}{{if .HasBody}}, contentType, bytes.NewReader(bodyBytes){{end}})
     }, true, "{{$opid}}", reqEditors...)
 {{else}}
     req, err := New{{$opid}}Request{{if .HasBody}}WithBody{{end}}(c.Server{{genParamNames .PathParams}}{{if $hasParams}}, params{{end}}{{if .HasBody}}, contentType, body{{end}})

--- a/go/templates/client.tmpl
+++ b/go/templates/client.tmpl
@@ -10,11 +10,12 @@ type HttpRequestDoer interface {
 
 {{$clientTypeName := opts.OutputOptions.ClientTypeName -}}
 
-// RetryConfig configures retry behavior for idempotent operations.
+// RetryConfig configures client-level retry overrides for idempotent operations.
+// Retryable status codes always come from each operation's API contract.
 type RetryConfig struct {
-	// MaxRetries is the maximum number of retry attempts (default: 3)
+	// MaxRetries overrides the operation's maximum attempts when explicitly configured.
 	MaxRetries int
-	// BaseDelay is the initial delay between retries (default: 1s)
+	// BaseDelay overrides the operation's initial delay when explicitly configured.
 	BaseDelay time.Duration
 	// MaxDelay is the maximum delay between retries (default: 30s)
 	MaxDelay time.Duration
@@ -30,6 +31,32 @@ func DefaultRetryConfig() RetryConfig {
 		MaxDelay:   30 * time.Second,
 		Multiplier: 2.0,
 	}
+}
+
+type retryPolicy struct {
+	MaxAttempts       int
+	BaseDelay         time.Duration
+	Backoff           string
+	RetryableStatuses []int
+}
+
+var operationRetryPolicies = map[string]retryPolicy{
+{{range . -}}
+{{$opid := .OperationId -}}
+{{if .Spec -}}
+{{if .Spec.Extensions -}}
+{{$retry := index .Spec.Extensions "x-hey-retry" -}}
+{{if $retry}}
+	"{{$opid}}": {MaxAttempts: {{index $retry "maxAttempts"}}, BaseDelay: time.Duration({{index $retry "baseDelayMs"}}) * time.Millisecond, Backoff: {{printf "%q" (index $retry "backoff")}}, RetryableStatuses: []int{ {{range index $retry "retryOn"}}{{.}}, {{end}} }},
+{{end -}}
+{{end -}}
+{{end -}}
+{{end}}
+}
+
+type retryOverrides struct {
+	MaxRetries bool
+	BaseDelay  bool
 }
 
 // {{ $clientTypeName }} which conforms to the OpenAPI3 specification for this service.
@@ -50,6 +77,7 @@ type {{ $clientTypeName }} struct {
 
 	// RetryConfig for idempotent operations
 	RetryConfig RetryConfig
+	retryOverrides retryOverrides
 
 	// Logger for debug output (optional)
 	Logger *slog.Logger
@@ -100,10 +128,31 @@ func WithRequestEditorFn(fn RequestEditorFn) ClientOption {
 	}
 }
 
-// WithRetryConfig allows setting custom retry configuration for idempotent operations.
+// WithRetryConfig overrides operation-specific attempt and delay defaults.
+// Retryable status codes remain operation-defined.
 func WithRetryConfig(cfg RetryConfig) ClientOption {
 	return func(c *{{ $clientTypeName }}) error {
 		c.RetryConfig = cfg
+		c.retryOverrides.MaxRetries = true
+		c.retryOverrides.BaseDelay = true
+		return nil
+	}
+}
+
+// WithMaxRetries overrides the maximum retries for idempotent operations.
+func WithMaxRetries(maxRetries int) ClientOption {
+	return func(c *{{ $clientTypeName }}) error {
+		c.RetryConfig.MaxRetries = maxRetries
+		c.retryOverrides.MaxRetries = true
+		return nil
+	}
+}
+
+// WithBaseDelay overrides the initial delay for idempotent operations.
+func WithBaseDelay(baseDelay time.Duration) ClientOption {
+	return func(c *{{ $clientTypeName }}) error {
+		c.RetryConfig.BaseDelay = baseDelay
+		c.retryOverrides.BaseDelay = true
 		return nil
 	}
 }
@@ -116,30 +165,58 @@ func WithLogger(logger *slog.Logger) ClientOption {
 	}
 }
 
-// isRetryableStatus returns true if the HTTP status code indicates a retryable error.
-func isRetryableStatus(statusCode int) bool {
-	switch statusCode {
-	case http.StatusTooManyRequests,       // 429
-		http.StatusInternalServerError,     // 500
-		http.StatusBadGateway,              // 502
-		http.StatusServiceUnavailable,      // 503
-		http.StatusGatewayTimeout:          // 504
-		return true
-	default:
-		return false
+func (p retryPolicy) retriesStatus(statusCode int) bool {
+	for _, retryableStatus := range p.RetryableStatuses {
+		if statusCode == retryableStatus {
+			return true
+		}
 	}
+	return false
 }
 
-// doWithRetry executes a request with retry logic for idempotent operations.
+func (p retryPolicy) nextDelay(current, maxDelay time.Duration, multiplier float64) time.Duration {
+	switch p.Backoff {
+	case "constant":
+		current = p.BaseDelay
+	case "linear":
+		current += p.BaseDelay
+	default:
+		current = time.Duration(float64(current) * multiplier)
+	}
+	if current > maxDelay {
+		return maxDelay
+	}
+	return current
+}
+
+func (c *{{ $clientTypeName }}) retryPolicy(operationId string) retryPolicy {
+	policy, ok := operationRetryPolicies[operationId]
+	if !ok {
+		return retryPolicy{MaxAttempts: 1}
+	}
+	if c.retryOverrides.MaxRetries {
+		policy.MaxAttempts = c.RetryConfig.MaxRetries + 1
+	}
+	if c.retryOverrides.BaseDelay {
+		policy.BaseDelay = c.RetryConfig.BaseDelay
+	}
+	if policy.MaxAttempts < 1 {
+		policy.MaxAttempts = 1
+	}
+	return policy
+}
+
+// doWithRetry executes a request using the operation's declared retry policy.
 func (c *{{ $clientTypeName }}) doWithRetry(ctx context.Context, buildRequest func() (*http.Request, error), isIdempotent bool, operationId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	policy := c.retryPolicy(operationId)
 	maxAttempts := 1
 	if isIdempotent {
-		maxAttempts = c.RetryConfig.MaxRetries + 1
+		maxAttempts = policy.MaxAttempts
 	}
 
 	var lastResp *http.Response
 	var lastErr error
-	delay := c.RetryConfig.BaseDelay
+	delay := policy.BaseDelay
 
 	for attempt := 1; attempt <= maxAttempts; attempt++ {
 		req, err := buildRequest()
@@ -168,17 +245,14 @@ func (c *{{ $clientTypeName }}) doWithRetry(ctx context.Context, buildRequest fu
 					return nil, ctx.Err()
 				case <-time.After(delay + time.Duration(rand.Int63n(int64(100*time.Millisecond)))):
 				}
-				delay = time.Duration(float64(delay) * c.RetryConfig.Multiplier)
-				if delay > c.RetryConfig.MaxDelay {
-					delay = c.RetryConfig.MaxDelay
-				}
+				delay = policy.nextDelay(delay, c.RetryConfig.MaxDelay, c.RetryConfig.Multiplier)
 				continue
 			}
 			return nil, err
 		}
 
 		// Success or non-retryable status
-		if !isRetryableStatus(resp.StatusCode) {
+		if !policy.retriesStatus(resp.StatusCode) {
 			return resp, nil
 		}
 
@@ -214,10 +288,7 @@ func (c *{{ $clientTypeName }}) doWithRetry(ctx context.Context, buildRequest fu
 			return nil, ctx.Err()
 		case <-time.After(retryDelay + time.Duration(rand.Int63n(int64(100*time.Millisecond)))):
 		}
-		delay = time.Duration(float64(delay) * c.RetryConfig.Multiplier)
-		if delay > c.RetryConfig.MaxDelay {
-			delay = c.RetryConfig.MaxDelay
-		}
+		delay = policy.nextDelay(delay, c.RetryConfig.MaxDelay, c.RetryConfig.Multiplier)
 	}
 
 	if lastErr != nil {
@@ -261,7 +332,7 @@ type ClientInterface interface {
 {{end -}}
 
 {{if $isIdempotent}}
-// {{$opid}}{{if .HasBody}}WithBody{{end}} is marked as idempotent and will be retried on transient failures.
+// {{$opid}}{{if .HasBody}}WithBody{{end}} is marked as idempotent and follows its operation retry policy.
 {{else}}
 // {{$opid}}{{if .HasBody}}WithBody{{end}} executes the {{$opid}} operation.
 {{end}}

--- a/openapi.json
+++ b/openapi.json
@@ -2953,6 +2953,66 @@
         }
       }
     },
+    "/clearances": {
+      "get": {
+        "description": "List the senders waiting in the Screener. HEY serves this collection as HTML.",
+        "operationId": "ListClearances",
+        "responses": {
+          "200": {
+            "description": "ListClearances 200 response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListClearancesOutputPayload"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "UnauthorizedError 401 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedErrorResponseContent"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "InternalServerError 500 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerErrorResponseContent"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "ServiceUnavailableError 503 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceUnavailableErrorResponseContent"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Clearances"
+        ],
+        "x-hey-retry": {
+          "maxAttempts": 3,
+          "baseDelayMs": 1000,
+          "backoff": "exponential",
+          "retryOn": [
+            429,
+            503
+          ]
+        }
+      }
+    },
     "/clearances.json": {
       "get": {
         "description": "Get the screener summary — how many senders are waiting to be screened",
@@ -3004,6 +3064,103 @@
         ],
         "x-hey-retry": {
           "maxAttempts": 3,
+          "baseDelayMs": 1000,
+          "backoff": "exponential",
+          "retryOn": [
+            429,
+            503
+          ]
+        }
+      }
+    },
+    "/clearances/{clearanceId}": {
+      "patch": {
+        "description": "Approve or deny a pending Screener clearance.",
+        "operationId": "UpdateClearance",
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateClearanceInputPayload"
+              }
+            }
+          },
+          "required": true
+        },
+        "parameters": [
+          {
+            "name": "clearanceId",
+            "in": "path",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "UpdateClearance 200 response"
+          },
+          "401": {
+            "description": "UnauthorizedError 401 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedErrorResponseContent"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFoundError 404 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundErrorResponseContent"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "UnprocessableEntityError 422 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnprocessableEntityErrorResponseContent"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "InternalServerError 500 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerErrorResponseContent"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "ServiceUnavailableError 503 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceUnavailableErrorResponseContent"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Clearances"
+        ],
+        "x-hey-idempotent": {
+          "natural": true
+        },
+        "x-hey-retry": {
+          "maxAttempts": 2,
           "baseDelayMs": 1000,
           "backoff": "exponential",
           "retryOn": [
@@ -9602,6 +9759,9 @@
       "ListCalendarsResponseContent": {
         "$ref": "#/components/schemas/CalendarListPayload"
       },
+      "ListClearancesOutputPayload": {
+        "type": "string"
+      },
       "ListClipsResponseContent": {
         "type": "array",
         "items": {
@@ -10911,6 +11071,9 @@
             "type": "string"
           }
         }
+      },
+      "UpdateClearanceInputPayload": {
+        "type": "string"
       },
       "UpdateCollectionRequestContent": {
         "type": "object",

--- a/spec/excluded-routes.json
+++ b/spec/excluded-routes.json
@@ -2950,11 +2950,6 @@
     "reason": "phase-2: screener clearances"
   },
   {
-    "method": "PATCH",
-    "path": "/clearances/{id}",
-    "reason": "phase-2: screener clearances"
-  },
-  {
     "method": "PUT",
     "path": "/clearances/{id}",
     "reason": "phase-2: screener clearances"

--- a/spec/hey.smithy
+++ b/spec/hey.smithy
@@ -36,6 +36,7 @@ use smithy.api#httpQuery
 use smithy.api#httpPayload
 use smithy.api#required
 use smithy.api#readonly
+use smithy.api#mediaType
 use smithy.api#idempotent
 use smithy.api#error
 use smithy.api#httpError
@@ -183,6 +184,10 @@ service HEY {
 
         // Boxes — posting sync
         GetBoxPostingChanges
+
+        // Clearances — pending Screener senders
+        ListClearances
+        UpdateClearance
 
         // Boxes — designations, groups, observation
         CreateBoxDesignation
@@ -431,6 +436,12 @@ structure Clearance {
     id: Long
     status: String
 }
+
+@mediaType("text/html")
+string HTMLDocument
+
+@mediaType("application/x-www-form-urlencoded")
+string FormURLEncodedDocument
 
 /// Account — a HEY account
 structure Account {
@@ -2815,6 +2826,42 @@ operation GetClearances {
 structure GetClearancesOutput {
     @required
     summary: ClearanceSummary
+}
+
+/// List the senders waiting in the Screener. HEY serves this collection as HTML.
+@readonly
+@http(method: "GET", uri: "/clearances")
+@tags(["Clearances"])
+@heyRetry(maxAttempts: 3, baseDelayMs: 1000, backoff: "exponential", retryOn: [429, 503])
+operation ListClearances {
+    output: ListClearancesOutput
+    errors: [UnauthorizedError, InternalServerError, ServiceUnavailableError]
+}
+
+structure ListClearancesOutput {
+    @httpPayload
+    @required
+    body: HTMLDocument
+}
+
+/// Approve or deny a pending Screener clearance.
+@heyIdempotent(natural: true)
+@http(method: "PATCH", uri: "/clearances/{clearanceId}")
+@tags(["Clearances"])
+@heyRetry(maxAttempts: 2, baseDelayMs: 1000, backoff: "exponential", retryOn: [429, 503])
+operation UpdateClearance {
+    input: UpdateClearanceInput
+    errors: [UnauthorizedError, NotFoundError, UnprocessableEntityError, InternalServerError, ServiceUnavailableError]
+}
+
+structure UpdateClearanceInput {
+    @httpLabel
+    @required
+    clearanceId: Long
+
+    @httpPayload
+    @required
+    body: FormURLEncodedDocument
 }
 
 // =============================================================================

--- a/spec/route-coverage.json
+++ b/spec/route-coverage.json
@@ -301,6 +301,11 @@
   },
   {
     "method": "GET",
+    "operationId": "ListClearances",
+    "path": "/clearances"
+  },
+  {
+    "method": "GET",
     "operationId": "ListClips",
     "path": "/clips.json"
   },
@@ -458,6 +463,11 @@
     "method": "DELETE",
     "operationId": "UnmutePostings",
     "path": "/postings/mutings.json"
+  },
+  {
+    "method": "PATCH",
+    "operationId": "UpdateClearance",
+    "path": "/clearances/{clearanceId}"
   },
   {
     "method": "PATCH",


### PR DESCRIPTION
## What changed

Adds generated operations for the HTML Screener list and clearance updates, plus a `ClearancesService` with `List`, `ListWithLimit`, `Approve`, and `Deny`.

`List` follows HEY's server-provided cursor links until there are no pages left. It rejects cross-origin links, detects loops, honors the SDK page cap, and removes duplicate clearance IDs.

The existing `/clearances.json` summary operation is unchanged. Generated requests now honor the requested response type before adding `.json`, so HTML and form routes keep their real paths.

## Why

`/clearances.json` returns the pending count, not the pending senders. The HTML `/clearances` response contains the sender cards in batches of eight. Reading one response silently returns only the first batch.

## Validation

- `env GOWORK=off mise x -- make check`
- 129 of 129 conformance cases passed
- A read-only live check matched the summary count across 36 pages with no duplicate IDs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds paginated Screener clearance operations and honors per‑operation retry policies. Previously `/clearances` returned only the first 8 senders and retries followed a global default; now the SDK lists all pages and retries match each operation’s contract.

- Implements ListClearances (GET `/clearances`, HTML) and UpdateClearance (PATCH `/clearances/{clearanceId}`, form). List retries up to 3 on 429/503; Update retries up to 2 on 429/503 and treats 302/303 redirects as success.
- Adds `ClearancesService` with `List`, `ListWithLimit`, `Approve`, `Deny`. Follows server cursor links, rejects cross-origin links/redirects, detects loops, respects `MaxPages`, and de‑duplicates IDs.
- Generated client honors the request’s Accept header before appending `.json`; HTML and form routes keep their real paths. Idempotent requests with bodies now buffer payloads for reliable retries. Client-level `WithMaxRetries`/`WithBaseDelay` override an operation only when explicitly set; otherwise the operation’s policy applies.
- Conformance adds path and retry tests; spec and route coverage updated.

**Migration/usage**
- No breaking changes; `/clearances.json` summary is unchanged.
- Use `client.Clearances().List(ctx)` to fetch pending senders and `Approve`/`Deny` to act on them.
- Set `Accept: application/json` to use automatic `.json` path extension; leave unset for HTML/form routes. Use `WithMaxRetries`/`WithBaseDelay` only if you need to override an operation’s retry limits/delay.

<sup>Written for commit 0e779b10202977e9d4561b921fcfd8f77ee6b9ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-sdk/pull/77?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

