### PR TITLE
Stop the release tagging a version the workflow will reject

### DIFF
--- a/.github/workflows/release-go.yml
+++ b/.github/workflows/release-go.yml
@@ -55,9 +55,9 @@ jobs:
 
           # Verify version.go matches the tag
           VERSION="${GITHUB_REF#refs/tags/v}"
-          if ! grep -Fq "Version = \"${VERSION}\"" pkg/hey/version.go; then
+          if ! grep -Fxq "const Version = \"${VERSION}\"" pkg/hey/version.go; then
             echo "::error::version.go does not match tag v${VERSION}"
-            echo "Expected: Version = \"${VERSION}\""
+            echo "Expected: const Version = \"${VERSION}\""
             echo "Found:    $(grep 'Version =' pkg/hey/version.go)"
             exit 1
           fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -170,6 +170,14 @@ jobs:
             exit "$status"
           fi
           rm -f /tmp/apidiff.stderr
+
+          # A release bumps Version, and DefaultUserAgent is built from it. apidiff counts
+          # a constant's new value as an incompatible change, which for these two is the
+          # point of the release rather than a break -- and it is why version.go went
+          # unbumped from v0.1.1 through v0.3.0.
+          CHANGES=$(printf '%s\n' "$CHANGES" | grep -Ev '^- (Version|DefaultUserAgent): value changed' || true)
+          CHANGES=$(printf '%s' "$CHANGES" | sed '/^$/d')
+
           if [ -n "$CHANGES" ]; then
             echo "::error::Incompatible API changes detected"
             echo "$CHANGES"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,4 +31,21 @@ The full step-by-step, including how the drift gates work, is in [AGENTS.md](AGE
 
 ## Release Process
 
-Releases are managed via `make release VERSION=x.y.z`.
+Two steps, in this order.
+
+```bash
+make bump VERSION=0.4.0     # rewrites go/pkg/hey/version.go
+# commit that, open a PR, merge it
+make release VERSION=0.4.0  # runs the gate, then tags v0.4.0 and go/v0.4.0
+```
+
+The bump has to land on main *before* the tag, because the release workflow checks that
+`version.go` matches the tag it was pushed for and refuses to publish otherwise. `make
+release` now checks the same thing up front, so a forgotten bump fails locally in a second
+rather than on GitHub after the tags are already pushed.
+
+Both tags matter: `v0.4.0` triggers the release, and `go/v0.4.0` is what `go get
+github.com/basecamp/hey-sdk/go@v0.4.0` resolves, since the module lives in a subdirectory.
+
+`Version` is not decorative — it goes out on every request as part of the User-Agent
+(`hey-sdk-go/0.4.0 (api:...)`), which is how HEY sees SDK traffic.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,12 +40,13 @@ make release VERSION=0.4.0  # runs the gate, then tags v0.4.0 and go/v0.4.0
 ```
 
 The bump has to land on main *before* the tag, because the release workflow checks that
-`version.go` matches the tag it was pushed for and refuses to publish otherwise. `make
-release` now checks the same thing up front, so a forgotten bump fails locally in a second
-rather than on GitHub after the tags are already pushed.
+`version.go` matches the tag it was pushed for and refuses to publish otherwise.
+`make release` now checks the same thing up front, so a forgotten bump fails locally
+in a second rather than on GitHub after the tags are already pushed.
 
-Both tags matter: `v0.4.0` triggers the release, and `go/v0.4.0` is what `go get
-github.com/basecamp/hey-sdk/go@v0.4.0` resolves, since the module lives in a subdirectory.
+Both tags matter: `v0.4.0` triggers the release, and `go/v0.4.0` is what
+`go get github.com/basecamp/hey-sdk/go@v0.4.0` resolves, since the module lives in a
+subdirectory.
 
 `Version` is not decorative — it goes out on every request as part of the User-Agent
 (`hey-sdk-go/0.4.0 (api:...)`), which is how HEY sees SDK traffic.

--- a/Makefile
+++ b/Makefile
@@ -162,7 +162,7 @@ endif
 	@echo "Releasing v$(VERSION)..."
 	@git diff --quiet && git diff --cached --quiet || \
 		{ echo "ERROR: Working tree has uncommitted changes."; exit 1; }
-	@grep -Fq 'const Version = "$(VERSION)"' go/pkg/hey/version.go || \
+	@grep -Fxq 'const Version = "$(VERSION)"' go/pkg/hey/version.go || \
 		{ echo "ERROR: go/pkg/hey/version.go does not say $(VERSION):"; \
 		  grep 'const Version' go/pkg/hey/version.go; \
 		  echo "       The release workflow checks this, so the tag would fail to publish."; \

--- a/Makefile
+++ b/Makefile
@@ -162,6 +162,12 @@ endif
 	@echo "Releasing v$(VERSION)..."
 	@git diff --quiet && git diff --cached --quiet || \
 		{ echo "ERROR: Working tree has uncommitted changes."; exit 1; }
+	@grep -Fq 'const Version = "$(VERSION)"' go/pkg/hey/version.go || \
+		{ echo "ERROR: go/pkg/hey/version.go does not say $(VERSION):"; \
+		  grep 'const Version' go/pkg/hey/version.go; \
+		  echo "       The release workflow checks this, so the tag would fail to publish."; \
+		  echo "       Run: make bump VERSION=$(VERSION) — then commit and merge that first."; \
+		  exit 1; }
 	@$(MAKE) check-mvp
 	git tag "v$(VERSION)"
 	git tag "go/v$(VERSION)"

--- a/go/pkg/hey/version.go
+++ b/go/pkg/hey/version.go
@@ -1,7 +1,7 @@
 package hey
 
 // Version is the current version of the HEY Go SDK.
-const Version = "0.1.1"
+const Version = "0.3.0"
 
 // APIVersion is the HEY API version this SDK targets.
 const APIVersion = "2026-03-04"


### PR DESCRIPTION
`make release` tags and pushes without ever looking at `version.go`. The release workflow
then checks that `version.go` matches the tag, fails, and skips publishing — which is why
**v0.2.0 and v0.3.0 both have failed release runs and v0.3.0 has no GitHub release at
all**, while the repo's "Latest" still points at v0.2.0 and the CLI runs v0.3.0.

The tags themselves survived because `make release` creates `go/vX.Y.Z` itself, so
`go get` kept working and nobody noticed.

The constant has said `0.1.1` since March. It isn't decorative:

```go
const DefaultUserAgent = "hey-sdk-go/" + Version + " (api:" + APIVersion + ")"
```

so every request the CLI makes has been telling HEY it's `hey-sdk-go/0.1.1`.

- `make release` now refuses to tag unless `version.go` matches `VERSION`, printing the
  line it found and the command to fix it. It fails in a second, before the gate runs and
  before anything is pushed.
- `version.go` is corrected to `0.3.0` — what's actually released, and what hey-cli pins.
- CONTRIBUTING documents the real sequence: bump and merge, then tag.

Cutting v0.4.0 then becomes `make bump VERSION=0.4.0` → PR → merge → `make release
VERSION=0.4.0`, and the release workflow publishes for the first time since March.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops tagging releases the workflow will reject by validating `go/pkg/hey/version.go` before tagging and tightening the workflow check to match the exact version line. Old behavior: `make release` tagged without checking, the workflow skipped publishing, and `apidiff` flagged version bumps; requests reported `0.1.1`. New behavior: `make release` fails fast if the file does not contain `const Version = "X.Y.Z"`, the workflow enforces the same exact match, the API compatibility job ignores value-only changes for `Version` and `DefaultUserAgent`, `Version` is set to `0.3.0`, and the User-Agent now reports `0.3.0`.

- Required developer action: Before releasing X.Y.Z, run `make bump VERSION=X.Y.Z`, commit and merge to `main`, then run `make release VERSION=X.Y.Z`.

<sup>Written for commit 8524e83ee04cbfaa3cb2e2362c01cc974993ea67. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-sdk/pull/81?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

