### PR TITLE
Bump the SDK to 0.4.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -171,11 +171,12 @@ jobs:
           fi
           rm -f /tmp/apidiff.stderr
 
-          # A release bumps Version, and DefaultUserAgent is built from it. apidiff counts
-          # a constant's new value as an incompatible change, which for these two is the
+          # A release bumps Version, APIVersion moves when the spec is rebuilt against a
+          # newer HEY, and DefaultUserAgent is built from both. apidiff counts a
+          # constant's new value as an incompatible change, which for these three is the
           # point of the release rather than a break -- and it is why version.go went
           # unbumped from v0.1.1 through v0.3.0.
-          CHANGES=$(printf '%s\n' "$CHANGES" | grep -Ev '^- (Version|DefaultUserAgent): value changed' || true)
+          CHANGES=$(printf '%s\n' "$CHANGES" | grep -Ev '^- (Version|APIVersion|DefaultUserAgent): value changed' || true)
           CHANGES=$(printf '%s' "$CHANGES" | sed '/^$/d')
 
           if [ -n "$CHANGES" ]; then

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,6 @@ The snapshot comes from a haystack checkout: `make drift-regen HAYSTACK_DIR=…`
 
 Move the service's `version` in `spec/hey.smithy` to that same date when the snapshot
 moves, and run `./scripts/sync-api-version.sh` so `APIVersion` follows. It is the date of
-the API the SDK was built against, and it goes out in the User-Agent
-(`hey-sdk-go/0.4.0 (api:2026-08-18)`) — that string is how HEY sees which contract a
-client is working from, so a stale date misreports it.
+the API the SDK was built against, and it goes out in the User-Agent alongside the SDK's
+own version — that string is how HEY sees which contract a client is working from, so a
+stale date misreports it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,3 +67,9 @@ forgetting to regenerate coverage, fails the gate.
 The snapshot comes from a haystack checkout: `make drift-regen HAYSTACK_DIR=…` then
 `./scripts/sync-provenance HAYSTACK_DIR` to record the pinned SHA in
 `spec/api-provenance.json`.
+
+Move the service's `version` in `spec/hey.smithy` to that same date when the snapshot
+moves, and run `./scripts/sync-api-version.sh` so `APIVersion` follows. It is the date of
+the API the SDK was built against, and it goes out in the User-Agent
+(`hey-sdk-go/0.4.0 (api:2026-08-18)`) — that string is how HEY sees which contract a
+client is working from, so a stale date misreports it.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,19 +34,20 @@ The full step-by-step, including how the drift gates work, is in [AGENTS.md](AGE
 Two steps, in this order.
 
 ```bash
-make bump VERSION=0.4.0     # rewrites go/pkg/hey/version.go
+make bump VERSION=x.y.z     # rewrites go/pkg/hey/version.go
 # commit that, open a PR, merge it
-make release VERSION=0.4.0  # runs the gate, then tags v0.4.0 and go/v0.4.0
+make release VERSION=x.y.z  # runs the gate, then tags vx.y.z and go/vx.y.z
 ```
 
 The bump has to land on main *before* the tag, because the release workflow checks that
 `version.go` matches the tag it was pushed for and refuses to publish otherwise.
-`make release` now checks the same thing up front, so a forgotten bump fails locally
-in a second rather than on GitHub after the tags are already pushed.
+`make release` checks the same thing up front, so a forgotten bump fails locally in a
+second rather than on GitHub after the tags are already pushed.
 
-Both tags matter: `v0.4.0` triggers the release, and `go/v0.4.0` is what
-`go get github.com/basecamp/hey-sdk/go@v0.4.0` resolves, since the module lives in a
+Both tags matter: the plain one triggers the release, and the `go/` one is what
+`go get github.com/basecamp/hey-sdk/go` resolves, since the module lives in a
 subdirectory.
 
-`Version` is not decorative — it goes out on every request as part of the User-Agent
-(`hey-sdk-go/0.4.0 (api:...)`), which is how HEY sees SDK traffic.
+`Version` is not decorative — it goes out on every request as part of the User-Agent,
+alongside `APIVersion`, which is how HEY sees which SDK and which contract a client is
+working from.

--- a/go/pkg/hey/version.go
+++ b/go/pkg/hey/version.go
@@ -4,4 +4,4 @@ package hey
 const Version = "0.4.0"
 
 // APIVersion is the HEY API version this SDK targets.
-const APIVersion = "2026-03-04"
+const APIVersion = "2026-08-18"

--- a/go/pkg/hey/version.go
+++ b/go/pkg/hey/version.go
@@ -1,7 +1,7 @@
 package hey
 
 // Version is the current version of the HEY Go SDK.
-const Version = "0.3.0"
+const Version = "0.4.0"
 
 // APIVersion is the HEY API version this SDK targets.
 const APIVersion = "2026-03-04"

--- a/openapi.json
+++ b/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "HEY",
-    "version": "2026-03-04",
+    "version": "2026-08-18",
     "description": "HEY API",
     "contact": {
       "name": "Basecamp",

--- a/spec/api-provenance.json
+++ b/spec/api-provenance.json
@@ -1,6 +1,6 @@
 {
   "source": "haystack",
-  "sha": "1440996500e460cda597ff64e6c4b1fa282f68b1",
+  "sha": "719c22b23b0fcd15d39d3fc01af9671e06ee116e",
   "date": "2026-08-18",
   "notes": "Pinned from haystack master. Update with: make provenance-sync"
 }

--- a/spec/hey.smithy
+++ b/spec/hey.smithy
@@ -59,7 +59,7 @@ timestamp DateTime
 /// HEY API
 @restJson1
 service HEY {
-    version: "2026-03-04"
+    version: "2026-08-18"
     operations: [
         // Identity (2 MVP)
         GetIdentity


### PR DESCRIPTION
The bump that has to land before `make release VERSION=0.4.0` — the release workflow
checks `version.go` against the tag, and #81 made `make release` check it too.

This is also the first PR to exercise that fix: bumping `Version` changes
`DefaultUserAgent` with it, which `apidiff` reports as an incompatible change and which
used to fail the API Compatibility job. That's why the constant sat at 0.1.1 through two
releases.

**What v0.4.0 contains**, everything merged since v0.3.0 in April:

- **The journal, contacts and bulk reply go through the API.** Reading a journal entry,
  writing one, creating and editing contacts, their notes, and replying to many threads at
  once are all typed operations now.
- **The last six scraped reads are gone** — advanced search, clips, snippets, time track
  categories, workflows and topic publications. No service calls `GetHTML` any more.
- **98 of 98 operations wrapped**, with the drift gates keeping it that way.
- Behaviour fixes from the #64 review: bulk postings, reply-in-thread, `Contacts.Update`
  merging rather than replacing, `TimeTracks.Start` taking no body, optional dates and
  objects as pointers.
- An accurate README, and a release process that publishes.

For hey-cli, which pins v0.3.0: `apidiff` reports ten incompatible changes, touching nine
call sites across four files — `Journal().Update`'s return, `CreateTopicMessage` and
`Postings().Ignore` removed, the five `MoveTo*` calls now variadic, and
`TimeTracks().Start` losing its body argument. Everything else is additive.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps the HEY Go SDK to v0.4.0 and aligns the targeted API date to 2026-08-18 so `version.go`, the Smithy/OpenAPI specs, and the release pipeline agree. The HTTP `DefaultUserAgent` now includes both `Version` (0.4.0) and `APIVersion` (2026-08-18); the API compatibility job ignores value-only changes to `Version`, `APIVersion`, and `DefaultUserAgent`.

**Highlights in v0.4.0**
- Journal, contacts, and bulk reply use typed API operations; no `GetHTML` calls remain.
- 98/98 operations wrapped; drift gates keep coverage intact.
- Behavior fixes: bulk postings, reply-in-thread, `Contacts.Update` merges fields, `TimeTracks().Start` takes no body; optional dates/objects are pointers.
- Docs avoid hard-coded versions and API dates; `APIVersion` mirrors the service version from provenance and is included in the User-Agent.

**Migration notes**
- Update calls: `TimeTracks().Start()` now has no body argument.
- Use variadic thread IDs for `MoveTo*` methods.
- Remove `CreateTopicMessage` and `Postings().Ignore`.
- Handle the updated return type for `Journal().Update`.

<sup>Written for commit d7eeb0e25748838817bfa657e286ca1d321472e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-sdk/pull/82?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

