### PR TITLE
Add attachment uploads and binary downloads

### DIFF
--- a/behavior-model.json
+++ b/behavior-model.json
@@ -155,6 +155,13 @@
         ]
       }
     },
+    "CreateDirectUpload": {
+      "idempotent": false,
+      "readonly": false,
+      "retry": {
+        "max": 0
+      }
+    },
     "CreateFolderForPostings": {
       "idempotent": false,
       "readonly": false,

--- a/conformance/runner/go/main.go
+++ b/conformance/runner/go/main.go
@@ -903,6 +903,16 @@ func executeOperation(client *generated.Client, ctx context.Context, tc TestCase
 			},
 		}
 		return client.CreateMessage(ctx, body)
+	case "CreateDirectUpload":
+		body := generated.CreateDirectUploadJSONRequestBody{
+			Blob: generated.DirectUploadBlob{
+				Filename:    getStringParam(tc.RequestBody, "filename"),
+				ByteSize:    getInt64Param(tc.RequestBody, "byte_size"),
+				Checksum:    getStringParam(tc.RequestBody, "checksum"),
+				ContentType: getStringParam(tc.RequestBody, "content_type"),
+			},
+		}
+		return client.CreateDirectUpload(ctx, body)
 	case "ListDrafts":
 		return client.ListDrafts(ctx, nil)
 	case "CreateReply":

--- a/conformance/tests/paths.json
+++ b/conformance/tests/paths.json
@@ -91,6 +91,60 @@
     ]
   },
   {
+    "name": "CreateDirectUpload uses /rails/active_storage/direct_uploads.json path",
+    "description": "Verifies that CreateDirectUpload sends Active Storage blob metadata to the direct upload endpoint",
+    "operation": "CreateDirectUpload",
+    "method": "POST",
+    "path": "/rails/active_storage/direct_uploads.json",
+    "requestBody": {
+      "filename": "quarterly-report.pdf",
+      "byte_size": 128,
+      "checksum": "YWJjZA==",
+      "content_type": "application/pdf"
+    },
+    "mockResponses": [
+      {
+        "status": 200,
+        "body": {
+          "signed_id": "signed-123",
+          "attachable_sgid": "sgid-456",
+          "direct_upload": {
+            "url": "https://uploads.example.com/blob",
+            "headers": {
+              "Content-Type": "application/pdf"
+            }
+          }
+        }
+      }
+    ],
+    "assertions": [
+      {
+        "type": "requestPath",
+        "expected": "/rails/active_storage/direct_uploads.json"
+      },
+      {
+        "type": "requestMethod",
+        "expected": "POST"
+      },
+      {
+        "type": "requestBody",
+        "expected": {
+          "blob.filename": "quarterly-report.pdf",
+          "blob.byte_size": 128,
+          "blob.checksum": "YWJjZA==",
+          "blob.content_type": "application/pdf"
+        }
+      },
+      {
+        "type": "noError"
+      }
+    ],
+    "tags": [
+      "path",
+      "attachments"
+    ]
+  },
+  {
     "name": "CreateMessage uses /messages.json path",
     "description": "Verifies that CreateMessage constructs the URL path /messages.json",
     "operation": "CreateMessage",

--- a/go/pkg/generated/client.gen.go
+++ b/go/pkg/generated/client.gen.go
@@ -403,6 +403,14 @@ type CreateContactRequestContent struct {
 // CreateContactResponseContent Contact — the identity of someone in HEY
 type CreateContactResponseContent = Contact
 
+// CreateDirectUploadRequestContent defines model for CreateDirectUploadRequestContent.
+type CreateDirectUploadRequestContent struct {
+	Blob DirectUploadBlob `json:"blob"`
+}
+
+// CreateDirectUploadResponseContent defines model for CreateDirectUploadResponseContent.
+type CreateDirectUploadResponseContent = DirectUpload
+
 // CreateFolderForPostingsRequestContent Wire format: {posting_ids: [...], folder: {name, status}}
 type CreateFolderForPostingsRequestContent struct {
 	Folder     FolderPayload `json:"folder"`
@@ -434,6 +442,30 @@ type CreateStickyResponseContent = Sticky
 
 // CreateTimeTrackResponseContent Recording — polymorphic by `type` (CalendarEvent, CalendarTodo, etc.)
 type CreateTimeTrackResponseContent = Recording
+
+// DirectUpload defines model for DirectUpload.
+type DirectUpload struct {
+	AttachableSgid string             `json:"attachable_sgid"`
+	DirectUpload   DirectUploadTarget `json:"direct_upload"`
+	SignedId       string             `json:"signed_id"`
+}
+
+// DirectUploadBlob defines model for DirectUploadBlob.
+type DirectUploadBlob struct {
+	ByteSize    int64  `json:"byte_size"`
+	Checksum    string `json:"checksum"`
+	ContentType string `json:"content_type"`
+	Filename    string `json:"filename"`
+}
+
+// DirectUploadHeaders defines model for DirectUploadHeaders.
+type DirectUploadHeaders map[string]string
+
+// DirectUploadTarget defines model for DirectUploadTarget.
+type DirectUploadTarget struct {
+	Headers DirectUploadHeaders `json:"headers,omitempty"`
+	Url     string              `json:"url"`
+}
 
 // Domain Domain — email domain
 type Domain struct {
@@ -1540,6 +1572,9 @@ type TrashPostingsJSONRequestBody = TrashPostingsRequestContent
 // MarkPostingsUnseenJSONRequestBody defines body for MarkPostingsUnseen for application/json ContentType.
 type MarkPostingsUnseenJSONRequestBody = MarkPostingsRequestContent
 
+// CreateDirectUploadJSONRequestBody defines body for CreateDirectUpload for application/json ContentType.
+type CreateDirectUploadJSONRequestBody = CreateDirectUploadRequestContent
+
 // CreateStickyJSONRequestBody defines body for CreateSticky for application/json ContentType.
 type CreateStickyJSONRequestBody = StickyRequestContent
 
@@ -2059,6 +2094,11 @@ type ClientInterface interface {
 	MarkPostingsUnseenWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	MarkPostingsUnseen(ctx context.Context, body MarkPostingsUnseenJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// CreateDirectUploadWithBody request with any body
+	CreateDirectUploadWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	CreateDirectUpload(ctx context.Context, body CreateDirectUploadJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetLaterbox request
 	GetLaterbox(ctx context.Context, params *GetLaterboxParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -3422,6 +3462,36 @@ func (c *Client) MarkPostingsUnseenWithBody(ctx context.Context, contentType str
 func (c *Client) MarkPostingsUnseen(ctx context.Context, body MarkPostingsUnseenJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 
 	req, err := NewMarkPostingsUnseenRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+
+}
+
+// CreateDirectUploadWithBody executes the CreateDirectUpload operation.
+
+func (c *Client) CreateDirectUploadWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+
+	req, err := NewCreateDirectUploadRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+
+}
+
+func (c *Client) CreateDirectUpload(ctx context.Context, body CreateDirectUploadJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+
+	req, err := NewCreateDirectUploadRequest(c.Server, body)
 	if err != nil {
 		return nil, err
 	}
@@ -6982,6 +7052,46 @@ func NewMarkPostingsUnseenRequestWithBody(server string, contentType string, bod
 	return req, nil
 }
 
+// NewCreateDirectUploadRequest calls the generic CreateDirectUpload builder with application/json body
+func NewCreateDirectUploadRequest(server string, body CreateDirectUploadJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewCreateDirectUploadRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewCreateDirectUploadRequestWithBody generates requests for CreateDirectUpload with any type of body
+func NewCreateDirectUploadRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/rails/active_storage/direct_uploads.json")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
 // NewGetLaterboxRequest generates requests for GetLaterbox
 func NewGetLaterboxRequest(server string, params *GetLaterboxParams) (*http.Request, error) {
 	var err error
@@ -7998,6 +8108,7 @@ var operationMetadata = map[string]OperationMetadata{
 	"MarkPostingsSpam":           {Idempotent: false, HasSensitiveParams: false},
 	"TrashPostings":              {Idempotent: false, HasSensitiveParams: false},
 	"MarkPostingsUnseen":         {Idempotent: false, HasSensitiveParams: false},
+	"CreateDirectUpload":         {Idempotent: false, HasSensitiveParams: false},
 	"GetLaterbox":                {Idempotent: true, HasSensitiveParams: false},
 	"GetAsidebox":                {Idempotent: true, HasSensitiveParams: false},
 	"ListSnippets":               {Idempotent: true, HasSensitiveParams: false},
@@ -9388,6 +9499,22 @@ type ClientWithResponsesInterface interface {
 	//
 	// Mark postings as unseen.
 	MarkPostingsUnseenWithResponse(ctx context.Context, body MarkPostingsUnseenJSONRequestBody, reqEditors ...RequestEditorFn) (*MarkPostingsUnseenResponse, error)
+
+	// CreateDirectUploadWithBodyWithResponse performs a POST /rails/active_storage/direct_uploads.json (the `CreateDirectUpload` operationId) request,
+	// with any type of body and a specified content type.
+	//
+	// Create an Active Storage direct upload for an outgoing attachment.
+	// The returned URL is self-authenticating and accepts the raw file bytes via PUT.
+	//
+	// Returns a wrapper object for the known response body format(s).
+	CreateDirectUploadWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateDirectUploadResponse, error)
+
+	// CreateDirectUploadWithResponse performs a POST /rails/active_storage/direct_uploads.json (the `CreateDirectUpload` operationId) request.
+	// Takes a body of the `application/json` content type, and returns a wrapper object for the known response body format(s).
+	//
+	// Create an Active Storage direct upload for an outgoing attachment.
+	// The returned URL is self-authenticating and accepts the raw file bytes via PUT.
+	CreateDirectUploadWithResponse(ctx context.Context, body CreateDirectUploadJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateDirectUploadResponse, error)
 
 	// GetLaterboxWithResponse performs a GET /reply_later.json (the `GetLaterbox` operationId) request.
 	//
@@ -14564,6 +14691,75 @@ func (r MarkPostingsUnseenResponse) ContentType() string {
 	return ""
 }
 
+type CreateDirectUploadResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	// JSON200 the response for an HTTP 200 `application/json` response
+	JSON200 *CreateDirectUploadResponseContent
+	// JSON401 the response for an HTTP 401 `application/json` response
+	JSON401 *UnauthorizedErrorResponseContent
+	// JSON422 the response for an HTTP 422 `application/json` response
+	JSON422 *UnprocessableEntityErrorResponseContent
+	// JSON500 the response for an HTTP 500 `application/json` response
+	JSON500 *InternalServerErrorResponseContent
+	// JSON503 the response for an HTTP 503 `application/json` response
+	JSON503 *ServiceUnavailableErrorResponseContent
+}
+
+// GetJSON200 returns the response for an HTTP 200 `application/json` response
+func (r CreateDirectUploadResponse) GetJSON200() *CreateDirectUploadResponseContent {
+	return r.JSON200
+}
+
+// GetJSON401 returns the response for an HTTP 401 `application/json` response
+func (r CreateDirectUploadResponse) GetJSON401() *UnauthorizedErrorResponseContent {
+	return r.JSON401
+}
+
+// GetJSON422 returns the response for an HTTP 422 `application/json` response
+func (r CreateDirectUploadResponse) GetJSON422() *UnprocessableEntityErrorResponseContent {
+	return r.JSON422
+}
+
+// GetJSON500 returns the response for an HTTP 500 `application/json` response
+func (r CreateDirectUploadResponse) GetJSON500() *InternalServerErrorResponseContent {
+	return r.JSON500
+}
+
+// GetJSON503 returns the response for an HTTP 503 `application/json` response
+func (r CreateDirectUploadResponse) GetJSON503() *ServiceUnavailableErrorResponseContent {
+	return r.JSON503
+}
+
+// GetBody returns the raw response body bytes
+func (r CreateDirectUploadResponse) GetBody() []byte {
+	return r.Body
+}
+
+// Status returns HTTPResponse.Status
+func (r CreateDirectUploadResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r CreateDirectUploadResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r CreateDirectUploadResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
 type GetLaterboxResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -17344,6 +17540,34 @@ func (c *ClientWithResponses) MarkPostingsUnseenWithResponse(ctx context.Context
 		return nil, err
 	}
 	return ParseMarkPostingsUnseenResponse(rsp)
+}
+
+// CreateDirectUploadWithBodyWithResponse performs a POST /rails/active_storage/direct_uploads.json (the `CreateDirectUpload` operationId) request,
+// with any type of body and a specified content type.
+//
+// Create an Active Storage direct upload for an outgoing attachment.
+// The returned URL is self-authenticating and accepts the raw file bytes via PUT.
+//
+// Returns a wrapper object for the known response body format(s).
+func (c *ClientWithResponses) CreateDirectUploadWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateDirectUploadResponse, error) {
+	rsp, err := c.CreateDirectUploadWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateDirectUploadResponse(rsp)
+}
+
+// CreateDirectUploadWithResponse performs a POST /rails/active_storage/direct_uploads.json (the `CreateDirectUpload` operationId) request.
+// Takes a body of the `application/json` content type, and returns a wrapper object for the known response body format(s).
+//
+// Create an Active Storage direct upload for an outgoing attachment.
+// The returned URL is self-authenticating and accepts the raw file bytes via PUT.
+func (c *ClientWithResponses) CreateDirectUploadWithResponse(ctx context.Context, body CreateDirectUploadJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateDirectUploadResponse, error) {
+	rsp, err := c.CreateDirectUpload(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateDirectUploadResponse(rsp)
 }
 
 // GetLaterboxWithResponse performs a GET /reply_later.json (the `GetLaterbox` operationId) request.
@@ -21612,6 +21836,60 @@ func ParseMarkPostingsUnseenResponse(rsp *http.Response) (*MarkPostingsUnseenRes
 			return nil, err
 		}
 		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalServerErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 503:
+		var dest ServiceUnavailableErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON503 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseCreateDirectUploadResponse parses an HTTP response from a CreateDirectUploadWithResponse call
+func ParseCreateDirectUploadResponse(rsp *http.Response) (*CreateDirectUploadResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &CreateDirectUploadResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest CreateDirectUploadResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest UnauthorizedErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest UnprocessableEntityErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest InternalServerErrorResponseContent

--- a/go/pkg/generated/client.gen.go
+++ b/go/pkg/generated/client.gen.go
@@ -408,9 +408,6 @@ type CreateDirectUploadRequestContent struct {
 	Blob DirectUploadBlob `json:"blob"`
 }
 
-// CreateDirectUploadResponseContent defines model for CreateDirectUploadResponseContent.
-type CreateDirectUploadResponseContent = DirectUpload
-
 // CreateFolderForPostingsRequestContent Wire format: {posting_ids: [...], folder: {name, status}}
 type CreateFolderForPostingsRequestContent struct {
 	Folder     FolderPayload `json:"folder"`
@@ -14695,7 +14692,7 @@ type CreateDirectUploadResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	// JSON200 the response for an HTTP 200 `application/json` response
-	JSON200 *CreateDirectUploadResponseContent
+	JSON200 *DirectUpload
 	// JSON401 the response for an HTTP 401 `application/json` response
 	JSON401 *UnauthorizedErrorResponseContent
 	// JSON422 the response for an HTTP 422 `application/json` response
@@ -14707,7 +14704,7 @@ type CreateDirectUploadResponse struct {
 }
 
 // GetJSON200 returns the response for an HTTP 200 `application/json` response
-func (r CreateDirectUploadResponse) GetJSON200() *CreateDirectUploadResponseContent {
+func (r CreateDirectUploadResponse) GetJSON200() *DirectUpload {
 	return r.JSON200
 }
 
@@ -21871,7 +21868,7 @@ func ParseCreateDirectUploadResponse(rsp *http.Response) (*CreateDirectUploadRes
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest CreateDirectUploadResponseContent
+		var dest DirectUpload
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/go/pkg/hey/attachments.go
+++ b/go/pkg/hey/attachments.go
@@ -2,6 +2,11 @@ package hey
 
 import (
 	"context"
+	"crypto/md5" //nolint:gosec // Active Storage requires a base64-encoded MD5 integrity checksum.
+	"encoding/base64"
+	"fmt"
+	"io"
+	"net/http"
 
 	"github.com/basecamp/hey-sdk/go/pkg/generated"
 )
@@ -37,4 +42,69 @@ func (s *AttachmentsService) CreateDirectUpload(ctx context.Context, body genera
 		return nil
 	})
 	return result, err
+}
+
+// Upload reserves an Active Storage blob and uploads the supplied bytes to its
+// self-authenticating storage URL. The returned attachment can be embedded in
+// rich text with its AttachableSgid.
+func (s *AttachmentsService) Upload(ctx context.Context, filename, contentType string, content io.ReadSeeker) (*generated.DirectUpload, error) {
+	if filename == "" {
+		return nil, ErrUsage("an attachment needs a filename")
+	}
+	if contentType == "" {
+		contentType = "application/octet-stream"
+	}
+	if content == nil {
+		return nil, ErrUsage("an attachment needs content")
+	}
+
+	if _, err := content.Seek(0, io.SeekStart); err != nil {
+		return nil, fmt.Errorf("seek attachment: %w", err)
+	}
+	hash := md5.New() //nolint:gosec // Active Storage requires MD5 for its Content-MD5 check.
+	byteSize, err := io.Copy(hash, content)
+	if err != nil {
+		return nil, fmt.Errorf("checksum attachment: %w", err)
+	}
+	checksum := base64.StdEncoding.EncodeToString(hash.Sum(nil))
+	if _, err := content.Seek(0, io.SeekStart); err != nil {
+		return nil, fmt.Errorf("rewind attachment: %w", err)
+	}
+
+	upload, err := s.CreateDirectUpload(ctx, generated.CreateDirectUploadRequestContent{
+		Blob: generated.DirectUploadBlob{
+			Filename:    filename,
+			ByteSize:    byteSize,
+			Checksum:    checksum,
+			ContentType: contentType,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	if upload == nil || upload.DirectUpload.Url == "" {
+		return nil, fmt.Errorf("HEY returned an empty attachment upload target")
+	}
+	if err := RequireSecureEndpoint(upload.DirectUpload.Url); err != nil {
+		return nil, fmt.Errorf("unsafe attachment upload target: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, upload.DirectUpload.Url, content)
+	if err != nil {
+		return nil, fmt.Errorf("create attachment upload request: %w", err)
+	}
+	req.ContentLength = byteSize
+	for name, value := range upload.DirectUpload.Headers {
+		req.Header.Set(name, value)
+	}
+
+	resp, err := s.client.httpClient.Do(req)
+	if err != nil {
+		return nil, ErrNetwork(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if err := CheckResponse(resp); err != nil {
+		return nil, err
+	}
+	return upload, nil
 }

--- a/go/pkg/hey/attachments.go
+++ b/go/pkg/hey/attachments.go
@@ -38,6 +38,9 @@ func (s *AttachmentsService) CreateDirectUpload(ctx context.Context, body genera
 		if responseErr := CheckResponse(resp.HTTPResponse); responseErr != nil {
 			return responseErr
 		}
+		if resp.JSON200 == nil || resp.JSON200.SignedId == "" || resp.JSON200.AttachableSgid == "" || resp.JSON200.DirectUpload.Url == "" {
+			return fmt.Errorf("HEY returned an empty attachment upload response")
+		}
 		result = resp.JSON200
 		return nil
 	})

--- a/go/pkg/hey/attachments.go
+++ b/go/pkg/hey/attachments.go
@@ -1,0 +1,40 @@
+package hey
+
+import (
+	"context"
+
+	"github.com/basecamp/hey-sdk/go/pkg/generated"
+)
+
+// AttachmentsService handles outgoing attachment uploads.
+type AttachmentsService struct {
+	client *Client
+}
+
+// NewAttachmentsService creates an AttachmentsService.
+func NewAttachmentsService(client *Client) *AttachmentsService {
+	return &AttachmentsService{client: client}
+}
+
+// CreateDirectUpload creates an Active Storage blob and returns the target for
+// uploading its bytes. The target URL is self-authenticating and must be used
+// with the exact headers returned by HEY.
+func (s *AttachmentsService) CreateDirectUpload(ctx context.Context, body generated.CreateDirectUploadJSONRequestBody) (result *generated.DirectUpload, err error) {
+	op := OperationInfo{
+		Service: "Attachments", Operation: "CreateDirectUpload",
+		ResourceType: "attachment", IsMutation: true,
+	}
+
+	err = s.client.instrument(ctx, op, func(ctx context.Context) error {
+		resp, requestErr := s.client.genClient().CreateDirectUploadWithResponse(ctx, body)
+		if requestErr != nil {
+			return requestErr
+		}
+		if responseErr := CheckResponse(resp.HTTPResponse); responseErr != nil {
+			return responseErr
+		}
+		result = resp.JSON200
+		return nil
+	})
+	return result, err
+}

--- a/go/pkg/hey/attachments.go
+++ b/go/pkg/hey/attachments.go
@@ -24,7 +24,7 @@ func NewAttachmentsService(client *Client) *AttachmentsService {
 // CreateDirectUpload creates an Active Storage blob and returns the target for
 // uploading its bytes. The target URL is self-authenticating and must be used
 // with the exact headers returned by HEY.
-func (s *AttachmentsService) CreateDirectUpload(ctx context.Context, body generated.CreateDirectUploadJSONRequestBody) (result *generated.DirectUpload, err error) {
+func (s *AttachmentsService) CreateDirectUpload(ctx context.Context, body generated.CreateDirectUploadRequestContent) (result *generated.DirectUpload, err error) {
 	op := OperationInfo{
 		Service: "Attachments", Operation: "CreateDirectUpload",
 		ResourceType: "attachment", IsMutation: true,
@@ -97,6 +97,8 @@ func (s *AttachmentsService) Upload(ctx context.Context, filename, contentType s
 	for name, value := range upload.DirectUpload.Headers {
 		req.Header.Set(name, value)
 	}
+	// The upload URL authenticates the storage request; HEY credentials stay on HEY.
+	req.Header.Del("Authorization")
 
 	resp, err := s.client.httpClient.Do(req)
 	if err != nil {

--- a/go/pkg/hey/attachments.go
+++ b/go/pkg/hey/attachments.go
@@ -111,5 +111,8 @@ func (s *AttachmentsService) Upload(ctx context.Context, filename, contentType s
 	if err := CheckResponse(resp); err != nil {
 		return nil, err
 	}
+	if _, err := io.Copy(io.Discard, resp.Body); err != nil {
+		return nil, fmt.Errorf("drain attachment upload response: %w", err)
+	}
 	return upload, nil
 }

--- a/go/pkg/hey/attachments_test.go
+++ b/go/pkg/hey/attachments_test.go
@@ -1,0 +1,72 @@
+package hey
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/basecamp/hey-sdk/go/pkg/generated"
+)
+
+func TestAttachmentsCreateDirectUpload(t *testing.T) {
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/rails/active_storage/direct_uploads.json" {
+			t.Errorf("path = %s, want /rails/active_storage/direct_uploads.json", r.URL.Path)
+		}
+
+		var body generated.CreateDirectUploadRequestContent
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		if body.Blob.Filename != "quarterly-report.pdf" {
+			t.Errorf("filename = %q", body.Blob.Filename)
+		}
+		if body.Blob.ByteSize != 128 {
+			t.Errorf("byte size = %d", body.Blob.ByteSize)
+		}
+		if body.Blob.Checksum != "YWJjZA==" {
+			t.Errorf("checksum = %q", body.Blob.Checksum)
+		}
+		if body.Blob.ContentType != "application/pdf" {
+			t.Errorf("content type = %q", body.Blob.ContentType)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"signed_id":"signed-123",
+			"attachable_sgid":"sgid-456",
+			"direct_upload":{
+				"url":"https://uploads.example.com/blob",
+				"headers":{"Content-Type":"application/pdf","Content-MD5":"YWJjZA=="}
+			}
+		}`))
+	})
+
+	result, err := client.Attachments().CreateDirectUpload(context.Background(), generated.CreateDirectUploadRequestContent{
+		Blob: generated.DirectUploadBlob{
+			Filename:    "quarterly-report.pdf",
+			ByteSize:    128,
+			Checksum:    "YWJjZA==",
+			ContentType: "application/pdf",
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateDirectUpload: %v", err)
+	}
+	if result.SignedId != "signed-123" {
+		t.Errorf("signed ID = %q", result.SignedId)
+	}
+	if result.AttachableSgid != "sgid-456" {
+		t.Errorf("attachable SGID = %q", result.AttachableSgid)
+	}
+	if result.DirectUpload.Url != "https://uploads.example.com/blob" {
+		t.Errorf("upload URL = %q", result.DirectUpload.Url)
+	}
+	if result.DirectUpload.Headers["Content-MD5"] != "YWJjZA==" {
+		t.Errorf("upload headers = %v", result.DirectUpload.Headers)
+	}
+}

--- a/go/pkg/hey/attachments_test.go
+++ b/go/pkg/hey/attachments_test.go
@@ -87,6 +87,20 @@ func TestAttachmentsUploadRejectsInsecureStorageTarget(t *testing.T) {
 	}
 }
 
+func TestAttachmentsCreateDirectUploadRequiresResponse(t *testing.T) {
+	client := newTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`null`))
+	})
+
+	_, err := client.Attachments().CreateDirectUpload(context.Background(), generated.CreateDirectUploadRequestContent{
+		Blob: generated.DirectUploadBlob{Filename: "report.pdf", ByteSize: 1, Checksum: "x", ContentType: "application/pdf"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "empty attachment upload response") {
+		t.Fatalf("CreateDirectUpload error = %v", err)
+	}
+}
+
 func TestAttachmentsCreateDirectUpload(t *testing.T) {
 	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {

--- a/go/pkg/hey/attachments_test.go
+++ b/go/pkg/hey/attachments_test.go
@@ -2,12 +2,90 @@ package hey
 
 import (
 	"context"
+	"crypto/md5" //nolint:gosec // Active Storage test checksum.
+	"encoding/base64"
 	"encoding/json"
+	"io"
 	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/basecamp/hey-sdk/go/pkg/generated"
 )
+
+func TestAttachmentsUpload(t *testing.T) {
+	const contents = "quarterly report contents"
+	checksumBytes := md5.Sum([]byte(contents)) //nolint:gosec // Active Storage requires MD5.
+	checksum := base64.StdEncoding.EncodeToString(checksumBytes[:])
+
+	uploadServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Errorf("method = %s, want PUT", r.Method)
+		}
+		if got := r.Header.Get("Authorization"); got != "" {
+			t.Errorf("storage Authorization = %q, want empty", got)
+		}
+		if got := r.Header.Get("Content-MD5"); got != checksum {
+			t.Errorf("Content-MD5 = %q, want %q", got, checksum)
+		}
+		if got := r.Header.Get("Content-Type"); got != "application/pdf" {
+			t.Errorf("Content-Type = %q", got)
+		}
+		if r.ContentLength != int64(len(contents)) {
+			t.Errorf("Content-Length = %d, want %d", r.ContentLength, len(contents))
+		}
+		body, _ := io.ReadAll(r.Body)
+		if string(body) != contents {
+			t.Errorf("body = %q", body)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(uploadServer.Close)
+
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		var body generated.CreateDirectUploadRequestContent
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		if body.Blob.Filename != "quarterly-report.pdf" || body.Blob.ByteSize != int64(len(contents)) || body.Blob.Checksum != checksum || body.Blob.ContentType != "application/pdf" {
+			t.Errorf("blob = %+v", body.Blob)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"signed_id":"signed-123",
+			"attachable_sgid":"sgid-456",
+			"direct_upload":{
+				"url":"` + uploadServer.URL + `/blob",
+				"headers":{"Content-Type":"application/pdf","Content-MD5":"` + checksum + `"}
+			}
+		}`))
+	})
+
+	upload, err := client.Attachments().Upload(context.Background(), "quarterly-report.pdf", "application/pdf", strings.NewReader(contents))
+	if err != nil {
+		t.Fatalf("Upload: %v", err)
+	}
+	if upload.AttachableSgid != "sgid-456" {
+		t.Errorf("attachable SGID = %q", upload.AttachableSgid)
+	}
+}
+
+func TestAttachmentsUploadRejectsInsecureStorageTarget(t *testing.T) {
+	client := newTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"signed_id":"signed-123",
+			"attachable_sgid":"sgid-456",
+			"direct_upload":{"url":"http://uploads.example.com/blob","headers":{}}
+		}`))
+	})
+
+	_, err := client.Attachments().Upload(context.Background(), "report.pdf", "application/pdf", strings.NewReader("report"))
+	if err == nil || !strings.Contains(err.Error(), "unsafe attachment upload target") {
+		t.Fatalf("Upload error = %v", err)
+	}
+}
 
 func TestAttachmentsCreateDirectUpload(t *testing.T) {
 	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {

--- a/go/pkg/hey/attachments_test.go
+++ b/go/pkg/hey/attachments_test.go
@@ -57,7 +57,7 @@ func TestAttachmentsUpload(t *testing.T) {
 			"attachable_sgid":"sgid-456",
 			"direct_upload":{
 				"url":"` + uploadServer.URL + `/blob",
-				"headers":{"Content-Type":"application/pdf","Content-MD5":"` + checksum + `"}
+				"headers":{"Content-Type":"application/pdf","Content-MD5":"` + checksum + `","Authorization":"Bearer must-not-leak"}
 			}
 		}`))
 	})

--- a/go/pkg/hey/client.go
+++ b/go/pkg/hey/client.go
@@ -298,45 +298,14 @@ func (c *Client) DownloadBlob(ctx context.Context, path string, destination io.W
 		return 0, nil, err
 	}
 
-	for attempt := 1; attempt <= 2; attempt++ {
-		req, requestErr := http.NewRequestWithContext(ctx, http.MethodGet, resolvedURL, nil)
-		if requestErr != nil {
-			return 0, nil, requestErr
-		}
-		if authErr := c.authStrategy.Authenticate(ctx, req); authErr != nil {
-			return 0, nil, authErr
-		}
-		req.Header.Set("User-Agent", c.userAgent)
-		req.Header.Set("Accept", "*/*")
-
-		resp, requestErr := c.httpClient.Do(req)
-		if requestErr != nil {
-			return 0, nil, ErrNetwork(requestErr)
-		}
-		if resp.StatusCode == http.StatusUnauthorized && attempt == 1 {
-			_ = resp.Body.Close()
-			if authManager, ok := c.tokenProvider.(*AuthManager); ok {
-				if refreshErr := authManager.Refresh(ctx); refreshErr == nil {
-					continue
-				}
-			}
-			return 0, nil, ErrAuth("Authentication failed")
-		}
-		if responseErr := CheckResponse(resp); responseErr != nil {
-			_ = resp.Body.Close()
-			return 0, nil, responseErr
-		}
-		written, copyErr := io.Copy(destination, resp.Body)
-		closeErr := resp.Body.Close()
-		if copyErr != nil {
-			return written, resp.Header, fmt.Errorf("download blob: %w", copyErr)
-		}
-		if closeErr != nil {
-			return written, resp.Header, fmt.Errorf("close blob download: %w", closeErr)
-		}
-		return written, resp.Header, nil
+	ctx = contextWithAccept(ctx, "*/*")
+	ctx = contextWithoutCache(ctx)
+	ctx, stream := contextWithStreamDestination(ctx, destination)
+	resp, err := c.doRequestURL(ctx, http.MethodGet, resolvedURL, nil)
+	if err != nil {
+		return stream.written, nil, err
 	}
-	return 0, nil, ErrAuth("Authentication failed")
+	return stream.written, resp.Headers, nil
 }
 
 func (c *Client) blobURL(path string) (string, error) {
@@ -542,6 +511,23 @@ func noCacheFromContext(ctx context.Context) bool {
 	return v
 }
 
+type contextKeyStreamDestination struct{}
+
+type streamDestination struct {
+	writer  io.Writer
+	written int64
+}
+
+func contextWithStreamDestination(ctx context.Context, writer io.Writer) (context.Context, *streamDestination) {
+	destination := &streamDestination{writer: writer}
+	return context.WithValue(ctx, contextKeyStreamDestination{}, destination), destination
+}
+
+func streamDestinationFromContext(ctx context.Context) *streamDestination {
+	destination, _ := ctx.Value(contextKeyStreamDestination{}).(*streamDestination)
+	return destination
+}
+
 func (c *Client) doRequest(ctx context.Context, method, path string, body any) (*Response, error) {
 	url, err := c.buildURL(path)
 	if err != nil {
@@ -671,6 +657,13 @@ func (c *Client) singleRequest(ctx context.Context, method, url string, body any
 		return nil, ErrAPI(304, "304 received but no cached response available")
 
 	case http.StatusOK, http.StatusCreated, http.StatusNoContent:
+		if destination := streamDestinationFromContext(ctx); destination != nil {
+			destination.written, err = io.Copy(destination.writer, resp.Body)
+			if err != nil {
+				return nil, fmt.Errorf("stream response: %w", err)
+			}
+			return &Response{StatusCode: resp.StatusCode, Headers: resp.Header}, nil
+		}
 		respBody, err := limitedReadAll(resp.Body, MaxResponseBodyBytes)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read response: %w", err)

--- a/go/pkg/hey/client.go
+++ b/go/pkg/hey/client.go
@@ -345,7 +345,7 @@ func (c *Client) blobURL(path string) (string, error) {
 		return "", err
 	}
 	if !isSameOrigin(c.cfg.BaseURL, resolvedURL) {
-		return "", fmt.Errorf("blob URL points to different origin: %s", resolvedURL)
+		return "", ErrUsage("a blob download URL must start on the HEY origin")
 	}
 	return resolvedURL, nil
 }

--- a/go/pkg/hey/client.go
+++ b/go/pkg/hey/client.go
@@ -272,6 +272,23 @@ func (c *Client) GetHTML(ctx context.Context, path string) (*Response, error) {
 	return c.doRequest(contextWithAccept(ctx, "text/html"), "GET", path, nil)
 }
 
+// GetBlob performs a same-origin GET request for binary content and bypasses
+// the response cache. Redirects may leave the HEY origin, but the HTTP client
+// strips authorization before following them.
+func (c *Client) GetBlob(ctx context.Context, path string) (*Response, error) {
+	resolvedURL, err := c.buildURL(path)
+	if err != nil {
+		return nil, err
+	}
+	if !isSameOrigin(c.cfg.BaseURL, resolvedURL) {
+		return nil, fmt.Errorf("blob URL points to different origin: %s", resolvedURL)
+	}
+
+	ctx = contextWithAccept(ctx, "*/*")
+	ctx = contextWithoutCache(ctx)
+	return c.doRequestURL(ctx, "GET", resolvedURL, nil)
+}
+
 // GetCSV performs a GET request with Accept: text/csv, returning the raw CSV bytes.
 // Use this for the export endpoints, which stream a file rather than a document.
 func (c *Client) GetCSV(ctx context.Context, path string) (*Response, error) {
@@ -453,6 +470,17 @@ func acceptFromContext(ctx context.Context) string {
 	return "application/json"
 }
 
+type contextKeyNoCache struct{}
+
+func contextWithoutCache(ctx context.Context) context.Context {
+	return context.WithValue(ctx, contextKeyNoCache{}, true)
+}
+
+func noCacheFromContext(ctx context.Context) bool {
+	v, _ := ctx.Value(contextKeyNoCache{}).(bool)
+	return v
+}
+
 func (c *Client) doRequest(ctx context.Context, method, path string, body any) (*Response, error) {
 	url, err := c.buildURL(path)
 	if err != nil {
@@ -547,7 +575,7 @@ func (c *Client) singleRequest(ctx context.Context, method, url string, body any
 	req.Header.Set("Accept", acceptFromContext(ctx))
 
 	var cacheKey string
-	if method == "GET" && c.cache != nil {
+	if method == "GET" && c.cache != nil && !noCacheFromContext(ctx) {
 		cacheKey = c.cache.Key(url, req.Header.Get("Authorization"))
 		if etag := c.cache.GetETag(cacheKey); etag != "" {
 			req.Header.Set("If-None-Match", etag)

--- a/go/pkg/hey/client.go
+++ b/go/pkg/hey/client.go
@@ -57,6 +57,7 @@ type Client struct {
 	postings       *PostingsService
 	topics         *TopicsService
 	messages       *MessagesService
+	attachments    *AttachmentsService
 	entries        *EntriesService
 	bulkReplies    *BulkRepliesService
 	contacts       *ContactsService
@@ -821,6 +822,16 @@ func (c *Client) Messages() *MessagesService {
 		c.messages = NewMessagesService(c)
 	}
 	return c.messages
+}
+
+// Attachments returns the attachment service.
+func (c *Client) Attachments() *AttachmentsService {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.attachments == nil {
+		c.attachments = NewAttachmentsService(c)
+	}
+	return c.attachments
 }
 
 // BulkReplies returns the bulk reply service, for answering many threads at once.

--- a/go/pkg/hey/client.go
+++ b/go/pkg/hey/client.go
@@ -277,17 +277,77 @@ func (c *Client) GetHTML(ctx context.Context, path string) (*Response, error) {
 // the response cache. Redirects may leave the HEY origin, but the HTTP client
 // strips authorization before following them.
 func (c *Client) GetBlob(ctx context.Context, path string) (*Response, error) {
-	resolvedURL, err := c.buildURL(path)
+	resolvedURL, err := c.blobURL(path)
 	if err != nil {
 		return nil, err
-	}
-	if !isSameOrigin(c.cfg.BaseURL, resolvedURL) {
-		return nil, fmt.Errorf("blob URL points to different origin: %s", resolvedURL)
 	}
 
 	ctx = contextWithAccept(ctx, "*/*")
 	ctx = contextWithoutCache(ctx)
 	return c.doRequestURL(ctx, "GET", resolvedURL, nil)
+}
+
+// DownloadBlob streams a blob to destination without placing the complete file
+// in memory. It returns the number of bytes written and the final response headers.
+func (c *Client) DownloadBlob(ctx context.Context, path string, destination io.Writer) (int64, http.Header, error) {
+	if destination == nil {
+		return 0, nil, ErrUsage("a blob download needs a destination")
+	}
+	resolvedURL, err := c.blobURL(path)
+	if err != nil {
+		return 0, nil, err
+	}
+
+	for attempt := 1; attempt <= 2; attempt++ {
+		req, requestErr := http.NewRequestWithContext(ctx, http.MethodGet, resolvedURL, nil)
+		if requestErr != nil {
+			return 0, nil, requestErr
+		}
+		if authErr := c.authStrategy.Authenticate(ctx, req); authErr != nil {
+			return 0, nil, authErr
+		}
+		req.Header.Set("User-Agent", c.userAgent)
+		req.Header.Set("Accept", "*/*")
+
+		resp, requestErr := c.httpClient.Do(req)
+		if requestErr != nil {
+			return 0, nil, ErrNetwork(requestErr)
+		}
+		if resp.StatusCode == http.StatusUnauthorized && attempt == 1 {
+			_ = resp.Body.Close()
+			if authManager, ok := c.tokenProvider.(*AuthManager); ok {
+				if refreshErr := authManager.Refresh(ctx); refreshErr == nil {
+					continue
+				}
+			}
+			return 0, nil, ErrAuth("Authentication failed")
+		}
+		if responseErr := CheckResponse(resp); responseErr != nil {
+			_ = resp.Body.Close()
+			return 0, nil, responseErr
+		}
+		written, copyErr := io.Copy(destination, resp.Body)
+		closeErr := resp.Body.Close()
+		if copyErr != nil {
+			return written, resp.Header, fmt.Errorf("download blob: %w", copyErr)
+		}
+		if closeErr != nil {
+			return written, resp.Header, fmt.Errorf("close blob download: %w", closeErr)
+		}
+		return written, resp.Header, nil
+	}
+	return 0, nil, ErrAuth("Authentication failed")
+}
+
+func (c *Client) blobURL(path string) (string, error) {
+	resolvedURL, err := c.buildURL(path)
+	if err != nil {
+		return "", err
+	}
+	if !isSameOrigin(c.cfg.BaseURL, resolvedURL) {
+		return "", fmt.Errorf("blob URL points to different origin: %s", resolvedURL)
+	}
+	return resolvedURL, nil
 }
 
 // GetCSV performs a GET request with Accept: text/csv, returning the raw CSV bytes.

--- a/go/pkg/hey/client.go
+++ b/go/pkg/hey/client.go
@@ -284,7 +284,7 @@ func (c *Client) GetBlob(ctx context.Context, path string) (*Response, error) {
 
 	ctx = contextWithAccept(ctx, "*/*")
 	ctx = contextWithoutCache(ctx)
-	return c.doRequestURL(ctx, "GET", resolvedURL, nil)
+	return c.doRequestURL(ctx, http.MethodGet, resolvedURL, nil)
 }
 
 // DownloadBlob streams a blob to destination without placing the complete file
@@ -314,7 +314,7 @@ func (c *Client) blobURL(path string) (string, error) {
 		return "", err
 	}
 	if !isSameOrigin(c.cfg.BaseURL, resolvedURL) {
-		return "", ErrUsage("a blob download URL must start on the HEY origin")
+		return "", ErrUsage("a blob URL must start on the HEY origin")
 	}
 	return resolvedURL, nil
 }
@@ -622,7 +622,7 @@ func (c *Client) singleRequest(ctx context.Context, method, url string, body any
 	req.Header.Set("Accept", acceptFromContext(ctx))
 
 	var cacheKey string
-	if method == "GET" && c.cache != nil && !noCacheFromContext(ctx) {
+	if method == http.MethodGet && c.cache != nil && !noCacheFromContext(ctx) {
 		cacheKey = c.cache.Key(url, req.Header.Get("Authorization"))
 		if etag := c.cache.GetETag(cacheKey); etag != "" {
 			req.Header.Set("If-None-Match", etag)
@@ -673,7 +673,7 @@ func (c *Client) singleRequest(ctx context.Context, method, url string, body any
 			respBody = json.RawMessage("null")
 		}
 
-		if method == "GET" && cacheKey != "" {
+		if method == http.MethodGet && cacheKey != "" {
 			if etag := resp.Header.Get("ETag"); etag != "" {
 				_ = c.cache.Set(cacheKey, respBody, etag)
 				c.logger.Debug("cache stored", "etag", etag)

--- a/go/pkg/hey/client.go
+++ b/go/pkg/hey/client.go
@@ -274,8 +274,9 @@ func (c *Client) GetHTML(ctx context.Context, path string) (*Response, error) {
 }
 
 // GetBlob performs a same-origin GET request for binary content and bypasses
-// the response cache. Redirects may leave the HEY origin, but the HTTP client
-// strips authorization before following them.
+// the response cache. It buffers up to MaxResponseBodyBytes; DownloadBlob streams
+// files of any size. Redirects may leave the HEY origin, and the HTTP client strips
+// authorization before following them.
 func (c *Client) GetBlob(ctx context.Context, path string) (*Response, error) {
 	resolvedURL, err := c.blobURL(path)
 	if err != nil {

--- a/go/pkg/hey/client_test.go
+++ b/go/pkg/hey/client_test.go
@@ -189,6 +189,54 @@ func TestClient_GetBlobStripsAuthorizationOnCrossOriginRedirect(t *testing.T) {
 	}
 }
 
+func TestClient_DownloadBlobStreamsCrossOriginRedirect(t *testing.T) {
+	binary := []byte{0x00, 0xff, 0x01, 0xfe}
+	var targetAuthorization atomic.Value
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		targetAuthorization.Store(r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "application/octet-stream")
+		_, _ = w.Write(binary)
+	}))
+	t.Cleanup(target.Close)
+
+	source := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			t.Errorf("source Authorization = %q, want Bearer token", got)
+		}
+		http.Redirect(w, r, target.URL+"/download/file.bin", http.StatusFound)
+	}))
+	t.Cleanup(source.Close)
+
+	client := NewClient(
+		&Config{BaseURL: source.URL},
+		&StaticTokenProvider{Token: "test-token"},
+		WithMaxRetries(0),
+	)
+	var destination bytes.Buffer
+	written, headers, err := client.DownloadBlob(context.Background(), "/rails/active_storage/blobs/redirect/abc/file.bin", &destination)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if written != int64(len(binary)) || !bytes.Equal(destination.Bytes(), binary) {
+		t.Fatalf("download = %d bytes %v, want %v", written, destination.Bytes(), binary)
+	}
+	if headers.Get("Content-Type") != "application/octet-stream" {
+		t.Errorf("Content-Type = %q", headers.Get("Content-Type"))
+	}
+	if got, _ := targetAuthorization.Load().(string); got != "" {
+		t.Errorf("target Authorization = %q, want empty", got)
+	}
+}
+
+func TestClient_DownloadBlobRequiresDestination(t *testing.T) {
+	client := newTestClient(t, func(http.ResponseWriter, *http.Request) {
+		t.Error("nil destination should be rejected before making a request")
+	})
+	if _, _, err := client.DownloadBlob(context.Background(), "/blob", nil); err == nil {
+		t.Fatal("expected destination error")
+	}
+}
+
 func TestClient_Post(t *testing.T) {
 	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != "POST" {

--- a/go/pkg/hey/client_test.go
+++ b/go/pkg/hey/client_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
@@ -226,6 +227,48 @@ func TestClient_DownloadBlobStreamsCrossOriginRedirect(t *testing.T) {
 	}
 	if got, _ := targetAuthorization.Load().(string); got != "" {
 		t.Errorf("target Authorization = %q, want empty", got)
+	}
+}
+
+type failingStreamWriter struct {
+	limit   int
+	written int
+}
+
+func (w *failingStreamWriter) Write(data []byte) (int, error) {
+	remaining := w.limit - w.written
+	if remaining <= 0 {
+		return 0, errors.New("destination failed")
+	}
+	if len(data) > remaining {
+		w.written += remaining
+		return remaining, errors.New("destination failed")
+	}
+	w.written += len(data)
+	return len(data), nil
+}
+
+func TestClient_DownloadBlobDoesNotRetryPartialWrites(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		_, _ = w.Write([]byte("streamed attachment"))
+	}))
+	t.Cleanup(server.Close)
+	client := NewClient(
+		&Config{BaseURL: server.URL},
+		&StaticTokenProvider{Token: "test-token"},
+		WithMaxRetries(3),
+		WithBaseDelay(time.Millisecond),
+		WithMaxJitter(time.Millisecond),
+	)
+	destination := &failingStreamWriter{limit: 4}
+	written, _, err := client.DownloadBlob(context.Background(), "/blob", destination)
+	if err == nil || written != 4 {
+		t.Fatalf("DownloadBlob = %d, %v", written, err)
+	}
+	if requests.Load() != 1 {
+		t.Errorf("requests = %d, want 1", requests.Load())
 	}
 }
 

--- a/go/pkg/hey/client_test.go
+++ b/go/pkg/hey/client_test.go
@@ -363,6 +363,9 @@ func TestClient_ServiceAccessors(t *testing.T) {
 	if c.Messages() == nil {
 		t.Fatal("expected non-nil MessagesService")
 	}
+	if c.Attachments() == nil {
+		t.Fatal("expected non-nil AttachmentsService")
+	}
 	if c.Entries() == nil {
 		t.Fatal("expected non-nil EntriesService")
 	}

--- a/go/pkg/hey/client_test.go
+++ b/go/pkg/hey/client_test.go
@@ -1,6 +1,7 @@
 package hey
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"net/http"
@@ -90,6 +91,101 @@ func TestClient_Get(t *testing.T) {
 	}
 	if resp.StatusCode != 200 {
 		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+}
+
+func TestClient_GetBlob(t *testing.T) {
+	binary := []byte{0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0xff, 0xfe}
+	var requests atomic.Int64
+	var lastIfNoneMatch atomic.Value
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		lastIfNoneMatch.Store(r.Header.Get("If-None-Match"))
+		if got := r.Header.Get("Accept"); got != "*/*" {
+			t.Errorf("Accept = %q, want %q", got, "*/*")
+		}
+		w.Header().Set("Content-Type", "image/png")
+		w.Header().Set("ETag", `"abc"`)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(binary)
+	}))
+	t.Cleanup(server.Close)
+
+	client := NewClient(
+		&Config{BaseURL: server.URL},
+		&StaticTokenProvider{Token: "test-token"},
+		WithMaxRetries(0),
+		WithBaseDelay(time.Millisecond),
+		WithMaxJitter(time.Millisecond),
+		WithCache(NewCache(t.TempDir())),
+	)
+
+	for i := 0; i < 2; i++ {
+		resp, err := client.GetBlob(context.Background(), "/rails/blobs/abc/image.png")
+		if err != nil {
+			t.Fatalf("request %d: %v", i+1, err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("request %d status = %d, want %d", i+1, resp.StatusCode, http.StatusOK)
+		}
+		if !bytes.Equal(resp.Data, binary) {
+			t.Fatalf("request %d body = %d bytes, want %d", i+1, len(resp.Data), len(binary))
+		}
+		if resp.FromCache {
+			t.Errorf("request %d unexpectedly came from cache", i+1)
+		}
+		if value, _ := lastIfNoneMatch.Load().(string); value != "" {
+			t.Errorf("request %d If-None-Match = %q, want empty", i+1, value)
+		}
+	}
+	if requests.Load() != 2 {
+		t.Errorf("requests = %d, want 2", requests.Load())
+	}
+}
+
+func TestClient_GetBlobRejectsCrossOriginURL(t *testing.T) {
+	client := newTestClient(t, func(http.ResponseWriter, *http.Request) {
+		t.Error("cross-origin blob URL should be rejected before making a request")
+	})
+
+	_, err := client.GetBlob(context.Background(), "https://files.example.org/report.pdf")
+	if err == nil {
+		t.Fatal("expected cross-origin URL error")
+	}
+}
+
+func TestClient_GetBlobStripsAuthorizationOnCrossOriginRedirect(t *testing.T) {
+	binary := []byte{0x00, 0xff, 0x01, 0xfe}
+	var targetAuthorization atomic.Value
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		targetAuthorization.Store(r.Header.Get("Authorization"))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(binary)
+	}))
+	t.Cleanup(target.Close)
+
+	source := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			t.Errorf("source Authorization = %q, want Bearer token", got)
+		}
+		http.Redirect(w, r, target.URL+"/download/file.bin", http.StatusFound)
+	}))
+	t.Cleanup(source.Close)
+
+	client := NewClient(
+		&Config{BaseURL: source.URL},
+		&StaticTokenProvider{Token: "test-token"},
+		WithMaxRetries(0),
+	)
+	resp, err := client.GetBlob(context.Background(), "/rails/active_storage/blobs/redirect/abc/file.bin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(resp.Data, binary) {
+		t.Fatalf("body = %v, want %v", resp.Data, binary)
+	}
+	if got, _ := targetAuthorization.Load().(string); got != "" {
+		t.Errorf("target Authorization = %q, want empty", got)
 	}
 }
 

--- a/go/pkg/hey/client_test.go
+++ b/go/pkg/hey/client_test.go
@@ -149,8 +149,9 @@ func TestClient_GetBlobRejectsCrossOriginURL(t *testing.T) {
 	})
 
 	_, err := client.GetBlob(context.Background(), "https://files.example.org/report.pdf")
-	if err == nil {
-		t.Fatal("expected cross-origin URL error")
+	sdkErr, ok := err.(*Error)
+	if !ok || sdkErr.Code != CodeUsage {
+		t.Fatalf("cross-origin error = %v, want usage", err)
 	}
 }
 

--- a/go/pkg/hey/doc.go
+++ b/go/pkg/hey/doc.go
@@ -34,6 +34,7 @@
 //   - [Client.Postings] - Bulk posting actions: seen, move, trash, spam, mute, file, bubble up
 //   - [Client.Topics] - Topics and views (sent, spam, trash, everything), status and moves
 //   - [Client.Messages] - Individual messages
+//   - [Client.Attachments] - Active Storage direct uploads for outgoing attachments
 //   - [Client.Entries] - Drafts, replies and forwards
 //   - [Client.Contacts] - Contacts, notes, screening and bundling
 //   - [Client.Calendars] - Calendar views and recordings

--- a/go/pkg/hey/url-routes.json
+++ b/go/pkg/hey/url-routes.json
@@ -630,6 +630,14 @@
       "params": {}
     },
     {
+      "pattern": "/rails/active_storage/direct_uploads",
+      "resource": "Attachments",
+      "operations": {
+        "POST": "CreateDirectUpload"
+      },
+      "params": {}
+    },
+    {
       "pattern": "/reply_later",
       "resource": "Boxes",
       "operations": {

--- a/openapi.json
+++ b/openapi.json
@@ -6062,7 +6062,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/CreateDirectUploadResponseContent"
+                  "$ref": "#/components/schemas/DirectUpload"
                 }
               }
             }
@@ -8779,9 +8779,6 @@
         "required": [
           "blob"
         ]
-      },
-      "CreateDirectUploadResponseContent": {
-        "$ref": "#/components/schemas/DirectUpload"
       },
       "CreateFolderForPostingsRequestContent": {
         "type": "object",

--- a/openapi.json
+++ b/openapi.json
@@ -6042,6 +6042,77 @@
         }
       }
     },
+    "/rails/active_storage/direct_uploads.json": {
+      "post": {
+        "description": "Create an Active Storage direct upload for an outgoing attachment.\nThe returned URL is self-authenticating and accepts the raw file bytes via PUT.",
+        "operationId": "CreateDirectUpload",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateDirectUploadRequestContent"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "CreateDirectUpload 200 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateDirectUploadResponseContent"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "UnauthorizedError 401 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedErrorResponseContent"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "UnprocessableEntityError 422 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnprocessableEntityErrorResponseContent"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "InternalServerError 500 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerErrorResponseContent"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "ServiceUnavailableError 503 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceUnavailableErrorResponseContent"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Attachments"
+        ]
+      }
+    },
     "/reply_later.json": {
       "get": {
         "description": "Get the Reply Later box",
@@ -8698,6 +8769,20 @@
       "CreateContactResponseContent": {
         "$ref": "#/components/schemas/Contact"
       },
+      "CreateDirectUploadRequestContent": {
+        "type": "object",
+        "properties": {
+          "blob": {
+            "$ref": "#/components/schemas/DirectUploadBlob"
+          }
+        },
+        "required": [
+          "blob"
+        ]
+      },
+      "CreateDirectUploadResponseContent": {
+        "$ref": "#/components/schemas/DirectUpload"
+      },
       "CreateFolderForPostingsRequestContent": {
         "type": "object",
         "description": "Wire format: {posting_ids: [...], folder: {name, status}}",
@@ -8768,6 +8853,72 @@
       },
       "CreateTimeTrackResponseContent": {
         "$ref": "#/components/schemas/Recording"
+      },
+      "DirectUpload": {
+        "type": "object",
+        "properties": {
+          "signed_id": {
+            "type": "string"
+          },
+          "attachable_sgid": {
+            "type": "string"
+          },
+          "direct_upload": {
+            "$ref": "#/components/schemas/DirectUploadTarget"
+          }
+        },
+        "required": [
+          "attachable_sgid",
+          "direct_upload",
+          "signed_id"
+        ]
+      },
+      "DirectUploadBlob": {
+        "type": "object",
+        "properties": {
+          "filename": {
+            "type": "string"
+          },
+          "byte_size": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "checksum": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "byte_size",
+          "checksum",
+          "content_type",
+          "filename"
+        ]
+      },
+      "DirectUploadHeaders": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "string"
+        },
+        "propertyNames": {
+          "type": "string"
+        }
+      },
+      "DirectUploadTarget": {
+        "type": "object",
+        "properties": {
+          "url": {
+            "type": "string"
+          },
+          "headers": {
+            "$ref": "#/components/schemas/DirectUploadHeaders"
+          }
+        },
+        "required": [
+          "url"
+        ]
       },
       "Domain": {
         "type": "object",

--- a/spec/hey.smithy
+++ b/spec/hey.smithy
@@ -87,6 +87,9 @@ service HEY {
         GetMessage
         CreateMessage
 
+        // Attachments
+        CreateDirectUpload
+
         // Entries (2 MVP)
         ListDrafts
         CreateReply
@@ -1363,6 +1366,73 @@ structure MessagePayload {
 
     @required
     content: String
+}
+
+// =============================================================================
+// ATTACHMENT OPERATIONS
+// =============================================================================
+
+/// Create an Active Storage direct upload for an outgoing attachment.
+/// The returned URL is self-authenticating and accepts the raw file bytes via PUT.
+@http(method: "POST", uri: "/rails/active_storage/direct_uploads.json")
+@tags(["Attachments"])
+operation CreateDirectUpload {
+    input: CreateDirectUploadInput
+    output: CreateDirectUploadOutput
+    errors: [UnauthorizedError, UnprocessableEntityError, InternalServerError, ServiceUnavailableError]
+}
+
+structure CreateDirectUploadInput {
+    @httpPayload
+    @required
+    body: CreateDirectUploadRequestContent
+}
+
+structure CreateDirectUploadRequestContent {
+    @required
+    blob: DirectUploadBlob
+}
+
+structure DirectUploadBlob {
+    @required
+    filename: String
+
+    @required
+    byte_size: Long
+
+    @required
+    checksum: String
+
+    @required
+    content_type: String
+}
+
+map DirectUploadHeaders {
+    key: String
+    value: String
+}
+
+structure DirectUploadTarget {
+    @required
+    url: String
+
+    headers: DirectUploadHeaders
+}
+
+structure DirectUpload {
+    @required
+    signed_id: String
+
+    @required
+    attachable_sgid: String
+
+    @required
+    direct_upload: DirectUploadTarget
+}
+
+structure CreateDirectUploadOutput {
+    @required
+    upload: DirectUpload
 }
 
 structure MessageEntryPayload {

--- a/spec/hey.smithy
+++ b/spec/hey.smithy
@@ -1431,6 +1431,7 @@ structure DirectUpload {
 }
 
 structure CreateDirectUploadOutput {
+    @httpPayload
     @required
     upload: DirectUpload
 }

--- a/spec/route-coverage.json
+++ b/spec/route-coverage.json
@@ -61,6 +61,11 @@
   },
   {
     "method": "POST",
+    "operationId": "CreateDirectUpload",
+    "path": "/rails/active_storage/direct_uploads.json"
+  },
+  {
+    "method": "POST",
     "operationId": "CreateFolderForPostings",
     "path": "/postings/folders.json"
   },

--- a/spec/shape-fingerprint.json
+++ b/spec/shape-fingerprint.json
@@ -6,7 +6,7 @@
   "CreateBulkReply": "5558743ff7d543e3f8d12036a2ef8378417b7f260c738fe28dc01b1823cfb4f6",
   "CreateCalendarTodo": "3e3226f5123ba16c946207e7c94c4eb179a6dfeaa4f3329b54ffeda0c7b8e585",
   "CreateContact": "52c57a7fb502f18cd0d56b56bdfa148a958b39847ca5bd10fb9064a8db9ea8cf",
-  "CreateDirectUpload": "76da4e9cf90916cb4713ca59665dcb56fb172f7759a93cfbb497309eed40adac",
+  "CreateDirectUpload": "acf11e04b0e09a71c455a20104ee5311ad10a3952da1b4feb4350ebdeb675f1a",
   "CreateHabit": "545c7bf2eddaf0b71a68ae839ac12e31d4e3d75c6dc70027a250cf89a7c9ac75",
   "CreateSticky": "109e08efe54f16e8275188b672d9387a55a02fefb69b15dae548e0965f5421f9",
   "CreateTimeTrack": "099983ea35840ec326931119b6bc4feecaee4500dc4f42b8a6259f138b632fd4",

--- a/spec/shape-fingerprint.json
+++ b/spec/shape-fingerprint.json
@@ -6,6 +6,7 @@
   "CreateBulkReply": "5558743ff7d543e3f8d12036a2ef8378417b7f260c738fe28dc01b1823cfb4f6",
   "CreateCalendarTodo": "3e3226f5123ba16c946207e7c94c4eb179a6dfeaa4f3329b54ffeda0c7b8e585",
   "CreateContact": "52c57a7fb502f18cd0d56b56bdfa148a958b39847ca5bd10fb9064a8db9ea8cf",
+  "CreateDirectUpload": "76da4e9cf90916cb4713ca59665dcb56fb172f7759a93cfbb497309eed40adac",
   "CreateHabit": "545c7bf2eddaf0b71a68ae839ac12e31d4e3d75c6dc70027a250cf89a7c9ac75",
   "CreateSticky": "109e08efe54f16e8275188b672d9387a55a02fefb69b15dae548e0965f5421f9",
   "CreateTimeTrack": "099983ea35840ec326931119b6bc4feecaee4500dc4f42b8a6259f138b632fd4",


### PR DESCRIPTION
## Summary

Add the SDK operations needed for hey-cli to send and save email attachments.

- model Active Storage direct-upload reservations as a generated operation
- add `Attachments().Upload`, which computes Active Storage's integrity checksum, reserves the blob, and uploads the bytes with the returned headers
- add `GetBlob` for small binary responses and streaming `DownloadBlob` for file downloads through HEY's same-origin blob URLs
- keep Authorization off storage uploads and strip it when blob downloads redirect across origins
- bypass the JSON response cache for binary downloads and stream saved files without a response-size cap

This refreshes and combines the work from #74 and #75 on current `main`, preserving their commits and adding the complete byte-upload helper required by the CLI. It is the SDK dependency for basecamp/hey-cli#117 and Basecamp card 10217261957.

## Validation

- `env GOWORK=off mise x -- make check`
- 143 of 143 conformance cases passed
- upload tests cover metadata, checksum, exact headers, content length, raw bytes, Authorization isolation, and secure target enforcement
- download tests cover cache bypass, same-origin enforcement, streaming binary content, destination validation, and Authorization stripping across redirects

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds attachment direct uploads and binary downloads so `hey-cli` can send and save attachments. Previously uploads were unsupported and blob GETs reused JSON caching and Authorization; now uploads are end-to-end, binary GETs bypass cache, streaming uses the shared pipeline, and Authorization is stripped on cross-origin redirects.

- Generates `CreateDirectUpload` at `/rails/active_storage/direct_uploads.json` with DirectUpload models; marked non-idempotent with no retries.
- Adds `Client.Attachments()` with `CreateDirectUpload` and `Upload(filename, contentType, content)`: computes base64 MD5, reserves the blob, requires an HTTPS storage target, PUTs bytes with returned headers, never sends Authorization to storage, and errors on empty responses (needs `signed_id`, `attachable_sgid`, `url`).
- Adds `Client.GetBlob(path)` and `Client.DownloadBlob(path, destination)`: sets Accept */*, requires the initial URL be same-origin (pre-request error otherwise), bypasses the JSON cache, strips Authorization on cross-origin redirects; `DownloadBlob` streams via the shared request pipeline, returns bytes written and response headers, and never retries after any bytes are written.
- Uses consistent “blob” terminology across helpers and tests; docs clarify buffered vs. streaming reads.
- No breaking changes. Migrate by using `Attachments().Upload` and the returned `attachable_sgid`/`signed_id`; use `GetBlob` for small reads and `DownloadBlob` for streaming files.

<sup>Written for commit a5c691340da3be3933a560569762c3cb4638a0c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-sdk/pull/83?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

