### PR TITLE
Read a box's posting changes as a typed operation

### DIFF
--- a/behavior-model.json
+++ b/behavior-model.json
@@ -409,6 +409,23 @@
         ]
       }
     },
+    "GetBoxPostingChanges": {
+      "idempotent": false,
+      "pagination": {
+        "style": "link",
+        "totalCountHeader": "X-Total-Count"
+      },
+      "readonly": true,
+      "retry": {
+        "backoff": "exponential",
+        "base_delay_ms": 1000,
+        "max": 3,
+        "retry_on": [
+          429,
+          503
+        ]
+      }
+    },
     "GetBubblebox": {
       "idempotent": false,
       "readonly": true,

--- a/conformance/runner/go/main.go
+++ b/conformance/runner/go/main.go
@@ -862,6 +862,16 @@ func executeOperation(client *generated.Client, ctx context.Context, tc TestCase
 	case "GetBox":
 		boxId := getInt64Param(tc.PathParams, "boxId")
 		return client.GetBox(ctx, boxId, nil)
+	case "GetBoxPostingChanges":
+		boxId := getInt64Param(tc.PathParams, "boxId")
+		params := &generated.GetBoxPostingChangesParams{Since: getStringParam(tc.QueryParams, "since")}
+		if version := getStringParam(tc.QueryParams, "v"); version != "" {
+			params.V = &version
+		}
+		if page := getStringParam(tc.QueryParams, "page"); page != "" {
+			params.Page = &page
+		}
+		return client.GetBoxPostingChanges(ctx, boxId, params)
 	case "GetImbox":
 		return client.GetImbox(ctx, nil)
 	case "GetFeedbox":

--- a/conformance/tests/paths.json
+++ b/conformance/tests/paths.json
@@ -3403,5 +3403,54 @@
       "path",
       "reads"
     ]
+  },
+  {
+    "name": "GetBoxPostingChanges uses /boxes/{boxId}/postings/changes.json path",
+    "description": "Verifies that GetBoxPostingChanges constructs the URL path /boxes/{boxId}/postings/changes.json and carries the sync cursor in the query",
+    "operation": "GetBoxPostingChanges",
+    "method": "GET",
+    "path": "/boxes/{boxId}/postings/changes.json",
+    "pathParams": {
+      "boxId": 24088
+    },
+    "queryParams": {
+      "since": "2026-08-18T09:00:00.000Z",
+      "v": "2"
+    },
+    "mockResponses": [
+      {
+        "status": 200,
+        "body": {
+          "added": [],
+          "updated": [],
+          "deleted": []
+        }
+      }
+    ],
+    "assertions": [
+      {
+        "type": "requestPath",
+        "expected": "/boxes/24088/postings/changes.json"
+      },
+      {
+        "type": "requestMethod",
+        "expected": "GET"
+      },
+      {
+        "type": "requestQuery",
+        "expected": {
+          "since": "2026-08-18T09:00:00.000Z",
+          "v": "2"
+        }
+      },
+      {
+        "type": "noError"
+      }
+    ],
+    "tags": [
+      "path",
+      "boxes",
+      "sync"
+    ]
   }
 ]

--- a/conformance/tests/status-codes.json
+++ b/conformance/tests/status-codes.json
@@ -178,6 +178,23 @@
     "tags": ["status-code", "429", "error", "rate-limit"]
   },
   {
+    "name": "409 Conflict on the changes feed means read the box in full",
+    "description": "Verifies that a sync cursor too far behind answers 409 with no body, rather than being retried or read as an increment",
+    "operation": "GetBoxPostingChanges",
+    "method": "GET",
+    "path": "/boxes/{boxId}/postings/changes.json",
+    "pathParams": {"boxId": 24088},
+    "queryParams": {"since": "2026-01-01T00:00:00.000Z", "v": "2"},
+    "mockResponses": [
+      {"status": 409, "body": {}}
+    ],
+    "assertions": [
+      {"type": "requestCount", "expected": 1},
+      {"type": "statusCode", "expected": 409}
+    ],
+    "tags": ["status-code", "409", "sync", "no-retry"]
+  },
+  {
     "name": "500 Internal Server Error is surfaced",
     "description": "Verifies that 500 responses are surfaced as InternalServerError",
     "operation": "GetBox",

--- a/go/pkg/generated/client.gen.go
+++ b/go/pkg/generated/client.gen.go
@@ -440,6 +440,15 @@ type CreateStickyResponseContent = Sticky
 // CreateTimeTrackResponseContent Recording — polymorphic by `type` (CalendarEvent, CalendarTodo, etc.)
 type CreateTimeTrackResponseContent = Recording
 
+// DeletedPosting DeletedPosting — the stub the changes feed answers with for a posting that is gone
+type DeletedPosting struct {
+	BoxId int64 `json:"box_id,omitempty"`
+
+	// DeletedAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
+	DeletedAt time.Time `json:"deleted_at,omitempty"`
+	Id        int64     `json:"id"`
+}
+
 // DirectUpload defines model for DirectUpload.
 type DirectUpload struct {
 	AttachableSgid string             `json:"attachable_sgid"`
@@ -576,6 +585,13 @@ type GetAdvancedSearchFiltersResponseContent = AdvancedSearchFilters
 // The API can return fields at root level or nested under a `box` key.
 // SDK response decoders normalize the nested variant to flat before decoding.
 type GetAsideboxResponseContent = BoxShowResponse
+
+// GetBoxPostingChangesResponseContent defines model for GetBoxPostingChangesResponseContent.
+type GetBoxPostingChangesResponseContent struct {
+	Added   []Posting        `json:"added,omitempty"`
+	Deleted []DeletedPosting `json:"deleted,omitempty"`
+	Updated []Posting        `json:"updated,omitempty"`
+}
 
 // GetBoxResponseContent BoxShowResponse — box detail with postings.
 // The API can return fields at root level or nested under a `box` key.
@@ -1367,6 +1383,14 @@ type GetBoxParams struct {
 	Page *string `form:"page,omitempty" json:"page,omitempty"`
 }
 
+// GetBoxPostingChangesParams defines parameters for GetBoxPostingChanges.
+type GetBoxPostingChangesParams struct {
+	Since   string  `form:"since" json:"since"`
+	V       *string `form:"v,omitempty" json:"v,omitempty"`
+	Page    *string `form:"page,omitempty" json:"page,omitempty"`
+	PerPage *string `form:"per_page,omitempty" json:"per_page,omitempty"`
+}
+
 // GetBubbleboxParams defines parameters for GetBubblebox.
 type GetBubbleboxParams struct {
 	Page *string `form:"page,omitempty" json:"page,omitempty"`
@@ -1846,6 +1870,9 @@ type ClientInterface interface {
 	// MarkBoxSeen request
 	MarkBoxSeen(ctx context.Context, boxId int64, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// GetBoxPostingChanges request
+	GetBoxPostingChanges(ctx context.Context, boxId int64, params *GetBoxPostingChangesParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// GetBubblebox request
 	GetBubblebox(ctx context.Context, params *GetBubbleboxParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -2315,6 +2342,16 @@ func (c *Client) MarkBoxSeen(ctx context.Context, boxId int64, reqEditors ...Req
 		return nil, err
 	}
 	return c.Client.Do(req)
+
+}
+
+// GetBoxPostingChanges is marked as idempotent and will be retried on transient failures.
+
+func (c *Client) GetBoxPostingChanges(ctx context.Context, boxId int64, params *GetBoxPostingChangesParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		return NewGetBoxPostingChangesRequest(c.Server, boxId, params)
+	}, true, "GetBoxPostingChanges", reqEditors...)
 
 }
 
@@ -4388,6 +4425,106 @@ func NewMarkBoxSeenRequest(server string, boxId int64) (*http.Request, error) {
 	}
 
 	req, err := http.NewRequest("POST", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewGetBoxPostingChangesRequest generates requests for GetBoxPostingChanges
+func NewGetBoxPostingChangesRequest(server string, boxId int64, params *GetBoxPostingChangesParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "boxId", runtime.ParamLocationPath, boxId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/boxes/%s/postings/changes.json", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "since", runtime.ParamLocationQuery, params.Since); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+		if params.V != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "v", runtime.ParamLocationQuery, *params.V); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Page != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "page", runtime.ParamLocationQuery, *params.Page); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.PerPage != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "per_page", runtime.ParamLocationQuery, *params.PerPage); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -8039,6 +8176,7 @@ var operationMetadata = map[string]OperationMetadata{
 	"CreateBoxGroup":             {Idempotent: false, HasSensitiveParams: false},
 	"DeleteBoxGroup":             {Idempotent: true, HasSensitiveParams: false},
 	"MarkBoxSeen":                {Idempotent: false, HasSensitiveParams: false},
+	"GetBoxPostingChanges":       {Idempotent: true, HasSensitiveParams: false},
 	"GetBubblebox":               {Idempotent: true, HasSensitiveParams: false},
 	"CreateBulkReply":            {Idempotent: false, HasSensitiveParams: false},
 	"NewBulkReply":               {Idempotent: true, HasSensitiveParams: false},
@@ -8825,6 +8963,21 @@ type ClientWithResponsesInterface interface {
 	//
 	// Returns a wrapper object for the known response body format(s).
 	MarkBoxSeenWithResponse(ctx context.Context, boxId int64, reqEditors ...RequestEditorFn) (*MarkBoxSeenResponse, error)
+
+	// GetBoxPostingChangesWithResponse performs a GET /boxes/{boxId}/postings/changes.json (the `GetBoxPostingChanges` operationId) request.
+	//
+	// Read what changed among a box's postings since a point in time.
+	//
+	// This is the incremental sync feed the mail clients follow rather than re-reading a
+	// box. `since` is an ISO 8601 timestamp with milliseconds and is exclusive, and `v` is
+	// the client's contract version — the server answers 409 when the caller is too far
+	// behind for an increment to carry the difference, which means read the box in full
+	// instead. A box's own `posting_changes_url` carries the `since` and `v` to start from,
+	// and the `Link` header names the next page while one remains and the next `since`
+	// cursor on the last page.
+	//
+	// Returns a wrapper object for the known response body format(s).
+	GetBoxPostingChangesWithResponse(ctx context.Context, boxId int64, params *GetBoxPostingChangesParams, reqEditors ...RequestEditorFn) (*GetBoxPostingChangesResponse, error)
 
 	// GetBubbleboxWithResponse performs a GET /bubble_up.json (the `GetBubblebox` operationId) request.
 	//
@@ -10345,6 +10498,82 @@ func (r MarkBoxSeenResponse) StatusCode() int {
 
 // ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
 func (r MarkBoxSeenResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type GetBoxPostingChangesResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	// JSON200 the response for an HTTP 200 `application/json` response
+	JSON200 *GetBoxPostingChangesResponseContent
+	// JSON401 the response for an HTTP 401 `application/json` response
+	JSON401 *UnauthorizedErrorResponseContent
+	// JSON404 the response for an HTTP 404 `application/json` response
+	JSON404 *NotFoundErrorResponseContent
+	// JSON409 the response for an HTTP 409 `application/json` response
+	JSON409 *ConflictErrorResponseContent
+	// JSON500 the response for an HTTP 500 `application/json` response
+	JSON500 *InternalServerErrorResponseContent
+	// JSON503 the response for an HTTP 503 `application/json` response
+	JSON503 *ServiceUnavailableErrorResponseContent
+}
+
+// GetJSON200 returns the response for an HTTP 200 `application/json` response
+func (r GetBoxPostingChangesResponse) GetJSON200() *GetBoxPostingChangesResponseContent {
+	return r.JSON200
+}
+
+// GetJSON401 returns the response for an HTTP 401 `application/json` response
+func (r GetBoxPostingChangesResponse) GetJSON401() *UnauthorizedErrorResponseContent {
+	return r.JSON401
+}
+
+// GetJSON404 returns the response for an HTTP 404 `application/json` response
+func (r GetBoxPostingChangesResponse) GetJSON404() *NotFoundErrorResponseContent {
+	return r.JSON404
+}
+
+// GetJSON409 returns the response for an HTTP 409 `application/json` response
+func (r GetBoxPostingChangesResponse) GetJSON409() *ConflictErrorResponseContent {
+	return r.JSON409
+}
+
+// GetJSON500 returns the response for an HTTP 500 `application/json` response
+func (r GetBoxPostingChangesResponse) GetJSON500() *InternalServerErrorResponseContent {
+	return r.JSON500
+}
+
+// GetJSON503 returns the response for an HTTP 503 `application/json` response
+func (r GetBoxPostingChangesResponse) GetJSON503() *ServiceUnavailableErrorResponseContent {
+	return r.JSON503
+}
+
+// GetBody returns the raw response body bytes
+func (r GetBoxPostingChangesResponse) GetBody() []byte {
+	return r.Body
+}
+
+// Status returns HTTPResponse.Status
+func (r GetBoxPostingChangesResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetBoxPostingChangesResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r GetBoxPostingChangesResponse) ContentType() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Header.Get("Content-Type")
 	}
@@ -16328,6 +16557,27 @@ func (c *ClientWithResponses) MarkBoxSeenWithResponse(ctx context.Context, boxId
 	return ParseMarkBoxSeenResponse(rsp)
 }
 
+// GetBoxPostingChangesWithResponse performs a GET /boxes/{boxId}/postings/changes.json (the `GetBoxPostingChanges` operationId) request.
+//
+// Read what changed among a box's postings since a point in time.
+//
+// This is the incremental sync feed the mail clients follow rather than re-reading a
+// box. `since` is an ISO 8601 timestamp with milliseconds and is exclusive, and `v` is
+// the client's contract version — the server answers 409 when the caller is too far
+// behind for an increment to carry the difference, which means read the box in full
+// instead. A box's own `posting_changes_url` carries the `since` and `v` to start from,
+// and the `Link` header names the next page while one remains and the next `since`
+// cursor on the last page.
+//
+// Returns a wrapper object for the known response body format(s).
+func (c *ClientWithResponses) GetBoxPostingChangesWithResponse(ctx context.Context, boxId int64, params *GetBoxPostingChangesParams, reqEditors ...RequestEditorFn) (*GetBoxPostingChangesResponse, error) {
+	rsp, err := c.GetBoxPostingChanges(ctx, boxId, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetBoxPostingChangesResponse(rsp)
+}
+
 // GetBubbleboxWithResponse performs a GET /bubble_up.json (the `GetBubblebox` operationId) request.
 //
 // Get the Bubble Up box.
@@ -18402,6 +18652,67 @@ func ParseMarkBoxSeenResponse(rsp *http.Response) (*MarkBoxSeenResponse, error) 
 			return nil, err
 		}
 		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalServerErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 503:
+		var dest ServiceUnavailableErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON503 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetBoxPostingChangesResponse parses an HTTP response from a GetBoxPostingChangesWithResponse call
+func ParseGetBoxPostingChangesResponse(rsp *http.Response) (*GetBoxPostingChangesResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetBoxPostingChangesResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest GetBoxPostingChangesResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest UnauthorizedErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFoundErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 409:
+		var dest ConflictErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON409 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest InternalServerErrorResponseContent

--- a/go/pkg/hey/postings.go
+++ b/go/pkg/hey/postings.go
@@ -3,6 +3,8 @@ package hey
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/basecamp/hey-sdk/go/pkg/generated"
@@ -259,6 +261,168 @@ func (s *PostingsService) BubbleUpNow(ctx context.Context, postingIDs ...int64) 
 		}
 		return CheckResponse(resp.HTTPResponse)
 	})
+}
+
+// PostingChangesCursor is where a read of a box's changes feed starts. Since is an ISO
+// 8601 timestamp with milliseconds and is exclusive; Version is the contract version the
+// caller speaks. A box's PostingChangesUrl carries the pair to begin with — read it with
+// PostingChangesCursorFrom rather than picking the query apart.
+type PostingChangesCursor struct {
+	Since   string
+	Version string
+	Page    string
+	PerPage string
+}
+
+// PostingChangesCursorFrom reads a cursor out of a changes URL the server issued, either
+// a box's PostingChangesUrl or a Link header the feed answered with.
+func PostingChangesCursorFrom(changesURL string) (PostingChangesCursor, error) {
+	parsed, err := url.Parse(changesURL)
+	if err != nil {
+		return PostingChangesCursor{}, fmt.Errorf("failed to read changes URL %q: %w", changesURL, err)
+	}
+
+	query := parsed.Query()
+	return PostingChangesCursor{
+		Since:   query.Get("since"),
+		Version: query.Get("v"),
+		Page:    query.Get("page"),
+		PerPage: query.Get("per_page"),
+	}, nil
+}
+
+// PostingChanges is everything that happened to a box's postings since a cursor.
+//
+// NextPage is set while this increment has more pages to read now. NextCursor is set on
+// the last page and is where the next read should resume; it is nil when nothing changed,
+// in which case the cursor that produced this page still stands. FullSyncRequired is set
+// when the cursor is too far behind for an increment to carry the difference, and the box
+// has to be read in full instead.
+type PostingChanges struct {
+	Added            []generated.Posting
+	Updated          []generated.Posting
+	Deleted          []generated.DeletedPosting
+	NextPage         *PostingChangesCursor
+	NextCursor       *PostingChangesCursor
+	FullSyncRequired bool
+}
+
+// AllChanges reads a box's posting changes feed from a cursor to its end.
+func (s *PostingsService) AllChanges(ctx context.Context, boxID int64, cursor PostingChangesCursor) (*PostingChanges, error) {
+	all := &PostingChanges{}
+
+	for page := 1; page <= s.client.httpOpts.MaxPages; page++ {
+		changes, err := s.Changes(ctx, boxID, cursor)
+		if err != nil {
+			return nil, err
+		}
+		if changes.FullSyncRequired {
+			return changes, nil
+		}
+
+		all.Added = append(all.Added, changes.Added...)
+		all.Updated = append(all.Updated, changes.Updated...)
+		all.Deleted = append(all.Deleted, changes.Deleted...)
+		all.NextCursor = changes.NextCursor
+
+		if changes.NextPage == nil {
+			return all, nil
+		}
+		cursor = *changes.NextPage
+	}
+
+	s.client.logger.Warn("posting changes pagination capped", "maxPages", s.client.httpOpts.MaxPages)
+	return all, nil
+}
+
+// Changes returns one page of a box's posting changes feed.
+func (s *PostingsService) Changes(ctx context.Context, boxID int64, cursor PostingChangesCursor) (result *PostingChanges, err error) {
+	if cursor.Since == "" {
+		return nil, ErrUsage("a since cursor is required — start from the box's posting_changes_url")
+	}
+
+	op := OperationInfo{
+		Service: "Postings", Operation: "GetBoxPostingChanges",
+		ResourceType: "posting", IsMutation: false, ResourceID: boxID,
+	}
+	if gater, ok := s.client.hooks.(GatingHooks); ok {
+		if ctx, err = gater.OnOperationGate(ctx, op); err != nil {
+			return
+		}
+	}
+	start := time.Now()
+	ctx = s.client.hooks.OnOperationStart(ctx, op)
+	defer func() { s.client.hooks.OnOperationEnd(ctx, op, err, time.Since(start)) }()
+
+	s.client.initGeneratedClient()
+	resp, err := s.client.gen.GetBoxPostingChangesWithResponse(ctx, boxID, cursor.params())
+	if err != nil {
+		return nil, err
+	}
+
+	// Too far behind for an increment: the server says so with a 409 and no body.
+	if resp.StatusCode() == http.StatusConflict {
+		return &PostingChanges{FullSyncRequired: true}, nil
+	}
+	if err = CheckResponse(resp.HTTPResponse); err != nil {
+		return nil, err
+	}
+
+	changes := &PostingChanges{}
+	if resp.JSON200 != nil {
+		changes.Added = resp.JSON200.Added
+		changes.Updated = resp.JSON200.Updated
+		changes.Deleted = resp.JSON200.Deleted
+	}
+
+	next, err := nextPostingChangesCursor(resp.HTTPResponse)
+	if err != nil {
+		return nil, err
+	}
+	if next != nil {
+		// The feed answers with a page link while an increment has more pages, and with a
+		// fresh since cursor on the last one.
+		if next.Page != "" {
+			changes.NextPage = next
+		} else {
+			changes.NextCursor = next
+		}
+	}
+
+	return changes, nil
+}
+
+func nextPostingChangesCursor(resp *http.Response) (*PostingChangesCursor, error) {
+	link := parseNextLink(resp.Header.Get("Link"))
+	if link == "" {
+		return nil, nil
+	}
+
+	requested := resp.Request.URL.String()
+	next := resolveURL(requested, link)
+	if !isSameOrigin(next, requested) {
+		return nil, fmt.Errorf("changes Link header points to a different origin: %s", next)
+	}
+
+	cursor, err := PostingChangesCursorFrom(next)
+	if err != nil {
+		return nil, err
+	}
+	return &cursor, nil
+}
+
+func (c PostingChangesCursor) params() *generated.GetBoxPostingChangesParams {
+	params := &generated.GetBoxPostingChangesParams{Since: c.Since}
+	if c.Version != "" {
+		params.V = &c.Version
+	}
+	if c.Page != "" {
+		params.Page = &c.Page
+	}
+	if c.PerPage != "" {
+		params.PerPage = &c.PerPage
+	}
+	return params
 }
 
 // BoxIDByKind returns the ID of the caller's box with the given kind

--- a/go/pkg/hey/postings_test.go
+++ b/go/pkg/hey/postings_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -350,5 +351,143 @@ func TestTopicsService_TrashSharedTopicNeedsConfirmation(t *testing.T) {
 	e := AsError(err)
 	if e == nil || e.Code != CodeUsage || e.Hint == "" {
 		t.Fatalf("expected a usage error telling the caller to confirm, got %#v", err)
+	}
+}
+
+// newChangesTestClient serves a box's posting changes feed with the given handler, and
+// answers with the cursor a box's posting_changes_url would carry.
+func newChangesTestClient(t *testing.T, handler http.HandlerFunc) (*Client, PostingChangesCursor) {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	c := NewClient(&Config{BaseURL: server.URL}, &StaticTokenProvider{Token: "test-token"},
+		WithMaxRetries(0), WithBaseDelay(time.Millisecond), WithMaxJitter(time.Millisecond))
+
+	cursor, err := PostingChangesCursorFrom(server.URL + "/boxes/24088/postings/changes.json?since=2026-08-18T09%3A00%3A00.000Z&v=2")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	return c, cursor
+}
+
+func TestPostingChangesCursorFrom(t *testing.T) {
+	cursor, err := PostingChangesCursorFrom("https://app.hey.com/boxes/24088/postings/changes.json?since=2026-08-18T09%3A00%3A00.000Z&v=2&page=3")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cursor.Since != "2026-08-18T09:00:00.000Z" {
+		t.Errorf("since = %q, want it decoded", cursor.Since)
+	}
+	if cursor.Version != "2" || cursor.Page != "3" {
+		t.Errorf("cursor = %+v, want v 2 and page 3", cursor)
+	}
+}
+
+func TestPostingsService_Changes(t *testing.T) {
+	var requested string
+	c, cursor := newChangesTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		requested = r.URL.String()
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Link", `<`+r.URL.Path+`?since=2026-08-18T09%3A14%3A22.031Z&v=2>; rel="next"`)
+		_, _ = w.Write([]byte(`{"added":[{"id":9001,"kind":"topic","box_id":24088}],
+			"updated":[{"id":9002,"kind":"topic","box_id":24088,"seen":true}],
+			"deleted":[{"id":9003,"box_id":24088,"deleted_at":"2026-08-18T09:14:00.000Z"}]}`))
+	})
+
+	changes, err := c.Postings().Changes(context.Background(), 24088, cursor)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if requested != "/boxes/24088/postings/changes.json?since=2026-08-18T09%3A00%3A00.000Z&v=2" {
+		t.Errorf("requested %q, want the box's own feed with the cursor", requested)
+	}
+	if len(changes.Added) != 1 || changes.Added[0].Id != 9001 {
+		t.Errorf("added = %+v, want posting 9001", changes.Added)
+	}
+	if len(changes.Updated) != 1 || !changes.Updated[0].Seen {
+		t.Errorf("updated = %+v, want a seen posting", changes.Updated)
+	}
+	if len(changes.Deleted) != 1 || changes.Deleted[0].Id != 9003 {
+		t.Errorf("deleted = %+v, want posting 9003", changes.Deleted)
+	}
+	if changes.NextPage != nil {
+		t.Errorf("next page = %+v, want none: a since link is a cursor, not a page", changes.NextPage)
+	}
+	if changes.NextCursor == nil || changes.NextCursor.Since != "2026-08-18T09:14:22.031Z" {
+		t.Errorf("cursor = %+v, want the since from the Link header", changes.NextCursor)
+	}
+}
+
+func TestPostingsService_AllChangesFollowsPages(t *testing.T) {
+	var requested []string
+	c, cursor := newChangesTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		requested = append(requested, r.URL.String())
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Query().Get("page") == "" {
+			w.Header().Set("Link", `<`+r.URL.Path+`?since=2026-08-18T09%3A00%3A00.000Z&v=2&page=2>; rel="next"`)
+			_, _ = w.Write([]byte(`{"added":[{"id":9001,"kind":"topic"}]}`))
+		} else {
+			w.Header().Set("Link", `<`+r.URL.Path+`?since=2026-08-18T09%3A30%3A00.000Z&v=2>; rel="next"`)
+			_, _ = w.Write([]byte(`{"added":[{"id":9002,"kind":"topic"}]}`))
+		}
+	})
+
+	changes, err := c.Postings().AllChanges(context.Background(), 24088, cursor)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(requested) != 2 {
+		t.Fatalf("requests = %v, want two pages", requested)
+	}
+	if !strings.Contains(requested[1], "page=2") {
+		t.Errorf("second request = %q, want the page from the Link header", requested[1])
+	}
+	if len(changes.Added) != 2 || changes.Added[0].Id != 9001 || changes.Added[1].Id != 9002 {
+		t.Errorf("added = %+v, want both pages", changes.Added)
+	}
+	if changes.NextCursor == nil || changes.NextCursor.Since != "2026-08-18T09:30:00.000Z" {
+		t.Errorf("cursor = %+v, want the last page's since", changes.NextCursor)
+	}
+}
+
+func TestPostingsService_ChangesTooFarBehind(t *testing.T) {
+	c, cursor := newChangesTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+	})
+
+	changes, err := c.Postings().AllChanges(context.Background(), 24088, cursor)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !changes.FullSyncRequired {
+		t.Error("a 409 should ask for a full sync rather than error")
+	}
+}
+
+func TestPostingsService_ChangesWithNothingNew(t *testing.T) {
+	c, cursor := newChangesTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	})
+
+	changes, err := c.Postings().AllChanges(context.Background(), 24088, cursor)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(changes.Added)+len(changes.Updated)+len(changes.Deleted) != 0 {
+		t.Errorf("changes = %+v, want none", changes)
+	}
+	if changes.NextCursor != nil {
+		t.Errorf("cursor = %+v, want none so the caller keeps the one it has", changes.NextCursor)
+	}
+}
+
+func TestPostingsService_ChangesRequiresACursor(t *testing.T) {
+	c, _ := newChangesTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("no request should be sent without a cursor")
+	})
+
+	if _, err := c.Postings().Changes(context.Background(), 24088, PostingChangesCursor{}); err == nil {
+		t.Fatal("expected error for a cursor with no since")
 	}
 }

--- a/go/pkg/hey/url-routes.json
+++ b/go/pkg/hey/url-routes.json
@@ -115,6 +115,19 @@
       }
     },
     {
+      "pattern": "/boxes/{boxId}/postings/changes",
+      "resource": "Boxes",
+      "operations": {
+        "GET": "GetBoxPostingChanges"
+      },
+      "params": {
+        "boxId": {
+          "role": "parent",
+          "type": "int64"
+        }
+      }
+    },
+    {
       "pattern": "/bubble_up",
       "resource": "Boxes",
       "operations": {

--- a/openapi.json
+++ b/openapi.json
@@ -904,6 +904,133 @@
         }
       }
     },
+    "/boxes/{boxId}/postings/changes.json": {
+      "get": {
+        "description": "Read what changed among a box's postings since a point in time.\n\nThis is the incremental sync feed the mail clients follow rather than re-reading a\nbox. `since` is an ISO 8601 timestamp with milliseconds and is exclusive, and `v` is\nthe client's contract version — the server answers 409 when the caller is too far\nbehind for an increment to carry the difference, which means read the box in full\ninstead. A box's own `posting_changes_url` carries the `since` and `v` to start from,\nand the `Link` header names the next page while one remains and the next `since`\ncursor on the last page.",
+        "operationId": "GetBoxPostingChanges",
+        "parameters": [
+          {
+            "name": "boxId",
+            "in": "path",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "required": true
+          },
+          {
+            "name": "since",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "name": "v",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "x-go-type-skip-optional-pointer": false
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "x-go-type-skip-optional-pointer": false
+            }
+          },
+          {
+            "name": "per_page",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "x-go-type-skip-optional-pointer": false
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "GetBoxPostingChanges 200 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetBoxPostingChangesResponseContent"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "UnauthorizedError 401 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedErrorResponseContent"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFoundError 404 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundErrorResponseContent"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "ConflictError 409 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConflictErrorResponseContent"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "InternalServerError 500 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerErrorResponseContent"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "ServiceUnavailableError 503 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceUnavailableErrorResponseContent"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Boxes"
+        ],
+        "x-hey-pagination": {
+          "style": "link",
+          "totalCountHeader": "X-Total-Count"
+        },
+        "x-hey-retry": {
+          "maxAttempts": 3,
+          "baseDelayMs": 1000,
+          "backoff": "exponential",
+          "retryOn": [
+            429,
+            503
+          ]
+        }
+      }
+    },
     "/bubble_up.json": {
       "get": {
         "description": "Get the Bubble Up box",
@@ -8851,6 +8978,32 @@
       "CreateTimeTrackResponseContent": {
         "$ref": "#/components/schemas/Recording"
       },
+      "DeletedPosting": {
+        "type": "object",
+        "description": "DeletedPosting — the stub the changes feed answers with for a posting that is gone",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "box_id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "deleted_at": {
+            "type": "string",
+            "description": "ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)",
+            "format": "date-time",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            }
+          }
+        },
+        "required": [
+          "id"
+        ]
+      },
       "DirectUpload": {
         "type": "object",
         "properties": {
@@ -9208,6 +9361,29 @@
       },
       "GetAsideboxResponseContent": {
         "$ref": "#/components/schemas/BoxShowResponse"
+      },
+      "GetBoxPostingChangesResponseContent": {
+        "type": "object",
+        "properties": {
+          "added": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Posting"
+            }
+          },
+          "updated": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Posting"
+            }
+          },
+          "deleted": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DeletedPosting"
+            }
+          }
+        }
       },
       "GetBoxResponseContent": {
         "$ref": "#/components/schemas/BoxShowResponse"

--- a/spec/excluded-routes.json
+++ b/spec/excluded-routes.json
@@ -1975,11 +1975,6 @@
     "reason": "phase-2: mobile triage surface"
   },
   {
-    "method": "GET",
-    "path": "/boxes/{box_id}/postings/changes",
-    "reason": "phase-2: mobile triage surface"
-  },
-  {
     "method": "DELETE",
     "path": "/boxes/{id}",
     "reason": "phase-2: mobile triage surface"

--- a/spec/hey.smithy
+++ b/spec/hey.smithy
@@ -181,6 +181,9 @@ service HEY {
         UpdateContactNote
         DeleteContactNote
 
+        // Boxes — posting sync
+        GetBoxPostingChanges
+
         // Boxes — designations, groups, observation
         CreateBoxDesignation
         DeleteBoxDesignation
@@ -2860,6 +2863,66 @@ structure DeleteBoxDesignationInput {
     @httpLabel
     @required
     designationId: Long
+}
+
+/// Read what changed among a box's postings since a point in time.
+///
+/// This is the incremental sync feed the mail clients follow rather than re-reading a
+/// box. `since` is an ISO 8601 timestamp with milliseconds and is exclusive, and `v` is
+/// the client's contract version — the server answers 409 when the caller is too far
+/// behind for an increment to carry the difference, which means read the box in full
+/// instead. A box's own `posting_changes_url` carries the `since` and `v` to start from,
+/// and the `Link` header names the next page while one remains and the next `since`
+/// cursor on the last page.
+@readonly
+@http(method: "GET", uri: "/boxes/{boxId}/postings/changes.json")
+@tags(["Boxes"])
+@heyRetry(maxAttempts: 3, baseDelayMs: 1000, backoff: "exponential", retryOn: [429, 503])
+@heyPagination(style: "link", totalCountHeader: "X-Total-Count")
+operation GetBoxPostingChanges {
+    input: GetBoxPostingChangesInput
+    output: GetBoxPostingChangesOutput
+    errors: [UnauthorizedError, NotFoundError, ConflictError, InternalServerError, ServiceUnavailableError]
+}
+
+structure GetBoxPostingChangesInput {
+    @httpLabel
+    @required
+    boxId: Long
+
+    @httpQuery("since")
+    @required
+    since: String
+
+    @httpQuery("v")
+    v: String
+
+    @httpQuery("page")
+    page: String
+
+    @httpQuery("per_page")
+    per_page: String
+}
+
+structure GetBoxPostingChangesOutput {
+    added: PostingList
+
+    updated: PostingList
+
+    deleted: DeletedPostingList
+}
+
+/// DeletedPosting — the stub the changes feed answers with for a posting that is gone
+structure DeletedPosting {
+    @required
+    id: Long
+
+    box_id: Long
+    deleted_at: DateTime
+}
+
+list DeletedPostingList {
+    member: DeletedPosting
 }
 
 /// List the Set Aside groups in a box

--- a/spec/route-coverage.json
+++ b/spec/route-coverage.json
@@ -161,6 +161,11 @@
   },
   {
     "method": "GET",
+    "operationId": "GetBoxPostingChanges",
+    "path": "/boxes/{boxId}/postings/changes.json"
+  },
+  {
+    "method": "GET",
     "operationId": "GetBubblebox",
     "path": "/bubble_up.json"
   },

--- a/spec/shape-fingerprint.json
+++ b/spec/shape-fingerprint.json
@@ -13,6 +13,7 @@
   "GetAdvancedSearchFilters": "b0cde27b441e5b00a350a4942174e9b4f82791f1c4c236eaf7fc9d7a5d514881",
   "GetAsidebox": "675d22b32c429ae536d4a4248a0c0c30d62adca2852fbb1d0defb12b7563521f",
   "GetBox": "373b5de0c686345126ca4da129f6991776936ecc1fa1e00fae00cd45cb6436e9",
+  "GetBoxPostingChanges": "003137f72b12fc7232fc2127316479999c0d0edcc0f89d53cb07eed1c3854ac1",
   "GetBubblebox": "b736b44d157cb75c0e50a75feb2be37c8f9988024aa8c6503ab7bde347560cce",
   "GetCalendarRecordings": "4ff27c9fc232cbd2f3ac3e0f4a4f7ee60e40d5c99e8c8efceefa2ea723e4b5ab",
   "GetClearances": "7d9ef1b6858f3dd07419c224882faf9ad2eb8f3dce3bff88308515121c9fa287",


### PR DESCRIPTION
A client that wants to follow a box has had to re-read it. The mail clients don't: they read `/boxes/{id}/postings/changes.json`, which answers what was added, updated and deleted since a cursor. That route sat in `excluded-routes.json` as phase-2 work, so nothing in the SDK could reach it.

This models it, and hands the wrapper a cursor rather than a URL:

```go
cursor, err := hey.PostingChangesCursorFrom(box.PostingChangesUrl)
changes, err := sdk.Postings().AllChanges(ctx, box.Id, cursor)
// changes.NextPage — more of this increment to read now
// changes.NextCursor — where to resume next time
```

A box's `posting_changes_url` carries the `since` and `v` to start from, so `PostingChangesCursorFrom` reads one out of it. The `Link` header names either the next page of the current increment or the `since` to resume from on the last page; the wrapper tells those apart and reports them separately, so a caller never has to guess which kind of link it got. A 409 means the cursor is too far behind for an increment to carry the difference — a fact about the feed rather than a failure — so it comes back as `FullSyncRequired` and the caller reads the box in full instead.

`AllChanges` drains an increment and stops at `MaxPages`, logging when it caps.

### Why now

`hey postings watch` in hey-cli follows a box over Action Cable. The broadcast is a doorbell — it carries ids, not postings — so the change itself is read from this feed. That also makes a missed broadcast harmless: the cursor is the source of truth, not the socket.

### Notes

- The other two changes feeds (`/calendar/changes`, `/calendars/{id}/recording/changes`) stay excluded; only the postings one is modelled here.
- Generated artifacts were rebuilt through the documented pipeline (`smithy-build`, `url-routes`, shape fingerprint, route coverage, `go-generate`). A no-op regenerate reproduces the checked-in files first, so there's no toolchain churn mixed in.
- Tests: Go unit tests for the cursor, paging, the 409 and the empty case; conformance cases for the path and query it builds, and for a 409 being answered once and not retried. `make check` passes, 144/144 conformance.
- hey-cli isn't updated yet — its call site needs the box-and-cursor signature once this is released.
