### PR TITLE
Send the time track category as category_title

### DIFF
--- a/go/pkg/generated/client.gen.go
+++ b/go/pkg/generated/client.gen.go
@@ -1276,7 +1276,11 @@ type UpdateStickyResponseContent = Sticky
 
 // UpdateTimeTrackPayload defines model for UpdateTimeTrackPayload.
 type UpdateTimeTrackPayload struct {
-	Category string `json:"category,omitempty"`
+	// CategoryTitle Files the track under a category, by title, matching CreateTimeTrack's
+	// category_title. The title has to name a category that already exists;
+	// haystack ignores an unknown one rather than creating it, and there is no
+	// way to clear a category once set -- neither "" nor null unsets it.
+	CategoryTitle string `json:"category_title,omitempty"`
 
 	// EndsAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
 	EndsAt *time.Time `json:"ends_at,omitempty"`
@@ -1287,7 +1291,7 @@ type UpdateTimeTrackPayload struct {
 	Title    string     `json:"title,omitempty"`
 }
 
-// UpdateTimeTrackRequestContent Wire format: {calendar_time_track: {title, notes, category, starts_at, ends_at}}
+// UpdateTimeTrackRequestContent Wire format: {calendar_time_track: {title, notes, category_title, starts_at, ends_at}}
 type UpdateTimeTrackRequestContent struct {
 	CalendarTimeTrack UpdateTimeTrackPayload `json:"calendar_time_track"`
 }

--- a/go/pkg/hey/services_test.go
+++ b/go/pkg/hey/services_test.go
@@ -838,6 +838,35 @@ func TestTimeTracksService_Update(t *testing.T) {
 	}
 }
 
+// The category goes out as category_title, the same spelling CreateTimeTrack
+// uses. Sent as category, haystack drops it and answers 200, so a wrong field
+// name here is silent -- the track just stays uncategorized.
+func TestTimeTracksService_Update_CategoryTitle(t *testing.T) {
+	client := newMutationTestClientWithValidation(t, "PUT", "/calendar/time_tracks/%s.json",
+		func(t *testing.T, body map[string]any) {
+			t.Helper()
+			tt, ok := body["calendar_time_track"].(map[string]any)
+			if !ok {
+				t.Fatal("missing calendar_time_track wrapper")
+			}
+			if tt["category_title"] != "Client work" {
+				t.Errorf("expected the category title, got %v", tt["category_title"])
+			}
+			if v, present := tt["category"]; present {
+				t.Errorf("category is not the field haystack reads; got category=%v", v)
+			}
+		},
+		`{"id":1,"type":"TimeTrack","category":"Client work"}`,
+	)
+
+	body := generated.UpdateTimeTrackJSONRequestBody{
+		CalendarTimeTrack: generated.UpdateTimeTrackPayload{CategoryTitle: "Client work"},
+	}
+	if _, err := client.TimeTracks().Update(context.Background(), 1, body); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestTimeTracksService_Stop(t *testing.T) {
 	client := newMutationTestClientWithValidation(t, "PUT", "/calendar/time_tracks/%s.json",
 		func(t *testing.T, body map[string]any) {
@@ -851,7 +880,7 @@ func TestTimeTracksService_Stop(t *testing.T) {
 			}
 			// Stop must not touch the start: a zero-valued starts_at would be
 			// applied by the server and rewrite the track to year 0001.
-			for _, k := range []string{"starts_at", "category", "notes", "title"} {
+			for _, k := range []string{"starts_at", "category", "category_title", "notes", "title"} {
 				if v, present := tt[k]; present {
 					t.Errorf("stop body must only carry ends_at; got %s=%v", k, v)
 				}

--- a/openapi.json
+++ b/openapi.json
@@ -10972,8 +10972,9 @@
           "notes": {
             "type": "string"
           },
-          "category": {
-            "type": "string"
+          "category_title": {
+            "type": "string",
+            "description": "Files the track under a category, by title, matching CreateTimeTrack's\ncategory_title. The title has to name a category that already exists;\nhaystack ignores an unknown one rather than creating it, and there is no\nway to clear a category once set -- neither \"\" nor null unsets it."
           },
           "starts_at": {
             "type": "string",
@@ -10999,7 +11000,7 @@
       },
       "UpdateTimeTrackRequestContent": {
         "type": "object",
-        "description": "Wire format: {calendar_time_track: {title, notes, category, starts_at, ends_at}}",
+        "description": "Wire format: {calendar_time_track: {title, notes, category_title, starts_at, ends_at}}",
         "properties": {
           "calendar_time_track": {
             "$ref": "#/components/schemas/UpdateTimeTrackPayload"

--- a/spec/hey.smithy
+++ b/spec/hey.smithy
@@ -1988,7 +1988,7 @@ structure UpdateTimeTrackInput {
     body: UpdateTimeTrackRequestContent
 }
 
-/// Wire format: {calendar_time_track: {title, notes, category, starts_at, ends_at}}
+/// Wire format: {calendar_time_track: {title, notes, category_title, starts_at, ends_at}}
 structure UpdateTimeTrackRequestContent {
     @required
     calendar_time_track: UpdateTimeTrackPayload
@@ -1997,7 +1997,13 @@ structure UpdateTimeTrackRequestContent {
 structure UpdateTimeTrackPayload {
     title: String
     notes: String
-    category: String
+
+    /// Files the track under a category, by title, matching CreateTimeTrack's
+    /// category_title. The title has to name a category that already exists;
+    /// haystack ignores an unknown one rather than creating it, and there is no
+    /// way to clear a category once set -- neither "" nor null unsets it.
+    category_title: String
+
     starts_at: DateTime
     ends_at: DateTime
 }


### PR DESCRIPTION
## What

`UpdateTimeTrackPayload` models the category as `category`. haystack doesn't read that field, so a PUT carrying it returns 200 and the track stays uncategorized. The field it reads is `category_title` — the same spelling `CreateTimeTrackRequestContent` already uses.

This renames the field in `spec/hey.smithy` and regenerates. Setting a category on an existing track isn't reachable through the SDK today; with this it is.

## How I verified

Against `app.hey.com` on a scratch time track I created and then deleted:

| Payload (inside `calendar_time_track`) | HTTP | `category` on read-back |
|---|---|---|
| `{"category": "Work"}` | 200 | `null` |
| `{"category": "172973"}` (id as string) | 200 | `null` |
| `{"category_id": 172973}` | 200 | `null` |
| `{"category_title": "Work"}` | 200 | `"Work"` |

`notes` sent in the same request persists in every case, so the requests were well-formed and correctly wrapped — the field name was the only thing wrong. The failure mode is silent, which is why it's easy to miss: no 422, just a track that quietly stays uncategorized.

Worth noting I inferred this from the wire, not from haystack — you can check the controller's permitted params to confirm.

## Changes

- `spec/hey.smithy` — `UpdateTimeTrackPayload.category` → `category_title`, with a doc comment on the two behaviours I hit: an unknown title is ignored rather than created, and a category can't be cleared once set (neither `""` nor `null` unsets it).
- `openapi.json`, `go/pkg/generated/client.gen.go` — regenerated via `make smithy-build` / `make go-generate`.
- `go/pkg/hey/services_test.go` — new `TestTimeTracksService_Update_CategoryTitle` asserting the wire field is `category_title` and that `category` is absent. Extended the `Stop` test's forbidden-key list to cover both spellings.

`url-routes`, `generate-shape-fingerprint` and `generate-route-coverage` were re-run per AGENTS.md; none of their outputs changed, since this touches an input shape rather than a route.

No hand-written service changes: `TimeTracks().Update` already takes the generated body, so the field becomes reachable on its own.

## Checks

`make check` passes — 145/145 conformance, all drift gates green.

## Not in this PR

- `title` in the same payload also appears to be dropped by the server. I left it alone since I don't know whether that's deliberate for time tracks.
- `hey timetrack stop --category …` in hey-cli, which is what sent me here. That needs a released SDK carrying this field, so it's a follow-up rather than something to land alongside.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Send time track category as `category_title` to match the server. Previously we sent `category`, which the server ignored (200 OK, track stayed uncategorized). This makes updating the category via the SDK work.

- Renames `UpdateTimeTrackPayload.category` to `category_title` in `spec/hey.smithy`; regenerates `openapi.json` and `go/pkg/generated/client.gen.go`.
- Adds a test asserting the wire field is `category_title` and updates the Stop test to forbid both `category` and `category_title`.
- No route or service changes; `TimeTracks().Update` continues to use the generated body.

**Migration**
- Replace uses of `UpdateTimeTrackPayload.Category` with `CategoryTitle` and pass a category title (not an ID).
- The server ignores unknown titles and does not allow clearing a category once set (neither empty string nor null).

<sup>Written for commit 3d1a9c92f99df747e1b534262fdcee3702b82e9d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-sdk/pull/86?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

