### PR TITLE
Add immutable linked-account clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,50 @@ Services on the client: `Identity`, `Boxes`, `Postings`, `Topics`, `Messages`, `
 `Journal`, `Search`, `Folders`, `Collections`, `Stickies`, `Clips`, `Snippets`, `Workflows`,
 `Publications`, `Designations`, `Extenzions`, `World`.
 
+### Linked accounts and separate identities
+
+A root client represents one authenticated HEY identity and presents mail from All Accounts.
+Derive an immutable client to present mail and choose acting users and senders for one linked
+account:
+
+```go
+work, err := client.ForAccount(ctx, workAccountID)
+if err != nil {
+    return err
+}
+postings, _ := work.Boxes().GetImbox(ctx, nil)
+_ = work.Messages().Create(ctx, "Subject", "Body", []string{"someone@example.com"}, nil, nil)
+```
+
+`ForAccount` verifies that the account is accessible to the authenticated identity when the
+scoped client is derived, then adds HEY's `filtered_account_id` to same-origin API requests,
+including pagination and retries. Long-lived applications can derive a fresh scoped client
+after observing identity or account-membership changes. It never adds the filter to signed external upload or download URLs.
+Account-scoped message sends resolve a sender from that account, and account-scoped contact
+creation resolves the identity's user in that account. Both operations return an error when
+the account has no matching sender or user rather than falling back to another account.
+
+Account scope follows HEY's mail-filter semantics; it is not an authorization boundary.
+Identity-owned services such as Calendar and Journal remain identity-wide. Use a client
+derived for a thread's account when replying or forwarding that thread.
+
+Separate, unlinked identities use separate root clients with separate token providers or auth
+strategies. Each root can independently derive its own linked-account clients:
+
+```go
+personal := hey.NewClient(cfg, personalTokenProvider)
+workIdentity := hey.NewClient(cfg, workTokenProvider)
+
+personalMail, _ := personal.ForAccount(ctx, personalAccountID)
+workMail, _ := workIdentity.ForAccount(ctx, workAccountID)
+```
+
 Every call reports itself to the client's `Hooks` (`hey.WithHooks`) as a named operation —
 `Postings.MovePostings`, `TimeTracks.StopTimeTrack` — and a `GatingHooks` implementation
 can refuse an operation before it runs. Retries, circuit breaking, bulkheads and rate limits
 are configured with `WithResilience`, `WithCircuitBreaker`, `WithBulkhead` and
-`WithRateLimit`; HTTP caching with `WithCache`.
+`WithRateLimit`; HTTP caching with `WithCache`. Response caching is active for requests with
+an `Authorization` header, which gives each authenticated identity a stable cache partition.
 
 ### Errors
 

--- a/conformance/runner/go/main.go
+++ b/conformance/runner/go/main.go
@@ -229,9 +229,28 @@ func runTest(tc TestCase) TestResult {
 		}
 	}
 
-	// Execute the operation
+	// Execute the operation. Account-scoped cases exercise the hand-written
+	// client layer because account scope is an SDK behavior rather than a
+	// generated Smithy operation.
 	ctx := context.Background()
-	sdkResp, sdkErr := executeOperation(client, ctx, tc)
+	var sdkResp *http.Response
+	var sdkErr error
+	if _, scoped := tc.ConfigOverrides["accountId"]; scoped {
+		accountID := getInt64Param(tc.ConfigOverrides, "accountId")
+		rootClient := hey.NewClient(
+			&hey.Config{BaseURL: server.URL},
+			&hey.StaticTokenProvider{Token: "conformance-test-token"},
+			hey.WithMaxRetries(0),
+		)
+		scopedClient, accountErr := rootClient.ForAccount(ctx, accountID)
+		if accountErr != nil {
+			sdkErr = accountErr
+		} else {
+			sdkErr = executeAccountScopedOperation(scopedClient, ctx, tc)
+		}
+	} else {
+		sdkResp, sdkErr = executeOperation(client, ctx, tc)
+	}
 
 	// Capture response body for responseBody assertions
 	var responseBodyBytes []byte
@@ -498,6 +517,18 @@ func checkAssertion(testName string, a Assertion, s checkState) TestResult {
 			return fail(testName, "Expected request path %q, got %q", expected, s.requestPaths[0])
 		}
 
+	case "lastRequestPath":
+		expected, ok := a.Expected.(string)
+		if !ok {
+			return fail(testName, "lastRequestPath: expected a string value, got %T", a.Expected)
+		}
+		if len(s.requestPaths) == 0 {
+			return fail(testName, "Expected a request, but none were recorded")
+		}
+		if got := s.requestPaths[len(s.requestPaths)-1]; got != expected {
+			return fail(testName, "Expected last request path %q, got %q", expected, got)
+		}
+
 	case "requestMethod":
 		expected, ok := a.Expected.(string)
 		if !ok {
@@ -530,6 +561,27 @@ func checkAssertion(testName string, a Assertion, s checkState) TestResult {
 			}
 			if got := q.Get(k); got != fmt.Sprint(v) {
 				return fail(testName, "Expected query param %s=%v, got %q", k, v, got)
+			}
+		}
+
+	case "lastRequestQuery":
+		expected, ok := a.Expected.(map[string]interface{})
+		if !ok {
+			return fail(testName, "lastRequestQuery: expected an object, got %T", a.Expected)
+		}
+		if len(s.requestQueries) == 0 {
+			return fail(testName, "Expected a request, but none were recorded")
+		}
+		q := s.requestQueries[len(s.requestQueries)-1]
+		for k, v := range expected {
+			if v == nil {
+				if q.Has(k) {
+					return fail(testName, "Expected last query param %q to be absent, got %q", k, q.Get(k))
+				}
+				continue
+			}
+			if got := q.Get(k); got != fmt.Sprint(v) {
+				return fail(testName, "Expected last query param %s=%v, got %q", k, v, got)
 			}
 		}
 
@@ -1285,6 +1337,16 @@ func executeOperation(client *generated.Client, ctx context.Context, tc TestCase
 
 	default:
 		return nil, fmt.Errorf("unknown operation: %s", tc.Operation)
+	}
+}
+
+func executeAccountScopedOperation(client *hey.Client, ctx context.Context, tc TestCase) error {
+	switch tc.Operation {
+	case "ListBoxes":
+		_, err := client.Boxes().List(ctx)
+		return err
+	default:
+		return fmt.Errorf("account-scoped conformance does not support operation: %s", tc.Operation)
 	}
 }
 

--- a/conformance/tests/account-scope.json
+++ b/conformance/tests/account-scope.json
@@ -1,0 +1,61 @@
+[
+  {
+    "name": "Account-scoped client filters generated operations",
+    "description": "Verifies that Client.ForAccount adds exactly one filtered_account_id to a generated request",
+    "operation": "ListBoxes",
+    "method": "GET",
+    "path": "/boxes.json",
+    "configOverrides": {
+      "accountId": 42
+    },
+    "mockResponses": [
+      {
+        "status": 200,
+        "body": {
+          "id": 1,
+          "accounts": [
+            {
+              "id": 42,
+              "status": "active"
+            }
+          ]
+        }
+      },
+      {
+        "status": 200,
+        "body": []
+      }
+    ],
+    "assertions": [
+      {
+        "type": "requestCount",
+        "expected": 2
+      },
+      {
+        "type": "requestPath",
+        "expected": "/identity.json"
+      },
+      {
+        "type": "lastRequestPath",
+        "expected": "/boxes.json"
+      },
+      {
+        "type": "lastRequestQuery",
+        "expected": {
+          "filtered_account_id": "42"
+        }
+      },
+      {
+        "type": "headerPresent",
+        "path": "Authorization"
+      },
+      {
+        "type": "noError"
+      }
+    ],
+    "tags": [
+      "account-scope",
+      "linked-accounts"
+    ]
+  }
+]

--- a/go/pkg/hey/account_scope.go
+++ b/go/pkg/hey/account_scope.go
@@ -28,7 +28,7 @@ func (c *Client) ForAccount(ctx context.Context, accountID int64) (*Client, erro
 		return nil, ErrUsage(fmt.Sprintf("account ID must be positive, got %d", accountID))
 	}
 
-	identityClient := &Client{clientShared: c.clientShared, httpClient: c.httpClient}
+	identityClient := &Client{clientShared: c.clientShared, httpClient: c.rootHTTPClient}
 	identity, err := identityClient.Identity().GetIdentity(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch identity for account validation: %w", err)
@@ -42,7 +42,7 @@ func (c *Client) ForAccount(ctx context.Context, accountID int64) (*Client, erro
 
 	client := &Client{
 		clientShared: c.clientShared,
-		httpClient:   accountScopedHTTPClient(c.httpClient),
+		httpClient:   accountScopedHTTPClient(c.rootHTTPClient, c.cfg.BaseURL, accountID),
 		accountID:    accountID,
 	}
 	client.seedAccountIdentity(identity)
@@ -152,32 +152,51 @@ func (c *Client) accountScopedURL(rawURL string) (string, error) {
 }
 
 func (c *Client) applyAccountScope(requestURL *url.URL) {
-	if c.accountID == 0 || requestURL == nil || c.cfg.BaseURL == "" || !isSameOrigin(c.cfg.BaseURL, requestURL.String()) {
+	applyAccountScope(c.cfg.BaseURL, c.accountID, requestURL)
+}
+
+func applyAccountScope(baseURL string, accountID int64, requestURL *url.URL) {
+	if accountID == 0 || requestURL == nil || baseURL == "" || !isSameOrigin(baseURL, requestURL.String()) {
 		return
 	}
 
 	query := requestURL.Query()
-	query.Set(filteredAccountIDParameter, strconv.FormatInt(c.accountID, 10))
+	query.Set(filteredAccountIDParameter, strconv.FormatInt(accountID, 10))
 	requestURL.RawQuery = query.Encode()
 }
 
-func accountScopedHTTPClient(source *http.Client) *http.Client {
+func accountScopedHTTPClient(source *http.Client, baseURL string, accountID int64) *http.Client {
 	client := *source
 	transport := source.Transport
 	if transport == nil {
 		transport = http.DefaultTransport
 	}
-	client.Transport = &filteredAccountCookieTransport{inner: transport}
+	client.Transport = &accountScopedTransport{
+		inner:     transport,
+		baseURL:   baseURL,
+		accountID: accountID,
+	}
+	if source.Jar != nil {
+		client.Jar = &accountScopedCookieJar{inner: source.Jar}
+	}
 	return &client
 }
 
-type filteredAccountCookieTransport struct {
-	inner http.RoundTripper
+type accountScopedTransport struct {
+	inner     http.RoundTripper
+	baseURL   string
+	accountID int64
 }
 
-func (t *filteredAccountCookieTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+func (t *accountScopedTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	request := req.Clone(req.Context())
 	request.Header = req.Header.Clone()
+	applyAccountScope(t.baseURL, t.accountID, request.URL)
+	removeAccountFilterCookie(request)
+	return t.inner.RoundTrip(request)
+}
+
+func removeAccountFilterCookie(request *http.Request) {
 	cookies := request.Cookies()
 	request.Header.Del("Cookie")
 	for _, cookie := range cookies {
@@ -185,5 +204,26 @@ func (t *filteredAccountCookieTransport) RoundTrip(req *http.Request) (*http.Res
 			request.AddCookie(cookie)
 		}
 	}
-	return t.inner.RoundTrip(request)
+}
+
+type accountScopedCookieJar struct {
+	inner http.CookieJar
+}
+
+func (j *accountScopedCookieJar) Cookies(u *url.URL) []*http.Cookie {
+	return cookiesWithoutAccountFilter(j.inner.Cookies(u))
+}
+
+func (j *accountScopedCookieJar) SetCookies(u *url.URL, cookies []*http.Cookie) {
+	j.inner.SetCookies(u, cookiesWithoutAccountFilter(cookies))
+}
+
+func cookiesWithoutAccountFilter(cookies []*http.Cookie) []*http.Cookie {
+	filtered := make([]*http.Cookie, 0, len(cookies))
+	for _, cookie := range cookies {
+		if cookie.Name != filteredAccountIDParameter {
+			filtered = append(filtered, cookie)
+		}
+	}
+	return filtered
 }

--- a/go/pkg/hey/account_scope.go
+++ b/go/pkg/hey/account_scope.go
@@ -1,0 +1,189 @@
+package hey
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+
+	"github.com/basecamp/hey-sdk/go/pkg/generated"
+)
+
+const filteredAccountIDParameter = "filtered_account_id"
+
+// ForAccount returns an immutable client that presents HEY's mail data for one
+// accessible linked account. It verifies the account against the authenticated
+// identity before returning. The returned client shares transport,
+// authentication, hooks, logging, configuration, and HTTP cache with its source
+// while maintaining its own generated client, services, and account-sensitive
+// caches.
+//
+// HEY applies account scope to mail-oriented operations. Identity-owned
+// operations, including Calendar and Journal, retain their identity-wide
+// semantics. Account scope is a presentation and acting-account context, not an
+// authorization boundary.
+func (c *Client) ForAccount(ctx context.Context, accountID int64) (*Client, error) {
+	if accountID <= 0 {
+		return nil, ErrUsage(fmt.Sprintf("account ID must be positive, got %d", accountID))
+	}
+
+	identityClient := &Client{clientShared: c.clientShared, httpClient: c.httpClient}
+	identity, err := identityClient.Identity().GetIdentity(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch identity for account validation: %w", err)
+	}
+	if identity == nil {
+		return nil, ErrAPI(0, "could not fetch identity")
+	}
+	if !identityHasAccessibleAccount(identity, accountID) {
+		return nil, ErrNotFound("accessible account", strconv.FormatInt(accountID, 10))
+	}
+
+	client := &Client{
+		clientShared: c.clientShared,
+		httpClient:   accountScopedHTTPClient(c.httpClient),
+		accountID:    accountID,
+	}
+	client.seedAccountIdentity(identity)
+	return client, nil
+}
+
+// AccountID returns the linked account selected for this client. The boolean is
+// false for an All Accounts client.
+func (c *Client) AccountID() (accountID int64, ok bool) {
+	return c.accountID, c.accountID > 0
+}
+
+// AccountUserID returns the authenticated identity's user ID in the selected
+// linked account.
+func (c *Client) AccountUserID(ctx context.Context) (int64, error) {
+	if c.accountID == 0 {
+		return 0, ErrUsage("account user ID requires an account-scoped client")
+	}
+
+	c.accountUserMu.Lock()
+	defer c.accountUserMu.Unlock()
+
+	if c.accountUserDone {
+		return c.accountUserID, nil
+	}
+
+	identity, err := c.Identity().GetIdentity(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("failed to fetch identity for account user ID: %w", err)
+	}
+	if identity == nil {
+		return 0, ErrAPI(0, "could not fetch identity")
+	}
+	for _, user := range identity.AllUsers {
+		if user.AccountId == c.accountID {
+			c.accountUserID = user.Id
+			c.accountUserDone = true
+			return c.accountUserID, nil
+		}
+	}
+
+	return 0, ErrNotFound("user for account", strconv.FormatInt(c.accountID, 10))
+}
+
+func identityHasAccessibleAccount(identity *generated.Identity, accountID int64) bool {
+	for _, account := range identity.Accounts {
+		if account.Id == accountID && accountIsAccessible(account) {
+			return true
+		}
+	}
+	return false
+}
+
+func accountIsAccessible(account generated.Account) bool {
+	return account.Status == "active" ||
+		(account.Status == "inactive" && (account.Purpose == "work" || account.Purpose == "domains"))
+}
+
+func (c *Client) seedAccountIdentity(identity *generated.Identity) {
+	for _, sender := range identity.Senders {
+		if sender.AccountId == c.accountID && sender.Default {
+			c.senderID = sender.Id
+			c.senderDone = true
+			break
+		}
+	}
+	if !c.senderDone {
+		for _, sender := range identity.Senders {
+			if sender.AccountId == c.accountID {
+				c.senderID = sender.Id
+				c.senderDone = true
+				break
+			}
+		}
+	}
+	for _, user := range identity.AllUsers {
+		if user.AccountId == c.accountID {
+			c.accountUserID = user.Id
+			c.accountUserDone = true
+			break
+		}
+	}
+}
+
+// prepareAPIRequest applies the client-wide properties shared by generated,
+// document, and form requests.
+func (c *Client) prepareAPIRequest(ctx context.Context, req *http.Request) error {
+	c.applyAccountScope(req.URL)
+	if err := c.authStrategy.Authenticate(ctx, req); err != nil {
+		return err
+	}
+	req.Header.Set("User-Agent", c.userAgent)
+	return nil
+}
+
+func (c *Client) accountScopedURL(rawURL string) (string, error) {
+	if c.accountID == 0 {
+		return rawURL, nil
+	}
+
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return "", err
+	}
+	c.applyAccountScope(parsed)
+	return parsed.String(), nil
+}
+
+func (c *Client) applyAccountScope(requestURL *url.URL) {
+	if c.accountID == 0 || requestURL == nil || c.cfg.BaseURL == "" || !isSameOrigin(c.cfg.BaseURL, requestURL.String()) {
+		return
+	}
+
+	query := requestURL.Query()
+	query.Set(filteredAccountIDParameter, strconv.FormatInt(c.accountID, 10))
+	requestURL.RawQuery = query.Encode()
+}
+
+func accountScopedHTTPClient(source *http.Client) *http.Client {
+	client := *source
+	transport := source.Transport
+	if transport == nil {
+		transport = http.DefaultTransport
+	}
+	client.Transport = &filteredAccountCookieTransport{inner: transport}
+	return &client
+}
+
+type filteredAccountCookieTransport struct {
+	inner http.RoundTripper
+}
+
+func (t *filteredAccountCookieTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	request := req.Clone(req.Context())
+	request.Header = req.Header.Clone()
+	cookies := request.Cookies()
+	request.Header.Del("Cookie")
+	for _, cookie := range cookies {
+		if cookie.Name != filteredAccountIDParameter {
+			request.AddCookie(cookie)
+		}
+	}
+	return t.inner.RoundTrip(request)
+}

--- a/go/pkg/hey/account_scope_test.go
+++ b/go/pkg/hey/account_scope_test.go
@@ -1,0 +1,904 @@
+package hey
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/cookiejar"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestClientForAccountIsImmutable(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":1,"accounts":[{"id":11,"status":"active"},{"id":22,"status":"active"},{"id":33,"status":"active"}]}`)
+	}))
+	t.Cleanup(server.Close)
+	root := NewClient(&Config{BaseURL: server.URL}, &StaticTokenProvider{Token: "token"})
+	first := mustForAccount(t, root, 11)
+	second := mustForAccount(t, root, 22)
+
+	if _, ok := root.AccountID(); ok {
+		t.Fatal("root client unexpectedly has an account")
+	}
+	if got, ok := first.AccountID(); !ok || got != 11 {
+		t.Fatalf("first AccountID = %d, %v, want 11, true", got, ok)
+	}
+	if got, ok := second.AccountID(); !ok || got != 22 {
+		t.Fatalf("second AccountID = %d, %v, want 22, true", got, ok)
+	}
+	if first.httpClient == root.httpClient || second.httpClient == root.httpClient {
+		t.Fatal("account-scoped clients should own cookie-filtering HTTP clients")
+	}
+	if first.clientShared != root.clientShared || second.clientShared != root.clientShared {
+		t.Fatal("account-scoped clients should share root client resources")
+	}
+	if first.Boxes() == root.Boxes() || first.Boxes() == second.Boxes() {
+		t.Fatal("account-scoped clients should own their service instances")
+	}
+
+	replaced := mustForAccount(t, first, 33)
+	if got, _ := first.AccountID(); got != 11 {
+		t.Fatalf("deriving another scope mutated first client to %d", got)
+	}
+	if got, _ := replaced.AccountID(); got != 33 {
+		t.Fatalf("replacement AccountID = %d, want 33", got)
+	}
+}
+
+func TestClientForAccountSeedsAccountIdentityState(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"id":1,
+			"accounts":[{"id":2,"status":"active"}],
+			"all_users":[{"id":202,"account_id":2}],
+			"senders":[{"id":22,"account_id":2}]
+		}`)
+	}))
+	t.Cleanup(server.Close)
+	root := NewClient(&Config{BaseURL: server.URL}, &StaticTokenProvider{Token: "token"})
+	client := mustForAccount(t, root, 2)
+
+	if got, err := client.DefaultSenderID(context.Background()); err != nil || got != 22 {
+		t.Fatalf("DefaultSenderID = %d, %v", got, err)
+	}
+	if got, err := client.AccountUserID(context.Background()); err != nil || got != 202 {
+		t.Fatalf("AccountUserID = %d, %v", got, err)
+	}
+	if requests.Load() != 1 {
+		t.Fatalf("identity requests = %d, want 1", requests.Load())
+	}
+}
+
+func TestClientForAccountRejectsInvalidIDs(t *testing.T) {
+	root := NewClient(&Config{BaseURL: "http://localhost:3000"}, &StaticTokenProvider{Token: "token"})
+	for _, accountID := range []int64{0, -1} {
+		t.Run(strconv.FormatInt(accountID, 10), func(t *testing.T) {
+			_, err := root.ForAccount(context.Background(), accountID)
+			if sdkErr, ok := err.(*Error); !ok || sdkErr.Code != CodeUsage {
+				t.Fatalf("ForAccount(%d) error = %v, want usage", accountID, err)
+			}
+		})
+	}
+}
+
+func TestClientForAccountRejectsUnknownAndInaccessibleAccounts(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":1,"accounts":[
+			{"id":1,"status":"active","purpose":"home"},
+			{"id":2,"status":"canceled","purpose":"home"},
+			{"id":3,"status":"inactive","purpose":"home"},
+			{"id":4,"status":"inactive","purpose":"work"}
+		]}`)
+	}))
+	t.Cleanup(server.Close)
+	root := NewClient(&Config{BaseURL: server.URL}, &StaticTokenProvider{Token: "token"})
+
+	for _, accountID := range []int64{2, 3, 99} {
+		_, err := root.ForAccount(context.Background(), accountID)
+		if sdkErr, ok := err.(*Error); !ok || sdkErr.Code != CodeNotFound {
+			t.Errorf("ForAccount(%d) error = %v, want not_found", accountID, err)
+		}
+	}
+	if _, err := root.ForAccount(context.Background(), 4); err != nil {
+		t.Fatalf("inactive work account should remain accessible: %v", err)
+	}
+	if requests.Load() != 4 {
+		t.Fatalf("identity requests = %d, want 4", requests.Load())
+	}
+}
+
+func TestAccountScopeRemovesConflictingFilterCookie(t *testing.T) {
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var mailCookies []*http.Cookie
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/identity.json" {
+			_, _ = io.WriteString(w, `{"id":1,"accounts":[{"id":2,"status":"active"}]}`)
+			return
+		}
+		mailCookies = r.Cookies()
+		if got := r.URL.Query().Get(filteredAccountIDParameter); got != "2" {
+			t.Errorf("query account = %q, want 2", got)
+		}
+		_, _ = io.WriteString(w, `{"ok":true}`)
+	}))
+	t.Cleanup(server.Close)
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	jar.SetCookies(serverURL, []*http.Cookie{
+		{Name: "session_token", Value: "session"},
+		{Name: filteredAccountIDParameter, Value: "1"},
+	})
+	root := NewClient(
+		&Config{BaseURL: server.URL},
+		&StaticTokenProvider{Token: "token"},
+		WithHTTPClient(&http.Client{Jar: jar}),
+	)
+	client := mustForAccount(t, root, 2)
+	if _, err := client.Get(context.Background(), "/mail.json"); err != nil {
+		t.Fatal(err)
+	}
+	cookies := map[string]string{}
+	for _, cookie := range mailCookies {
+		cookies[cookie.Name] = cookie.Value
+	}
+	if cookies["session_token"] != "session" {
+		t.Errorf("session cookie = %q", cookies["session_token"])
+	}
+	if _, present := cookies[filteredAccountIDParameter]; present {
+		t.Errorf("filter cookie reached scoped request: %v", cookies)
+	}
+}
+
+func TestAccountScopeGeneratedAndDocumentRequests(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		if got := r.URL.Query()[filteredAccountIDParameter]; len(got) != 1 || got[0] != "42" {
+			t.Errorf("%s query values = %v, want [42]", r.URL.Path, got)
+		}
+		if got := r.URL.Query().Get("keep"); r.URL.Path == "/manual.json" && got != "yes" {
+			t.Errorf("keep = %q, want yes", got)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer token" {
+			t.Errorf("Authorization = %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/boxes.json":
+			_, _ = io.WriteString(w, `[]`)
+		case "/manual.json":
+			_, _ = io.WriteString(w, `{"ok":true}`)
+		case "/page":
+			if got := r.Header.Get("Accept"); got != "text/html" {
+				t.Errorf("Accept = %q, want text/html", got)
+			}
+			_, _ = io.WriteString(w, `<h1>HEY</h1>`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	root := NewClient(&Config{BaseURL: server.URL}, &StaticTokenProvider{Token: "token"}, WithMaxRetries(0))
+	client := scopedTestClient(root, 42)
+	if _, err := client.Boxes().List(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.Get(context.Background(), "/manual.json?keep=yes&filtered_account_id=7"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.GetHTML(context.Background(), "/page"); err != nil {
+		t.Fatal(err)
+	}
+	if requests.Load() != 3 {
+		t.Fatalf("requests = %d, want 3", requests.Load())
+	}
+}
+
+func TestAllAccountsClientLeavesRequestsUnchanged(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if _, present := r.URL.Query()[filteredAccountIDParameter]; present {
+			t.Errorf("unscoped request query = %v", r.URL.Query())
+		}
+		_, _ = io.WriteString(w, `{"ok":true}`)
+	}))
+	t.Cleanup(server.Close)
+
+	client := NewClient(&Config{BaseURL: server.URL}, &StaticTokenProvider{Token: "token"}, WithMaxRetries(0))
+	if _, err := client.Get(context.Background(), "/manual.json?keep=yes"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAccountScopeFormAndMultipartRequests(t *testing.T) {
+	var paths []string
+	var mu sync.Mutex
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get(filteredAccountIDParameter); got != "42" {
+			t.Errorf("%s account = %q, want 42", r.URL.Path, got)
+		}
+		mu.Lock()
+		paths = append(paths, r.URL.Path)
+		mu.Unlock()
+		http.Redirect(w, r, "/done", http.StatusSeeOther)
+	}))
+	t.Cleanup(server.Close)
+
+	root := NewClient(&Config{BaseURL: server.URL}, &StaticTokenProvider{Token: "token"}, WithMaxRetries(0))
+	client := scopedTestClient(root, 42)
+	if _, err := client.PostForm(context.Background(), "/form", url.Values{"name": {"Jane"}}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.PostMultipart(context.Background(), "/multipart", "multipart/form-data; boundary=test", []byte("--test--")); err != nil {
+		t.Fatal(err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if fmt.Sprint(paths) != "[/form /multipart]" {
+		t.Fatalf("paths = %v", paths)
+	}
+}
+
+func TestAccountScopeRetriesAndHooksUseFinalURL(t *testing.T) {
+	var requests atomic.Int32
+	hooks := &accountScopeRecordingHooks{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get(filteredAccountIDParameter); got != "42" {
+			t.Errorf("account = %q, want 42", got)
+		}
+		if requests.Add(1) == 1 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		_, _ = io.WriteString(w, `{"ok":true}`)
+	}))
+	t.Cleanup(server.Close)
+
+	root := NewClient(
+		&Config{BaseURL: server.URL},
+		&StaticTokenProvider{Token: "token"},
+		WithMaxRetries(1),
+		WithBaseDelay(time.Millisecond),
+		WithMaxJitter(time.Nanosecond),
+		WithHooks(hooks),
+	)
+	client := scopedTestClient(root, 42)
+	if _, err := client.Get(context.Background(), "/retry.json"); err != nil {
+		t.Fatal(err)
+	}
+	if requests.Load() != 2 {
+		t.Fatalf("requests = %d, want 2", requests.Load())
+	}
+	for _, rawURL := range hooks.requestURLs() {
+		parsed, err := url.Parse(rawURL)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := parsed.Query().Get(filteredAccountIDParameter); got != "42" {
+			t.Errorf("hook URL %q account = %q", rawURL, got)
+		}
+	}
+	if got := hooks.retryURL(); got == "" {
+		t.Fatal("retry hook did not receive a URL")
+	} else if parsed, _ := url.Parse(got); parsed.Query().Get(filteredAccountIDParameter) != "42" {
+		t.Errorf("retry URL = %q", got)
+	}
+}
+
+func TestAccountScopeGeneratedRetriesRetainFilter(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get(filteredAccountIDParameter); got != "42" {
+			t.Errorf("account = %q, want 42", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if requests.Add(1) == 1 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		_, _ = io.WriteString(w, `[]`)
+	}))
+	t.Cleanup(server.Close)
+
+	root := NewClient(&Config{BaseURL: server.URL}, &StaticTokenProvider{Token: "token"})
+	client := scopedTestClient(root, 42)
+	if _, err := client.Boxes().List(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if requests.Load() != 2 {
+		t.Fatalf("requests = %d, want 2", requests.Load())
+	}
+}
+
+func TestAccountScopePaginationReappliesFilter(t *testing.T) {
+	var pages []string
+	var mu sync.Mutex
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get(filteredAccountIDParameter); got != "42" {
+			t.Errorf("account = %q, want 42", got)
+		}
+		page := r.URL.Query().Get("page")
+		mu.Lock()
+		pages = append(pages, page)
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		if page == "" {
+			w.Header().Set("Link", fmt.Sprintf(`<%s/items.json?page=2>; rel="next"`, serverURLFromRequest(r)))
+			_, _ = io.WriteString(w, `[{"id":1}]`)
+			return
+		}
+		_, _ = io.WriteString(w, `[{"id":2}]`)
+	}))
+	t.Cleanup(server.Close)
+
+	root := NewClient(&Config{BaseURL: server.URL}, &StaticTokenProvider{Token: "token"}, WithMaxRetries(0))
+	client := scopedTestClient(root, 42)
+	items, err := client.GetAll(context.Background(), "/items.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("items = %d, want 2", len(items))
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if fmt.Sprint(pages) != "[ 2]" {
+		t.Fatalf("pages = %v", pages)
+	}
+}
+
+func TestAccountScopeDoesNotReachCrossOriginUpload(t *testing.T) {
+	var storageQuery url.Values
+	var storageAuthorization string
+	storage := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		storageQuery = r.URL.Query()
+		storageAuthorization = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(storage.Close)
+
+	hey := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get(filteredAccountIDParameter); got != "42" {
+			t.Errorf("HEY account = %q, want 42", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"signed_id":       "signed-123",
+			"attachable_sgid": "sgid-123",
+			"direct_upload": map[string]any{
+				"url":     storage.URL + "/signed-upload?signature=abc",
+				"headers": map[string]string{"Content-Type": "text/plain"},
+			},
+		})
+	}))
+	t.Cleanup(hey.Close)
+
+	root := NewClient(&Config{BaseURL: hey.URL}, &StaticTokenProvider{Token: "token"}, WithMaxRetries(0))
+	client := scopedTestClient(root, 42)
+	if _, err := client.Attachments().Upload(context.Background(), "notes.txt", "text/plain", bytes.NewReader([]byte("hello"))); err != nil {
+		t.Fatal(err)
+	}
+	if got := storageQuery.Get("signature"); got != "abc" {
+		t.Errorf("signature = %q", got)
+	}
+	if _, present := storageQuery[filteredAccountIDParameter]; present {
+		t.Errorf("storage query includes account scope: %v", storageQuery)
+	}
+	if storageAuthorization != "" {
+		t.Errorf("storage Authorization = %q", storageAuthorization)
+	}
+}
+
+func TestAccountScopeDoesNotReachCrossOriginDownloadRedirect(t *testing.T) {
+	var targetQuery url.Values
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		targetQuery = r.URL.Query()
+		_, _ = io.WriteString(w, "download")
+	}))
+	t.Cleanup(target.Close)
+
+	source := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get(filteredAccountIDParameter); got != "42" {
+			t.Errorf("HEY account = %q, want 42", got)
+		}
+		http.Redirect(w, r, target.URL+"/signed-download?signature=abc", http.StatusFound)
+	}))
+	t.Cleanup(source.Close)
+
+	root := NewClient(&Config{BaseURL: source.URL}, &StaticTokenProvider{Token: "token"}, WithMaxRetries(0))
+	client := scopedTestClient(root, 42)
+	if _, err := client.GetBlob(context.Background(), "/blob"); err != nil {
+		t.Fatal(err)
+	}
+	if got := targetQuery.Get("signature"); got != "abc" {
+		t.Errorf("signature = %q", got)
+	}
+	if _, present := targetQuery[filteredAccountIDParameter]; present {
+		t.Errorf("download query includes account scope: %v", targetQuery)
+	}
+}
+
+func TestAccountScopeSeparatesSharedCacheKeys(t *testing.T) {
+	var mu sync.Mutex
+	conditional := map[string][]string{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		accountID := r.URL.Query().Get(filteredAccountIDParameter)
+		mu.Lock()
+		conditional[accountID] = append(conditional[accountID], r.Header.Get("If-None-Match"))
+		mu.Unlock()
+		etag := `"account-` + accountID + `"`
+		if r.Header.Get("If-None-Match") == etag {
+			w.WriteHeader(http.StatusNotModified)
+			return
+		}
+		w.Header().Set("ETag", etag)
+		_, _ = io.WriteString(w, `{"account_id":`+accountID+`}`)
+	}))
+	t.Cleanup(server.Close)
+
+	root := NewClient(
+		&Config{BaseURL: server.URL},
+		&StaticTokenProvider{Token: "token"},
+		WithMaxRetries(0),
+		WithCache(NewCache(t.TempDir())),
+	)
+	for _, client := range []*Client{scopedTestClient(root, 1), scopedTestClient(root, 2), scopedTestClient(root, 1), scopedTestClient(root, 2)} {
+		if _, err := client.Get(context.Background(), "/cached.json"); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	for accountID, requests := range conditional {
+		want := []string{"", `"account-` + accountID + `"`}
+		if fmt.Sprint(requests) != fmt.Sprint(want) {
+			t.Errorf("account %s conditionals = %v, want %v", accountID, requests, want)
+		}
+	}
+}
+
+func TestDefaultSenderIDUsesSelectedAccountAndSeparateCaches(t *testing.T) {
+	var identityRequests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		identityRequests.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"id": 1,
+			"primary_contact": {"id": 10},
+			"accounts": [{"id": 1, "status": "active"}, {"id": 2, "status": "active"}],
+			"senders": [
+				{"id": 11, "account_id": 1, "default": true},
+				{"id": 21, "account_id": 2},
+				{"id": 22, "account_id": 2, "default": true}
+			]
+		}`)
+	}))
+	t.Cleanup(server.Close)
+
+	root := NewClient(&Config{BaseURL: server.URL}, &StaticTokenProvider{Token: "token"}, WithMaxRetries(0))
+	first := mustForAccount(t, root, 1)
+	second := mustForAccount(t, root, 2)
+
+	for i := 0; i < 2; i++ {
+		if got, err := first.DefaultSenderID(context.Background()); err != nil || got != 11 {
+			t.Fatalf("first sender = %d, %v", got, err)
+		}
+		if got, err := second.DefaultSenderID(context.Background()); err != nil || got != 22 {
+			t.Fatalf("second sender = %d, %v", got, err)
+		}
+	}
+	if got, err := root.DefaultSenderID(context.Background()); err != nil || got != 11 {
+		t.Fatalf("root sender = %d, %v", got, err)
+	}
+	if identityRequests.Load() != 3 {
+		t.Fatalf("identity requests = %d, want 3 cached independently", identityRequests.Load())
+	}
+}
+
+func TestAccountScopedClientsDoNotExchangeConcurrentSenderState(t *testing.T) {
+	var mu sync.Mutex
+	requests := map[string]int{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		accountID := r.URL.Query().Get(filteredAccountIDParameter)
+		mu.Lock()
+		requests[accountID]++
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w, `{"id":1,"senders":[{"id":%s0,"account_id":%s,"default":true}]}`, accountID, accountID)
+	}))
+	t.Cleanup(server.Close)
+
+	root := NewClient(&Config{BaseURL: server.URL}, &StaticTokenProvider{Token: "token"}, WithMaxRetries(0))
+	clients := []struct {
+		client *Client
+		want   int64
+	}{{scopedTestClient(root, 1), 10}, {scopedTestClient(root, 2), 20}}
+
+	var wg sync.WaitGroup
+	for _, test := range clients {
+		for range 20 {
+			wg.Add(1)
+			go func(client *Client, want int64) {
+				defer wg.Done()
+				if got, err := client.DefaultSenderID(context.Background()); err != nil || got != want {
+					t.Errorf("sender = %d, %v, want %d", got, err, want)
+				}
+			}(test.client, test.want)
+		}
+	}
+	wg.Wait()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if requests["1"] != 1 || requests["2"] != 1 {
+		t.Fatalf("identity requests = %v, want one per account", requests)
+	}
+}
+
+func TestDefaultSenderIDDoesNotCrossAccountFallback(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":1,"accounts":[{"id":2,"status":"active"}],"primary_contact":{"id":10},"senders":[{"id":11,"account_id":1,"default":true}]}`)
+	}))
+	t.Cleanup(server.Close)
+
+	root := NewClient(&Config{BaseURL: server.URL}, &StaticTokenProvider{Token: "token"}, WithMaxRetries(0))
+	client := mustForAccount(t, root, 2)
+	for i := 0; i < 2; i++ {
+		_, err := client.DefaultSenderID(context.Background())
+		if sdkErr, ok := err.(*Error); !ok || sdkErr.Code != CodeNotFound {
+			t.Fatalf("error = %v, want not_found", err)
+		}
+	}
+	if requests.Load() != 3 {
+		t.Fatalf("failed sender lookups were cached; requests = %d", requests.Load())
+	}
+}
+
+func TestScopedMessageAndReplyUseAccountSender(t *testing.T) {
+	var mu sync.Mutex
+	actingSenders := map[string]int64{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get(filteredAccountIDParameter); got != "2" {
+			t.Errorf("%s account = %q, want 2", r.URL.Path, got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/identity.json" {
+			_, _ = io.WriteString(w, `{"id":1,"senders":[{"id":11,"account_id":1,"default":true},{"id":22,"account_id":2}]}`)
+			return
+		}
+		var body struct {
+			ActingSenderID int64 `json:"acting_sender_id"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Error(err)
+		}
+		mu.Lock()
+		actingSenders[r.URL.Path] = body.ActingSenderID
+		mu.Unlock()
+		w.WriteHeader(http.StatusCreated)
+	}))
+	t.Cleanup(server.Close)
+
+	root := NewClient(&Config{BaseURL: server.URL}, &StaticTokenProvider{Token: "token"}, WithMaxRetries(0))
+	client := scopedTestClient(root, 2)
+	if err := client.Messages().Create(context.Background(), "Subject", "Body", []string{"jane@example.com"}, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := client.Entries().CreateReply(context.Background(), 99, "Reply", []string{"jane@example.com"}, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if actingSenders["/messages.json"] != 22 || actingSenders["/entries/99/replies.json"] != 22 {
+		t.Fatalf("acting senders = %v, want account sender 22", actingSenders)
+	}
+}
+
+func TestAccountUserIDUsesSelectedAccountAndCaches(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":1,"all_users":[{"id":101,"account_id":1},{"id":202,"account_id":2}]}`)
+	}))
+	t.Cleanup(server.Close)
+
+	root := NewClient(&Config{BaseURL: server.URL}, &StaticTokenProvider{Token: "token"}, WithMaxRetries(0))
+	client := scopedTestClient(root, 2)
+	for i := 0; i < 2; i++ {
+		if got, err := client.AccountUserID(context.Background()); err != nil || got != 202 {
+			t.Fatalf("AccountUserID = %d, %v", got, err)
+		}
+	}
+	if requests.Load() != 1 {
+		t.Fatalf("identity requests = %d, want 1", requests.Load())
+	}
+}
+
+func TestAccountUserIDRequiresMatchingScope(t *testing.T) {
+	root := NewClient(&Config{BaseURL: "http://localhost:3000"}, &StaticTokenProvider{Token: "token"})
+	if _, err := root.AccountUserID(context.Background()); err == nil {
+		t.Fatal("All Accounts client AccountUserID returned no error")
+	}
+
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":1,"all_users":[{"id":101,"account_id":1}]}`)
+	}))
+	t.Cleanup(server.Close)
+	scopedRoot := NewClient(&Config{BaseURL: server.URL}, &StaticTokenProvider{Token: "token"}, WithMaxRetries(0))
+	client := scopedTestClient(scopedRoot, 2)
+	for i := 0; i < 2; i++ {
+		_, err := client.AccountUserID(context.Background())
+		if sdkErr, ok := err.(*Error); !ok || sdkErr.Code != CodeNotFound {
+			t.Fatalf("error = %v, want not_found", err)
+		}
+	}
+	if requests.Load() != 2 {
+		t.Fatalf("failed user lookups were cached; requests = %d", requests.Load())
+	}
+}
+
+func TestScopedContactCreateResolvesAndValidatesAccountUser(t *testing.T) {
+	var contactRequests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get(filteredAccountIDParameter); got != "2" {
+			t.Errorf("%s account = %q, want 2", r.URL.Path, got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/identity.json":
+			_, _ = io.WriteString(w, `{"id":1,"all_users":[{"id":101,"account_id":1},{"id":202,"account_id":2}]}`)
+		case "/contacts.json":
+			contactRequests.Add(1)
+			var body struct {
+				ActingUserID int64 `json:"acting_user_id"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Error(err)
+			}
+			if body.ActingUserID != 202 {
+				t.Errorf("acting_user_id = %d, want 202", body.ActingUserID)
+			}
+			w.WriteHeader(http.StatusCreated)
+			_, _ = io.WriteString(w, `{"id":55,"name":"Jane","email_address":"jane@example.com"}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	root := NewClient(&Config{BaseURL: server.URL}, &StaticTokenProvider{Token: "token"}, WithMaxRetries(0))
+	client := scopedTestClient(root, 2)
+	contact, err := client.Contacts().Create(context.Background(), ContactParams{Name: "Jane", EmailAddress: "jane@example.com"})
+	if err != nil || contact == nil || contact.Id != 55 {
+		t.Fatalf("Create = %#v, %v", contact, err)
+	}
+	_, err = client.Contacts().Create(context.Background(), ContactParams{
+		Name: "John", EmailAddress: "john@example.com", AccountUserID: 101,
+	})
+	if sdkErr, ok := err.(*Error); !ok || sdkErr.Code != CodeUsage {
+		t.Fatalf("mismatched account user error = %v, want usage", err)
+	}
+	if contactRequests.Load() != 1 {
+		t.Fatalf("contact requests = %d, want 1", contactRequests.Load())
+	}
+}
+
+func TestSeparateIdentityClientsDoNotShareCachedResponses(t *testing.T) {
+	var mu sync.Mutex
+	conditionals := map[string][]string{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		token := r.Header.Get("Authorization")
+		mu.Lock()
+		conditionals[token] = append(conditionals[token], r.Header.Get("If-None-Match"))
+		mu.Unlock()
+		etag := `"` + token + `"`
+		if r.Header.Get("If-None-Match") == etag {
+			w.WriteHeader(http.StatusNotModified)
+			return
+		}
+		w.Header().Set("ETag", etag)
+		_, _ = fmt.Fprintf(w, `{"token":%q}`, token)
+	}))
+	t.Cleanup(server.Close)
+
+	cache := NewCache(t.TempDir())
+	personalRoot := NewClient(&Config{BaseURL: server.URL}, &StaticTokenProvider{Token: "personal-token"}, WithMaxRetries(0), WithCache(cache))
+	workRoot := NewClient(&Config{BaseURL: server.URL}, &StaticTokenProvider{Token: "work-token"}, WithMaxRetries(0), WithCache(cache))
+	personal := scopedTestClient(personalRoot, 1)
+	work := scopedTestClient(workRoot, 1)
+	for _, client := range []*Client{personal, work, personal, work} {
+		if _, err := client.Get(context.Background(), "/cached.json"); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	for token, requests := range conditionals {
+		want := []string{"", `"` + token + `"`}
+		if fmt.Sprint(requests) != fmt.Sprint(want) {
+			t.Errorf("%s conditionals = %v, want %v", token, requests, want)
+		}
+	}
+}
+
+func TestCustomAuthenticationWithoutAuthorizationDisablesResponseCache(t *testing.T) {
+	var mu sync.Mutex
+	conditionals := map[string][]string{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		identity := r.Header.Get("X-Test-Identity")
+		mu.Lock()
+		conditionals[identity] = append(conditionals[identity], r.Header.Get("If-None-Match"))
+		mu.Unlock()
+		w.Header().Set("ETag", `"shared-url"`)
+		_, _ = fmt.Fprintf(w, `{"identity":%q}`, identity)
+	}))
+	t.Cleanup(server.Close)
+
+	cache := NewCache(t.TempDir())
+	personal := NewClient(
+		&Config{BaseURL: server.URL}, nil,
+		WithAuthStrategy(testHeaderAuth{identity: "personal"}),
+		WithMaxRetries(0), WithCache(cache),
+	)
+	work := NewClient(
+		&Config{BaseURL: server.URL}, nil,
+		WithAuthStrategy(testHeaderAuth{identity: "work"}),
+		WithMaxRetries(0), WithCache(cache),
+	)
+	for _, client := range []*Client{personal, work, personal, work} {
+		resp, err := client.Get(context.Background(), "/cached.json")
+		if err != nil {
+			t.Fatal(err)
+		}
+		var body struct {
+			Identity string `json:"identity"`
+		}
+		if err := resp.UnmarshalData(&body); err != nil {
+			t.Fatal(err)
+		}
+		if body.Identity == "" {
+			t.Fatal("response lost custom identity")
+		}
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	for identity, requests := range conditionals {
+		if fmt.Sprint(requests) != "[ ]" {
+			t.Errorf("%s conditionals = %v, want caching disabled", identity, requests)
+		}
+	}
+}
+
+func TestSeparateIdentityClientsDoNotShareAuthenticationOrSenderState(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		token := r.Header.Get("Authorization")
+		accountID := r.URL.Query().Get(filteredAccountIDParameter)
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/identity.json" {
+			senderID := int64(101)
+			if token == "Bearer work-token" {
+				senderID = 202
+			}
+			_, _ = fmt.Fprintf(w, `{"id":1,"senders":[{"id":%d,"account_id":%s,"default":true}]}`, senderID, accountID)
+			return
+		}
+		_, _ = io.WriteString(w, `{"ok":true}`)
+	}))
+	t.Cleanup(server.Close)
+
+	personalRoot := NewClient(&Config{BaseURL: server.URL}, &StaticTokenProvider{Token: "personal-token"}, WithMaxRetries(0))
+	workRoot := NewClient(&Config{BaseURL: server.URL}, &StaticTokenProvider{Token: "work-token"}, WithMaxRetries(0))
+	personal := scopedTestClient(personalRoot, 1)
+	work := scopedTestClient(workRoot, 2)
+
+	var wg sync.WaitGroup
+	for _, test := range []struct {
+		client *Client
+		want   int64
+	}{{personal, 101}, {work, 202}} {
+		for range 10 {
+			wg.Add(1)
+			go func(client *Client, want int64) {
+				defer wg.Done()
+				if got, err := client.DefaultSenderID(context.Background()); err != nil || got != want {
+					t.Errorf("sender = %d, %v, want %d", got, err, want)
+				}
+			}(test.client, test.want)
+		}
+	}
+	wg.Wait()
+}
+
+type testHeaderAuth struct {
+	identity string
+}
+
+func (a testHeaderAuth) Authenticate(_ context.Context, req *http.Request) error {
+	req.Header.Set("X-Test-Identity", a.identity)
+	return nil
+}
+
+type accountScopeRecordingHooks struct {
+	NoopHooks
+	mu       sync.Mutex
+	requests []string
+	retry    string
+}
+
+func (h *accountScopeRecordingHooks) OnRequestStart(ctx context.Context, info RequestInfo) context.Context {
+	h.mu.Lock()
+	h.requests = append(h.requests, info.URL)
+	h.mu.Unlock()
+	return ctx
+}
+
+func (h *accountScopeRecordingHooks) OnRetry(_ context.Context, info RequestInfo, _ int, _ error) {
+	h.mu.Lock()
+	h.retry = info.URL
+	h.mu.Unlock()
+}
+
+func (h *accountScopeRecordingHooks) requestURLs() []string {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return append([]string(nil), h.requests...)
+}
+
+func (h *accountScopeRecordingHooks) retryURL() string {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.retry
+}
+
+func serverURLFromRequest(r *http.Request) string {
+	return "http://" + r.Host
+}
+
+func mustForAccount(t *testing.T, client *Client, accountID int64) *Client {
+	t.Helper()
+	scoped, err := client.ForAccount(context.Background(), accountID)
+	if err != nil {
+		t.Fatalf("ForAccount(%d): %v", accountID, err)
+	}
+	return scoped
+}
+
+func scopedTestClient(root *Client, accountID int64) *Client {
+	return &Client{
+		clientShared: root.clientShared,
+		httpClient:   accountScopedHTTPClient(root.httpClient),
+		accountID:    accountID,
+	}
+}

--- a/go/pkg/hey/account_scope_test.go
+++ b/go/pkg/hey/account_scope_test.go
@@ -18,8 +18,17 @@ import (
 )
 
 func TestClientForAccountIsImmutable(t *testing.T) {
+	var requestedAccount string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/probe.json" {
+			requestedAccount = r.URL.Query().Get(filteredAccountIDParameter)
+			_, _ = io.WriteString(w, `{"ok":true}`)
+			return
+		}
+		if got := r.URL.Query().Get(filteredAccountIDParameter); got != "" {
+			t.Errorf("account validation was scoped to %q", got)
+		}
 		_, _ = io.WriteString(w, `{"id":1,"accounts":[{"id":11,"status":"active"},{"id":22,"status":"active"},{"id":33,"status":"active"}]}`)
 	}))
 	t.Cleanup(server.Close)
@@ -52,6 +61,12 @@ func TestClientForAccountIsImmutable(t *testing.T) {
 	}
 	if got, _ := replaced.AccountID(); got != 33 {
 		t.Fatalf("replacement AccountID = %d, want 33", got)
+	}
+	if _, err := replaced.Get(context.Background(), "/probe.json"); err != nil {
+		t.Fatal(err)
+	}
+	if requestedAccount != "33" {
+		t.Fatalf("replacement request account = %q, want 33", requestedAccount)
 	}
 }
 
@@ -168,6 +183,83 @@ func TestAccountScopeRemovesConflictingFilterCookie(t *testing.T) {
 	}
 	if _, present := cookies[filteredAccountIDParameter]; present {
 		t.Errorf("filter cookie reached scoped request: %v", cookies)
+	}
+}
+
+func TestAccountScopeFollowsSameOriginRedirects(t *testing.T) {
+	var startAccount, finalAccount string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/identity.json":
+			_, _ = io.WriteString(w, `{"id":1,"accounts":[{"id":42,"status":"active"}]}`)
+		case "/start":
+			startAccount = r.URL.Query().Get(filteredAccountIDParameter)
+			http.Redirect(w, r, "/final", http.StatusFound)
+		case "/final":
+			finalAccount = r.URL.Query().Get(filteredAccountIDParameter)
+			_, _ = io.WriteString(w, `{"ok":true}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	root := NewClient(&Config{BaseURL: server.URL}, &StaticTokenProvider{Token: "token"}, WithMaxRetries(0))
+	client := mustForAccount(t, root, 42)
+	if _, err := client.Get(context.Background(), "/start"); err != nil {
+		t.Fatal(err)
+	}
+	if startAccount != "42" || finalAccount != "42" {
+		t.Fatalf("redirect accounts = start %q, final %q; want 42", startAccount, finalAccount)
+	}
+}
+
+func TestScopedResponseDoesNotSetRootAccountFilterCookie(t *testing.T) {
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var rootCookies []*http.Cookie
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/identity.json":
+			_, _ = io.WriteString(w, `{"id":1,"accounts":[{"id":42,"status":"active"}]}`)
+		case "/scoped.json":
+			http.SetCookie(w, &http.Cookie{Name: filteredAccountIDParameter, Value: "42"})
+			http.SetCookie(w, &http.Cookie{Name: "session_update", Value: "kept"})
+			_, _ = io.WriteString(w, `{"ok":true}`)
+		case "/root.json":
+			rootCookies = r.Cookies()
+			_, _ = io.WriteString(w, `{"ok":true}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	root := NewClient(
+		&Config{BaseURL: server.URL},
+		&StaticTokenProvider{Token: "token"},
+		WithHTTPClient(&http.Client{Jar: jar}),
+	)
+	client := mustForAccount(t, root, 42)
+	if _, err := client.Get(context.Background(), "/scoped.json"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := root.Get(context.Background(), "/root.json"); err != nil {
+		t.Fatal(err)
+	}
+	cookies := map[string]string{}
+	for _, cookie := range rootCookies {
+		cookies[cookie.Name] = cookie.Value
+	}
+	if _, present := cookies[filteredAccountIDParameter]; present {
+		t.Errorf("scoped filter cookie reached root request: %v", cookies)
+	}
+	if cookies["session_update"] != "kept" {
+		t.Errorf("session update cookie = %q, want kept", cookies["session_update"])
 	}
 }
 
@@ -898,7 +990,7 @@ func mustForAccount(t *testing.T, client *Client, accountID int64) *Client {
 func scopedTestClient(root *Client, accountID int64) *Client {
 	return &Client{
 		clientShared: root.clientShared,
-		httpClient:   accountScopedHTTPClient(root.httpClient),
+		httpClient:   accountScopedHTTPClient(root.rootHTTPClient, root.cfg.BaseURL, accountID),
 		accountID:    accountID,
 	}
 }

--- a/go/pkg/hey/cache.go
+++ b/go/pkg/hey/cache.go
@@ -20,8 +20,9 @@ func NewCache(dir string) *Cache {
 	return &Cache{dir: dir}
 }
 
-// Key generates a cache key for a URL and token.
-// Unlike Basecamp, HEY has no account ID — key is URL + token hash.
+// Key generates a cache key for a URL and authorization value. Account-scoped
+// request URLs carry their account filter in the query, so each linked account
+// has distinct cache entries.
 func (c *Cache) Key(url, token string) string {
 	tokenHash := ""
 	if token != "" {

--- a/go/pkg/hey/client.go
+++ b/go/pkg/hey/client.go
@@ -21,13 +21,7 @@ import (
 // DefaultUserAgent is the default User-Agent header value.
 const DefaultUserAgent = "hey-sdk-go/" + Version + " (api:" + APIVersion + ")"
 
-// Client is an HTTP client for the HEY API.
-// Unlike the Basecamp SDK, HEY is user-scoped — services hang directly
-// off Client with no AccountClient or ForAccount indirection.
-//
-// Client is safe for concurrent use after construction.
-type Client struct {
-	httpClient    *http.Client
+type clientShared struct {
 	tokenProvider TokenProvider
 	authStrategy  AuthStrategy
 	cfg           *Config
@@ -36,8 +30,19 @@ type Client struct {
 	logger        *slog.Logger
 	httpOpts      HTTPOptions
 	hooks         Hooks
+}
 
-	// Generated client (single shared instance)
+// Client is an HTTP client for the HEY API. A root client represents the
+// authenticated identity and presents mail from All Accounts. ForAccount
+// derives an immutable client that presents mail for one linked account.
+//
+// Client is safe for concurrent use after construction.
+type Client struct {
+	*clientShared
+	httpClient *http.Client
+	accountID  int64
+
+	// Generated client for this account scope
 	genOnce sync.Once
 	gen     *generated.ClientWithResponses
 
@@ -45,6 +50,11 @@ type Client struct {
 	senderMu   sync.Mutex
 	senderID   int64
 	senderDone bool
+
+	// Cached user ID for the selected account (lazy-initialized, retries on error)
+	accountUserMu   sync.Mutex
+	accountUserID   int64
+	accountUserDone bool
 
 	// Cached box IDs by kind (imbox, feedbox, ...), lazy-initialized from ListBoxes
 	boxMu     sync.Mutex
@@ -148,14 +158,14 @@ func WithAuthStrategy(strategy AuthStrategy) ClientOption {
 // NewClient creates a new API client.
 func NewClient(cfg *Config, tokenProvider TokenProvider, opts ...ClientOption) *Client {
 	cfgCopy := *cfg
-	c := &Client{
+	c := &Client{clientShared: &clientShared{
 		tokenProvider: tokenProvider,
 		cfg:           &cfgCopy,
 		userAgent:     DefaultUserAgent,
 		logger:        slog.New(discardHandler{}),
 		hooks:         NoopHooks{},
 		httpOpts:      DefaultHTTPOptions(),
-	}
+	}}
 
 	for _, opt := range opts {
 		opt(c)
@@ -210,23 +220,22 @@ func NewClient(cfg *Config, tokenProvider TokenProvider, opts ...ClientOption) *
 	return c
 }
 
-// initGeneratedClient initializes the shared generated OpenAPI client.
+// initGeneratedClient initializes the generated OpenAPI client for this account scope.
 func (c *Client) initGeneratedClient() {
 	c.genOnce.Do(func() {
 		serverURL := strings.TrimSuffix(c.cfg.BaseURL, "/")
 		authEditor := func(ctx context.Context, req *http.Request) error {
-			if err := c.authStrategy.Authenticate(ctx, req); err != nil {
-				return err
-			}
-			req.Header.Set("User-Agent", c.userAgent)
-			if req.Header.Get("Content-Type") == "" {
-				req.Header.Set("Content-Type", "application/json")
-			}
-			req.Header.Set("Accept", "application/json")
 			req.URL.Path = withJSONExtension(req.URL.Path)
 			if req.URL.RawPath != "" {
 				req.URL.RawPath = withJSONExtension(req.URL.RawPath)
 			}
+			if err := c.prepareAPIRequest(ctx, req); err != nil {
+				return err
+			}
+			if req.Header.Get("Content-Type") == "" {
+				req.Header.Set("Content-Type", "application/json")
+			}
+			req.Header.Set("Accept", "application/json")
 			return nil
 		}
 		gen, err := generated.NewClientWithResponses(serverURL,
@@ -410,16 +419,15 @@ func (c *Client) doBodyRequest(ctx context.Context, method, path, contentType st
 		return nil, err
 	}
 
-	if err := c.authStrategy.Authenticate(ctx, req); err != nil {
+	if err := c.prepareAPIRequest(ctx, req); err != nil {
 		return nil, err
 	}
-	req.Header.Set("User-Agent", c.userAgent)
 	if contentType != "" {
 		req.Header.Set("Content-Type", contentType)
 	}
 	req.Header.Set("Accept", "*/*")
 
-	c.logger.Debug("http form request", "method", method, "url", reqURL)
+	c.logger.Debug("http form request", "method", method, "url", req.URL.String())
 
 	// Use a derived client that captures redirects instead of following them.
 	// This is thread-safe because it shares the transport but not the redirect policy.
@@ -538,6 +546,12 @@ func (c *Client) doRequest(ctx context.Context, method, path string, body any) (
 }
 
 func (c *Client) doRequestURL(ctx context.Context, method, url string, body any) (*Response, error) {
+	requestURL, err := c.accountScopedURL(url)
+	if err != nil {
+		return nil, err
+	}
+	url = requestURL
+
 	// Non-idempotent mutations: Don't retry on 429/5xx to avoid duplicating data.
 	// Only retry once after successful 401 token refresh.
 	if method == "POST" || method == "PATCH" {
@@ -615,23 +629,24 @@ func (c *Client) singleRequest(ctx context.Context, method, url string, body any
 		return nil, err
 	}
 
-	if err := c.authStrategy.Authenticate(ctx, req); err != nil {
+	if err := c.prepareAPIRequest(ctx, req); err != nil {
 		return nil, err
 	}
-	req.Header.Set("User-Agent", c.userAgent)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", acceptFromContext(ctx))
 
+	requestURL := req.URL.String()
 	var cacheKey string
-	if method == http.MethodGet && c.cache != nil && !noCacheFromContext(ctx) {
-		cacheKey = c.cache.Key(url, req.Header.Get("Authorization"))
+	authorization := req.Header.Get("Authorization")
+	if method == http.MethodGet && c.cache != nil && authorization != "" && !noCacheFromContext(ctx) {
+		cacheKey = c.cache.Key(requestURL, authorization)
 		if etag := c.cache.GetETag(cacheKey); etag != "" {
 			req.Header.Set("If-None-Match", etag)
 			c.logger.Debug("cache conditional request", "etag", etag)
 		}
 	}
 
-	c.logger.Debug("http request", "method", method, "url", url, "attempt", attempt)
+	c.logger.Debug("http request", "method", method, "url", requestURL, "attempt", attempt)
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
@@ -1088,10 +1103,12 @@ func (c *Client) World() *WorldService {
 	return c.world
 }
 
-// DefaultSenderID returns the current user's default sender contact ID.
-// The result is cached after the first successful call. Transient errors
-// are not cached, so subsequent calls will retry the identity fetch.
-// This is required for mutation operations that need an acting_sender_id.
+// DefaultSenderID returns the default sender contact ID for this client. An
+// account-scoped client selects only senders belonging to its account. An All
+// Accounts client preserves the identity-wide default sender behavior.
+//
+// The result is cached after the first successful call. Transient errors are
+// not cached, so subsequent calls retry the identity fetch.
 func (c *Client) DefaultSenderID(ctx context.Context) (int64, error) {
 	c.senderMu.Lock()
 	defer c.senderMu.Unlock()
@@ -1107,9 +1124,28 @@ func (c *Client) DefaultSenderID(ctx context.Context) (int64, error) {
 	if identity == nil {
 		return 0, ErrAPI(0, "could not fetch identity")
 	}
-	for _, s := range identity.Senders {
-		if s.Default {
-			c.senderID = s.Id
+
+	if c.accountID > 0 {
+		for _, sender := range identity.Senders {
+			if sender.AccountId == c.accountID && sender.Default {
+				c.senderID = sender.Id
+				c.senderDone = true
+				return c.senderID, nil
+			}
+		}
+		for _, sender := range identity.Senders {
+			if sender.AccountId == c.accountID {
+				c.senderID = sender.Id
+				c.senderDone = true
+				return c.senderID, nil
+			}
+		}
+		return 0, ErrNotFound("sender for account", strconv.FormatInt(c.accountID, 10))
+	}
+
+	for _, sender := range identity.Senders {
+		if sender.Default {
+			c.senderID = sender.Id
 			c.senderDone = true
 			return c.senderID, nil
 		}

--- a/go/pkg/hey/client.go
+++ b/go/pkg/hey/client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -22,14 +23,15 @@ import (
 const DefaultUserAgent = "hey-sdk-go/" + Version + " (api:" + APIVersion + ")"
 
 type clientShared struct {
-	tokenProvider TokenProvider
-	authStrategy  AuthStrategy
-	cfg           *Config
-	cache         *Cache
-	userAgent     string
-	logger        *slog.Logger
-	httpOpts      HTTPOptions
-	hooks         Hooks
+	tokenProvider  TokenProvider
+	authStrategy   AuthStrategy
+	rootHTTPClient *http.Client
+	cfg            *Config
+	cache          *Cache
+	userAgent      string
+	logger         *slog.Logger
+	httpOpts       HTTPOptions
+	hooks          Hooks
 }
 
 // Client is an HTTP client for the HEY API. A root client represents the
@@ -217,6 +219,7 @@ func NewClient(cfg *Config, tokenProvider TokenProvider, opts ...ClientOption) *
 		c.cache = NewCache(cfg.CacheDir)
 	}
 
+	c.rootHTTPClient = c.httpClient
 	return c
 }
 
@@ -596,7 +599,13 @@ func (c *Client) doRequestURL(ctx context.Context, method, url string, body any)
 			return nil, err
 		}
 
-		c.logger.Debug("retrying request", "attempt", attempt, "maxRetries", c.httpOpts.MaxRetries, "delay", delay, "error", lastErr)
+		c.logger.Debug(
+			"retrying request",
+			"attempt", attempt,
+			"maxRetries", c.httpOpts.MaxRetries,
+			"delay", delay,
+			"errorCode", errorCodeForLog(lastErr),
+		)
 
 		info := RequestInfo{Method: method, URL: url, Attempt: attempt}
 		c.hooks.OnRetry(ctx, info, attempt+1, lastErr)
@@ -610,6 +619,14 @@ func (c *Client) doRequestURL(ctx context.Context, method, url string, body any)
 	}
 
 	return nil, fmt.Errorf("request failed after %d retries: %w", c.httpOpts.MaxRetries, lastErr)
+}
+
+func errorCodeForLog(err error) string {
+	var sdkErr *Error
+	if errors.As(err, &sdkErr) {
+		return sdkErr.Code
+	}
+	return CodeAPI
 }
 
 func (c *Client) singleRequest(ctx context.Context, method, url string, body any, attempt int) (*Response, error) {

--- a/go/pkg/hey/client.go
+++ b/go/pkg/hey/client.go
@@ -427,7 +427,7 @@ func (c *Client) doBodyRequest(ctx context.Context, method, path, contentType st
 	}
 	req.Header.Set("Accept", "*/*")
 
-	c.logger.Debug("http form request", "method", method, "url", req.URL.String())
+	c.logger.Debug("http form request", "method", method)
 
 	// Use a derived client that captures redirects instead of following them.
 	// This is thread-safe because it shares the transport but not the redirect policy.
@@ -646,7 +646,7 @@ func (c *Client) singleRequest(ctx context.Context, method, url string, body any
 		}
 	}
 
-	c.logger.Debug("http request", "method", method, "url", requestURL, "attempt", attempt)
+	c.logger.Debug("http request", "method", method, "attempt", attempt)
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {

--- a/go/pkg/hey/contacts.go
+++ b/go/pkg/hey/contacts.go
@@ -200,6 +200,17 @@ func (s *ContactsService) Create(ctx context.Context, params ContactParams) (con
 	}
 
 	err = s.client.instrument(ctx, op, func(ctx context.Context) error {
+		if accountID, scoped := s.client.AccountID(); scoped {
+			accountUserID, rerr := s.client.AccountUserID(ctx)
+			if rerr != nil {
+				return rerr
+			}
+			if params.AccountUserID != 0 && params.AccountUserID != accountUserID {
+				return ErrUsage(fmt.Sprintf("account user %d does not belong to selected account %d", params.AccountUserID, accountID))
+			}
+			params.AccountUserID = accountUserID
+		}
+
 		resp, rerr := s.client.genClient().CreateContactWithResponse(ctx, createContactBody(params))
 		if rerr != nil {
 			return rerr

--- a/go/pkg/hey/doc.go
+++ b/go/pkg/hey/doc.go
@@ -44,6 +44,26 @@
 //   - [Client.Publications] - Public links for threads
 //   - [Client.Designations], [Client.Extenzions], [Client.World] - Where mail lands, extra addresses, and HEY World
 //
+// # Linked Accounts and Separate Identities
+//
+// A root client represents one authenticated HEY identity and presents mail
+// from All Accounts. [Client.ForAccount] derives an immutable client that
+// presents mail and resolves acting senders and users for one linked account:
+//
+//	work, err := client.ForAccount(ctx, workAccountID)
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//	postings, err := work.Boxes().GetImbox(ctx, nil)
+//
+// Separate identities use separate root clients with their own token providers
+// or authentication strategies. Each root client can derive its own linked
+// account clients.
+//
+// Account scope follows HEY's mail-filter semantics and is not an authorization
+// boundary. Identity-owned services such as Calendar and Journal remain
+// identity-wide.
+//
 // # Working with Boxes
 //
 // List all mailboxes:

--- a/go/pkg/hey/http.go
+++ b/go/pkg/hey/http.go
@@ -157,9 +157,7 @@ func (t *loggingTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 	}()
 
 	if t.client.logger != nil {
-		t.client.logger.Debug("http request",
-			"method", req.Method,
-			"url", req.URL.String())
+		t.client.logger.Debug("http request", "method", req.Method)
 	}
 
 	resp, err := t.inner.RoundTrip(req)

--- a/go/pkg/hey/security_test.go
+++ b/go/pkg/hey/security_test.go
@@ -3,6 +3,7 @@ package hey
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"log/slog"
 	"net/http"
@@ -10,6 +11,7 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestRequireHTTPS(t *testing.T) {
@@ -161,6 +163,33 @@ func TestRequestLogsExcludeUserProvidedURLs(t *testing.T) {
 	if !strings.Contains(output, "method=GET") {
 		t.Fatalf("request method missing from logs: %s", output)
 	}
+
+	logs.Reset()
+	failingClient := NewClient(
+		&Config{BaseURL: "https://example.com"},
+		&StaticTokenProvider{Token: "token"},
+		WithLogger(logger),
+		WithTransport(failingRoundTripper{}),
+		WithMaxRetries(1),
+		WithBaseDelay(time.Nanosecond),
+		WithMaxJitter(time.Nanosecond),
+	)
+	if _, err := failingClient.Get(context.Background(), "/messages.json?subject=forged-network-log-entry"); err == nil {
+		t.Fatal("failing request returned no error")
+	}
+	output = logs.String()
+	if strings.Contains(output, "forged-network-log-entry") {
+		t.Fatalf("network error URL reached logs: %s", output)
+	}
+	if !strings.Contains(output, "errorCode=network") {
+		t.Fatalf("network error code missing from retry log: %s", output)
+	}
+}
+
+type failingRoundTripper struct{}
+
+func (failingRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	return nil, errors.New("connection failed")
 }
 
 func TestLimitedReadAll(t *testing.T) {

--- a/go/pkg/hey/security_test.go
+++ b/go/pkg/hey/security_test.go
@@ -1,7 +1,12 @@
 package hey
 
 import (
+	"bytes"
+	"context"
+	"io"
+	"log/slog"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
@@ -121,6 +126,40 @@ func TestRedactHeaders(t *testing.T) {
 	// Original should not be modified
 	if h.Get("Authorization") != "Bearer secret" {
 		t.Fatal("expected original header unchanged")
+	}
+}
+
+func TestRequestLogsExcludeUserProvidedURLs(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"ok":true}`)
+	}))
+	t.Cleanup(server.Close)
+
+	var logs bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	client := NewClient(
+		&Config{BaseURL: server.URL},
+		&StaticTokenProvider{Token: "token"},
+		WithLogger(logger),
+	)
+	if _, err := client.Get(context.Background(), "/messages.json?subject=forged-document-log-entry"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.PostForm(
+		context.Background(),
+		"/messages.json?subject=forged-form-log-entry",
+		url.Values{"body": {"hello"}},
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	output := logs.String()
+	if strings.Contains(output, "forged-document-log-entry") || strings.Contains(output, "forged-form-log-entry") {
+		t.Fatalf("request URL reached logs: %s", output)
+	}
+	if !strings.Contains(output, "method=GET") {
+		t.Fatalf("request method missing from logs: %s", output)
 	}
 }
 


### PR DESCRIPTION
<!-- pr-review-readiness-head: 1037f51a49db67178712e22eb83ad276c7a43068 -->

SDK consumers need one authenticated identity to safely present either All Accounts or one linked mail account, while independent identities continue to use separate root clients. This adds that reusable SDK boundary without adding CLI profiles, changing identity-wide services, or requiring a Haystack change.

**Review readiness:** ✅ Yes  
**Risk:** 🟡 Medium — account scope now participates in shared request preparation, authentication, caching, and acting-sender/user resolution.  
**Decision:** Confirm that derivation-time account validation is the right first-release boundary while server-side fail-closed enforcement remains deferred.

<details>
<summary>✅ Change — linked accounts gain an immutable, validated SDK scope</summary>

### Before

```text
One authenticated HEY identity
├── All Accounts mail
└── ❌ no reusable SDK client for one linked account
```

### After

```text
One authenticated HEY identity
├── root client → All Accounts mail remains unchanged
└── ForAccount(ctx, accountID)
    ├── validates accessible identity membership
    ├── ✅ scopes same-origin mail requests  ← CHANGED
    └── resolves only that account's sender and user

Independent HEY identity
└── separate root client and auth state
```

The scoped client applies `filtered_account_id` across generated, document, form, multipart, retry, and pagination requests. It replaces duplicate account parameters, reapplies scope across same-origin redirects, isolates filter-cookie reads and writes, leaves signed external transfers untouched, and keeps account-sensitive caches and services isolated.

</details>

<details>
<summary>✅ Evidence — scoped behavior, isolation, compatibility, and review findings are covered</summary>

- ✅ [`account_scope_test.go`](https://github.com/basecamp/hey-sdk/blob/1037f51a49db67178712e22eb83ad276c7a43068/go/pkg/hey/account_scope_test.go) covers account validation, immutable/concurrent scopes, all request paths, retries, pagination, cache partitions, cookies, external URLs, sender/user selection, compose/reply/contact acting IDs, separate identities, and unchanged All Accounts behavior.
- ✅ [`account-scope.json`](https://github.com/basecamp/hey-sdk/blob/1037f51a49db67178712e22eb83ad276c7a43068/conformance/tests/account-scope.json) proves the public generated-operation path validates identity access and sends the selected account filter.
- ✅ [`TestRequestLogsExcludeUserProvidedURLs`](https://github.com/basecamp/hey-sdk/blob/1037f51a49db67178712e22eb83ad276c7a43068/go/pkg/hey/security_test.go) covers the resolved URL-logging findings for document, form, and retried network-error paths.
- ➖ No visual evidence: this PR changes a backend Go SDK API and has no user-visible interface or generated deliverable.

```text
GOWORK=off make check
→ MVP gate passed; 146/146 conformance cases passed

GOWORK=off go test -race -count=1 ./pkg/hey
→ ok github.com/basecamp/hey-sdk/go/pkg/hey
```

</details>

<details>
<summary>✅ Scope — additive SDK foundation with existing behavior preserved</summary>

**Included**

- `Client.ForAccount(ctx, accountID)` with fail-closed identity membership validation.
- Central same-origin request scoping and account-aware sender/user helpers.
- Safe cache partitioning for Bearer identities; response caching stays off when custom auth supplies no stable `Authorization` partition.
- Separate root-client isolation for unlinked identities.

**Preserved**

- Existing `NewClient`, service signatures, generated operations, and unscoped All Accounts behavior.
- Calendar, Journal, todos, habits, recordings, and time tracking remain identity-wide.

**Deferred / non-goals**

- CLI profile names, credential selection, account-switching UX, and TUI work.
- Haystack changes or treating account scope as an authorization boundary.
- Strict resource-ID/account-filter rejection.

</details>

<details>
<summary>➖ Delivery — no migration, configuration, dependency, or data operation</summary>

No feature flag, schema change, migration, backfill, new runtime dependency, deploy ordering, credential update, monitoring change, or cleanup is required. The capability ships through the normal SDK release process; rollback is reverting the additive SDK change before release or pinning consumers to the prior SDK version.

Existing consumers and records are unchanged until a caller explicitly derives an account-scoped client.

</details>

<details>
<summary>⚠️ Review decision — focus on scope propagation and the validation boundary</summary>

1. Confirm the root-client/immutable-child split is the right composition for linked accounts and separate authenticated identities.
2. Trace `filtered_account_id` through shared request preparation, redirects/external URLs, cookies, retries, pagination, and caches.

Account accessibility is verified when the scoped client is derived. If membership changes while a long-lived scoped client remains active, eliminating the final validation/request race requires Haystack to reject an explicit inaccessible `filtered_account_id`; that server hardening is intentionally deferred. Long-lived callers can derive a fresh scoped client after observing identity membership changes.

</details>

<details>
<summary>✅ Review path — runtime, proof, conformance, and docs are accounted for</summary>

1. **Foundation:** [`account_scope.go`](https://github.com/basecamp/hey-sdk/blob/1037f51a49db67178712e22eb83ad276c7a43068/go/pkg/hey/account_scope.go) and [`client.go`](https://github.com/basecamp/hey-sdk/blob/1037f51a49db67178712e22eb83ad276c7a43068/go/pkg/hey/client.go) — derivation, shared state, request preparation, and cache behavior.
2. **Write/auth edges:** [`contacts.go`](https://github.com/basecamp/hey-sdk/blob/1037f51a49db67178712e22eb83ad276c7a43068/go/pkg/hey/contacts.go), [`cache.go`](https://github.com/basecamp/hey-sdk/blob/1037f51a49db67178712e22eb83ad276c7a43068/go/pkg/hey/cache.go), and [`http.go`](https://github.com/basecamp/hey-sdk/blob/1037f51a49db67178712e22eb83ad276c7a43068/go/pkg/hey/http.go) — acting user, identity partitions, cookies, transport, and safe request logging.
3. **Proof:** [`account_scope_test.go`](https://github.com/basecamp/hey-sdk/blob/1037f51a49db67178712e22eb83ad276c7a43068/go/pkg/hey/account_scope_test.go) and [`security_test.go`](https://github.com/basecamp/hey-sdk/blob/1037f51a49db67178712e22eb83ad276c7a43068/go/pkg/hey/security_test.go) — behavioral and security regressions.
4. **Conformance:** [`account-scope.json`](https://github.com/basecamp/hey-sdk/blob/1037f51a49db67178712e22eb83ad276c7a43068/conformance/tests/account-scope.json) and [`runner/go/main.go`](https://github.com/basecamp/hey-sdk/blob/1037f51a49db67178712e22eb83ad276c7a43068/conformance/runner/go/main.go) — public SDK contract coverage.
5. **Consumer docs:** [`README.md`](https://github.com/basecamp/hey-sdk/blob/1037f51a49db67178712e22eb83ad276c7a43068/README.md) and [`doc.go`](https://github.com/basecamp/hey-sdk/blob/1037f51a49db67178712e22eb83ad276c7a43068/go/pkg/hey/doc.go) — API usage and linked/unlinked composition.

**Origin and supporting links:** [SDK foundation card](https://app.basecamp.com/2914079/buckets/48521764/card_tables/cards/10220851126) · [Linked-account CLI/TUI card](https://app.basecamp.com/2914079/buckets/48521764/card_tables/cards/10220542794) · [Unlinked-profile CLI/TUI card](https://app.basecamp.com/2914079/buckets/48521764/card_tables/cards/10220649596)

</details>
