### PR TITLE
Bump the SDK to 0.6.0

### DIFF
--- a/go/pkg/hey/version.go
+++ b/go/pkg/hey/version.go
@@ -1,7 +1,7 @@
 package hey
 
 // Version is the current version of the HEY Go SDK.
-const Version = "0.5.0"
+const Version = "0.6.0"
 
 // APIVersion is the HEY API version this SDK targets.
 const APIVersion = "2026-08-18"


### PR DESCRIPTION
Publishes the additive linked-account client foundation from #88 as the next minor Go SDK release.

## Change

- Bump `hey.Version` from `0.5.0` to `0.6.0`.
- No API, dependency, generated-code, schema, or runtime changes are included in this release commit.

## Validation

```text
GOWORK=off make check
→ MVP gate passed; 146/146 conformance cases passed
```

## Release

After this lands on `main`, run:

```text
make release VERSION=0.6.0
```

This creates `v0.6.0` and `go/v0.6.0`; the release workflow verifies the tag is on `main`, confirms `version.go`, reruns tests and race tests, then publishes the Go module tag.

Feature PR: https://github.com/basecamp/hey-sdk/pull/88
Basecamp card: https://app.basecamp.com/2914079/buckets/48521764/card_tables/cards/10220851126


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps `hey.Version` from 0.5.0 to 0.6.0 to cut the next minor Go SDK release that exposes the linked-account client foundation. No API, dependency, generated-code, schema, or runtime behavior changes.

- After merging to `main`, run: `make release VERSION=0.6.0` to create and publish tag `v0.6.0`.

<sup>Written for commit ef3bdd2c6357a93bd3a3633d92023090ba664bab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-sdk/pull/89?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

