### PR TITLE
Expose folder pagination metadata

### DIFF
--- a/go/pkg/hey/folders.go
+++ b/go/pkg/hey/folders.go
@@ -2,6 +2,9 @@ package hey
 
 import (
 	"context"
+	"net/url"
+	"strconv"
+	"strings"
 
 	"github.com/basecamp/hey-sdk/go/pkg/generated"
 )
@@ -16,11 +19,27 @@ func NewFoldersService(client *Client) *FoldersService {
 	return &FoldersService{client: client}
 }
 
-// Get returns a folder and the postings filed in it.
+// FolderPage contains one page of a folder and its pagination state.
+type FolderPage struct {
+	Folder     *generated.FolderWithPostings
+	NextPage   string
+	TotalCount int
+}
+
+// Get returns a folder and the postings filed in its requested page.
 //
 // Creating and deleting folders has no JSON surface; use PostingsService.CreateFolder to
 // make one while filing a selection into it.
-func (s *FoldersService) Get(ctx context.Context, folderID int64, params *generated.GetFolderParams) (result *generated.FolderWithPostings, err error) {
+func (s *FoldersService) Get(ctx context.Context, folderID int64, params *generated.GetFolderParams) (*generated.FolderWithPostings, error) {
+	page, err := s.GetPage(ctx, folderID, params)
+	if err != nil || page == nil {
+		return nil, err
+	}
+	return page.Folder, nil
+}
+
+// GetPage returns a folder page with its next cursor and total posting count.
+func (s *FoldersService) GetPage(ctx context.Context, folderID int64, params *generated.GetFolderParams) (result *FolderPage, err error) {
 	op := OperationInfo{
 		Service: "Folders", Operation: "GetFolder",
 		ResourceType: "folder", IsMutation: false, ResourceID: folderID,
@@ -34,8 +53,68 @@ func (s *FoldersService) Get(ctx context.Context, folderID int64, params *genera
 		if cerr := CheckResponse(resp.HTTPResponse); cerr != nil {
 			return cerr
 		}
-		result = resp.JSON200
+		result = &FolderPage{Folder: resp.JSON200}
+		if resp.HTTPResponse != nil {
+			result.TotalCount, _ = strconv.Atoi(resp.HTTPResponse.Header.Get("X-Total-Count"))
+			result.NextPage = folderPageFromLink(resp.HTTPResponse.Header.Get("Link"))
+		}
 		return nil
 	})
 	return result, err
+}
+
+func folderPageFromLink(header string) string {
+	next := folderNextLink(header)
+	if next == "" {
+		return ""
+	}
+	parsed, err := url.Parse(next)
+	if err != nil {
+		return ""
+	}
+	return parsed.Query().Get("page")
+}
+
+func folderNextLink(header string) string {
+	remainder := header
+	for {
+		start := strings.IndexByte(remainder, '<')
+		if start < 0 {
+			return ""
+		}
+		remainder = remainder[start+1:]
+		end := strings.IndexByte(remainder, '>')
+		if end < 0 {
+			return ""
+		}
+		target := remainder[:end]
+		after := remainder[end+1:]
+		nextStart := strings.IndexByte(after, '<')
+		params := after
+		if nextStart >= 0 {
+			params = after[:nextStart]
+		}
+		if folderLinkIsNext(params) {
+			return target
+		}
+		if nextStart < 0 {
+			return ""
+		}
+		remainder = after[nextStart:]
+	}
+}
+
+func folderLinkIsNext(params string) bool {
+	for _, param := range strings.Split(params, ";") {
+		parts := strings.SplitN(strings.TrimSpace(strings.Trim(param, ",")), "=", 2)
+		if len(parts) != 2 || !strings.EqualFold(parts[0], "rel") {
+			continue
+		}
+		for _, relation := range strings.Fields(strings.Trim(parts[1], `"`)) {
+			if strings.EqualFold(relation, "next") {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/go/pkg/hey/services_test.go
+++ b/go/pkg/hey/services_test.go
@@ -1753,6 +1753,52 @@ func TestFoldersService_Get(t *testing.T) {
 	}
 }
 
+func TestFoldersService_GetPage(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/folders/12.json" {
+			t.Errorf("path = %q, want /folders/12.json", r.URL.Path)
+		}
+		if page := r.URL.Query().Get("page"); page != "current-cursor" {
+			t.Errorf("page = %q, want current-cursor", page)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Total-Count", "42")
+		w.Header().Set("Link", `<http://`+r.Host+`/folders/12.json?page=next-cursor>; rel="next"`)
+		_, _ = io.WriteString(w, `{"id":12,"name":"Receipts","postings":[{"id":1,"kind":"topic"}]}`)
+	}))
+	t.Cleanup(server.Close)
+
+	client := NewClient(&Config{BaseURL: server.URL}, &StaticTokenProvider{Token: "test-token"}, WithMaxRetries(0))
+	cursor := "current-cursor"
+	page, err := client.Folders().GetPage(context.Background(), 12, &generated.GetFolderParams{Page: &cursor})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if page.Folder == nil || page.Folder.Name != "Receipts" || page.TotalCount != 42 || page.NextPage != "next-cursor" {
+		t.Errorf("unexpected folder page: %+v", page)
+	}
+}
+
+func TestFolderPageFromLink(t *testing.T) {
+	tests := []struct {
+		header string
+		want   string
+	}{
+		{header: `<https://app.hey.com/folders/12.json?page=next>; rel="next"`, want: "next"},
+		{header: `<https://app.hey.com/folders/12.json?page=previous>; rel="prev", <https://app.hey.com/folders/12.json?page=a,b>; rel="next"`, want: "a,b"},
+	}
+	for _, tt := range tests {
+		if got := folderPageFromLink(tt.header); got != tt.want {
+			t.Errorf("folderPageFromLink(%q) = %q, want %q", tt.header, got, tt.want)
+		}
+	}
+	for _, header := range []string{"", "not a URL", `<https://app.hey.com/folders/12.json>; rel="next"`} {
+		if got := folderPageFromLink(header); got != "" {
+			t.Errorf("folderPageFromLink(%q) = %q, want empty", header, got)
+		}
+	}
+}
+
 // --- Collections ---
 
 func TestCollectionsService_List(t *testing.T) {


### PR DESCRIPTION
## Summary

- add `Folders().GetPage` alongside the existing source-compatible `Get`
- expose HEY's `X-Total-Count` and opaque `rel="next"` page cursor
- keep pagination requests on the configured origin by returning only the cursor for generated `GetFolder` calls

This unblocks complete folder traversal in hey-cli's CLI and TUI.

Basecamp card: https://app.basecamp.com/2914079/buckets/48521764/card_tables/cards/10206892850

## Validation

- `GOWORK=off make check` — pass (146 conformance cases)
- `GOWORK=off go test -race -count=1 ./pkg/hey` — pass
- `git diff --check` — pass
- independent review — no blocking/P2 findings

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose folder pagination so clients can traverse folders completely. Old: `Folders().Get` returned a folder page without pagination info. New: add `Folders().GetPage` that returns the folder plus `TotalCount` and a `NextPage` cursor; `Get` now delegates to `GetPage` and still returns only the folder.

- Introduces `FolderPage` with `Folder`, `NextPage`, and `TotalCount`.
- Adds `FoldersService.GetPage(...)`; parses `X-Total-Count` and `Link`, returning only the `page` cursor to keep pagination on the configured origin.
- Updates `FoldersService.Get` to call `GetPage` and return `Folder`; signature and behavior remain unchanged.
- Migration: To paginate, call `GetPage` and iterate using `NextPage`; no changes required for existing `Get` usage.

<sup>Written for commit 00da6397e617d7564b2b42b9e56f1a216d6b15d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-sdk/pull/90?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

