### PR TITLE
Bump the SDK to 0.6.1

### DIFF
--- a/go/pkg/hey/version.go
+++ b/go/pkg/hey/version.go
@@ -1,7 +1,7 @@
 package hey
 
 // Version is the current version of the HEY Go SDK.
-const Version = "0.6.0"
+const Version = "0.6.1"
 
 // APIVersion is the HEY API version this SDK targets.
 const APIVersion = "2026-08-18"


### PR DESCRIPTION
## Summary

- bump the Go SDK version to 0.6.1
- prepare the additive folder pagination metadata release from #90

## Validation

- `GOWORK=off make check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps the HEY Go SDK version from 0.6.0 to 0.6.1 to cut the patch release that prepares for the additive folder pagination metadata from #90. The SDK now reports version 0.6.1 (was 0.6.0); API targeting remains `2026-08-18`, and no behavior changes are introduced.

- Single change in `go/pkg/hey/version.go`: update the `Version` constant to `0.6.1`.
- No migration required; consumers can upgrade to `v0.6.1` directly.
- Validate locally with: `GOWORK=off make check`.

<sup>Written for commit 629e56d1af4ec5936e843589023c7387beadc624. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-sdk/pull/91?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

