### PR TITLE
The Screener becomes typed operations

### DIFF
--- a/behavior-model.json
+++ b/behavior-model.json
@@ -44,6 +44,19 @@
         ]
       }
     },
+    "BulkUpdateClearances": {
+      "idempotent": true,
+      "readonly": false,
+      "retry": {
+        "backoff": "exponential",
+        "base_delay_ms": 1000,
+        "max": 2,
+        "retry_on": [
+          429,
+          503
+        ]
+      }
+    },
     "BundleContact": {
       "idempotent": false,
       "readonly": false,
@@ -457,6 +470,10 @@
     },
     "GetClearances": {
       "idempotent": false,
+      "pagination": {
+        "style": "link",
+        "totalCountHeader": "X-Total-Count"
+      },
       "readonly": true,
       "retry": {
         "backoff": "exponential",
@@ -595,6 +612,23 @@
     },
     "GetMessage": {
       "idempotent": false,
+      "readonly": true,
+      "retry": {
+        "backoff": "exponential",
+        "base_delay_ms": 1000,
+        "max": 3,
+        "retry_on": [
+          429,
+          503
+        ]
+      }
+    },
+    "GetMyClearances": {
+      "idempotent": false,
+      "pagination": {
+        "style": "link",
+        "totalCountHeader": "X-Total-Count"
+      },
       "readonly": true,
       "retry": {
         "backoff": "exponential",
@@ -1070,6 +1104,19 @@
         ]
       }
     },
+    "PuntClearances": {
+      "idempotent": false,
+      "readonly": false,
+      "retry": {
+        "backoff": "exponential",
+        "base_delay_ms": 1000,
+        "max": 2,
+        "retry_on": [
+          429,
+          503
+        ]
+      }
+    },
     "RemovePostingsFromBoxGroup": {
       "idempotent": true,
       "readonly": false,
@@ -1239,6 +1286,19 @@
         ]
       }
     },
+    "UpdateClearance": {
+      "idempotent": true,
+      "readonly": false,
+      "retry": {
+        "backoff": "exponential",
+        "base_delay_ms": 1000,
+        "max": 2,
+        "retry_on": [
+          429,
+          503
+        ]
+      }
+    },
     "UpdateCollection": {
       "idempotent": true,
       "readonly": false,
@@ -1306,6 +1366,19 @@
     },
     "UpdateJournalEntry": {
       "idempotent": false,
+      "readonly": false,
+      "retry": {
+        "backoff": "exponential",
+        "base_delay_ms": 1000,
+        "max": 2,
+        "retry_on": [
+          429,
+          503
+        ]
+      }
+    },
+    "UpdateMyClearance": {
+      "idempotent": true,
       "readonly": false,
       "retry": {
         "backoff": "exponential",

--- a/conformance/runner/go/main.go
+++ b/conformance/runner/go/main.go
@@ -1209,7 +1209,25 @@ func executeOperation(client *generated.Client, ctx context.Context, tc TestCase
 		body := generated.UpdateContactClearanceJSONRequestBody{Status: getStringParam(tc.RequestBody, "status")}
 		return client.UpdateContactClearance(ctx, contactId, body)
 	case "GetClearances":
-		return client.GetClearances(ctx)
+		return client.GetClearances(ctx, &generated.GetClearancesParams{})
+	case "UpdateClearance":
+		clearanceId := getInt64Param(tc.PathParams, "clearanceId")
+		body := generated.UpdateClearanceJSONRequestBody{Status: getStringParam(tc.RequestBody, "status")}
+		return client.UpdateClearance(ctx, clearanceId, body)
+	case "BulkUpdateClearances":
+		body := generated.BulkUpdateClearancesJSONRequestBody{
+			Ids:    getStringParam(tc.RequestBody, "ids"),
+			Status: getStringParam(tc.RequestBody, "status"),
+		}
+		return client.BulkUpdateClearances(ctx, body)
+	case "PuntClearances":
+		return client.PuntClearances(ctx)
+	case "GetMyClearances":
+		return client.GetMyClearances(ctx, &generated.GetMyClearancesParams{})
+	case "UpdateMyClearance":
+		clearanceId := getInt64Param(tc.PathParams, "clearanceId")
+		body := generated.UpdateMyClearanceJSONRequestBody{Status: getStringParam(tc.RequestBody, "status")}
+		return client.UpdateMyClearance(ctx, clearanceId, body)
 
 	// Contact writing and notes
 	case "CreateContact":

--- a/conformance/tests/paths.json
+++ b/conformance/tests/paths.json
@@ -3452,5 +3452,181 @@
       "boxes",
       "sync"
     ]
+  },
+  {
+    "name": "UpdateClearance uses /clearances/{clearanceId} path",
+    "description": "Verifies that UpdateClearance constructs the URL path /clearances/{clearanceId}",
+    "operation": "UpdateClearance",
+    "method": "PATCH",
+    "path": "/clearances/{clearanceId}",
+    "pathParams": {
+      "clearanceId": 91
+    },
+    "requestBody": {
+      "status": "approved"
+    },
+    "mockResponses": [
+      {
+        "status": 200,
+        "body": {
+          "id": 91,
+          "status": "approved"
+        }
+      }
+    ],
+    "assertions": [
+      {
+        "type": "requestPath",
+        "expected": "/clearances/91"
+      },
+      {
+        "type": "requestMethod",
+        "expected": "PATCH"
+      },
+      {
+        "type": "noError"
+      }
+    ],
+    "tags": [
+      "path",
+      "clearances"
+    ]
+  },
+  {
+    "name": "BulkUpdateClearances uses /clearances/bulk.json path",
+    "description": "Verifies that BulkUpdateClearances constructs the URL path /clearances/bulk.json",
+    "operation": "BulkUpdateClearances",
+    "method": "PATCH",
+    "path": "/clearances/bulk.json",
+    "requestBody": {
+      "ids": "91,92",
+      "status": "denied"
+    },
+    "mockResponses": [
+      {
+        "status": 200,
+        "body": {
+          "clearances": []
+        }
+      }
+    ],
+    "assertions": [
+      {
+        "type": "requestPath",
+        "expected": "/clearances/bulk.json"
+      },
+      {
+        "type": "requestMethod",
+        "expected": "PATCH"
+      },
+      {
+        "type": "noError"
+      }
+    ],
+    "tags": [
+      "path",
+      "clearances"
+    ]
+  },
+  {
+    "name": "PuntClearances uses /clearances/punt.json path",
+    "description": "Verifies that PuntClearances constructs the URL path /clearances/punt.json",
+    "operation": "PuntClearances",
+    "method": "POST",
+    "path": "/clearances/punt.json",
+    "mockResponses": [
+      {
+        "status": 202,
+        "body": null
+      }
+    ],
+    "assertions": [
+      {
+        "type": "requestPath",
+        "expected": "/clearances/punt.json"
+      },
+      {
+        "type": "requestMethod",
+        "expected": "POST"
+      },
+      {
+        "type": "noError"
+      }
+    ],
+    "tags": [
+      "path",
+      "clearances"
+    ]
+  },
+  {
+    "name": "GetMyClearances uses /my/clearances.json path",
+    "description": "Verifies that GetMyClearances constructs the URL path /my/clearances.json",
+    "operation": "GetMyClearances",
+    "method": "GET",
+    "path": "/my/clearances.json",
+    "mockResponses": [
+      {
+        "status": 200,
+        "body": {
+          "clearances": []
+        }
+      }
+    ],
+    "assertions": [
+      {
+        "type": "requestPath",
+        "expected": "/my/clearances.json"
+      },
+      {
+        "type": "requestMethod",
+        "expected": "GET"
+      },
+      {
+        "type": "noError"
+      }
+    ],
+    "tags": [
+      "path",
+      "clearances"
+    ]
+  },
+  {
+    "name": "UpdateMyClearance uses /my/clearances/{clearanceId} path",
+    "description": "Verifies that UpdateMyClearance constructs the URL path /my/clearances/{clearanceId}",
+    "operation": "UpdateMyClearance",
+    "method": "PATCH",
+    "path": "/my/clearances/{clearanceId}",
+    "pathParams": {
+      "clearanceId": 91
+    },
+    "requestBody": {
+      "status": "denied"
+    },
+    "mockResponses": [
+      {
+        "status": 200,
+        "body": {
+          "id": 91,
+          "status": "denied"
+        }
+      }
+    ],
+    "assertions": [
+      {
+        "type": "requestPath",
+        "expected": "/my/clearances/91"
+      },
+      {
+        "type": "requestMethod",
+        "expected": "PATCH"
+      },
+      {
+        "type": "noError"
+      }
+    ],
+    "tags": [
+      "path",
+      "clearances"
+    ]
   }
 ]

--- a/go/pkg/generated/client.gen.go
+++ b/go/pkg/generated/client.gen.go
@@ -177,6 +177,16 @@ type BulkReplyRequestContent struct {
 	Message  BulkReplyMessagePayload `json:"message"`
 }
 
+// BulkUpdateClearancesRequestContent defines model for BulkUpdateClearancesRequestContent.
+type BulkUpdateClearancesRequestContent struct {
+	Ids    string `json:"ids"`
+	Spam   *bool  `json:"spam,omitempty"`
+	Status string `json:"status"`
+}
+
+// BulkUpdateClearancesResponseContent ClearanceListResponse — wire format: {clearances: [...]}
+type BulkUpdateClearancesResponseContent = ClearanceListResponse
+
 // Calendar Calendar
 type Calendar struct {
 	Color string `json:"color,omitempty"`
@@ -222,15 +232,38 @@ type CalendarWithRecordingChangesUrl struct {
 }
 
 // Clearance Clearance — screening status for a contact
+//
+// petitioner and most_recent_entry are only filled in by the Screener reads. The
+// contact reads answer a clearance with nothing but its id and status.
 type Clearance struct {
-	Id     int64  `json:"id"`
-	Status string `json:"status,omitempty"`
+	// CreatedAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
+	CreatedAt time.Time `json:"created_at,omitempty"`
+	Id        int64     `json:"id"`
+
+	// MostRecentEntry Entry — a message entry within a topic
+	MostRecentEntry Entry `json:"most_recent_entry,omitempty"`
+
+	// Petitioner Contact — the identity of someone in HEY
+	Petitioner Contact `json:"petitioner,omitempty"`
+	Status     string  `json:"status,omitempty"`
+
+	// UpdatedAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
+	UpdatedAt time.Time `json:"updated_at,omitempty"`
 }
 
-// ClearanceSummary ClearanceSummary — the screener's pending count, not the clearances themselves
+// ClearanceListResponse ClearanceListResponse — wire format: {clearances: [...]}
+type ClearanceListResponse struct {
+	Clearances []Clearance `json:"clearances,omitempty"`
+}
+
+// ClearanceSummary ClearanceSummary — the Screener's pending count, and the queue itself when asked for
+//
+// clearances is only present when the read passes include_clearances. Without it HEY
+// answers the count alone, which is what its own apps sync.
 type ClearanceSummary struct {
-	PendingClearancesCount int32  `json:"pending_clearances_count,omitempty"`
-	SignedStreamName       string `json:"signed_stream_name,omitempty"`
+	Clearances             []Clearance `json:"clearances,omitempty"`
+	PendingClearancesCount int32       `json:"pending_clearances_count,omitempty"`
+	SignedStreamName       string      `json:"signed_stream_name,omitempty"`
 }
 
 // Clip defines model for Clip.
@@ -319,6 +352,9 @@ type ContactDetail struct {
 	AvatarUrl             string    `json:"avatar_url,omitempty"`
 
 	// Clearance Clearance — screening status for a contact
+	//
+	// petitioner and most_recent_entry are only filled in by the Screener reads. The
+	// contact reads answer a clearance with nothing but its id and status.
 	Clearance       Clearance `json:"clearance,omitempty"`
 	ContactableType string    `json:"contactable_type,omitempty"`
 
@@ -514,7 +550,9 @@ type Entry struct {
 	Creator Contact `json:"creator,omitempty"`
 	Id      int64   `json:"id"`
 	Kind    string  `json:"kind,omitempty"`
+	Subject string  `json:"subject,omitempty"`
 	Summary string  `json:"summary,omitempty"`
+	TopicId int64   `json:"topic_id,omitempty"`
 
 	// UpdatedAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
 	UpdatedAt time.Time `json:"updated_at,omitempty"`
@@ -606,7 +644,10 @@ type GetBubbleboxResponseContent = BoxShowResponse
 // GetCalendarRecordingsResponseContent CalendarRecordingsResponse — recordings grouped by type
 type GetCalendarRecordingsResponseContent = CalendarRecordingsResponse
 
-// GetClearancesResponseContent ClearanceSummary — the screener's pending count, not the clearances themselves
+// GetClearancesResponseContent ClearanceSummary — the Screener's pending count, and the queue itself when asked for
+//
+// clearances is only present when the read passes include_clearances. Without it HEY
+// answers the count alone, which is what its own apps sync.
 type GetClearancesResponseContent = ClearanceSummary
 
 // GetContactNoteResponseContent A contact's private note. Empty strings when there is no note.
@@ -644,6 +685,9 @@ type GetLaterboxResponseContent = BoxShowResponse
 
 // GetMessageResponseContent Message — full message detail
 type GetMessageResponseContent = Message
+
+// GetMyClearancesResponseContent ClearanceListResponse — wire format: {clearances: [...]}
+type GetMyClearancesResponseContent = ClearanceListResponse
 
 // GetNavigationResponseContent NavigationResponse
 type GetNavigationResponseContent = NavigationResponse
@@ -1244,6 +1288,20 @@ type UnprocessableEntityErrorResponseContent struct {
 	Message string   `json:"message,omitempty"`
 }
 
+// UpdateClearanceRequestContent Wire format: {status: "approved"|"denied"} — top level, not nested under a clearance key.
+type UpdateClearanceRequestContent struct {
+	DesignationBoxId int64  `json:"designation_box_id,omitempty"`
+	MarkTopicsAsSeen *bool  `json:"mark_topics_as_seen,omitempty"`
+	Spam             *bool  `json:"spam,omitempty"`
+	Status           string `json:"status"`
+}
+
+// UpdateClearanceResponseContent Clearance — screening status for a contact
+//
+// petitioner and most_recent_entry are only filled in by the Screener reads. The
+// contact reads answer a clearance with nothing but its id and status.
+type UpdateClearanceResponseContent = Clearance
+
 // UpdateCollectionRequestContent Wire format: {collection: {name, summary}}
 type UpdateCollectionRequestContent struct {
 	Collection CollectionPayload `json:"collection"`
@@ -1270,6 +1328,17 @@ type UpdateJournalEntryRequestContent struct {
 
 // UpdateJournalEntryResponseContent Recording — polymorphic by `type` (CalendarEvent, CalendarTodo, etc.)
 type UpdateJournalEntryResponseContent = Recording
+
+// UpdateMyClearanceRequestContent defines model for UpdateMyClearanceRequestContent.
+type UpdateMyClearanceRequestContent struct {
+	Status string `json:"status"`
+}
+
+// UpdateMyClearanceResponseContent Clearance — screening status for a contact
+//
+// petitioner and most_recent_entry are only filled in by the Screener reads. The
+// contact reads answer a clearance with nothing but its id and status.
+type UpdateMyClearanceResponseContent = Clearance
 
 // UpdateStickyResponseContent Sticky — a note on the stickies board
 type UpdateStickyResponseContent = Sticky
@@ -1408,6 +1477,12 @@ type GetCalendarRecordingsParams struct {
 	EndsOn   *string `form:"ends_on,omitempty" json:"ends_on,omitempty"`
 }
 
+// GetClearancesParams defines parameters for GetClearances.
+type GetClearancesParams struct {
+	IncludeClearances *bool   `form:"include_clearances,omitempty" json:"include_clearances,omitempty"`
+	Page              *string `form:"page,omitempty" json:"page,omitempty"`
+}
+
 // ListClipsParams defines parameters for ListClips.
 type ListClipsParams struct {
 	Page *string `form:"page,omitempty" json:"page,omitempty"`
@@ -1436,6 +1511,11 @@ type GetFolderParams struct {
 
 // GetImboxParams defines parameters for GetImbox.
 type GetImboxParams struct {
+	Page *string `form:"page,omitempty" json:"page,omitempty"`
+}
+
+// GetMyClearancesParams defines parameters for GetMyClearances.
+type GetMyClearancesParams struct {
 	Page *string `form:"page,omitempty" json:"page,omitempty"`
 }
 
@@ -1542,6 +1622,12 @@ type UpdateTimeTrackJSONRequestBody = UpdateTimeTrackRequestContent
 // CreateCalendarTodoJSONRequestBody defines body for CreateCalendarTodo for application/json ContentType.
 type CreateCalendarTodoJSONRequestBody = CreateCalendarTodoRequestContent
 
+// BulkUpdateClearancesJSONRequestBody defines body for BulkUpdateClearances for application/json ContentType.
+type BulkUpdateClearancesJSONRequestBody = BulkUpdateClearancesRequestContent
+
+// UpdateClearanceJSONRequestBody defines body for UpdateClearance for application/json ContentType.
+type UpdateClearanceJSONRequestBody = UpdateClearanceRequestContent
+
 // UpdateCollectionJSONRequestBody defines body for UpdateCollection for application/json ContentType.
 type UpdateCollectionJSONRequestBody = UpdateCollectionRequestContent
 
@@ -1562,6 +1648,9 @@ type CreateReplyJSONRequestBody = CreateReplyRequestContent
 
 // CreateMessageJSONRequestBody defines body for CreateMessage for application/json ContentType.
 type CreateMessageJSONRequestBody = CreateMessageRequestContent
+
+// UpdateMyClearanceJSONRequestBody defines body for UpdateMyClearance for application/json ContentType.
+type UpdateMyClearanceJSONRequestBody = UpdateMyClearanceRequestContent
 
 // AddPostingsToBoxGroupJSONRequestBody defines body for AddPostingsToBoxGroup for application/json ContentType.
 type AddPostingsToBoxGroupJSONRequestBody = AddPostingsToBoxGroupRequestContent
@@ -1960,7 +2049,20 @@ type ClientInterface interface {
 	GetCalendarRecordings(ctx context.Context, calendarId int64, params *GetCalendarRecordingsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetClearances request
-	GetClearances(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+	GetClearances(ctx context.Context, params *GetClearancesParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// BulkUpdateClearancesWithBody request with any body
+	BulkUpdateClearancesWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	BulkUpdateClearances(ctx context.Context, body BulkUpdateClearancesJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// PuntClearances request
+	PuntClearances(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UpdateClearanceWithBody request with any body
+	UpdateClearanceWithBody(ctx context.Context, clearanceId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	UpdateClearance(ctx context.Context, clearanceId int64, body UpdateClearanceJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// ListClips request
 	ListClips(ctx context.Context, params *ListClipsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -2050,6 +2152,14 @@ type ClientInterface interface {
 
 	// GetMessage request
 	GetMessage(ctx context.Context, messageId int64, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetMyClearances request
+	GetMyClearances(ctx context.Context, params *GetMyClearancesParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UpdateMyClearanceWithBody request with any body
+	UpdateMyClearanceWithBody(ctx context.Context, clearanceId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	UpdateMyClearance(ctx context.Context, clearanceId int64, body UpdateMyClearanceJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetNavigation request
 	GetNavigation(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -2737,11 +2847,87 @@ func (c *Client) GetCalendarRecordings(ctx context.Context, calendarId int64, pa
 
 // GetClearances is marked as idempotent and will be retried on transient failures.
 
-func (c *Client) GetClearances(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+func (c *Client) GetClearances(ctx context.Context, params *GetClearancesParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
-		return NewGetClearancesRequest(c.Server)
+		return NewGetClearancesRequest(c.Server, params)
 	}, true, "GetClearances", reqEditors...)
+
+}
+
+// BulkUpdateClearancesWithBody executes the BulkUpdateClearances operation.
+
+func (c *Client) BulkUpdateClearancesWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+
+	req, err := NewBulkUpdateClearancesRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+
+}
+
+func (c *Client) BulkUpdateClearances(ctx context.Context, body BulkUpdateClearancesJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+
+	req, err := NewBulkUpdateClearancesRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+
+}
+
+// PuntClearances executes the PuntClearances operation.
+
+func (c *Client) PuntClearances(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+
+	req, err := NewPuntClearancesRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+
+}
+
+// UpdateClearanceWithBody executes the UpdateClearance operation.
+
+func (c *Client) UpdateClearanceWithBody(ctx context.Context, clearanceId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+
+	req, err := NewUpdateClearanceRequestWithBody(c.Server, clearanceId, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+
+}
+
+func (c *Client) UpdateClearance(ctx context.Context, clearanceId int64, body UpdateClearanceJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+
+	req, err := NewUpdateClearanceRequest(c.Server, clearanceId, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
 
 }
 
@@ -3144,6 +3330,46 @@ func (c *Client) GetMessage(ctx context.Context, messageId int64, reqEditors ...
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewGetMessageRequest(c.Server, messageId)
 	}, true, "GetMessage", reqEditors...)
+
+}
+
+// GetMyClearances is marked as idempotent and will be retried on transient failures.
+
+func (c *Client) GetMyClearances(ctx context.Context, params *GetMyClearancesParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		return NewGetMyClearancesRequest(c.Server, params)
+	}, true, "GetMyClearances", reqEditors...)
+
+}
+
+// UpdateMyClearanceWithBody executes the UpdateMyClearance operation.
+
+func (c *Client) UpdateMyClearanceWithBody(ctx context.Context, clearanceId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+
+	req, err := NewUpdateMyClearanceRequestWithBody(c.Server, clearanceId, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+
+}
+
+func (c *Client) UpdateMyClearance(ctx context.Context, clearanceId int64, body UpdateMyClearanceJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+
+	req, err := NewUpdateMyClearanceRequest(c.Server, clearanceId, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
 
 }
 
@@ -5462,7 +5688,7 @@ func NewGetCalendarRecordingsRequest(server string, calendarId int64, params *Ge
 }
 
 // NewGetClearancesRequest generates requests for GetClearances
-func NewGetClearancesRequest(server string) (*http.Request, error) {
+func NewGetClearancesRequest(server string, params *GetClearancesParams) (*http.Request, error) {
 	var err error
 
 	serverURL, err := url.Parse(server)
@@ -5480,10 +5706,162 @@ func NewGetClearancesRequest(server string) (*http.Request, error) {
 		return nil, err
 	}
 
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.IncludeClearances != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "include_clearances", runtime.ParamLocationQuery, *params.IncludeClearances); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Page != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "page", runtime.ParamLocationQuery, *params.Page); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
 	req, err := http.NewRequest("GET", queryURL.String(), nil)
 	if err != nil {
 		return nil, err
 	}
+
+	return req, nil
+}
+
+// NewBulkUpdateClearancesRequest calls the generic BulkUpdateClearances builder with application/json body
+func NewBulkUpdateClearancesRequest(server string, body BulkUpdateClearancesJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewBulkUpdateClearancesRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewBulkUpdateClearancesRequestWithBody generates requests for BulkUpdateClearances with any type of body
+func NewBulkUpdateClearancesRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/clearances/bulk.json")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("PATCH", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewPuntClearancesRequest generates requests for PuntClearances
+func NewPuntClearancesRequest(server string) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/clearances/punt.json")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewUpdateClearanceRequest calls the generic UpdateClearance builder with application/json body
+func NewUpdateClearanceRequest(server string, clearanceId int64, body UpdateClearanceJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewUpdateClearanceRequestWithBody(server, clearanceId, "application/json", bodyReader)
+}
+
+// NewUpdateClearanceRequestWithBody generates requests for UpdateClearance with any type of body
+func NewUpdateClearanceRequestWithBody(server string, clearanceId int64, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "clearanceId", runtime.ParamLocationPath, clearanceId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/clearances/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("PATCH", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
 
 	return req, nil
 }
@@ -6510,6 +6888,102 @@ func NewGetMessageRequest(server string, messageId int64) (*http.Request, error)
 	if err != nil {
 		return nil, err
 	}
+
+	return req, nil
+}
+
+// NewGetMyClearancesRequest generates requests for GetMyClearances
+func NewGetMyClearancesRequest(server string, params *GetMyClearancesParams) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/my/clearances.json")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.Page != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "page", runtime.ParamLocationQuery, *params.Page); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewUpdateMyClearanceRequest calls the generic UpdateMyClearance builder with application/json body
+func NewUpdateMyClearanceRequest(server string, clearanceId int64, body UpdateMyClearanceJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewUpdateMyClearanceRequestWithBody(server, clearanceId, "application/json", bodyReader)
+}
+
+// NewUpdateMyClearanceRequestWithBody generates requests for UpdateMyClearance with any type of body
+func NewUpdateMyClearanceRequestWithBody(server string, clearanceId int64, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "clearanceId", runtime.ParamLocationPath, clearanceId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/my/clearances/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("PATCH", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
 
 	return req, nil
 }
@@ -8202,6 +8676,9 @@ var operationMetadata = map[string]OperationMetadata{
 	"ListCalendars":              {Idempotent: true, HasSensitiveParams: false},
 	"GetCalendarRecordings":      {Idempotent: true, HasSensitiveParams: false},
 	"GetClearances":              {Idempotent: true, HasSensitiveParams: false},
+	"BulkUpdateClearances":       {Idempotent: false, HasSensitiveParams: false},
+	"PuntClearances":             {Idempotent: false, HasSensitiveParams: false},
+	"UpdateClearance":            {Idempotent: false, HasSensitiveParams: false},
 	"ListClips":                  {Idempotent: true, HasSensitiveParams: false},
 	"ListCollections":            {Idempotent: true, HasSensitiveParams: false},
 	"UpdateCollection":           {Idempotent: false, HasSensitiveParams: false},
@@ -8227,6 +8704,8 @@ var operationMetadata = map[string]OperationMetadata{
 	"GetImbox":                   {Idempotent: true, HasSensitiveParams: false},
 	"CreateMessage":              {Idempotent: false, HasSensitiveParams: false},
 	"GetMessage":                 {Idempotent: true, HasSensitiveParams: false},
+	"GetMyClearances":            {Idempotent: true, HasSensitiveParams: false},
+	"UpdateMyClearance":          {Idempotent: false, HasSensitiveParams: false},
 	"GetNavigation":              {Idempotent: true, HasSensitiveParams: false},
 	"GetTrailbox":                {Idempotent: true, HasSensitiveParams: false},
 	"RemovePostingsFromBoxGroup": {Idempotent: true, HasSensitiveParams: false},
@@ -9210,10 +9689,51 @@ type ClientWithResponsesInterface interface {
 
 	// GetClearancesWithResponse performs a GET /clearances.json (the `GetClearances` operationId) request.
 	//
-	// Get the screener summary — how many senders are waiting to be screened.
+	// Get the Screener — the pending count, and the senders waiting when asked for them
 	//
 	// Returns a wrapper object for the known response body format(s).
-	GetClearancesWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetClearancesResponse, error)
+	GetClearancesWithResponse(ctx context.Context, params *GetClearancesParams, reqEditors ...RequestEditorFn) (*GetClearancesResponse, error)
+
+	// BulkUpdateClearancesWithBodyWithResponse performs a PATCH /clearances/bulk.json (the `BulkUpdateClearances` operationId) request,
+	// with any type of body and a specified content type.
+	//
+	// Screen several senders out at once. ids is a comma-separated list.
+	//
+	// Returns a wrapper object for the known response body format(s).
+	BulkUpdateClearancesWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*BulkUpdateClearancesResponse, error)
+
+	// BulkUpdateClearancesWithResponse performs a PATCH /clearances/bulk.json (the `BulkUpdateClearances` operationId) request.
+	// Takes a body of the `application/json` content type, and returns a wrapper object for the known response body format(s).
+	//
+	// Screen several senders out at once. ids is a comma-separated list.
+	BulkUpdateClearancesWithResponse(ctx context.Context, body BulkUpdateClearancesJSONRequestBody, reqEditors ...RequestEditorFn) (*BulkUpdateClearancesResponse, error)
+
+	// PuntClearancesWithResponse performs a POST /clearances/punt.json (the `PuntClearances` operationId) request.
+	//
+	// Clear the Screener — every pending sender is punted and reexamined on their next email.
+	//
+	// Returns a wrapper object for the known response body format(s).
+	PuntClearancesWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*PuntClearancesResponse, error)
+
+	// UpdateClearanceWithBodyWithResponse performs a PATCH /clearances/{clearanceId} (the `UpdateClearance` operationId) request,
+	// with any type of body and a specified content type.
+	//
+	// Screen a sender in or out of the Screener
+	//
+	// designation_box_id files everything they send into that box instead of the Imbox.
+	// spam marks what is already waiting as spam and trains the filter on it.
+	//
+	// Returns a wrapper object for the known response body format(s).
+	UpdateClearanceWithBodyWithResponse(ctx context.Context, clearanceId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateClearanceResponse, error)
+
+	// UpdateClearanceWithResponse performs a PATCH /clearances/{clearanceId} (the `UpdateClearance` operationId) request.
+	// Takes a body of the `application/json` content type, and returns a wrapper object for the known response body format(s).
+	//
+	// Screen a sender in or out of the Screener
+	//
+	// designation_box_id files everything they send into that box instead of the Imbox.
+	// spam marks what is already waiting as spam and trains the filter on it.
+	UpdateClearanceWithResponse(ctx context.Context, clearanceId int64, body UpdateClearanceJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateClearanceResponse, error)
 
 	// ListClipsWithResponse performs a GET /clips.json (the `ListClips` operationId) request.
 	//
@@ -9445,6 +9965,27 @@ type ClientWithResponsesInterface interface {
 	//
 	// Returns a wrapper object for the known response body format(s).
 	GetMessageWithResponse(ctx context.Context, messageId int64, reqEditors ...RequestEditorFn) (*GetMessageResponse, error)
+
+	// GetMyClearancesWithResponse performs a GET /my/clearances.json (the `GetMyClearances` operationId) request.
+	//
+	// The senders already screened in or out.
+	//
+	// Returns a wrapper object for the known response body format(s).
+	GetMyClearancesWithResponse(ctx context.Context, params *GetMyClearancesParams, reqEditors ...RequestEditorFn) (*GetMyClearancesResponse, error)
+
+	// UpdateMyClearanceWithBodyWithResponse performs a PATCH /my/clearances/{clearanceId} (the `UpdateMyClearance` operationId) request,
+	// with any type of body and a specified content type.
+	//
+	// Rescreen a sender who was already screened in or out.
+	//
+	// Returns a wrapper object for the known response body format(s).
+	UpdateMyClearanceWithBodyWithResponse(ctx context.Context, clearanceId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateMyClearanceResponse, error)
+
+	// UpdateMyClearanceWithResponse performs a PATCH /my/clearances/{clearanceId} (the `UpdateMyClearance` operationId) request.
+	// Takes a body of the `application/json` content type, and returns a wrapper object for the known response body format(s).
+	//
+	// Rescreen a sender who was already screened in or out.
+	UpdateMyClearanceWithResponse(ctx context.Context, clearanceId int64, body UpdateMyClearanceJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateMyClearanceResponse, error)
 
 	// GetNavigationWithResponse performs a GET /my/navigation.json (the `GetNavigation` operationId) request.
 	//
@@ -12270,6 +12811,206 @@ func (r GetClearancesResponse) ContentType() string {
 	return ""
 }
 
+type BulkUpdateClearancesResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	// JSON200 the response for an HTTP 200 `application/json` response
+	JSON200 *BulkUpdateClearancesResponseContent
+	// JSON401 the response for an HTTP 401 `application/json` response
+	JSON401 *UnauthorizedErrorResponseContent
+	// JSON404 the response for an HTTP 404 `application/json` response
+	JSON404 *NotFoundErrorResponseContent
+	// JSON500 the response for an HTTP 500 `application/json` response
+	JSON500 *InternalServerErrorResponseContent
+	// JSON503 the response for an HTTP 503 `application/json` response
+	JSON503 *ServiceUnavailableErrorResponseContent
+}
+
+// GetJSON200 returns the response for an HTTP 200 `application/json` response
+func (r BulkUpdateClearancesResponse) GetJSON200() *BulkUpdateClearancesResponseContent {
+	return r.JSON200
+}
+
+// GetJSON401 returns the response for an HTTP 401 `application/json` response
+func (r BulkUpdateClearancesResponse) GetJSON401() *UnauthorizedErrorResponseContent {
+	return r.JSON401
+}
+
+// GetJSON404 returns the response for an HTTP 404 `application/json` response
+func (r BulkUpdateClearancesResponse) GetJSON404() *NotFoundErrorResponseContent {
+	return r.JSON404
+}
+
+// GetJSON500 returns the response for an HTTP 500 `application/json` response
+func (r BulkUpdateClearancesResponse) GetJSON500() *InternalServerErrorResponseContent {
+	return r.JSON500
+}
+
+// GetJSON503 returns the response for an HTTP 503 `application/json` response
+func (r BulkUpdateClearancesResponse) GetJSON503() *ServiceUnavailableErrorResponseContent {
+	return r.JSON503
+}
+
+// GetBody returns the raw response body bytes
+func (r BulkUpdateClearancesResponse) GetBody() []byte {
+	return r.Body
+}
+
+// Status returns HTTPResponse.Status
+func (r BulkUpdateClearancesResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r BulkUpdateClearancesResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r BulkUpdateClearancesResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type PuntClearancesResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	// JSON401 the response for an HTTP 401 `application/json` response
+	JSON401 *UnauthorizedErrorResponseContent
+	// JSON500 the response for an HTTP 500 `application/json` response
+	JSON500 *InternalServerErrorResponseContent
+	// JSON503 the response for an HTTP 503 `application/json` response
+	JSON503 *ServiceUnavailableErrorResponseContent
+}
+
+// GetJSON401 returns the response for an HTTP 401 `application/json` response
+func (r PuntClearancesResponse) GetJSON401() *UnauthorizedErrorResponseContent {
+	return r.JSON401
+}
+
+// GetJSON500 returns the response for an HTTP 500 `application/json` response
+func (r PuntClearancesResponse) GetJSON500() *InternalServerErrorResponseContent {
+	return r.JSON500
+}
+
+// GetJSON503 returns the response for an HTTP 503 `application/json` response
+func (r PuntClearancesResponse) GetJSON503() *ServiceUnavailableErrorResponseContent {
+	return r.JSON503
+}
+
+// GetBody returns the raw response body bytes
+func (r PuntClearancesResponse) GetBody() []byte {
+	return r.Body
+}
+
+// Status returns HTTPResponse.Status
+func (r PuntClearancesResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r PuntClearancesResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r PuntClearancesResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type UpdateClearanceResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	// JSON200 the response for an HTTP 200 `application/json` response
+	JSON200 *UpdateClearanceResponseContent
+	// JSON401 the response for an HTTP 401 `application/json` response
+	JSON401 *UnauthorizedErrorResponseContent
+	// JSON403 the response for an HTTP 403 `application/json` response
+	JSON403 *ForbiddenErrorResponseContent
+	// JSON404 the response for an HTTP 404 `application/json` response
+	JSON404 *NotFoundErrorResponseContent
+	// JSON500 the response for an HTTP 500 `application/json` response
+	JSON500 *InternalServerErrorResponseContent
+	// JSON503 the response for an HTTP 503 `application/json` response
+	JSON503 *ServiceUnavailableErrorResponseContent
+}
+
+// GetJSON200 returns the response for an HTTP 200 `application/json` response
+func (r UpdateClearanceResponse) GetJSON200() *UpdateClearanceResponseContent {
+	return r.JSON200
+}
+
+// GetJSON401 returns the response for an HTTP 401 `application/json` response
+func (r UpdateClearanceResponse) GetJSON401() *UnauthorizedErrorResponseContent {
+	return r.JSON401
+}
+
+// GetJSON403 returns the response for an HTTP 403 `application/json` response
+func (r UpdateClearanceResponse) GetJSON403() *ForbiddenErrorResponseContent {
+	return r.JSON403
+}
+
+// GetJSON404 returns the response for an HTTP 404 `application/json` response
+func (r UpdateClearanceResponse) GetJSON404() *NotFoundErrorResponseContent {
+	return r.JSON404
+}
+
+// GetJSON500 returns the response for an HTTP 500 `application/json` response
+func (r UpdateClearanceResponse) GetJSON500() *InternalServerErrorResponseContent {
+	return r.JSON500
+}
+
+// GetJSON503 returns the response for an HTTP 503 `application/json` response
+func (r UpdateClearanceResponse) GetJSON503() *ServiceUnavailableErrorResponseContent {
+	return r.JSON503
+}
+
+// GetBody returns the raw response body bytes
+func (r UpdateClearanceResponse) GetBody() []byte {
+	return r.Body
+}
+
+// Status returns HTTPResponse.Status
+func (r UpdateClearanceResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UpdateClearanceResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r UpdateClearanceResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
 type ListClipsResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -13933,6 +14674,144 @@ func (r GetMessageResponse) StatusCode() int {
 
 // ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
 func (r GetMessageResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type GetMyClearancesResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	// JSON200 the response for an HTTP 200 `application/json` response
+	JSON200 *GetMyClearancesResponseContent
+	// JSON401 the response for an HTTP 401 `application/json` response
+	JSON401 *UnauthorizedErrorResponseContent
+	// JSON500 the response for an HTTP 500 `application/json` response
+	JSON500 *InternalServerErrorResponseContent
+	// JSON503 the response for an HTTP 503 `application/json` response
+	JSON503 *ServiceUnavailableErrorResponseContent
+}
+
+// GetJSON200 returns the response for an HTTP 200 `application/json` response
+func (r GetMyClearancesResponse) GetJSON200() *GetMyClearancesResponseContent {
+	return r.JSON200
+}
+
+// GetJSON401 returns the response for an HTTP 401 `application/json` response
+func (r GetMyClearancesResponse) GetJSON401() *UnauthorizedErrorResponseContent {
+	return r.JSON401
+}
+
+// GetJSON500 returns the response for an HTTP 500 `application/json` response
+func (r GetMyClearancesResponse) GetJSON500() *InternalServerErrorResponseContent {
+	return r.JSON500
+}
+
+// GetJSON503 returns the response for an HTTP 503 `application/json` response
+func (r GetMyClearancesResponse) GetJSON503() *ServiceUnavailableErrorResponseContent {
+	return r.JSON503
+}
+
+// GetBody returns the raw response body bytes
+func (r GetMyClearancesResponse) GetBody() []byte {
+	return r.Body
+}
+
+// Status returns HTTPResponse.Status
+func (r GetMyClearancesResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetMyClearancesResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r GetMyClearancesResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type UpdateMyClearanceResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	// JSON200 the response for an HTTP 200 `application/json` response
+	JSON200 *UpdateMyClearanceResponseContent
+	// JSON401 the response for an HTTP 401 `application/json` response
+	JSON401 *UnauthorizedErrorResponseContent
+	// JSON403 the response for an HTTP 403 `application/json` response
+	JSON403 *ForbiddenErrorResponseContent
+	// JSON404 the response for an HTTP 404 `application/json` response
+	JSON404 *NotFoundErrorResponseContent
+	// JSON500 the response for an HTTP 500 `application/json` response
+	JSON500 *InternalServerErrorResponseContent
+	// JSON503 the response for an HTTP 503 `application/json` response
+	JSON503 *ServiceUnavailableErrorResponseContent
+}
+
+// GetJSON200 returns the response for an HTTP 200 `application/json` response
+func (r UpdateMyClearanceResponse) GetJSON200() *UpdateMyClearanceResponseContent {
+	return r.JSON200
+}
+
+// GetJSON401 returns the response for an HTTP 401 `application/json` response
+func (r UpdateMyClearanceResponse) GetJSON401() *UnauthorizedErrorResponseContent {
+	return r.JSON401
+}
+
+// GetJSON403 returns the response for an HTTP 403 `application/json` response
+func (r UpdateMyClearanceResponse) GetJSON403() *ForbiddenErrorResponseContent {
+	return r.JSON403
+}
+
+// GetJSON404 returns the response for an HTTP 404 `application/json` response
+func (r UpdateMyClearanceResponse) GetJSON404() *NotFoundErrorResponseContent {
+	return r.JSON404
+}
+
+// GetJSON500 returns the response for an HTTP 500 `application/json` response
+func (r UpdateMyClearanceResponse) GetJSON500() *InternalServerErrorResponseContent {
+	return r.JSON500
+}
+
+// GetJSON503 returns the response for an HTTP 503 `application/json` response
+func (r UpdateMyClearanceResponse) GetJSON503() *ServiceUnavailableErrorResponseContent {
+	return r.JSON503
+}
+
+// GetBody returns the raw response body bytes
+func (r UpdateMyClearanceResponse) GetBody() []byte {
+	return r.Body
+}
+
+// Status returns HTTPResponse.Status
+func (r UpdateMyClearanceResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UpdateMyClearanceResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r UpdateMyClearanceResponse) ContentType() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Header.Get("Content-Type")
 	}
@@ -16995,15 +17874,86 @@ func (c *ClientWithResponses) GetCalendarRecordingsWithResponse(ctx context.Cont
 
 // GetClearancesWithResponse performs a GET /clearances.json (the `GetClearances` operationId) request.
 //
-// Get the screener summary — how many senders are waiting to be screened.
+// # Get the Screener — the pending count, and the senders waiting when asked for them
 //
 // Returns a wrapper object for the known response body format(s).
-func (c *ClientWithResponses) GetClearancesWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetClearancesResponse, error) {
-	rsp, err := c.GetClearances(ctx, reqEditors...)
+func (c *ClientWithResponses) GetClearancesWithResponse(ctx context.Context, params *GetClearancesParams, reqEditors ...RequestEditorFn) (*GetClearancesResponse, error) {
+	rsp, err := c.GetClearances(ctx, params, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
 	return ParseGetClearancesResponse(rsp)
+}
+
+// BulkUpdateClearancesWithBodyWithResponse performs a PATCH /clearances/bulk.json (the `BulkUpdateClearances` operationId) request,
+// with any type of body and a specified content type.
+//
+// Screen several senders out at once. ids is a comma-separated list.
+//
+// Returns a wrapper object for the known response body format(s).
+func (c *ClientWithResponses) BulkUpdateClearancesWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*BulkUpdateClearancesResponse, error) {
+	rsp, err := c.BulkUpdateClearancesWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseBulkUpdateClearancesResponse(rsp)
+}
+
+// BulkUpdateClearancesWithResponse performs a PATCH /clearances/bulk.json (the `BulkUpdateClearances` operationId) request.
+// Takes a body of the `application/json` content type, and returns a wrapper object for the known response body format(s).
+//
+// Screen several senders out at once. ids is a comma-separated list.
+func (c *ClientWithResponses) BulkUpdateClearancesWithResponse(ctx context.Context, body BulkUpdateClearancesJSONRequestBody, reqEditors ...RequestEditorFn) (*BulkUpdateClearancesResponse, error) {
+	rsp, err := c.BulkUpdateClearances(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseBulkUpdateClearancesResponse(rsp)
+}
+
+// PuntClearancesWithResponse performs a POST /clearances/punt.json (the `PuntClearances` operationId) request.
+//
+// Clear the Screener — every pending sender is punted and reexamined on their next email.
+//
+// Returns a wrapper object for the known response body format(s).
+func (c *ClientWithResponses) PuntClearancesWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*PuntClearancesResponse, error) {
+	rsp, err := c.PuntClearances(ctx, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePuntClearancesResponse(rsp)
+}
+
+// UpdateClearanceWithBodyWithResponse performs a PATCH /clearances/{clearanceId} (the `UpdateClearance` operationId) request,
+// with any type of body and a specified content type.
+//
+// # Screen a sender in or out of the Screener
+//
+// designation_box_id files everything they send into that box instead of the Imbox.
+// spam marks what is already waiting as spam and trains the filter on it.
+//
+// Returns a wrapper object for the known response body format(s).
+func (c *ClientWithResponses) UpdateClearanceWithBodyWithResponse(ctx context.Context, clearanceId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateClearanceResponse, error) {
+	rsp, err := c.UpdateClearanceWithBody(ctx, clearanceId, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateClearanceResponse(rsp)
+}
+
+// UpdateClearanceWithResponse performs a PATCH /clearances/{clearanceId} (the `UpdateClearance` operationId) request.
+// Takes a body of the `application/json` content type, and returns a wrapper object for the known response body format(s).
+//
+// # Screen a sender in or out of the Screener
+//
+// designation_box_id files everything they send into that box instead of the Imbox.
+// spam marks what is already waiting as spam and trains the filter on it.
+func (c *ClientWithResponses) UpdateClearanceWithResponse(ctx context.Context, clearanceId int64, body UpdateClearanceJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateClearanceResponse, error) {
+	rsp, err := c.UpdateClearance(ctx, clearanceId, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateClearanceResponse(rsp)
 }
 
 // ListClipsWithResponse performs a GET /clips.json (the `ListClips` operationId) request.
@@ -17427,6 +18377,45 @@ func (c *ClientWithResponses) GetMessageWithResponse(ctx context.Context, messag
 		return nil, err
 	}
 	return ParseGetMessageResponse(rsp)
+}
+
+// GetMyClearancesWithResponse performs a GET /my/clearances.json (the `GetMyClearances` operationId) request.
+//
+// The senders already screened in or out.
+//
+// Returns a wrapper object for the known response body format(s).
+func (c *ClientWithResponses) GetMyClearancesWithResponse(ctx context.Context, params *GetMyClearancesParams, reqEditors ...RequestEditorFn) (*GetMyClearancesResponse, error) {
+	rsp, err := c.GetMyClearances(ctx, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetMyClearancesResponse(rsp)
+}
+
+// UpdateMyClearanceWithBodyWithResponse performs a PATCH /my/clearances/{clearanceId} (the `UpdateMyClearance` operationId) request,
+// with any type of body and a specified content type.
+//
+// Rescreen a sender who was already screened in or out.
+//
+// Returns a wrapper object for the known response body format(s).
+func (c *ClientWithResponses) UpdateMyClearanceWithBodyWithResponse(ctx context.Context, clearanceId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateMyClearanceResponse, error) {
+	rsp, err := c.UpdateMyClearanceWithBody(ctx, clearanceId, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateMyClearanceResponse(rsp)
+}
+
+// UpdateMyClearanceWithResponse performs a PATCH /my/clearances/{clearanceId} (the `UpdateMyClearance` operationId) request.
+// Takes a body of the `application/json` content type, and returns a wrapper object for the known response body format(s).
+//
+// Rescreen a sender who was already screened in or out.
+func (c *ClientWithResponses) UpdateMyClearanceWithResponse(ctx context.Context, clearanceId int64, body UpdateMyClearanceJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateMyClearanceResponse, error) {
+	rsp, err := c.UpdateMyClearance(ctx, clearanceId, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateMyClearanceResponse(rsp)
 }
 
 // GetNavigationWithResponse performs a GET /my/navigation.json (the `GetNavigation` operationId) request.
@@ -20063,6 +21052,164 @@ func ParseGetClearancesResponse(rsp *http.Response) (*GetClearancesResponse, err
 	return response, nil
 }
 
+// ParseBulkUpdateClearancesResponse parses an HTTP response from a BulkUpdateClearancesWithResponse call
+func ParseBulkUpdateClearancesResponse(rsp *http.Response) (*BulkUpdateClearancesResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &BulkUpdateClearancesResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest BulkUpdateClearancesResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest UnauthorizedErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFoundErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalServerErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 503:
+		var dest ServiceUnavailableErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON503 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParsePuntClearancesResponse parses an HTTP response from a PuntClearancesWithResponse call
+func ParsePuntClearancesResponse(rsp *http.Response) (*PuntClearancesResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &PuntClearancesResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case rsp.StatusCode == 200:
+		break // No content-type
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest UnauthorizedErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalServerErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 503:
+		var dest ServiceUnavailableErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON503 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUpdateClearanceResponse parses an HTTP response from a UpdateClearanceWithResponse call
+func ParseUpdateClearanceResponse(rsp *http.Response) (*UpdateClearanceResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UpdateClearanceResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest UpdateClearanceResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest UnauthorizedErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest ForbiddenErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFoundErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalServerErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 503:
+		var dest ServiceUnavailableErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON503 = &dest
+
+	}
+
+	return response, nil
+}
+
 // ParseListClipsResponse parses an HTTP response from a ListClipsWithResponse call
 func ParseListClipsResponse(rsp *http.Response) (*ListClipsResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
@@ -21357,6 +22504,114 @@ func ParseGetMessageResponse(rsp *http.Response) (*GetMessageResponse, error) {
 			return nil, err
 		}
 		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFoundErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalServerErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 503:
+		var dest ServiceUnavailableErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON503 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetMyClearancesResponse parses an HTTP response from a GetMyClearancesWithResponse call
+func ParseGetMyClearancesResponse(rsp *http.Response) (*GetMyClearancesResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetMyClearancesResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest GetMyClearancesResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest UnauthorizedErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalServerErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 503:
+		var dest ServiceUnavailableErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON503 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUpdateMyClearanceResponse parses an HTTP response from a UpdateMyClearanceWithResponse call
+func ParseUpdateMyClearanceResponse(rsp *http.Response) (*UpdateMyClearanceResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UpdateMyClearanceResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest UpdateMyClearanceResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest UnauthorizedErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest ForbiddenErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
 		var dest NotFoundErrorResponseContent

--- a/go/pkg/hey/clearances.go
+++ b/go/pkg/hey/clearances.go
@@ -1,0 +1,253 @@
+package hey
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/basecamp/hey-sdk/go/pkg/generated"
+)
+
+// ClearancesService works the Screener: who is waiting to be let in, and letting them in
+// or turning them away.
+type ClearancesService struct {
+	client *Client
+}
+
+// NewClearancesService creates a new ClearancesService.
+func NewClearancesService(client *Client) *ClearancesService {
+	return &ClearancesService{client: client}
+}
+
+// PendingCount answers how many senders are waiting, without fetching them.
+//
+// This is the cheap read HEY's own apps sync for the Screener badge. Use Pending when you
+// want the senders themselves.
+func (s *ClearancesService) PendingCount(ctx context.Context) (count int, err error) {
+	op := OperationInfo{
+		Service: "Clearances", Operation: "GetClearances",
+		ResourceType: "clearance", IsMutation: false,
+	}
+
+	err = s.client.instrument(ctx, op, func(ctx context.Context) error {
+		resp, rerr := s.client.genClient().GetClearancesWithResponse(ctx, &generated.GetClearancesParams{})
+		if rerr != nil {
+			return rerr
+		}
+		if cerr := CheckResponse(resp.HTTPResponse); cerr != nil {
+			return cerr
+		}
+		if resp.JSON200 != nil {
+			count = int(resp.JSON200.PendingClearancesCount)
+		}
+		return nil
+	})
+	return count, err
+}
+
+// Pending answers the senders waiting to be screened, a page at a time.
+//
+// Each one carries the petitioner and the most recent entry they sent, so a caller can
+// show who is asking and what they wrote without a second read. Pass the page token from
+// a previous answer to walk the queue.
+func (s *ClearancesService) Pending(ctx context.Context, page string) (summary *generated.ClearanceSummary, err error) {
+	op := OperationInfo{
+		Service: "Clearances", Operation: "GetClearances",
+		ResourceType: "clearance", IsMutation: false,
+	}
+
+	err = s.client.instrument(ctx, op, func(ctx context.Context) error {
+		include := true
+		params := &generated.GetClearancesParams{IncludeClearances: &include}
+		if page != "" {
+			params.Page = &page
+		}
+
+		resp, rerr := s.client.genClient().GetClearancesWithResponse(ctx, params)
+		if rerr != nil {
+			return rerr
+		}
+		if cerr := CheckResponse(resp.HTTPResponse); cerr != nil {
+			return cerr
+		}
+		summary = resp.JSON200
+		return nil
+	})
+	return summary, err
+}
+
+// Screen answers the Screener for one sender. Status is ClearanceApproved or
+// ClearanceDenied.
+//
+// The options are all optional: file everything they send into a box instead of the Imbox,
+// mark what is already waiting as spam, or mark it seen so it does not arrive unread.
+func (s *ClearancesService) Screen(ctx context.Context, clearanceID int64, status string, opts ScreenOptions) (clearance *generated.Clearance, err error) {
+	op := OperationInfo{
+		Service: "Clearances", Operation: "UpdateClearance",
+		ResourceType: "clearance", IsMutation: true, ResourceID: clearanceID,
+	}
+
+	if err := validateClearanceStatus(status); err != nil {
+		return nil, err
+	}
+
+	err = s.client.instrument(ctx, op, func(ctx context.Context) error {
+		body := generated.UpdateClearanceJSONRequestBody{Status: status}
+		if opts.DesignationBoxID != 0 {
+			body.DesignationBoxId = opts.DesignationBoxID
+		}
+		if opts.Spam {
+			spam := true
+			body.Spam = &spam
+		}
+		if opts.MarkTopicsAsSeen {
+			seen := true
+			body.MarkTopicsAsSeen = &seen
+		}
+
+		resp, rerr := s.client.genClient().UpdateClearanceWithResponse(ctx, clearanceID, body)
+		if rerr != nil {
+			return rerr
+		}
+		if cerr := CheckResponse(resp.HTTPResponse); cerr != nil {
+			return cerr
+		}
+		clearance = resp.JSON200
+		return nil
+	})
+	return clearance, err
+}
+
+// ScreenOptions carries what to do beyond setting the status.
+type ScreenOptions struct {
+	// DesignationBoxID files everything the sender sends into that box rather than the Imbox.
+	DesignationBoxID int64
+	// Spam marks the topics already waiting as spam and trains the filter on them.
+	Spam bool
+	// MarkTopicsAsSeen screens the sender in without their waiting mail arriving unread.
+	MarkTopicsAsSeen bool
+}
+
+// ScreenMany screens several senders at once and answers the clearances it changed.
+//
+// HEY answers 404 when none of the ids belong to the caller. A partial match succeeds and
+// answers only what it touched, so compare the answer against what you sent.
+func (s *ClearancesService) ScreenMany(ctx context.Context, clearanceIDs []int64, status string, spam bool) (clearances []generated.Clearance, err error) {
+	op := OperationInfo{
+		Service: "Clearances", Operation: "BulkUpdateClearances",
+		ResourceType: "clearance", IsMutation: true,
+	}
+
+	if len(clearanceIDs) == 0 {
+		return nil, ErrUsage("at least one clearance is required")
+	}
+	if err := validateClearanceStatus(status); err != nil {
+		return nil, err
+	}
+
+	err = s.client.instrument(ctx, op, func(ctx context.Context) error {
+		body := generated.BulkUpdateClearancesJSONRequestBody{
+			Ids:    joinIDs(clearanceIDs),
+			Status: status,
+		}
+		if spam {
+			body.Spam = &spam
+		}
+
+		resp, rerr := s.client.genClient().BulkUpdateClearancesWithResponse(ctx, body)
+		if rerr != nil {
+			return rerr
+		}
+		if cerr := CheckResponse(resp.HTTPResponse); cerr != nil {
+			return cerr
+		}
+		if resp.JSON200 != nil {
+			clearances = resp.JSON200.Clearances
+		}
+		return nil
+	})
+	return clearances, err
+}
+
+// Punt clears the Screener. Everyone waiting is dropped and reexamined the next time they
+// write, so nothing is decided for them.
+//
+// The work is queued, so the senders are still pending when this returns.
+func (s *ClearancesService) Punt(ctx context.Context) error {
+	op := OperationInfo{
+		Service: "Clearances", Operation: "PuntClearances",
+		ResourceType: "clearance", IsMutation: true,
+	}
+
+	return s.client.instrument(ctx, op, func(ctx context.Context) error {
+		resp, err := s.client.genClient().PuntClearancesWithResponse(ctx)
+		if err != nil {
+			return err
+		}
+		return CheckResponse(resp.HTTPResponse)
+	})
+}
+
+// Screened answers the senders already screened in or out, newest decision first, a page
+// at a time.
+func (s *ClearancesService) Screened(ctx context.Context, page string) (clearances []generated.Clearance, err error) {
+	op := OperationInfo{
+		Service: "Clearances", Operation: "GetMyClearances",
+		ResourceType: "clearance", IsMutation: false,
+	}
+
+	err = s.client.instrument(ctx, op, func(ctx context.Context) error {
+		params := &generated.GetMyClearancesParams{}
+		if page != "" {
+			params.Page = &page
+		}
+
+		resp, rerr := s.client.genClient().GetMyClearancesWithResponse(ctx, params)
+		if rerr != nil {
+			return rerr
+		}
+		if cerr := CheckResponse(resp.HTTPResponse); cerr != nil {
+			return cerr
+		}
+		if resp.JSON200 != nil {
+			clearances = resp.JSON200.Clearances
+		}
+		return nil
+	})
+	return clearances, err
+}
+
+// Rescreen changes its mind about a sender already screened in or out.
+//
+// This is the decided list, not the queue: Screen is what answers a pending sender.
+func (s *ClearancesService) Rescreen(ctx context.Context, clearanceID int64, status string) (clearance *generated.Clearance, err error) {
+	op := OperationInfo{
+		Service: "Clearances", Operation: "UpdateMyClearance",
+		ResourceType: "clearance", IsMutation: true, ResourceID: clearanceID,
+	}
+
+	if err := validateClearanceStatus(status); err != nil {
+		return nil, err
+	}
+
+	err = s.client.instrument(ctx, op, func(ctx context.Context) error {
+		body := generated.UpdateMyClearanceJSONRequestBody{Status: status}
+
+		resp, rerr := s.client.genClient().UpdateMyClearanceWithResponse(ctx, clearanceID, body)
+		if rerr != nil {
+			return rerr
+		}
+		if cerr := CheckResponse(resp.HTTPResponse); cerr != nil {
+			return cerr
+		}
+		clearance = resp.JSON200
+		return nil
+	})
+	return clearance, err
+}
+
+func validateClearanceStatus(status string) error {
+	if status != ClearanceApproved && status != ClearanceDenied {
+		return &Error{Code: CodeValidation, Message: fmt.Sprintf("clearance status must be %q or %q, got %q", ClearanceApproved, ClearanceDenied, status)}
+	}
+	return nil
+}

--- a/go/pkg/hey/clearances_test.go
+++ b/go/pkg/hey/clearances_test.go
@@ -1,0 +1,264 @@
+package hey
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// The apps sync this endpoint for the Screener badge, so the count must not drag the queue
+// along with it.
+func TestClearancesService_PendingCountAsksForTheCountAlone(t *testing.T) {
+	var gotQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/clearances.json" {
+			t.Errorf("expected GET /clearances.json, got %s %s", r.Method, r.URL.Path)
+		}
+		gotQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"pending_clearances_count":3,"signed_stream_name":"abc"}`))
+	}))
+	t.Cleanup(srv.Close)
+	client := NewClient(&Config{BaseURL: srv.URL}, &StaticTokenProvider{Token: "t"}, WithMaxRetries(0))
+
+	count, err := client.Clearances().PendingCount(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if count != 3 {
+		t.Errorf("expected 3 pending, got %d", count)
+	}
+	if gotQuery != "" {
+		t.Errorf("expected no query, got %q", gotQuery)
+	}
+}
+
+func TestClearancesService_Pending(t *testing.T) {
+	var gotInclude, gotPage string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/clearances.json" {
+			t.Errorf("expected GET /clearances.json, got %s %s", r.Method, r.URL.Path)
+		}
+		gotInclude = r.URL.Query().Get("include_clearances")
+		gotPage = r.URL.Query().Get("page")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"pending_clearances_count":1,"clearances":[
+			{"id":91,"status":"pending","petitioner":{"id":51,"name":"Hollis Heimboch","email_address":"hollis@example.com"},
+			 "most_recent_entry":{"id":71,"subject":"New numbers!","topic_id":81,"summary":"The latest sales numbers"}}]}`))
+	}))
+	t.Cleanup(srv.Close)
+	client := NewClient(&Config{BaseURL: srv.URL}, &StaticTokenProvider{Token: "t"}, WithMaxRetries(0))
+
+	summary, err := client.Clearances().Pending(context.Background(), "eyJwYWdlIjoyfQ")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotInclude != "true" {
+		t.Errorf("expected include_clearances=true, got %q", gotInclude)
+	}
+	if gotPage != "eyJwYWdlIjoyfQ" {
+		t.Errorf("expected the page token to be passed through, got %q", gotPage)
+	}
+	if len(summary.Clearances) != 1 {
+		t.Fatalf("expected one clearance, got %+v", summary.Clearances)
+	}
+
+	clearance := summary.Clearances[0]
+	if clearance.Petitioner.EmailAddress != "hollis@example.com" {
+		t.Errorf("expected the petitioner, got %+v", clearance.Petitioner)
+	}
+	if clearance.MostRecentEntry.Subject != "New numbers!" {
+		t.Errorf("expected the subject, got %q", clearance.MostRecentEntry.Subject)
+	}
+	if clearance.MostRecentEntry.TopicId != 81 {
+		t.Errorf("expected the topic to reply to, got %d", clearance.MostRecentEntry.TopicId)
+	}
+}
+
+func TestClearancesService_Screen(t *testing.T) {
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch || r.URL.Path != "/clearances/91.json" {
+			t.Errorf("expected PATCH /clearances/91.json, got %s %s", r.Method, r.URL.Path)
+		}
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":91,"status":"approved"}`))
+	}))
+	t.Cleanup(srv.Close)
+	client := NewClient(&Config{BaseURL: srv.URL}, &StaticTokenProvider{Token: "t"}, WithMaxRetries(0))
+
+	clearance, err := client.Clearances().Screen(context.Background(), 91, ClearanceApproved,
+		ScreenOptions{DesignationBoxID: 7, MarkTopicsAsSeen: true})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if clearance.Status != "approved" {
+		t.Errorf("expected the updated clearance, got %+v", clearance)
+	}
+	if gotBody["status"] != "approved" {
+		t.Errorf("expected the status at the top level, got %+v", gotBody)
+	}
+	if gotBody["designation_box_id"] != float64(7) {
+		t.Errorf("expected the designation box, got %+v", gotBody["designation_box_id"])
+	}
+	if gotBody["mark_topics_as_seen"] != true {
+		t.Errorf("expected mark_topics_as_seen, got %+v", gotBody["mark_topics_as_seen"])
+	}
+	// Options left alone stay off the wire entirely, since HEY reads them for truthiness.
+	if _, sent := gotBody["spam"]; sent {
+		t.Errorf("expected no spam key, got %+v", gotBody)
+	}
+}
+
+// The Screener only takes a decision. Anything else is a caller bug, and HEY answers 403,
+// so it is worth catching before the round trip.
+func TestClearancesService_ScreenRejectsOtherStatuses(t *testing.T) {
+	client := NewClient(&Config{BaseURL: "https://example.invalid"}, &StaticTokenProvider{Token: "t"}, WithMaxRetries(0))
+
+	for _, status := range []string{"pending", "unexamined", "punting", ""} {
+		_, err := client.Clearances().Screen(context.Background(), 91, status, ScreenOptions{})
+
+		var heyErr *Error
+		if !errors.As(err, &heyErr) || heyErr.Code != CodeValidation {
+			t.Errorf("expected a validation error for %q, got %v", status, err)
+		}
+	}
+}
+
+func TestClearancesService_ScreenMany(t *testing.T) {
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch || r.URL.Path != "/clearances/bulk.json" {
+			t.Errorf("expected PATCH /clearances/bulk.json, got %s %s", r.Method, r.URL.Path)
+		}
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"clearances":[{"id":91,"status":"denied"},{"id":92,"status":"denied"}]}`))
+	}))
+	t.Cleanup(srv.Close)
+	client := NewClient(&Config{BaseURL: srv.URL}, &StaticTokenProvider{Token: "t"}, WithMaxRetries(0))
+
+	clearances, err := client.Clearances().ScreenMany(context.Background(), []int64{91, 92}, ClearanceDenied, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotBody["ids"] != "91,92" {
+		t.Errorf("expected a comma separated list of ids, got %+v", gotBody["ids"])
+	}
+	if gotBody["spam"] != true {
+		t.Errorf("expected spam, got %+v", gotBody["spam"])
+	}
+	if len(clearances) != 2 || clearances[1].Id != 92 {
+		t.Errorf("expected both clearances back, got %+v", clearances)
+	}
+}
+
+func TestClearancesService_ScreenManyRequiresClearances(t *testing.T) {
+	client := NewClient(&Config{BaseURL: "https://example.invalid"}, &StaticTokenProvider{Token: "t"}, WithMaxRetries(0))
+
+	_, err := client.Clearances().ScreenMany(context.Background(), nil, ClearanceDenied, false)
+
+	var heyErr *Error
+	if !errors.As(err, &heyErr) || heyErr.Code != CodeUsage {
+		t.Fatalf("expected a usage error, got %v", err)
+	}
+}
+
+// HEY answers 404 when none of the ids belong to the caller, rather than reporting an
+// empty success.
+func TestClearancesService_ScreenManySurfacesUnknownIDs(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(srv.Close)
+	client := NewClient(&Config{BaseURL: srv.URL}, &StaticTokenProvider{Token: "t"}, WithMaxRetries(0))
+
+	_, err := client.Clearances().ScreenMany(context.Background(), []int64{404}, ClearanceDenied, false)
+
+	var heyErr *Error
+	if !errors.As(err, &heyErr) || heyErr.Code != CodeNotFound {
+		t.Fatalf("expected a not found error, got %v", err)
+	}
+}
+
+func TestClearancesService_Punt(t *testing.T) {
+	var called bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		if r.Method != http.MethodPost || r.URL.Path != "/clearances/punt.json" {
+			t.Errorf("expected POST /clearances/punt.json, got %s %s", r.Method, r.URL.Path)
+		}
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	t.Cleanup(srv.Close)
+	client := NewClient(&Config{BaseURL: srv.URL}, &StaticTokenProvider{Token: "t"}, WithMaxRetries(0))
+
+	if err := client.Clearances().Punt(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !called {
+		t.Error("expected the punt to be sent")
+	}
+}
+
+func TestClearancesService_Screened(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/my/clearances.json" {
+			t.Errorf("expected GET /my/clearances.json, got %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"clearances":[
+			{"id":91,"status":"approved","petitioner":{"id":51,"name":"Glenn"}},
+			{"id":92,"status":"denied","petitioner":{"id":52,"name":"Spammer"}}]}`))
+	}))
+	t.Cleanup(srv.Close)
+	client := NewClient(&Config{BaseURL: srv.URL}, &StaticTokenProvider{Token: "t"}, WithMaxRetries(0))
+
+	clearances, err := client.Clearances().Screened(context.Background(), "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(clearances) != 2 {
+		t.Fatalf("expected two clearances, got %+v", clearances)
+	}
+	if clearances[0].Status != "approved" || clearances[1].Status != "denied" {
+		t.Errorf("expected both decisions, got %+v", clearances)
+	}
+	if clearances[0].Petitioner.Name != "Glenn" {
+		t.Errorf("expected the petitioner, got %+v", clearances[0].Petitioner)
+	}
+}
+
+func TestClearancesService_Rescreen(t *testing.T) {
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch || r.URL.Path != "/my/clearances/91.json" {
+			t.Errorf("expected PATCH /my/clearances/91.json, got %s %s", r.Method, r.URL.Path)
+		}
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":91,"status":"denied"}`))
+	}))
+	t.Cleanup(srv.Close)
+	client := NewClient(&Config{BaseURL: srv.URL}, &StaticTokenProvider{Token: "t"}, WithMaxRetries(0))
+
+	clearance, err := client.Clearances().Rescreen(context.Background(), 91, ClearanceDenied)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// HEY takes the status flat here, not nested under a clearance key like its own form.
+	if gotBody["status"] != "denied" {
+		t.Errorf("expected the status at the top level, got %+v", gotBody)
+	}
+	if clearance.Status != "denied" {
+		t.Errorf("expected the updated clearance, got %+v", clearance)
+	}
+}

--- a/go/pkg/hey/client.go
+++ b/go/pkg/hey/client.go
@@ -73,6 +73,7 @@ type Client struct {
 	entries        *EntriesService
 	bulkReplies    *BulkRepliesService
 	contacts       *ContactsService
+	clearances     *ClearancesService
 	calendars      *CalendarsService
 	calendarTodos  *CalendarTodosService
 	calendarEvents *CalendarEventsService
@@ -948,6 +949,16 @@ func (c *Client) Contacts() *ContactsService {
 		c.contacts = NewContactsService(c)
 	}
 	return c.contacts
+}
+
+// Clearances returns the ClearancesService, for working the Screener.
+func (c *Client) Clearances() *ClearancesService {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.clearances == nil {
+		c.clearances = NewClearancesService(c)
+	}
+	return c.clearances
 }
 
 // Calendars returns the CalendarsService.

--- a/go/pkg/hey/contacts.go
+++ b/go/pkg/hey/contacts.go
@@ -132,7 +132,9 @@ func (s *ContactsService) Screen(ctx context.Context, contactID int64, status st
 }
 
 // Clearances returns the screener summary — how many senders are waiting to be screened.
-// The API does not expose the pending senders themselves here.
+//
+// Deprecated: use Client.Clearances(). PendingCount answers the same count, and Pending
+// answers the senders themselves.
 func (s *ContactsService) Clearances(ctx context.Context) (result *generated.ClearanceSummary, err error) {
 	op := OperationInfo{
 		Service: "Contacts", Operation: "GetClearances",
@@ -140,7 +142,7 @@ func (s *ContactsService) Clearances(ctx context.Context) (result *generated.Cle
 	}
 
 	err = s.client.instrument(ctx, op, func(ctx context.Context) error {
-		resp, rerr := s.client.genClient().GetClearancesWithResponse(ctx)
+		resp, rerr := s.client.genClient().GetClearancesWithResponse(ctx, &generated.GetClearancesParams{})
 		if rerr != nil {
 			return rerr
 		}

--- a/go/pkg/hey/url-routes.json
+++ b/go/pkg/hey/url-routes.json
@@ -323,6 +323,35 @@
       "params": {}
     },
     {
+      "pattern": "/clearances/bulk",
+      "resource": "Contacts",
+      "operations": {
+        "PATCH": "BulkUpdateClearances"
+      },
+      "params": {}
+    },
+    {
+      "pattern": "/clearances/punt",
+      "resource": "Contacts",
+      "operations": {
+        "POST": "PuntClearances"
+      },
+      "params": {}
+    },
+    {
+      "pattern": "/clearances/{clearanceId}",
+      "resource": "Contacts",
+      "operations": {
+        "PATCH": "UpdateClearance"
+      },
+      "params": {
+        "clearanceId": {
+          "role": "recording",
+          "type": "int64"
+        }
+      }
+    },
+    {
       "pattern": "/clips",
       "resource": "Clips",
       "operations": {
@@ -530,6 +559,27 @@
       },
       "params": {
         "messageId": {
+          "role": "recording",
+          "type": "int64"
+        }
+      }
+    },
+    {
+      "pattern": "/my/clearances",
+      "resource": "Contacts",
+      "operations": {
+        "GET": "GetMyClearances"
+      },
+      "params": {}
+    },
+    {
+      "pattern": "/my/clearances/{clearanceId}",
+      "resource": "Contacts",
+      "operations": {
+        "PATCH": "UpdateMyClearance"
+      },
+      "params": {
+        "clearanceId": {
           "role": "recording",
           "type": "int64"
         }

--- a/openapi.json
+++ b/openapi.json
@@ -2955,8 +2955,26 @@
     },
     "/clearances.json": {
       "get": {
-        "description": "Get the screener summary — how many senders are waiting to be screened",
+        "description": "Get the Screener — the pending count, and the senders waiting when asked for them",
         "operationId": "GetClearances",
+        "parameters": [
+          {
+            "name": "include_clearances",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "x-go-type-skip-optional-pointer": false
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "x-go-type-skip-optional-pointer": false
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "GetClearances 200 response",
@@ -3002,8 +3020,246 @@
         "tags": [
           "Contacts"
         ],
+        "x-hey-pagination": {
+          "style": "link",
+          "totalCountHeader": "X-Total-Count"
+        },
         "x-hey-retry": {
           "maxAttempts": 3,
+          "baseDelayMs": 1000,
+          "backoff": "exponential",
+          "retryOn": [
+            429,
+            503
+          ]
+        }
+      }
+    },
+    "/clearances/bulk.json": {
+      "patch": {
+        "description": "Screen several senders out at once. ids is a comma-separated list.",
+        "operationId": "BulkUpdateClearances",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BulkUpdateClearancesRequestContent"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "BulkUpdateClearances 200 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BulkUpdateClearancesResponseContent"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "UnauthorizedError 401 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedErrorResponseContent"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFoundError 404 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundErrorResponseContent"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "InternalServerError 500 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerErrorResponseContent"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "ServiceUnavailableError 503 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceUnavailableErrorResponseContent"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Contacts"
+        ],
+        "x-hey-retry": {
+          "maxAttempts": 2,
+          "baseDelayMs": 1000,
+          "backoff": "exponential",
+          "retryOn": [
+            429,
+            503
+          ]
+        }
+      }
+    },
+    "/clearances/punt.json": {
+      "post": {
+        "description": "Clear the Screener — every pending sender is punted and reexamined on their next email",
+        "operationId": "PuntClearances",
+        "responses": {
+          "200": {
+            "description": "PuntClearances 200 response"
+          },
+          "401": {
+            "description": "UnauthorizedError 401 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedErrorResponseContent"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "InternalServerError 500 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerErrorResponseContent"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "ServiceUnavailableError 503 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceUnavailableErrorResponseContent"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Contacts"
+        ],
+        "x-hey-retry": {
+          "maxAttempts": 2,
+          "baseDelayMs": 1000,
+          "backoff": "exponential",
+          "retryOn": [
+            429,
+            503
+          ]
+        }
+      }
+    },
+    "/clearances/{clearanceId}": {
+      "patch": {
+        "description": "Screen a sender in or out of the Screener\n\ndesignation_box_id files everything they send into that box instead of the Imbox.\nspam marks what is already waiting as spam and trains the filter on it.",
+        "operationId": "UpdateClearance",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateClearanceRequestContent"
+              }
+            }
+          },
+          "required": true
+        },
+        "parameters": [
+          {
+            "name": "clearanceId",
+            "in": "path",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "UpdateClearance 200 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateClearanceResponseContent"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "UnauthorizedError 401 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedErrorResponseContent"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "ForbiddenError 403 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ForbiddenErrorResponseContent"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFoundError 404 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundErrorResponseContent"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "InternalServerError 500 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerErrorResponseContent"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "ServiceUnavailableError 503 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceUnavailableErrorResponseContent"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Contacts"
+        ],
+        "x-hey-retry": {
+          "maxAttempts": 2,
           "baseDelayMs": 1000,
           "backoff": "exponential",
           "retryOn": [
@@ -5017,6 +5273,181 @@
         ],
         "x-hey-retry": {
           "maxAttempts": 3,
+          "baseDelayMs": 1000,
+          "backoff": "exponential",
+          "retryOn": [
+            429,
+            503
+          ]
+        }
+      }
+    },
+    "/my/clearances.json": {
+      "get": {
+        "description": "The senders already screened in or out",
+        "operationId": "GetMyClearances",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "x-go-type-skip-optional-pointer": false
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "GetMyClearances 200 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetMyClearancesResponseContent"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "UnauthorizedError 401 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedErrorResponseContent"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "InternalServerError 500 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerErrorResponseContent"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "ServiceUnavailableError 503 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceUnavailableErrorResponseContent"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Contacts"
+        ],
+        "x-hey-pagination": {
+          "style": "link",
+          "totalCountHeader": "X-Total-Count"
+        },
+        "x-hey-retry": {
+          "maxAttempts": 3,
+          "baseDelayMs": 1000,
+          "backoff": "exponential",
+          "retryOn": [
+            429,
+            503
+          ]
+        }
+      }
+    },
+    "/my/clearances/{clearanceId}": {
+      "patch": {
+        "description": "Rescreen a sender who was already screened in or out",
+        "operationId": "UpdateMyClearance",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateMyClearanceRequestContent"
+              }
+            }
+          },
+          "required": true
+        },
+        "parameters": [
+          {
+            "name": "clearanceId",
+            "in": "path",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "UpdateMyClearance 200 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateMyClearanceResponseContent"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "UnauthorizedError 401 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedErrorResponseContent"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "ForbiddenError 403 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ForbiddenErrorResponseContent"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFoundError 404 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundErrorResponseContent"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "InternalServerError 500 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerErrorResponseContent"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "ServiceUnavailableError 503 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceUnavailableErrorResponseContent"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Contacts"
+        ],
+        "x-hey-retry": {
+          "maxAttempts": 2,
           "baseDelayMs": 1000,
           "backoff": "exponential",
           "retryOn": [
@@ -8342,6 +8773,28 @@
           "message"
         ]
       },
+      "BulkUpdateClearancesRequestContent": {
+        "type": "object",
+        "properties": {
+          "ids": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "spam": {
+            "type": "boolean",
+            "x-go-type-skip-optional-pointer": false
+          }
+        },
+        "required": [
+          "ids",
+          "status"
+        ]
+      },
+      "BulkUpdateClearancesResponseContent": {
+        "$ref": "#/components/schemas/ClearanceListResponse"
+      },
       "Calendar": {
         "type": "object",
         "description": "Calendar",
@@ -8465,7 +8918,7 @@
       },
       "Clearance": {
         "type": "object",
-        "description": "Clearance — screening status for a contact",
+        "description": "Clearance — screening status for a contact\n\npetitioner and most_recent_entry are only filled in by the Screener reads. The\ncontact reads answer a clearance with nothing but its id and status.",
         "properties": {
           "id": {
             "type": "integer",
@@ -8473,15 +8926,51 @@
           },
           "status": {
             "type": "string"
+          },
+          "created_at": {
+            "type": "string",
+            "description": "ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)",
+            "format": "date-time",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            }
+          },
+          "updated_at": {
+            "type": "string",
+            "description": "ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)",
+            "format": "date-time",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            }
+          },
+          "petitioner": {
+            "$ref": "#/components/schemas/Contact"
+          },
+          "most_recent_entry": {
+            "$ref": "#/components/schemas/Entry"
           }
         },
         "required": [
           "id"
         ]
       },
+      "ClearanceListResponse": {
+        "type": "object",
+        "description": "ClearanceListResponse — wire format: {clearances: [...]}",
+        "properties": {
+          "clearances": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Clearance"
+            }
+          }
+        }
+      },
       "ClearanceSummary": {
         "type": "object",
-        "description": "ClearanceSummary — the screener's pending count, not the clearances themselves",
+        "description": "ClearanceSummary — the Screener's pending count, and the queue itself when asked for\n\nclearances is only present when the read passes include_clearances. Without it HEY\nanswers the count alone, which is what its own apps sync.",
         "properties": {
           "pending_clearances_count": {
             "type": "integer",
@@ -8489,6 +8978,12 @@
           },
           "signed_stream_name": {
             "type": "string"
+          },
+          "clearances": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Clearance"
+            }
           }
         }
       },
@@ -9191,6 +9686,13 @@
           },
           "app_url": {
             "type": "string"
+          },
+          "subject": {
+            "type": "string"
+          },
+          "topic_id": {
+            "type": "integer",
+            "format": "int64"
           }
         },
         "required": [
@@ -9426,6 +9928,9 @@
       },
       "GetMessageResponseContent": {
         "$ref": "#/components/schemas/Message"
+      },
+      "GetMyClearancesResponseContent": {
+        "$ref": "#/components/schemas/ClearanceListResponse"
       },
       "GetNavigationResponseContent": {
         "$ref": "#/components/schemas/NavigationResponse"
@@ -10912,6 +11417,33 @@
           }
         }
       },
+      "UpdateClearanceRequestContent": {
+        "type": "object",
+        "description": "Wire format: {status: \"approved\"|\"denied\"} — top level, not nested under a clearance key.",
+        "properties": {
+          "status": {
+            "type": "string"
+          },
+          "designation_box_id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "spam": {
+            "type": "boolean",
+            "x-go-type-skip-optional-pointer": false
+          },
+          "mark_topics_as_seen": {
+            "type": "boolean",
+            "x-go-type-skip-optional-pointer": false
+          }
+        },
+        "required": [
+          "status"
+        ]
+      },
+      "UpdateClearanceResponseContent": {
+        "$ref": "#/components/schemas/Clearance"
+      },
       "UpdateCollectionRequestContent": {
         "type": "object",
         "description": "Wire format: {collection: {name, summary}}",
@@ -10959,6 +11491,20 @@
       },
       "UpdateJournalEntryResponseContent": {
         "$ref": "#/components/schemas/Recording"
+      },
+      "UpdateMyClearanceRequestContent": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "status"
+        ]
+      },
+      "UpdateMyClearanceResponseContent": {
+        "$ref": "#/components/schemas/Clearance"
       },
       "UpdateStickyResponseContent": {
         "$ref": "#/components/schemas/Sticky"

--- a/spec/excluded-routes.json
+++ b/spec/excluded-routes.json
@@ -2495,16 +2495,6 @@
     "reason": "phase-2: personal settings and preferences"
   },
   {
-    "method": "GET",
-    "path": "/my/clearances",
-    "reason": "phase-2: personal settings and preferences"
-  },
-  {
-    "method": "PATCH",
-    "path": "/my/clearances/{id}",
-    "reason": "phase-2: personal settings and preferences"
-  },
-  {
     "method": "PUT",
     "path": "/my/clearances/{id}",
     "reason": "phase-2: personal settings and preferences"
@@ -2895,11 +2885,6 @@
     "reason": "phase-2: screener clearances"
   },
   {
-    "method": "PATCH",
-    "path": "/clearances/bulk",
-    "reason": "phase-2: screener clearances"
-  },
-  {
     "method": "POST",
     "path": "/clearances/bulk",
     "reason": "phase-2: screener clearances"
@@ -2930,11 +2915,6 @@
     "reason": "phase-2: screener clearances"
   },
   {
-    "method": "POST",
-    "path": "/clearances/punt",
-    "reason": "phase-2: screener clearances"
-  },
-  {
     "method": "PUT",
     "path": "/clearances/punt",
     "reason": "phase-2: screener clearances"
@@ -2946,11 +2926,6 @@
   },
   {
     "method": "GET",
-    "path": "/clearances/{id}",
-    "reason": "phase-2: screener clearances"
-  },
-  {
-    "method": "PATCH",
     "path": "/clearances/{id}",
     "reason": "phase-2: screener clearances"
   },

--- a/spec/hey.smithy
+++ b/spec/hey.smithy
@@ -171,6 +171,11 @@ service HEY {
         UnbundleContact
         UpdateContactClearance
         GetClearances
+        UpdateClearance
+        BulkUpdateClearances
+        PuntClearances
+        GetMyClearances
+        UpdateMyClearance
 
         // Contacts — writing and notes
         CreateContact
@@ -426,10 +431,26 @@ structure Domain {
 }
 
 /// Clearance — screening status for a contact
+///
+/// petitioner and most_recent_entry are only filled in by the Screener reads. The
+/// contact reads answer a clearance with nothing but its id and status.
 structure Clearance {
     @required
     id: Long
     status: String
+    created_at: DateTime
+    updated_at: DateTime
+    petitioner: Contact
+    most_recent_entry: Entry
+}
+
+list ClearanceList {
+    member: Clearance
+}
+
+/// ClearanceListResponse — wire format: {clearances: [...]}
+structure ClearanceListResponse {
+    clearances: ClearanceList
 }
 
 /// Account — a HEY account
@@ -506,6 +527,8 @@ structure Entry {
     summary: String
     kind: String
     app_url: String
+    subject: String
+    topic_id: Long
 }
 
 list EntryList {
@@ -2334,10 +2357,14 @@ structure FolderWithPostings {
     postings: PostingList
 }
 
-/// ClearanceSummary — the screener's pending count, not the clearances themselves
+/// ClearanceSummary — the Screener's pending count, and the queue itself when asked for
+///
+/// clearances is only present when the read passes include_clearances. Without it HEY
+/// answers the count alone, which is what its own apps sync.
 structure ClearanceSummary {
     pending_clearances_count: Integer
     signed_stream_name: String
+    clearances: ClearanceList
 }
 
 /// MessageDraft — a prefilled compose payload (forward, reply). Unsent, so it has no id.
@@ -2802,19 +2829,156 @@ structure UpdateContactClearanceRequestContent {
     status: String
 }
 
-/// Get the screener summary — how many senders are waiting to be screened
+/// Get the Screener — the pending count, and the senders waiting when asked for them
 @readonly
 @http(method: "GET", uri: "/clearances.json")
 @tags(["Contacts"])
 @heyRetry(maxAttempts: 3, baseDelayMs: 1000, backoff: "exponential", retryOn: [429, 503])
+@heyPagination(style: "link", totalCountHeader: "X-Total-Count")
 operation GetClearances {
+    input: GetClearancesInput
     output: GetClearancesOutput
     errors: [UnauthorizedError, InternalServerError, ServiceUnavailableError]
+}
+
+structure GetClearancesInput {
+    @httpQuery("include_clearances")
+    include_clearances: Boolean
+
+    @httpQuery("page")
+    page: String
 }
 
 structure GetClearancesOutput {
     @required
     summary: ClearanceSummary
+}
+
+/// Screen a sender in or out of the Screener
+///
+/// designation_box_id files everything they send into that box instead of the Imbox.
+/// spam marks what is already waiting as spam and trains the filter on it.
+@idempotent
+@http(method: "PATCH", uri: "/clearances/{clearanceId}")
+@tags(["Contacts"])
+@heyRetry(maxAttempts: 2, baseDelayMs: 1000, backoff: "exponential", retryOn: [429, 503])
+operation UpdateClearance {
+    input: UpdateClearanceInput
+    output: UpdateClearanceOutput
+    errors: [UnauthorizedError, ForbiddenError, NotFoundError, InternalServerError, ServiceUnavailableError]
+}
+
+structure UpdateClearanceInput {
+    @httpLabel
+    @required
+    clearanceId: Long
+
+    @httpPayload
+    @required
+    body: UpdateClearanceRequestContent
+}
+
+/// Wire format: {status: "approved"|"denied"} — top level, not nested under a clearance key.
+structure UpdateClearanceRequestContent {
+    @required
+    status: String
+
+    designation_box_id: Long
+    spam: Boolean
+    mark_topics_as_seen: Boolean
+}
+
+structure UpdateClearanceOutput {
+    @required
+    clearance: Clearance
+}
+
+/// Screen several senders out at once. ids is a comma-separated list.
+@idempotent
+@http(method: "PATCH", uri: "/clearances/bulk.json")
+@tags(["Contacts"])
+@heyRetry(maxAttempts: 2, baseDelayMs: 1000, backoff: "exponential", retryOn: [429, 503])
+operation BulkUpdateClearances {
+    input: BulkUpdateClearancesInput
+    output: BulkUpdateClearancesOutput
+    errors: [UnauthorizedError, NotFoundError, InternalServerError, ServiceUnavailableError]
+}
+
+structure BulkUpdateClearancesInput {
+    @httpPayload
+    @required
+    body: BulkUpdateClearancesRequestContent
+}
+
+structure BulkUpdateClearancesRequestContent {
+    @required
+    ids: String
+
+    @required
+    status: String
+
+    spam: Boolean
+}
+
+structure BulkUpdateClearancesOutput {
+    @required
+    response: ClearanceListResponse
+}
+
+/// Clear the Screener — every pending sender is punted and reexamined on their next email
+@http(method: "POST", uri: "/clearances/punt.json")
+@tags(["Contacts"])
+@heyRetry(maxAttempts: 2, baseDelayMs: 1000, backoff: "exponential", retryOn: [429, 503])
+operation PuntClearances {
+    errors: [UnauthorizedError, InternalServerError, ServiceUnavailableError]
+}
+
+/// The senders already screened in or out
+@readonly
+@http(method: "GET", uri: "/my/clearances.json")
+@tags(["Contacts"])
+@heyRetry(maxAttempts: 3, baseDelayMs: 1000, backoff: "exponential", retryOn: [429, 503])
+@heyPagination(style: "link", totalCountHeader: "X-Total-Count")
+operation GetMyClearances {
+    input: PagedInput
+    output: GetMyClearancesOutput
+    errors: [UnauthorizedError, InternalServerError, ServiceUnavailableError]
+}
+
+structure GetMyClearancesOutput {
+    @required
+    response: ClearanceListResponse
+}
+
+/// Rescreen a sender who was already screened in or out
+@idempotent
+@http(method: "PATCH", uri: "/my/clearances/{clearanceId}")
+@tags(["Contacts"])
+@heyRetry(maxAttempts: 2, baseDelayMs: 1000, backoff: "exponential", retryOn: [429, 503])
+operation UpdateMyClearance {
+    input: UpdateMyClearanceInput
+    output: UpdateMyClearanceOutput
+    errors: [UnauthorizedError, ForbiddenError, NotFoundError, InternalServerError, ServiceUnavailableError]
+}
+
+structure UpdateMyClearanceInput {
+    @httpLabel
+    @required
+    clearanceId: Long
+
+    @httpPayload
+    @required
+    body: UpdateMyClearanceRequestContent
+}
+
+structure UpdateMyClearanceRequestContent {
+    @required
+    status: String
+}
+
+structure UpdateMyClearanceOutput {
+    @required
+    clearance: Clearance
 }
 
 // =============================================================================

--- a/spec/route-coverage.json
+++ b/spec/route-coverage.json
@@ -15,6 +15,11 @@
     "path": "/postings/bulk_bubble_up_now.json"
   },
   {
+    "method": "PATCH",
+    "operationId": "BulkUpdateClearances",
+    "path": "/clearances/bulk.json"
+  },
+  {
     "method": "POST",
     "operationId": "BundleContact",
     "path": "/contacts/{contactId}/bundle.json"
@@ -231,6 +236,11 @@
   },
   {
     "method": "GET",
+    "operationId": "GetMyClearances",
+    "path": "/my/clearances.json"
+  },
+  {
+    "method": "GET",
     "operationId": "GetNavigation",
     "path": "/my/navigation.json"
   },
@@ -395,6 +405,11 @@
     "path": "/entries/{entryId}/forwards/new.json"
   },
   {
+    "method": "POST",
+    "operationId": "PuntClearances",
+    "path": "/clearances/punt.json"
+  },
+  {
     "method": "DELETE",
     "operationId": "RemovePostingsFromBoxGroup",
     "path": "/postings/box_groups.json"
@@ -461,6 +476,11 @@
   },
   {
     "method": "PATCH",
+    "operationId": "UpdateClearance",
+    "path": "/clearances/{clearanceId}"
+  },
+  {
+    "method": "PATCH",
     "operationId": "UpdateCollection",
     "path": "/collections/{collectionId}"
   },
@@ -488,6 +508,11 @@
     "method": "PATCH",
     "operationId": "UpdateJournalEntry",
     "path": "/calendar/days/{day}/journal_entry"
+  },
+  {
+    "method": "PATCH",
+    "operationId": "UpdateMyClearance",
+    "path": "/my/clearances/{clearanceId}"
   },
   {
     "method": "PATCH",

--- a/spec/shape-fingerprint.json
+++ b/spec/shape-fingerprint.json
@@ -1,5 +1,6 @@
 {
   "AdvancedSearch": "4a09f43f1c3ebd17edc3260a9e171d910bc9e96e7967bd6509d80a72d6fc035e",
+  "BulkUpdateClearances": "d4dab559212cc1468322e5cc96c2e650ee64a70e98c147b584d649ee708eeeab",
   "CompleteCalendarTodo": "3a6804f346bb5301f410dac434453eddee1569b54e1f7dd4413b8a0d23c270b2",
   "CompleteHabit": "9bb7a50c07c31309731cb6ae3289aab6c496d65b4458c13ac535ba6919e69bc5",
   "CreateBoxGroup": "d04089956551c379f18238cfef578d7241682aa98b660a5292deb551ce891ed4",
@@ -27,6 +28,7 @@
   "GetJournalEntry": "f045610c5289ac1d282c60805cc787a4df2d6b2ab8d41a59ba2299a56abab6a4",
   "GetLaterbox": "6cc7e63b0f9142d966565eae669bbd7e3d0475164e904b277961c657d75da23f",
   "GetMessage": "449eb645bc61901cd766000b7f7acc22f0432336e3ba1d9f1503f79dda61fe14",
+  "GetMyClearances": "c477f38fb70e472bc2e653f56a812de9e161e364bbab6fb6c5a7e68183723547",
   "GetNavigation": "37f9720f7dbacb2beb0dba5eaa65937569f2d4ac7b1feafb6980f0c7ecc618fe",
   "GetOngoingTimeTrack": "1a011516b31b02ee0229083aec5e0d75b2500cd16d803c2dbf264ac7899868d6",
   "GetSentTopics": "71c0d4f58d450b6b8d4b5a4654053e122103622fabf7e76929aab8c61ed5c2fb",
@@ -53,10 +55,12 @@
   "StartTimeTrack": "631c6e31e91d56c667db4f53df609e0006de3787de580f1f52366f8da283ec91",
   "UncompleteCalendarTodo": "2034f18325d4021bdf67313966275d25c100b11e77bcacfbcddfd3f2ab551783",
   "UncompleteHabit": "d6cbfd918a4f869bf812a29ebc40aeeb203fe88736c424701274b15c94041c43",
+  "UpdateClearance": "c1597f10d3d5f9fabcf67ee69776dfedfe3f67752799276cda904caa9440b502",
   "UpdateContact": "e02333bf4001ecc7ef74a7fef1df25e15d77cf692f31a4e61e314a0446240aaf",
   "UpdateContactNote": "8333012b045fd6fef793cc5e757cbca113eda36bc1d592a3e91a8b60abe6f2b6",
   "UpdateHabit": "abdae94f7cb43bfa8d8fc2db6ead534ae9911b6f73d71a5d9bb212d876802444",
   "UpdateJournalEntry": "c28bc6186595cfc9bb61c3e90f3735fb90e50c81a78a60e45c08189713db9004",
+  "UpdateMyClearance": "8339f944b2987935481a7ed6d5ece614d3bda79633778c5d685906fda9bf842b",
   "UpdateSticky": "59bd8472ed21daeff7a1c0e91ba53dff8821810a7badd9d1d05cf0e3f8bac339",
   "UpdateTimeTrack": "eb9135887276c0f3262eb6b4c74c5f9a533499d66d9b10d5965f791850fc496b"
 }


### PR DESCRIPTION
`GetClearances` answered a count and a signed stream name. That is all the SDK could say about the Screener — how many people were waiting, never who. Screening someone in or out had no typed operation at all, so a client could count strangers and do nothing about them.

This models the Screener: the queue, the decision, the bulk decision, clearing it, and the senders already decided on.

### Operations

| Operation | Route |
|---|---|
| `GetClearances` (extended) | `GET /clearances.json?include_clearances=true` |
| `UpdateClearance` | `PATCH /clearances/{clearanceId}` |
| `BulkUpdateClearances` | `PATCH /clearances/bulk.json` |
| `PuntClearances` | `POST /clearances/punt.json` |
| `GetMyClearances` | `GET /my/clearances.json` |
| `UpdateMyClearance` | `PATCH /my/clearances/{clearanceId}` |

All five new routes were sitting in `spec/excluded-routes.json` as `phase-2`; those entries are gone, which is what lets the reverse drift check accept them.

`Clearance` gains `created_at`, `updated_at`, `petitioner` and `most_recent_entry`, so one read tells a caller who is asking and what they wrote. `Entry` gains `subject` and `topic_id` — the topic is what a caller needs to reply to the thread rather than the sender.

### Service

`hey.ClearancesService`, reached through `client.Clearances()`:

- `PendingCount` — the badge count, and nothing else on the wire
- `Pending(page)` — the queue, a page at a time
- `Screen(id, status, opts)` — one decision, with `DesignationBoxID`, `Spam`, `MarkTopicsAsSeen`
- `ScreenMany(ids, status, spam)` — several at once
- `Punt` — clear the queue
- `Screened(page)` / `Rescreen(id, status)` — the decided list, and changing your mind

`PendingCount` and `Pending` are separate methods on purpose rather than one call with a flag. HEY's own apps sync this endpoint for the Screener badge on every box sync, and asking for the queue there costs about 30 extra queries server-side for data they never read. Keeping the cheap read a named method makes the expensive one deliberate.

`ContactsService.Clearances` still works and is marked deprecated pointing here. Its generated signature gained a params argument, so the call site moved with it.

### Notes for review

**Status is validated before the round trip.** HEY only accepts `approved` or `denied`; the other three enum values in its own model are rejected with 403. `Screen`, `ScreenMany` and `Rescreen` all answer a validation error instead, which is what `ContactsService.Screen` already did.

**Optional booleans stay off the wire.** `spam` and `mark_topics_as_seen` generate as `*bool` with `omitempty` and are only set when true, because HEY reads them for truthiness. There is a test asserting no `spam` key is sent when the option is left alone.

**`BulkUpdateClearances` accepts partial matches.** Five ids with one valid answers 200 and reports the one it touched; only a set with nothing valid in it answers 404. `ScreenMany`'s doc says to compare the answer against what was sent.

**Path modelling.** `UpdateClearance` and `UpdateMyClearance` are modelled without `.json`, since Smithy rejects a literal suffix on a label segment and `withJSONExtension` appends it at request time — the same shape as `GetContact` at `/contacts/{contactId}`.

**Response wrapping.** `clearances` went onto `ClearanceSummary` rather than the output wrapper, because the mapper flattens single-member outputs. `ClearanceListResponse` is the named shape for the `{clearances: [...]}` bodies, matching how `GetSentTopicsOutput` wraps `TopicListResponse`.

### Not done here

No `make bump`. Per CONTRIBUTING the version bump lands separately before the tag.

The route snapshot and `spec/api-provenance.json` are untouched. These are all existing Rails routes, so they were already in the snapshot — only their JSON capability changed, which the snapshot does not record.

### Caveat worth blocking on

**The server side is not merged.** These operations depend on basecamp/haystack#8647, which adds the JSON to endpoints that until now only answered HTML. Releasing the SDK before that ships would publish a client for endpoints that are not there yet.

### Checks

`make check`: 147 conformance tests, 0 failures, MVP gate passed. Service coverage 103/103 operations. 10 new unit tests in `clearances_test.go`.
