### PR TITLE
Bump the SDK to 0.7.0

### DIFF
--- a/go/pkg/hey/version.go
+++ b/go/pkg/hey/version.go
@@ -1,7 +1,7 @@
 package hey
 
 // Version is the current version of the HEY Go SDK.
-const Version = "0.6.1"
+const Version = "0.7.0"
 
 // APIVersion is the HEY API version this SDK targets.
-const APIVersion = "2026-08-18"
+const APIVersion = "2026-08-20"

--- a/openapi.json
+++ b/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "HEY",
-    "version": "2026-08-18",
+    "version": "2026-08-20",
     "description": "HEY API",
     "contact": {
       "name": "Basecamp",

--- a/spec/api-provenance.json
+++ b/spec/api-provenance.json
@@ -1,6 +1,6 @@
 {
   "source": "haystack",
-  "sha": "719c22b23b0fcd15d39d3fc01af9671e06ee116e",
-  "date": "2026-08-18",
+  "sha": "be9a68fa7dbcf06516308778a517facb3c84ea06",
+  "date": "2026-08-20",
   "notes": "Pinned from haystack master. Update with: make provenance-sync"
 }

--- a/spec/hey.smithy
+++ b/spec/hey.smithy
@@ -59,7 +59,7 @@ timestamp DateTime
 /// HEY API
 @restJson1
 service HEY {
-    version: "2026-08-18"
+    version: "2026-08-20"
     operations: [
         // Identity (2 MVP)
         GetIdentity


### PR DESCRIPTION
Release prep for the Screener operations (#92), now that basecamp/haystack#8647 is merged and deployed.

Minor rather than patch: the release adds five operations, and `GetClearances` gained an input, so `GetClearancesWithResponse` on the generated client takes a params argument it did not take in 0.6.1. Callers of the hand-written `hey` package are unaffected.

### APIVersion moves to 2026-08-20

The route snapshot is unchanged — the Screener endpoints were already routes, and only their JSON capability changed, which the snapshot does not record. So `make drift-regen` produced no diff.

The contract did change though, and `APIVersion` goes out in the User-Agent as the API this SDK was built against. Leaving it at `2026-08-18` would tell HEY a client is working from a contract that predates the endpoints this release depends on. The service `version` in `spec/hey.smithy` moves to `2026-08-20`, `openapi.json` follows from the build, and `./scripts/sync-api-version.sh` carries it into `version.go`.

`spec/api-provenance.json` is pinned to haystack `be9a68fa7dbcf06516308778a517facb3c84ea06`, which is master with #8647 in it.

Worth a second opinion: AGENTS.md ties the version date to the snapshot moving, and here it did not. I moved it anyway because the snapshot cannot see a route gaining JSON, so following the letter would have misreported the contract for exactly the change this release exists for. Say the word if you would rather it stayed put.

### Checks

`make check`: 151 conformance tests, 0 failures, MVP gate passed.

`make release VERSION=0.7.0` is next, once this lands — it verifies `version.go` matches the tag before pushing `v0.7.0` and `go/v0.7.0`.
