### PR TITLE
Honor per-operation retry policies in the generated client

### DIFF
--- a/conformance/runner/go/main.go
+++ b/conformance/runner/go/main.go
@@ -1,7 +1,8 @@
 // Package main provides a conformance test runner for the HEY Go SDK.
 //
-// This runner reads JSON test definitions from conformance/tests/ and
-// executes them against the SDK using a mock HTTP server.
+// This runner reads shared JSON test definitions from conformance/tests/ and
+// Go-specific definitions from conformance/tests/go/, then executes them
+// against the SDK using a mock HTTP server.
 package main
 
 import (
@@ -72,10 +73,17 @@ type TestResult struct {
 func main() {
 	testsDir := filepath.Join("..", "..", "tests")
 
-	files, err := filepath.Glob(filepath.Join(testsDir, "*.json"))
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error finding test files: %v\n", err)
-		os.Exit(1)
+	var files []string
+	for _, pattern := range []string{
+		filepath.Join(testsDir, "*.json"),
+		filepath.Join(testsDir, "go", "*.json"),
+	} {
+		matches, err := filepath.Glob(pattern)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error finding test files: %v\n", err)
+			os.Exit(1)
+		}
+		files = append(files, matches...)
 	}
 
 	if len(files) == 0 {
@@ -220,12 +228,6 @@ func runTest(tc TestCase) TestResult {
 	// Create generated client pointing to mock server with auth header
 	credentials := newConformanceCredentials(tc)
 	client, err := generated.NewClient(server.URL,
-		generated.WithRetryConfig(generated.RetryConfig{
-			MaxRetries: 3,
-			BaseDelay:  1 * time.Second,
-			MaxDelay:   30 * time.Second,
-			Multiplier: 2.0,
-		}),
 		generated.WithAuthRefresher(credentials.refresh),
 		generated.WithRequestEditorFn(func(ctx context.Context, req *http.Request) error {
 			token, _ := credentials.AccessToken(ctx)
@@ -287,7 +289,15 @@ func runTest(tc TestCase) TestResult {
 			sdkErr = executeAccountScopedOperation(scopedClient, ctx, tc)
 		}
 	} else {
-		sdkResp, sdkErr = executeOperation(client, ctx, tc)
+		for range max(tc.RepeatOperation, 1) {
+			if sdkResp != nil && sdkResp.Body != nil {
+				_ = sdkResp.Body.Close()
+			}
+			sdkResp, sdkErr = executeOperation(client, ctx, tc)
+			if sdkErr != nil {
+				break
+			}
+		}
 	}
 
 	// Capture response body for responseBody assertions

--- a/conformance/tests/go/retry-policy.json
+++ b/conformance/tests/go/retry-policy.json
@@ -1,0 +1,22 @@
+[
+  {
+    "name": "Generated operation uses its retry status list and attempt limit",
+    "description": "DeleteBoxDesignation stops its first call on undeclared 500, then retries declared 503 once and stops at two attempts before the 200 sentinel",
+    "operation": "DeleteBoxDesignation",
+    "method": "DELETE",
+    "path": "/boxes/{boxId}/designations/{designationId}",
+    "pathParams": {"boxId": 12345, "designationId": 67890},
+    "mockResponses": [
+      {"status": 500},
+      {"status": 503},
+      {"status": 503},
+      {"status": 200}
+    ],
+    "repeatOperation": 2,
+    "assertions": [
+      {"type": "requestCount", "expected": 3},
+      {"type": "statusCode", "expected": 503}
+    ],
+    "tags": ["retry", "operation-policy", "retry-on", "max-attempts"]
+  }
+]

--- a/go/pkg/generated/client.gen.go
+++ b/go/pkg/generated/client.gen.go
@@ -2091,9 +2091,10 @@ type HttpRequestDoer interface {
 	Do(req *http.Request) (*http.Response, error)
 }
 
-// RetryConfig configures retry behavior for idempotent operations.
+// RetryConfig configures client-level retry overrides and delays for idempotent operations.
+// Retryable status codes always come from each operation's API contract.
 type RetryConfig struct {
-	// MaxRetries is the maximum number of retry attempts (default: 3)
+	// MaxRetries overrides an operation's maximum attempts when WithRetryConfig is used.
 	MaxRetries int
 	// BaseDelay is the initial delay between retries (default: 1s)
 	BaseDelay time.Duration
@@ -2113,6 +2114,140 @@ func DefaultRetryConfig() RetryConfig {
 	}
 }
 
+type retryPolicy struct {
+	MaxAttempts       int
+	RetryableStatuses []int
+}
+
+var operationRetryPolicies = map[string]retryPolicy{
+	"DeleteExtenzion":               {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
+	"AdvancedSearch":                {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
+	"GetAdvancedSearchFilters":      {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
+	"ListBoxes":                     {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
+	"GetBox":                        {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
+	"CreateBoxDesignation":          {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
+	"DeleteBoxDesignation":          {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
+	"ListBoxGroups":                 {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
+	"CreateBoxGroup":                {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
+	"DeleteBoxGroup":                {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
+	"GetBoxGroup":                   {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
+	"MarkBoxSeen":                   {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
+	"GetBoxPostingChanges":          {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
+	"GetBubblebox":                  {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
+	"NewBulkReply":                  {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
+	"ListCalendarDays":              {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
+	"GetCalendarDay":                {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
+	"UncompleteHabit":               {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
+	"CompleteHabit":                 {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
+	"GetJournalEntry":               {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
+	"UpdateJournalEntry":            {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
+	"DeleteCalendarEvent":           {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
+	"DeleteCalendarEventOccurrence": {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
+	"CreateHabit":                   {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
+	"DeleteHabit":                   {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
+	"UpdateHabit":                   {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
+	"ResumeHabit":                   {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
+	"StopHabit":                     {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
+	"UpdateFirstWeekDay":            {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
+	"ListJournalEntries":            {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
+	"GetOngoingTimeTrack":           {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
+	"StartTimeTrack":                {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
+	"ListTimeTracks":                {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
+	"CreateTimeTrack":               {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
+	"ListTimeTrackCategories":       {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
+	"DeleteTimeTrack":               {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
+	"UpdateTimeTrack":               {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
+	"CreateCalendarTodo":            {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
+	"DeleteCalendarTodo":            {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
+	"UpdateCalendarTodo":            {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
+	"UncompleteCalendarTodo":        {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
+	"CompleteCalendarTodo":          {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
+	"ListCalendarWeeks":             {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
+	"GetCalendarWeek":               {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
+	"GetCalendarYear":               {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
+	"ListCalendars":                 {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
+	"GetCalendarRecordings":         {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
+	"ToggleCalendar":                {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
+	"GetClearances":                 {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
+	"BulkUpdateClearances":          {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
+	"PuntClearances":                {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
+	"UpdateClearance":               {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
+	"ListClips":                     {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
+	"ListCollections":               {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
+	"GetCollection":                 {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
+	"UpdateCollection":              {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
+	"ListContacts":                  {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
+	"CreateContact":                 {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
+	"HideContact":                   {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
+	"GetContact":                    {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
+	"UpdateContact":                 {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
+	"UnbundleContact":               {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
+	"BundleContact":                 {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
+	"UpdateContactClearance":        {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
+	"DeleteContactNote":             {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
+	"GetContactNote":                {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
+	"UpdateContactNote":             {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
+	"RevealContact":                 {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
+	"ListDrafts":                    {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
+	"DeleteDraft":                   {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
+	"NewEntryForward":               {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
+	"CreateReply":                   {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
+	"NewEntryReply":                 {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
+	"MarkEntrySpam":                 {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
+	"GetFeedbox":                    {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
+	"GetFolder":                     {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
+	"GetIdentity":                   {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
+	"UpdateTimeFormat":              {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
+	"GetImbox":                      {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
+	"GetImboxSeen":                  {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
+	"CreateMessage":                 {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
+	"GetMessage":                    {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
+	"UpdateMessage":                 {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
+	"GetMessageEdit":                {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
+	"GetMyClearances":               {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
+	"UpdateMyClearance":             {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
+	"GetNavigation":                 {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
+	"GetTrailbox":                   {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
+	"RemovePostingsFromBoxGroup":    {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
+	"AddPostingsToBoxGroup":         {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
+	"CancelPostingsBubbleUp":        {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
+	"SchedulePostingsBubbleUp":      {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
+	"BubbleUpPostingsNow":           {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
+	"UnfilePostings":                {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
+	"FilePostings":                  {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
+	"CreateFolderForPostings":       {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
+	"MovePostings":                  {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
+	"UnmutePostings":                {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
+	"MutePostings":                  {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
+	"MarkPostingsSeen":              {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
+	"MarkPostingsSpam":              {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
+	"TrashPostings":                 {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
+	"MarkPostingsUnseen":            {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
+	"GetBundleUnseenPostings":       {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
+	"GetLaterbox":                   {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
+	"GetAsidebox":                   {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
+	"ListSnippets":                  {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
+	"ListStickies":                  {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
+	"CreateSticky":                  {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
+	"MoveSticky":                    {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
+	"DeleteSticky":                  {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
+	"UpdateSticky":                  {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
+	"GetEverythingTopics":           {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
+	"GetSentTopics":                 {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
+	"GetSpamTopics":                 {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
+	"EmptySpam":                     {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
+	"GetTrashTopics":                {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
+	"EmptyTrash":                    {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
+	"GetTopic":                      {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
+	"GetTopicEntries":               {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
+	"MoveTopic":                     {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
+	"GetTopicPublication":           {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
+	"RestoreTopic":                  {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
+	"MarkTopicHam":                  {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
+	"TrashTopic":                    {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
+	"GetWorkflow":                   {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
+}
+
 // Client which conforms to the OpenAPI3 specification for this service.
 type Client struct {
 	// The endpoint of the server conforming to this interface, with scheme,
@@ -2130,7 +2265,8 @@ type Client struct {
 	RequestEditors []RequestEditorFn
 
 	// RetryConfig for idempotent operations
-	RetryConfig RetryConfig
+	RetryConfig           RetryConfig
+	retryAttemptsOverride bool
 
 	// AuthRefresher is asked once when a response is 401. It renews whatever the request
 	// editors authenticate with and reports whether it could; when it could, the request
@@ -2213,6 +2349,7 @@ func WithRequestEditorFn(fn RequestEditorFn) ClientOption {
 func WithRetryConfig(cfg RetryConfig) ClientOption {
 	return func(c *Client) error {
 		c.RetryConfig = cfg
+		c.retryAttemptsOverride = true
 		return nil
 	}
 }
@@ -2242,18 +2379,27 @@ func WithLogger(logger *slog.Logger) ClientOption {
 	}
 }
 
-// isRetryableStatus returns true if the HTTP status code indicates a retryable error.
-func isRetryableStatus(statusCode int) bool {
-	switch statusCode {
-	case http.StatusTooManyRequests, // 429
-		http.StatusInternalServerError, // 500
-		http.StatusBadGateway,          // 502
-		http.StatusServiceUnavailable,  // 503
-		http.StatusGatewayTimeout:      // 504
-		return true
-	default:
-		return false
+func (p retryPolicy) retriesStatus(statusCode int) bool {
+	for _, retryableStatus := range p.RetryableStatuses {
+		if statusCode == retryableStatus {
+			return true
+		}
 	}
+	return false
+}
+
+// retryPolicy returns the operation's declared policy. WithRetryConfig can override its
+// attempt count, while retryable statuses remain operation-defined.
+func (c *Client) retryPolicy(operationId string) retryPolicy {
+	policy, ok := operationRetryPolicies[operationId]
+	if !ok {
+		policy = retryPolicy{MaxAttempts: 1}
+	}
+	if c.retryAttemptsOverride {
+		policy.MaxAttempts = max(c.RetryConfig.MaxRetries, 0) + 1
+	}
+	policy.MaxAttempts = max(policy.MaxAttempts, 1)
+	return policy
 }
 
 // doWithRetry executes a request with retry logic for idempotent operations, and sends
@@ -2261,11 +2407,12 @@ func isRetryableStatus(statusCode int) bool {
 // whatever retry budget the operation has left rather than starting a fresh one, and is
 // always granted at least the one attempt.
 func (c *Client) doWithRetry(ctx context.Context, buildRequest func() (*http.Request, error), isIdempotent bool, operationId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	policy := c.retryPolicy(operationId)
 	maxAttempts := 1
 	if isIdempotent {
-		maxAttempts = c.RetryConfig.MaxRetries + 1
+		maxAttempts = policy.MaxAttempts
 	}
-	resp, req, err := c.doAttempts(ctx, buildRequest, 1, maxAttempts, operationId, reqEditors...)
+	resp, req, err := c.doAttempts(ctx, buildRequest, 1, maxAttempts, policy, operationId, reqEditors...)
 	if err != nil || resp.StatusCode != http.StatusUnauthorized || c.AuthRefresher == nil || !c.AuthRefresher(ctx) {
 		return resp, err
 	}
@@ -2277,7 +2424,7 @@ func (c *Client) doWithRetry(ctx context.Context, buildRequest func() (*http.Req
 	if err := c.announce(ctx, Retry{Request: req, Attempt: failed + 1, Response: resp}); err != nil {
 		return nil, err
 	}
-	resp, _, err = c.doAttempts(ctx, buildRequest, failed+1, failed+max(maxAttempts-failed, 1), operationId, reqEditors...)
+	resp, _, err = c.doAttempts(ctx, buildRequest, failed+1, failed+max(maxAttempts-failed, 1), policy, operationId, reqEditors...)
 	return resp, err
 }
 
@@ -2345,7 +2492,7 @@ type readOnly struct{ io.Reader }
 // transient failures with backoff between them. Along with the last response it returns
 // the request that response answered, as the editors left it: a transport is free to
 // leave Response.Request unset, so the loop does not rely on it.
-func (c *Client) doAttempts(ctx context.Context, buildRequest func() (*http.Request, error), first, last int, operationId string, reqEditors ...RequestEditorFn) (*http.Response, *http.Request, error) {
+func (c *Client) doAttempts(ctx context.Context, buildRequest func() (*http.Request, error), first, last int, policy retryPolicy, operationId string, reqEditors ...RequestEditorFn) (*http.Response, *http.Request, error) {
 
 	var lastResp *http.Response
 	var lastReq *http.Request
@@ -2385,7 +2532,7 @@ func (c *Client) doAttempts(ctx context.Context, buildRequest func() (*http.Requ
 		}
 
 		// Success or non-retryable status
-		if !isRetryableStatus(resp.StatusCode) {
+		if !policy.retriesStatus(resp.StatusCode) {
 			return resp, req, nil
 		}
 

--- a/go/templates/client.tmpl
+++ b/go/templates/client.tmpl
@@ -10,9 +10,10 @@ type HttpRequestDoer interface {
 
 {{$clientTypeName := opts.OutputOptions.ClientTypeName -}}
 
-// RetryConfig configures retry behavior for idempotent operations.
+// RetryConfig configures client-level retry overrides and delays for idempotent operations.
+// Retryable status codes always come from each operation's API contract.
 type RetryConfig struct {
-	// MaxRetries is the maximum number of retry attempts (default: 3)
+	// MaxRetries overrides an operation's maximum attempts when WithRetryConfig is used.
 	MaxRetries int
 	// BaseDelay is the initial delay between retries (default: 1s)
 	BaseDelay time.Duration
@@ -32,6 +33,15 @@ func DefaultRetryConfig() RetryConfig {
 	}
 }
 
+type retryPolicy struct {
+	MaxAttempts       int
+	RetryableStatuses []int
+}
+
+var operationRetryPolicies = map[string]retryPolicy{
+{{range .}}{{$opid := .OperationId}}{{if .Spec}}{{if .Spec.Extensions}}{{$retry := index .Spec.Extensions "x-hey-retry"}}{{if $retry}}	"{{$opid}}": {MaxAttempts: {{index $retry "maxAttempts"}}, RetryableStatuses: []int{ {{range index $retry "retryOn"}}{{.}}, {{end}} }},
+{{end}}{{end}}{{end}}{{end}}}
+
 // {{ $clientTypeName }} which conforms to the OpenAPI3 specification for this service.
 type {{ $clientTypeName }} struct {
 	// The endpoint of the server conforming to this interface, with scheme,
@@ -50,6 +60,7 @@ type {{ $clientTypeName }} struct {
 
 	// RetryConfig for idempotent operations
 	RetryConfig RetryConfig
+	retryAttemptsOverride bool
 
 	// AuthRefresher is asked once when a response is 401. It renews whatever the request
 	// editors authenticate with and reports whether it could; when it could, the request
@@ -132,6 +143,7 @@ func WithRequestEditorFn(fn RequestEditorFn) ClientOption {
 func WithRetryConfig(cfg RetryConfig) ClientOption {
 	return func(c *{{ $clientTypeName }}) error {
 		c.RetryConfig = cfg
+		c.retryAttemptsOverride = true
 		return nil
 	}
 }
@@ -161,18 +173,27 @@ func WithLogger(logger *slog.Logger) ClientOption {
 	}
 }
 
-// isRetryableStatus returns true if the HTTP status code indicates a retryable error.
-func isRetryableStatus(statusCode int) bool {
-	switch statusCode {
-	case http.StatusTooManyRequests,       // 429
-		http.StatusInternalServerError,     // 500
-		http.StatusBadGateway,              // 502
-		http.StatusServiceUnavailable,      // 503
-		http.StatusGatewayTimeout:          // 504
-		return true
-	default:
-		return false
+func (p retryPolicy) retriesStatus(statusCode int) bool {
+	for _, retryableStatus := range p.RetryableStatuses {
+		if statusCode == retryableStatus {
+			return true
+		}
 	}
+	return false
+}
+
+// retryPolicy returns the operation's declared policy. WithRetryConfig can override its
+// attempt count, while retryable statuses remain operation-defined.
+func (c *{{ $clientTypeName }}) retryPolicy(operationId string) retryPolicy {
+	policy, ok := operationRetryPolicies[operationId]
+	if !ok {
+		policy = retryPolicy{MaxAttempts: 1}
+	}
+	if c.retryAttemptsOverride {
+		policy.MaxAttempts = max(c.RetryConfig.MaxRetries, 0) + 1
+	}
+	policy.MaxAttempts = max(policy.MaxAttempts, 1)
+	return policy
 }
 
 // doWithRetry executes a request with retry logic for idempotent operations, and sends
@@ -180,11 +201,12 @@ func isRetryableStatus(statusCode int) bool {
 // whatever retry budget the operation has left rather than starting a fresh one, and is
 // always granted at least the one attempt.
 func (c *{{ $clientTypeName }}) doWithRetry(ctx context.Context, buildRequest func() (*http.Request, error), isIdempotent bool, operationId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	policy := c.retryPolicy(operationId)
 	maxAttempts := 1
 	if isIdempotent {
-		maxAttempts = c.RetryConfig.MaxRetries + 1
+		maxAttempts = policy.MaxAttempts
 	}
-	resp, req, err := c.doAttempts(ctx, buildRequest, 1, maxAttempts, operationId, reqEditors...)
+	resp, req, err := c.doAttempts(ctx, buildRequest, 1, maxAttempts, policy, operationId, reqEditors...)
 	if err != nil || resp.StatusCode != http.StatusUnauthorized || c.AuthRefresher == nil || !c.AuthRefresher(ctx) {
 		return resp, err
 	}
@@ -196,7 +218,7 @@ func (c *{{ $clientTypeName }}) doWithRetry(ctx context.Context, buildRequest fu
 	if err := c.announce(ctx, Retry{Request: req, Attempt: failed + 1, Response: resp}); err != nil {
 		return nil, err
 	}
-	resp, _, err = c.doAttempts(ctx, buildRequest, failed+1, failed+max(maxAttempts-failed, 1), operationId, reqEditors...)
+	resp, _, err = c.doAttempts(ctx, buildRequest, failed+1, failed+max(maxAttempts-failed, 1), policy, operationId, reqEditors...)
 	return resp, err
 }
 
@@ -264,7 +286,7 @@ type readOnly struct{ io.Reader }
 // transient failures with backoff between them. Along with the last response it returns
 // the request that response answered, as the editors left it: a transport is free to
 // leave Response.Request unset, so the loop does not rely on it.
-func (c *{{ $clientTypeName }}) doAttempts(ctx context.Context, buildRequest func() (*http.Request, error), first, last int, operationId string, reqEditors ...RequestEditorFn) (*http.Response, *http.Request, error) {
+func (c *{{ $clientTypeName }}) doAttempts(ctx context.Context, buildRequest func() (*http.Request, error), first, last int, policy retryPolicy, operationId string, reqEditors ...RequestEditorFn) (*http.Response, *http.Request, error) {
 
 	var lastResp *http.Response
 	var lastReq *http.Request
@@ -304,7 +326,7 @@ func (c *{{ $clientTypeName }}) doAttempts(ctx context.Context, buildRequest fun
 		}
 
 		// Success or non-retryable status
-		if !isRetryableStatus(resp.StatusCode) {
+		if !policy.retriesStatus(resp.StatusCode) {
 			return resp, req, nil
 		}
 


### PR DESCRIPTION
## What changed

The generated Go client now reads each operation's `x-hey-retry` contract:

- `maxAttempts` sets the operation default attempt budget
- `retryOn` sets the operation-specific HTTP status list
- explicit `WithRetryConfig` still overrides the attempt count, while retryable statuses remain contract-defined
- the credential-refresh resend and `Hooks.OnRetry` behavior added by #137 and #139 remain intact

The patch is limited to the Go client template, its regenerated output, and one Go-only conformance case plus the runner support needed to discover it. The case uses `DeleteBoxDesignation`: one call stops immediately on undeclared 500, then a second call retries declared 503 once and stops at the operation's two-attempt limit before a 200 sentinel.

Rust retry behavior and the higher-level `hey.Client` default retry override are intentionally unchanged.

## Validation

- `GOWORK=off mise exec -- make check`
- Go conformance: 188/188
- Rust conformance: 187/187
- generated output reproduces byte-for-byte
