### PR TITLE
Add typed collection detail operation

### DIFF
--- a/behavior-model.json
+++ b/behavior-model.json
@@ -485,6 +485,23 @@
         ]
       }
     },
+    "GetCollection": {
+      "idempotent": false,
+      "pagination": {
+        "style": "link",
+        "totalCountHeader": "X-Total-Count"
+      },
+      "readonly": true,
+      "retry": {
+        "backoff": "exponential",
+        "base_delay_ms": 1000,
+        "max": 3,
+        "retry_on": [
+          429,
+          503
+        ]
+      }
+    },
     "GetContact": {
       "idempotent": false,
       "readonly": true,

--- a/conformance/runner/go/main.go
+++ b/conformance/runner/go/main.go
@@ -647,6 +647,22 @@ func checkAssertion(testName string, a Assertion, s checkState) TestResult {
 			if actual != expected {
 				return fail(testName, "Expected X-Total-Count=%d, got %d", expected, actual)
 			}
+		case "nextPage":
+			if s.sdkResp == nil {
+				return fail(testName, "No HTTP response to check Link header")
+			}
+			next := extractNextLinkURL(s.sdkResp.Header.Get("Link"))
+			parsed, err := url.Parse(next)
+			if err != nil || next == "" {
+				return fail(testName, "Link header does not contain a valid next URL")
+			}
+			expected, ok := a.Expected.(string)
+			if !ok {
+				return fail(testName, "responseMeta.nextPage: expected a string, got %T", a.Expected)
+			}
+			if actual := parsed.Query().Get("page"); actual != expected {
+				return fail(testName, "Expected next page %q, got %q", expected, actual)
+			}
 		default:
 			return fail(testName, "Unknown responseMeta path: %s", a.Path)
 		}
@@ -689,13 +705,13 @@ func checkAssertion(testName string, a Assertion, s checkState) TestResult {
 		if len(s.responseBodyBytes) == 0 {
 			return fail(testName, "Expected responseBody.%s, but no response body captured", fieldPath)
 		}
-		var resultMap map[string]interface{}
+		var responseBody interface{}
 		dec := json.NewDecoder(bytes.NewReader(s.responseBodyBytes))
 		dec.UseNumber()
-		if err := dec.Decode(&resultMap); err != nil {
+		if err := dec.Decode(&responseBody); err != nil {
 			return fail(testName, "Failed to decode response body for responseBody assertion: %v", err)
 		}
-		actual, ok := resultMap[fieldPath]
+		actual, ok := lookupJSONPath(responseBody, fieldPath)
 		if !ok {
 			return fail(testName, "Expected responseBody.%s, but field not present", fieldPath)
 		}
@@ -1291,6 +1307,14 @@ func executeOperation(client *generated.Client, ctx context.Context, tc TestCase
 	// Collections
 	case "ListCollections":
 		return client.ListCollections(ctx)
+	case "GetCollection":
+		collectionId := getInt64Param(tc.PathParams, "collectionId")
+		params := &generated.GetCollectionParams{}
+		if _, ok := tc.QueryParams["page"]; ok {
+			page := getStringParam(tc.QueryParams, "page")
+			params.Page = &page
+		}
+		return client.GetCollection(ctx, collectionId, params)
 	case "UpdateCollection":
 		collectionId := getInt64Param(tc.PathParams, "collectionId")
 		body := generated.UpdateCollectionJSONRequestBody{

--- a/conformance/tests/pagination.json
+++ b/conformance/tests/pagination.json
@@ -42,5 +42,45 @@
       {"type": "noError"}
     ],
     "tags": ["pagination", "total-count"]
+  },
+  {
+    "name": "Collection detail contract exposes postings and pagination metadata",
+    "description": "Verifies the collection detail wire response and its Link and X-Total-Count pagination contract",
+    "operation": "GetCollection",
+    "method": "GET",
+    "path": "/collections/{collectionId}",
+    "pathParams": {
+      "collectionId": 33
+    },
+    "mockResponses": [
+      {
+        "status": 200,
+        "headers": {
+          "Link": "</collections/33.json?page=next-cursor>; rel=\"next\"",
+          "X-Total-Count": "42"
+        },
+        "body": {
+          "id": 33,
+          "name": "Kitchen remodel",
+          "postings": [
+            {
+              "id": 91,
+              "kind": "topic"
+            }
+          ]
+        }
+      }
+    ],
+    "assertions": [
+      {"type": "requestCount", "expected": 1},
+      {"type": "statusCode", "expected": 200},
+      {"type": "responseBody", "path": "id", "expected": 33},
+      {"type": "responseBody", "path": "postings.0.id", "expected": 91},
+      {"type": "responseBody", "path": "postings.0.kind", "expected": "topic"},
+      {"type": "responseMeta", "path": "nextPage", "expected": "next-cursor"},
+      {"type": "responseMeta", "path": "totalCount", "expected": 42},
+      {"type": "noError"}
+    ],
+    "tags": ["pagination", "collections", "link-header", "total-count"]
   }
 ]

--- a/conformance/tests/paths.json
+++ b/conformance/tests/paths.json
@@ -2725,6 +2725,57 @@
     ]
   },
   {
+    "name": "GetCollection uses /collections/{collectionId} path",
+    "description": "Verifies that GetCollection constructs the collection detail path and carries the opaque page cursor",
+    "operation": "GetCollection",
+    "method": "GET",
+    "path": "/collections/{collectionId}",
+    "pathParams": {
+      "collectionId": 33
+    },
+    "queryParams": {
+      "page": "next-cursor"
+    },
+    "mockResponses": [
+      {
+        "status": 200,
+        "body": {
+          "id": 33,
+          "name": "Kitchen remodel",
+          "postings": [
+            {
+              "id": 91,
+              "kind": "topic"
+            }
+          ]
+        }
+      }
+    ],
+    "assertions": [
+      {
+        "type": "requestPath",
+        "expected": "/collections/33"
+      },
+      {
+        "type": "requestMethod",
+        "expected": "GET"
+      },
+      {
+        "type": "requestQuery",
+        "expected": {
+          "page": "next-cursor"
+        }
+      },
+      {
+        "type": "noError"
+      }
+    ],
+    "tags": [
+      "path",
+      "collections"
+    ]
+  },
+  {
     "name": "UpdateCollection uses /collections/{collectionId} path",
     "description": "Verifies that UpdateCollection constructs the URL path /collections/{collectionId}",
     "operation": "UpdateCollection",

--- a/go/pkg/generated/client.gen.go
+++ b/go/pkg/generated/client.gen.go
@@ -308,6 +308,20 @@ type CollectionPayload struct {
 	Summary string `json:"summary,omitempty"`
 }
 
+// CollectionWithPostings CollectionWithPostings — collection detail with its threads as posting objects
+type CollectionWithPostings struct {
+	AppUrl string `json:"app_url,omitempty"`
+
+	// CreatedAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
+	CreatedAt time.Time `json:"created_at,omitempty"`
+	Id        int64     `json:"id"`
+	Name      string    `json:"name,omitempty"`
+	Postings  []Posting `json:"postings,omitempty"`
+
+	// UpdatedAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
+	UpdatedAt time.Time `json:"updated_at,omitempty"`
+}
+
 // CompleteCalendarTodoResponseContent Recording — polymorphic by `type` (CalendarEvent, CalendarTodo, etc.)
 type CompleteCalendarTodoResponseContent = Recording
 
@@ -649,6 +663,9 @@ type GetCalendarRecordingsResponseContent = CalendarRecordingsResponse
 // clearances is only present when the read passes include_clearances. Without it HEY
 // answers the count alone, which is what its own apps sync.
 type GetClearancesResponseContent = ClearanceSummary
+
+// GetCollectionResponseContent CollectionWithPostings — collection detail with its threads as posting objects
+type GetCollectionResponseContent = CollectionWithPostings
 
 // GetContactNoteResponseContent A contact's private note. Empty strings when there is no note.
 type GetContactNoteResponseContent = ContactNote
@@ -1488,6 +1505,11 @@ type ListClipsParams struct {
 	Page *string `form:"page,omitempty" json:"page,omitempty"`
 }
 
+// GetCollectionParams defines parameters for GetCollection.
+type GetCollectionParams struct {
+	Page *string `form:"page,omitempty" json:"page,omitempty"`
+}
+
 // ListContactsParams defines parameters for ListContacts.
 type ListContactsParams struct {
 	Page *string `form:"page,omitempty" json:"page,omitempty"`
@@ -2069,6 +2091,9 @@ type ClientInterface interface {
 
 	// ListCollections request
 	ListCollections(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetCollection request
+	GetCollection(ctx context.Context, collectionId int64, params *GetCollectionParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// UpdateCollectionWithBody request with any body
 	UpdateCollectionWithBody(ctx context.Context, collectionId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -2948,6 +2973,16 @@ func (c *Client) ListCollections(ctx context.Context, reqEditors ...RequestEdito
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewListCollectionsRequest(c.Server)
 	}, true, "ListCollections", reqEditors...)
+
+}
+
+// GetCollection is marked as idempotent and will be retried on transient failures.
+
+func (c *Client) GetCollection(ctx context.Context, collectionId int64, params *GetCollectionParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		return NewGetCollectionRequest(c.Server, collectionId, params)
+	}, true, "GetCollection", reqEditors...)
 
 }
 
@@ -5942,6 +5977,62 @@ func NewListCollectionsRequest(server string) (*http.Request, error) {
 	return req, nil
 }
 
+// NewGetCollectionRequest generates requests for GetCollection
+func NewGetCollectionRequest(server string, collectionId int64, params *GetCollectionParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "collectionId", runtime.ParamLocationPath, collectionId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/collections/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.Page != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "page", runtime.ParamLocationQuery, *params.Page); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewUpdateCollectionRequest calls the generic UpdateCollection builder with application/json body
 func NewUpdateCollectionRequest(server string, collectionId int64, body UpdateCollectionJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
@@ -8681,6 +8772,7 @@ var operationMetadata = map[string]OperationMetadata{
 	"UpdateClearance":            {Idempotent: false, HasSensitiveParams: false},
 	"ListClips":                  {Idempotent: true, HasSensitiveParams: false},
 	"ListCollections":            {Idempotent: true, HasSensitiveParams: false},
+	"GetCollection":              {Idempotent: true, HasSensitiveParams: false},
 	"UpdateCollection":           {Idempotent: false, HasSensitiveParams: false},
 	"ListContacts":               {Idempotent: true, HasSensitiveParams: false},
 	"CreateContact":              {Idempotent: false, HasSensitiveParams: false},
@@ -9748,6 +9840,13 @@ type ClientWithResponsesInterface interface {
 	//
 	// Returns a wrapper object for the known response body format(s).
 	ListCollectionsWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListCollectionsResponse, error)
+
+	// GetCollectionWithResponse performs a GET /collections/{collectionId} (the `GetCollection` operationId) request.
+	//
+	// Get a collection and one page of its active, accessible threads
+	//
+	// Returns a wrapper object for the known response body format(s).
+	GetCollectionWithResponse(ctx context.Context, collectionId int64, params *GetCollectionParams, reqEditors ...RequestEditorFn) (*GetCollectionResponse, error)
 
 	// UpdateCollectionWithBodyWithResponse performs a PATCH /collections/{collectionId} (the `UpdateCollection` operationId) request,
 	// with any type of body and a specified content type.
@@ -13129,6 +13228,75 @@ func (r ListCollectionsResponse) StatusCode() int {
 
 // ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
 func (r ListCollectionsResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type GetCollectionResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	// JSON200 the response for an HTTP 200 `application/json` response
+	JSON200 *GetCollectionResponseContent
+	// JSON401 the response for an HTTP 401 `application/json` response
+	JSON401 *UnauthorizedErrorResponseContent
+	// JSON404 the response for an HTTP 404 `application/json` response
+	JSON404 *NotFoundErrorResponseContent
+	// JSON500 the response for an HTTP 500 `application/json` response
+	JSON500 *InternalServerErrorResponseContent
+	// JSON503 the response for an HTTP 503 `application/json` response
+	JSON503 *ServiceUnavailableErrorResponseContent
+}
+
+// GetJSON200 returns the response for an HTTP 200 `application/json` response
+func (r GetCollectionResponse) GetJSON200() *GetCollectionResponseContent {
+	return r.JSON200
+}
+
+// GetJSON401 returns the response for an HTTP 401 `application/json` response
+func (r GetCollectionResponse) GetJSON401() *UnauthorizedErrorResponseContent {
+	return r.JSON401
+}
+
+// GetJSON404 returns the response for an HTTP 404 `application/json` response
+func (r GetCollectionResponse) GetJSON404() *NotFoundErrorResponseContent {
+	return r.JSON404
+}
+
+// GetJSON500 returns the response for an HTTP 500 `application/json` response
+func (r GetCollectionResponse) GetJSON500() *InternalServerErrorResponseContent {
+	return r.JSON500
+}
+
+// GetJSON503 returns the response for an HTTP 503 `application/json` response
+func (r GetCollectionResponse) GetJSON503() *ServiceUnavailableErrorResponseContent {
+	return r.JSON503
+}
+
+// GetBody returns the raw response body bytes
+func (r GetCollectionResponse) GetBody() []byte {
+	return r.Body
+}
+
+// Status returns HTTPResponse.Status
+func (r GetCollectionResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetCollectionResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r GetCollectionResponse) ContentType() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Header.Get("Content-Type")
 	}
@@ -17982,6 +18150,19 @@ func (c *ClientWithResponses) ListCollectionsWithResponse(ctx context.Context, r
 	return ParseListCollectionsResponse(rsp)
 }
 
+// GetCollectionWithResponse performs a GET /collections/{collectionId} (the `GetCollection` operationId) request.
+//
+// # Get a collection and one page of its active, accessible threads
+//
+// Returns a wrapper object for the known response body format(s).
+func (c *ClientWithResponses) GetCollectionWithResponse(ctx context.Context, collectionId int64, params *GetCollectionParams, reqEditors ...RequestEditorFn) (*GetCollectionResponse, error) {
+	rsp, err := c.GetCollection(ctx, collectionId, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetCollectionResponse(rsp)
+}
+
 // UpdateCollectionWithBodyWithResponse performs a PATCH /collections/{collectionId} (the `UpdateCollection` operationId) request,
 // with any type of body and a specified content type.
 //
@@ -21284,6 +21465,60 @@ func ParseListCollectionsResponse(rsp *http.Response) (*ListCollectionsResponse,
 			return nil, err
 		}
 		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalServerErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 503:
+		var dest ServiceUnavailableErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON503 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetCollectionResponse parses an HTTP response from a GetCollectionWithResponse call
+func ParseGetCollectionResponse(rsp *http.Response) (*GetCollectionResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetCollectionResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest GetCollectionResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest UnauthorizedErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFoundErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest InternalServerErrorResponseContent

--- a/go/pkg/hey/collections.go
+++ b/go/pkg/hey/collections.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"strconv"
 
 	"github.com/basecamp/hey-sdk/go/pkg/generated"
 )
@@ -35,6 +36,13 @@ type UpdateCollectionParams struct {
 	Summary string
 }
 
+// CollectionPage contains one page of a collection and its pagination state.
+type CollectionPage struct {
+	Collection *generated.CollectionWithPostings
+	NextPage   string
+	TotalCount int
+}
+
 // List returns your collections.
 func (s *CollectionsService) List(ctx context.Context) (result *generated.ListCollectionsResponseContent, err error) {
 	op := OperationInfo{
@@ -51,6 +59,40 @@ func (s *CollectionsService) List(ctx context.Context) (result *generated.ListCo
 			return cerr
 		}
 		result = resp.JSON200
+		return nil
+	})
+	return result, err
+}
+
+// Get returns a collection and the active, accessible threads in its requested page.
+func (s *CollectionsService) Get(ctx context.Context, collectionID int64, params *generated.GetCollectionParams) (*generated.CollectionWithPostings, error) {
+	page, err := s.GetPage(ctx, collectionID, params)
+	if err != nil || page == nil {
+		return nil, err
+	}
+	return page.Collection, nil
+}
+
+// GetPage returns a collection page with its next cursor and total posting count.
+func (s *CollectionsService) GetPage(ctx context.Context, collectionID int64, params *generated.GetCollectionParams) (result *CollectionPage, err error) {
+	op := OperationInfo{
+		Service: "Collections", Operation: "GetCollection",
+		ResourceType: "collection", IsMutation: false, ResourceID: collectionID,
+	}
+
+	err = s.client.instrument(ctx, op, func(ctx context.Context) error {
+		resp, rerr := s.client.genClient().GetCollectionWithResponse(ctx, collectionID, params)
+		if rerr != nil {
+			return rerr
+		}
+		if cerr := CheckResponse(resp.HTTPResponse); cerr != nil {
+			return cerr
+		}
+		result = &CollectionPage{Collection: resp.JSON200}
+		if resp.HTTPResponse != nil {
+			result.TotalCount, _ = strconv.Atoi(resp.HTTPResponse.Header.Get("X-Total-Count"))
+			result.NextPage = gearedPageFromLink(resp.HTTPResponse.Header.Get("Link"))
+		}
 		return nil
 	})
 	return result, err

--- a/go/pkg/hey/folders.go
+++ b/go/pkg/hey/folders.go
@@ -2,9 +2,7 @@ package hey
 
 import (
 	"context"
-	"net/url"
 	"strconv"
-	"strings"
 
 	"github.com/basecamp/hey-sdk/go/pkg/generated"
 )
@@ -56,65 +54,9 @@ func (s *FoldersService) GetPage(ctx context.Context, folderID int64, params *ge
 		result = &FolderPage{Folder: resp.JSON200}
 		if resp.HTTPResponse != nil {
 			result.TotalCount, _ = strconv.Atoi(resp.HTTPResponse.Header.Get("X-Total-Count"))
-			result.NextPage = folderPageFromLink(resp.HTTPResponse.Header.Get("Link"))
+			result.NextPage = gearedPageFromLink(resp.HTTPResponse.Header.Get("Link"))
 		}
 		return nil
 	})
 	return result, err
-}
-
-func folderPageFromLink(header string) string {
-	next := folderNextLink(header)
-	if next == "" {
-		return ""
-	}
-	parsed, err := url.Parse(next)
-	if err != nil {
-		return ""
-	}
-	return parsed.Query().Get("page")
-}
-
-func folderNextLink(header string) string {
-	remainder := header
-	for {
-		start := strings.IndexByte(remainder, '<')
-		if start < 0 {
-			return ""
-		}
-		remainder = remainder[start+1:]
-		end := strings.IndexByte(remainder, '>')
-		if end < 0 {
-			return ""
-		}
-		target := remainder[:end]
-		after := remainder[end+1:]
-		nextStart := strings.IndexByte(after, '<')
-		params := after
-		if nextStart >= 0 {
-			params = after[:nextStart]
-		}
-		if folderLinkIsNext(params) {
-			return target
-		}
-		if nextStart < 0 {
-			return ""
-		}
-		remainder = after[nextStart:]
-	}
-}
-
-func folderLinkIsNext(params string) bool {
-	for _, param := range strings.Split(params, ";") {
-		parts := strings.SplitN(strings.TrimSpace(strings.Trim(param, ",")), "=", 2)
-		if len(parts) != 2 || !strings.EqualFold(parts[0], "rel") {
-			continue
-		}
-		for _, relation := range strings.Fields(strings.Trim(parts[1], `"`)) {
-			if strings.EqualFold(relation, "next") {
-				return true
-			}
-		}
-	}
-	return false
 }

--- a/go/pkg/hey/pagination.go
+++ b/go/pkg/hey/pagination.go
@@ -52,7 +52,9 @@ func gearedNextLink(header string) string {
 
 func gearedLinkIsNext(params string) bool {
 	for _, param := range strings.Split(params, ";") {
-		parts := strings.SplitN(strings.TrimSpace(strings.Trim(param, ",")), "=", 2)
+		param = strings.TrimSpace(param)
+		param = strings.TrimSpace(strings.TrimSuffix(param, ","))
+		parts := strings.SplitN(param, "=", 2)
 		if len(parts) != 2 || !strings.EqualFold(parts[0], "rel") {
 			continue
 		}

--- a/go/pkg/hey/pagination.go
+++ b/go/pkg/hey/pagination.go
@@ -6,7 +6,64 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 )
+
+func gearedPageFromLink(header string) string {
+	next := gearedNextLink(header)
+	if next == "" {
+		return ""
+	}
+	parsed, err := url.Parse(next)
+	if err != nil {
+		return ""
+	}
+	return parsed.Query().Get("page")
+}
+
+func gearedNextLink(header string) string {
+	remainder := header
+	for {
+		start := strings.IndexByte(remainder, '<')
+		if start < 0 {
+			return ""
+		}
+		remainder = remainder[start+1:]
+		end := strings.IndexByte(remainder, '>')
+		if end < 0 {
+			return ""
+		}
+		target := remainder[:end]
+		after := remainder[end+1:]
+		nextStart := strings.IndexByte(after, '<')
+		params := after
+		if nextStart >= 0 {
+			params = after[:nextStart]
+		}
+		if gearedLinkIsNext(params) {
+			return target
+		}
+		if nextStart < 0 {
+			return ""
+		}
+		remainder = after[nextStart:]
+	}
+}
+
+func gearedLinkIsNext(params string) bool {
+	for _, param := range strings.Split(params, ";") {
+		parts := strings.SplitN(strings.TrimSpace(strings.Trim(param, ",")), "=", 2)
+		if len(parts) != 2 || !strings.EqualFold(parts[0], "rel") {
+			continue
+		}
+		for _, relation := range strings.Fields(strings.Trim(parts[1], `"`)) {
+			if strings.EqualFold(relation, "next") {
+				return true
+			}
+		}
+	}
+	return false
+}
 
 // FollowPagination fetches additional pages following Link headers from an HTTP response.
 // firstPageCount is the number of items already collected from the first page.

--- a/go/pkg/hey/services_test.go
+++ b/go/pkg/hey/services_test.go
@@ -1779,7 +1779,7 @@ func TestFoldersService_GetPage(t *testing.T) {
 	}
 }
 
-func TestFolderPageFromLink(t *testing.T) {
+func TestGearedPageFromLink(t *testing.T) {
 	tests := []struct {
 		header string
 		want   string
@@ -1788,13 +1788,13 @@ func TestFolderPageFromLink(t *testing.T) {
 		{header: `<https://app.hey.com/folders/12.json?page=previous>; rel="prev", <https://app.hey.com/folders/12.json?page=a,b>; rel="next"`, want: "a,b"},
 	}
 	for _, tt := range tests {
-		if got := folderPageFromLink(tt.header); got != tt.want {
-			t.Errorf("folderPageFromLink(%q) = %q, want %q", tt.header, got, tt.want)
+		if got := gearedPageFromLink(tt.header); got != tt.want {
+			t.Errorf("gearedPageFromLink(%q) = %q, want %q", tt.header, got, tt.want)
 		}
 	}
 	for _, header := range []string{"", "not a URL", `<https://app.hey.com/folders/12.json>; rel="next"`} {
-		if got := folderPageFromLink(header); got != "" {
-			t.Errorf("folderPageFromLink(%q) = %q, want empty", header, got)
+		if got := gearedPageFromLink(header); got != "" {
+			t.Errorf("gearedPageFromLink(%q) = %q, want empty", header, got)
 		}
 	}
 }
@@ -1812,6 +1812,59 @@ func TestCollectionsService_List(t *testing.T) {
 	}
 	if len(*collections) != 1 || (*collections)[0].Name != "Kitchen remodel" {
 		t.Errorf("expected one Kitchen remodel collection, got %+v", collections)
+	}
+}
+
+func TestCollectionsService_Get(t *testing.T) {
+	client := newServiceTestClient(t, map[string]string{
+		"/collections/%s": `{"id":33,"name":"Kitchen remodel","app_url":"https://app.hey.com/collections/33","postings":[{"id":91,"kind":"topic","account_id":7,"seen":true,"name":"Contractor quotes"}]}`,
+	})
+
+	collection, err := client.Collections().Get(context.Background(), 33, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if collection.Id != 33 || collection.Name != "Kitchen remodel" || len(collection.Postings) != 1 {
+		t.Fatalf("unexpected collection: %+v", collection)
+	}
+	posting := collection.Postings[0]
+	if posting.Id != 91 || posting.Kind != "topic" || posting.AccountId != 7 || !posting.Seen || posting.Name != "Contractor quotes" {
+		t.Errorf("unexpected posting: %+v", posting)
+	}
+}
+
+func TestCollectionsService_GetPage(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/collections/33.json" {
+			t.Errorf("path = %q, want /collections/33.json", r.URL.Path)
+		}
+		if page := r.URL.Query().Get("page"); page != "current-cursor" {
+			t.Errorf("page = %q, want current-cursor", page)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Total-Count", "42")
+		w.Header().Set("Link", `<http://`+r.Host+`/collections/33.json?page=next-cursor>; rel="next"`)
+		_, _ = io.WriteString(w, `{"id":33,"name":"Kitchen remodel","postings":[{"id":91,"kind":"topic"}]}`)
+	}))
+	t.Cleanup(server.Close)
+
+	client := NewClient(&Config{BaseURL: server.URL}, &StaticTokenProvider{Token: "test-token"}, WithMaxRetries(0))
+	cursor := "current-cursor"
+	page, err := client.Collections().GetPage(context.Background(), 33, &generated.GetCollectionParams{Page: &cursor})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if page.Collection == nil || page.Collection.Name != "Kitchen remodel" || len(page.Collection.Postings) != 1 || page.TotalCount != 42 || page.NextPage != "next-cursor" {
+		t.Errorf("unexpected collection page: %+v", page)
+	}
+}
+
+func TestCollectionsService_GetNotFound(t *testing.T) {
+	client := newServiceTestClient(t, map[string]string{})
+
+	_, err := client.Collections().Get(context.Background(), 33, nil)
+	if err == nil || AsError(err).Code != CodeNotFound {
+		t.Fatalf("expected not found, got %v", err)
 	}
 }
 

--- a/go/pkg/hey/services_test.go
+++ b/go/pkg/hey/services_test.go
@@ -1781,18 +1781,22 @@ func TestFoldersService_GetPage(t *testing.T) {
 
 func TestGearedPageFromLink(t *testing.T) {
 	tests := []struct {
+		name   string
 		header string
 		want   string
 	}{
-		{header: `<https://app.hey.com/folders/12.json?page=next>; rel="next"`, want: "next"},
-		{header: `<https://app.hey.com/folders/12.json?page=previous>; rel="prev", <https://app.hey.com/folders/12.json?page=a,b>; rel="next"`, want: "a,b"},
+		{name: "single next link", header: `<https://app.hey.com/folders/12.json?page=next>; rel="next"`, want: "next"},
+		{name: "next link last", header: `<https://app.hey.com/folders/12.json?page=previous>; rel="prev", <https://app.hey.com/folders/12.json?page=a,b>; rel="next"`, want: "a,b"},
+		{name: "next link first", header: `<https://app.hey.com/folders/12.json?page=next>; rel="next", <https://app.hey.com/folders/12.json?page=previous>; rel="prev"`, want: "next"},
 	}
 	for _, tt := range tests {
-		if got := gearedPageFromLink(tt.header); got != tt.want {
-			t.Errorf("gearedPageFromLink(%q) = %q, want %q", tt.header, got, tt.want)
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			if got := gearedPageFromLink(tt.header); got != tt.want {
+				t.Errorf("gearedPageFromLink(%q) = %q, want %q", tt.header, got, tt.want)
+			}
+		})
 	}
-	for _, header := range []string{"", "not a URL", `<https://app.hey.com/folders/12.json>; rel="next"`} {
+	for _, header := range []string{"", "not a URL", `<https://app.hey.com/folders/12.json>; rel="next"`, `<https://app.hey.com/folders/12.json?page=previous>; rel="prev", <https://app.hey.com/folders/12.json?page=last>; rel="last"`} {
 		if got := gearedPageFromLink(header); got != "" {
 			t.Errorf("gearedPageFromLink(%q) = %q, want empty", header, got)
 		}

--- a/go/pkg/hey/url-routes.json
+++ b/go/pkg/hey/url-routes.json
@@ -371,6 +371,7 @@
       "pattern": "/collections/{collectionId}",
       "resource": "Collections",
       "operations": {
+        "GET": "GetCollection",
         "PATCH": "UpdateCollection"
       },
       "params": {

--- a/go/pkg/hey/version.go
+++ b/go/pkg/hey/version.go
@@ -4,4 +4,4 @@ package hey
 const Version = "0.7.0"
 
 // APIVersion is the HEY API version this SDK targets.
-const APIVersion = "2026-08-20"
+const APIVersion = "2026-08-21"

--- a/openapi.json
+++ b/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "HEY",
-    "version": "2026-08-20",
+    "version": "2026-08-21",
     "description": "HEY API",
     "contact": {
       "name": "Basecamp",
@@ -3404,6 +3404,97 @@
       }
     },
     "/collections/{collectionId}": {
+      "get": {
+        "description": "Get a collection and one page of its active, accessible threads",
+        "operationId": "GetCollection",
+        "parameters": [
+          {
+            "name": "collectionId",
+            "in": "path",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "required": true
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "x-go-type-skip-optional-pointer": false
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "GetCollection 200 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetCollectionResponseContent"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "UnauthorizedError 401 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedErrorResponseContent"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFoundError 404 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundErrorResponseContent"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "InternalServerError 500 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerErrorResponseContent"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "ServiceUnavailableError 503 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceUnavailableErrorResponseContent"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Collections"
+        ],
+        "x-hey-pagination": {
+          "style": "link",
+          "totalCountHeader": "X-Total-Count"
+        },
+        "x-hey-retry": {
+          "maxAttempts": 3,
+          "baseDelayMs": 1000,
+          "backoff": "exponential",
+          "retryOn": [
+            429,
+            503
+          ]
+        }
+      },
       "patch": {
         "description": "Rename a collection or change its summary",
         "operationId": "UpdateCollection",
@@ -9094,6 +9185,49 @@
           }
         }
       },
+      "CollectionWithPostings": {
+        "type": "object",
+        "description": "CollectionWithPostings — collection detail with its threads as posting objects",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "name": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string",
+            "description": "ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)",
+            "format": "date-time",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            }
+          },
+          "updated_at": {
+            "type": "string",
+            "description": "ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)",
+            "format": "date-time",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            }
+          },
+          "app_url": {
+            "type": "string"
+          },
+          "postings": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Posting"
+            }
+          }
+        },
+        "required": [
+          "id"
+        ]
+      },
       "CompleteCalendarTodoResponseContent": {
         "$ref": "#/components/schemas/Recording"
       },
@@ -9898,6 +10032,9 @@
       },
       "GetClearancesResponseContent": {
         "$ref": "#/components/schemas/ClearanceSummary"
+      },
+      "GetCollectionResponseContent": {
+        "$ref": "#/components/schemas/CollectionWithPostings"
       },
       "GetContactNoteResponseContent": {
         "$ref": "#/components/schemas/ContactNote"

--- a/spec/api-provenance.json
+++ b/spec/api-provenance.json
@@ -1,6 +1,6 @@
 {
   "source": "haystack",
-  "sha": "be9a68fa7dbcf06516308778a517facb3c84ea06",
-  "date": "2026-08-20",
+  "sha": "40f469e5dbf8d0a3f06f48962adbbbece486a97d",
+  "date": "2026-08-21",
   "notes": "Pinned from haystack master. Update with: make provenance-sync"
 }

--- a/spec/excluded-routes.json
+++ b/spec/excluded-routes.json
@@ -1350,11 +1350,6 @@
     "reason": "phase-2: collections"
   },
   {
-    "method": "GET",
-    "path": "/collections/{id}",
-    "reason": "phase-2: collections"
-  },
-  {
     "method": "PUT",
     "path": "/collections/{id}",
     "reason": "phase-2: collections"

--- a/spec/hey.smithy
+++ b/spec/hey.smithy
@@ -59,7 +59,7 @@ timestamp DateTime
 /// HEY API
 @restJson1
 service HEY {
-    version: "2026-08-20"
+    version: "2026-08-21"
     operations: [
         // Identity (2 MVP)
         GetIdentity
@@ -202,6 +202,7 @@ service HEY {
 
         // Collections
         ListCollections
+        GetCollection
         UpdateCollection
 
         // Stickies
@@ -375,6 +376,17 @@ structure Collection {
 
 list CollectionList {
     member: Collection
+}
+
+/// CollectionWithPostings — collection detail with its threads as posting objects
+structure CollectionWithPostings {
+    @required
+    id: Long
+    name: String
+    created_at: DateTime
+    updated_at: DateTime
+    app_url: String
+    postings: PostingList
 }
 
 /// Folder — email folder
@@ -3225,6 +3237,32 @@ operation ListCollections {
 structure ListCollectionsOutput {
     @required
     collections: CollectionList
+}
+
+/// Get a collection and one page of its active, accessible threads
+@readonly
+@http(method: "GET", uri: "/collections/{collectionId}")
+@tags(["Collections"])
+@heyRetry(maxAttempts: 3, baseDelayMs: 1000, backoff: "exponential", retryOn: [429, 503])
+@heyPagination(style: "link", totalCountHeader: "X-Total-Count")
+operation GetCollection {
+    input: GetCollectionInput
+    output: GetCollectionOutput
+    errors: [UnauthorizedError, NotFoundError, InternalServerError, ServiceUnavailableError]
+}
+
+structure GetCollectionInput {
+    @httpLabel
+    @required
+    collectionId: Long
+
+    @httpQuery("page")
+    page: String
+}
+
+structure GetCollectionOutput {
+    @required
+    collection: CollectionWithPostings
 }
 
 /// Rename a collection or change its summary

--- a/spec/route-coverage.json
+++ b/spec/route-coverage.json
@@ -186,6 +186,11 @@
   },
   {
     "method": "GET",
+    "operationId": "GetCollection",
+    "path": "/collections/{collectionId}"
+  },
+  {
+    "method": "GET",
     "operationId": "GetContact",
     "path": "/contacts/{contactId}"
   },

--- a/spec/shape-fingerprint.json
+++ b/spec/shape-fingerprint.json
@@ -18,6 +18,7 @@
   "GetBubblebox": "b736b44d157cb75c0e50a75feb2be37c8f9988024aa8c6503ab7bde347560cce",
   "GetCalendarRecordings": "4ff27c9fc232cbd2f3ac3e0f4a4f7ee60e40d5c99e8c8efceefa2ea723e4b5ab",
   "GetClearances": "7d9ef1b6858f3dd07419c224882faf9ad2eb8f3dce3bff88308515121c9fa287",
+  "GetCollection": "c9f6a51fe3f9498322d1b8b2f1119c152068fd76d4bbadaad4e52d925f34abe0",
   "GetContact": "9ea11bb9cddb65d3de993b71f35d35bc1111a8b2f2a349fd53e8420ba12e36a3",
   "GetContactNote": "04d07cd3532ce3b2c3d60e8cf10be9edff73362abf2d9273e604711a5c1d6ca6",
   "GetEverythingTopics": "3ab2bced12a79ff0e1031ee984fad8f54159e9d093b57f44b0041ae1d630cd4b",


### PR DESCRIPTION
<!-- pr-review-readiness-head: d380f4038d8631eefc014a2d2fb575c5c33bd7d8 -->

HEY SDK clients can list and rename collections but cannot open one. This adds an additive, typed collection-detail read with posting objects and pagination metadata; releasing the SDK and adding CLI/TUI presentation remain outside this PR.

**Review readiness:** ✅ Yes — focused tests, full local checks, current-head CI, and production verification are complete  
**Risk:** 🟡 Medium — this adds a generated public operation and reuses pagination parsing across folders and collections  
**Decision:** Confirm that `CollectionWithPostings` plus `CollectionPage` is the right public shape for metadata, postings, cursor, and total count

<details>
<summary>✅ Change — collections can be opened as typed, paginated detail</summary>

### Before

```text
SDK client
├── list collections
├── rename a collection
└── open a collection
    └── ❌ no typed operation
```

### After

```text
SDK client
├── Get(collection ID, page)
│   └── ✅ collection metadata + posting objects  ← CHANGED
└── GetPage(collection ID, page)
    └── ✅ detail + next cursor + total count      ← CHANGED
```

`GetCollection` models `GET /collections/{collectionId}.json`. It follows existing generated-client auth, account-scope, retry, instrumentation, error-mapping, and runtime `.json` path behavior.

</details>

<details>
<summary>✅ Evidence — wire shape, service behavior, pagination, and production response are covered</summary>

- ✅ Go service tests cover typed collection metadata/postings, `.json` routing, `page`, opaque Link cursor parsing, `X-Total-Count`, and 404 mapping.
- ✅ Conformance covers the generated path/query contract and asserts collection ID, posting ID/kind, next cursor, and total count.
- ✅ Production verification against `https://app.hey.com` decoded every collection detail in the authenticated account through this branch; [verification record](https://app.basecamp.com/2914079/buckets/48521764/card_tables/cards/10225277027#__recording_10225573991).
- ⚠️ Those production collections all fit on one page, so the next-cursor path is proven by unit and conformance tests rather than a production response.

```text
mise exec -- env GOWORK=off make check
└── MVP gate passed; 153 conformance cases passed; generated service coverage 106/106
```

</details>

<details>
<summary>✅ Scope — additive SDK contract only; release and product UI are deferred</summary>

Included:
- Smithy `GetCollection` and `CollectionWithPostings`, generated OpenAPI/Go artifacts, and drift metadata.
- `CollectionsService.Get` / `GetPage` and shared Geared Pagination Link parsing for folders and collections.
- API provenance pinned to deployed Haystack merge `40f469e5dbf8d0a3f06f48962adbbbece486a97d`; `APIVersion` moves to `2026-08-21`.

Compatibility:
- The operation is additive; existing callers, records, permissions, and collection workflows are unchanged.
- Account-scoped clients keep the existing `filtered_account_id` behavior.
- Haystack does not emit collection `summary`, so the response type intentionally models only emitted fields.

Not included: SDK version/release work, CLI/TUI behavior, or server changes.

</details>

<details>
<summary>✅ Delivery — server deployed; no migration, flag, configuration, or data work</summary>

[Haystack #8650](https://github.com/basecamp/haystack/pull/8650) is deployed, and authenticated read-only production requests returned the expected detail shape. No migration, backfill, feature flag, new dependency, credential, cleanup, or monitoring change is required. The SDK capability remains unavailable to released consumers until a later SDK release; rollback is reverting this additive SDK commit.

</details>

<details>
<summary>⚠️ Review decision — focus on the public response wrapper and shared Link parser</summary>

Please start with:
1. Whether `CollectionWithPostings` faithfully exposes the canonical posting wire objects without adding fields Haystack does not emit.
2. Whether sharing the Geared Pagination Link parser preserves folder behavior while correctly handling collection cursors.

Known limitation: production verification did not encounter a multi-page collection; automated behavioral coverage supplies that evidence.

</details>

<details>
<summary>✅ Review path — model, handwritten service, generated artifacts, and proof</summary>

1. [Smithy contract](https://github.com/basecamp/hey-sdk/blob/d380f4038d8631eefc014a2d2fb575c5c33bd7d8/spec/hey.smithy) — operation, response shape, pagination trait, and API version.
2. [Collections service](https://github.com/basecamp/hey-sdk/blob/d380f4038d8631eefc014a2d2fb575c5c33bd7d8/go/pkg/hey/collections.go) and [shared pagination](https://github.com/basecamp/hey-sdk/blob/d380f4038d8631eefc014a2d2fb575c5c33bd7d8/go/pkg/hey/pagination.go) — handwritten public surface and metadata extraction; `folders.go` is the existing consumer moved to the shared helper.
3. [Service tests](https://github.com/basecamp/hey-sdk/blob/d380f4038d8631eefc014a2d2fb575c5c33bd7d8/go/pkg/hey/services_test.go) and [pagination conformance](https://github.com/basecamp/hey-sdk/blob/d380f4038d8631eefc014a2d2fb575c5c33bd7d8/conformance/tests/pagination.json) — behavioral proof; `paths.json` and the Go runner supply generated path dispatch/assertions.
4. Generated and drift groups: `openapi.json`, `behavior-model.json`, `go/pkg/generated/client.gen.go`, route/exclusion/coverage/fingerprint/provenance JSON, generated URL routes, and `version.go` all follow from the model and provenance refresh.

**Origin and supporting links:** [SDK card](https://app.basecamp.com/2914079/buckets/48521764/card_tables/cards/10225277027) · [API card](https://app.basecamp.com/2914079/buckets/48521764/card_tables/cards/10225159222) · [Haystack PR](https://github.com/basecamp/haystack/pull/8650)

</details>

