### PR TITLE
Bump the SDK to 0.8.0

### DIFF
--- a/go/pkg/hey/version.go
+++ b/go/pkg/hey/version.go
@@ -1,7 +1,7 @@
 package hey
 
 // Version is the current version of the HEY Go SDK.
-const Version = "0.7.0"
+const Version = "0.8.0"
 
 // APIVersion is the HEY API version this SDK targets.
 const APIVersion = "2026-08-21"


### PR DESCRIPTION
Release prep for the typed collection-detail operation in #97, now that the Haystack endpoint is deployed and the SDK change is merged.

This is a minor bump because the release adds the public `GetCollection` generated operation plus `CollectionsService.Get` and `GetPage`. Existing SDK callers remain compatible.

`APIVersion` stays at `2026-08-21`; this PR changes only the SDK `Version` sent in the User-Agent from `0.7.0` to `0.8.0`.

### Validation

- `mise exec -- env GOWORK=off make go-check` — passed
- `make bump VERSION=0.8.0` — changed only `go/pkg/hey/version.go`
- The local full gate reached the existing generated-client retry conformance instability tracked by #94; no failure involved the version change. Current-head GitHub CI is the full-gate evidence for this one-line bump.

After this merges, `make release VERSION=0.8.0` will run the release gate and create both `v0.8.0` and `go/v0.8.0`.

Collection SDK card: https://app.basecamp.com/2914079/buckets/48521764/card_tables/cards/10225277027


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps the HEY Go SDK version from 0.7.0 to 0.8.0 to publish the typed collection-detail API. Previously the SDK sent `User-Agent` version 0.7.0; now it sends 0.8.0. `APIVersion` remains `2026-08-21`.

- Single-line change in `go/pkg/hey/version.go`; no behavior change beyond the reported SDK version.
- 0.8.0 includes the generated `GetCollection` operation and `CollectionsService.Get` / `CollectionsService.GetPage`; no migrations required.
- After merge: run `make release VERSION=0.8.0` to publish `v0.8.0` and `go/v0.8.0`.

<sup>Written for commit 76ba069393b721f1d6d6e31bcdca8afb7204b168. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-sdk/pull/98?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

