### PR TITLE
The Screener's cheap read keeps its stream name

### DIFF
--- a/go/pkg/hey/clearances.go
+++ b/go/pkg/hey/clearances.go
@@ -21,8 +21,24 @@ func NewClearancesService(client *Client) *ClearancesService {
 // PendingCount answers how many senders are waiting, without fetching them.
 //
 // This is the cheap read HEY's own apps sync for the Screener badge. Use Pending when you
-// want the senders themselves.
+// want the senders themselves, or Summary when you also want the stream to follow.
 func (s *ClearancesService) PendingCount(ctx context.Context) (count int, err error) {
+	summary, err := s.Summary(ctx)
+	if err != nil {
+		return 0, err
+	}
+	if summary == nil {
+		return 0, nil
+	}
+	return int(summary.PendingClearancesCount), nil
+}
+
+// Summary answers everything HEY says about the Screener without the queue itself: how
+// many senders are waiting, and the signed stream name to subscribe to on HEY's cable
+// server to be told when that changes.
+//
+// It is the same read as PendingCount — the count alone, no queue dragged along.
+func (s *ClearancesService) Summary(ctx context.Context) (summary *generated.ClearanceSummary, err error) {
 	op := OperationInfo{
 		Service: "Clearances", Operation: "GetClearances",
 		ResourceType: "clearance", IsMutation: false,
@@ -36,12 +52,10 @@ func (s *ClearancesService) PendingCount(ctx context.Context) (count int, err er
 		if cerr := CheckResponse(resp.HTTPResponse); cerr != nil {
 			return cerr
 		}
-		if resp.JSON200 != nil {
-			count = int(resp.JSON200.PendingClearancesCount)
-		}
+		summary = resp.JSON200
 		return nil
 	})
-	return count, err
+	return summary, err
 }
 
 // Pending answers the senders waiting to be screened, a page at a time.

--- a/go/pkg/hey/clearances_test.go
+++ b/go/pkg/hey/clearances_test.go
@@ -37,6 +37,39 @@ func TestClearancesService_PendingCountAsksForTheCountAlone(t *testing.T) {
 	}
 }
 
+// The Screener's stream name comes with the count, so a client can follow it without a
+// second read — and without the queue either.
+func TestClearancesService_SummaryCarriesTheStreamToFollow(t *testing.T) {
+	var gotQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/clearances.json" {
+			t.Errorf("expected GET /clearances.json, got %s %s", r.Method, r.URL.Path)
+		}
+		gotQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"pending_clearances_count":3,"signed_stream_name":"eyJpZGVudGl0eSI6MX0--sig"}`))
+	}))
+	t.Cleanup(srv.Close)
+	client := NewClient(&Config{BaseURL: srv.URL}, &StaticTokenProvider{Token: "t"}, WithMaxRetries(0))
+
+	summary, err := client.Clearances().Summary(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if summary.PendingClearancesCount != 3 {
+		t.Errorf("expected 3 pending, got %d", summary.PendingClearancesCount)
+	}
+	if summary.SignedStreamName != "eyJpZGVudGl0eSI6MX0--sig" {
+		t.Errorf("stream name = %q", summary.SignedStreamName)
+	}
+	if len(summary.Clearances) != 0 {
+		t.Errorf("expected no queue, got %d clearances", len(summary.Clearances))
+	}
+	if gotQuery != "" {
+		t.Errorf("expected no query, got %q", gotQuery)
+	}
+}
+
 func TestClearancesService_Pending(t *testing.T) {
 	var gotInclude, gotPage string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
`GET /clearances.json` answers two things: `pending_clearances_count`, and the signed name of the Turbo stream haystack re-renders the Screener's button on (`Clearance::Broadcasting` → `[identity, :clearances, :button]`). `PendingCount` read both and kept only the count.

So a client that wants to be *told* when the count changes, rather than polling it, has to reach for `Pending` — which carries the name but asks `include_clearances`, dragging a page of the queue along for a string. That's the read this comment exists to prevent:

> The apps sync this endpoint for the Screener badge, so the count must not drag the queue along with it.

`Summary` is the same read with nothing discarded: same method, same path, no query, the whole `ClearanceSummary` back. `PendingCount` becomes a wrapper over it and answers exactly what it answered before.

No spec change — `GetClearances` is modelled and `ClearanceSummary.signed_stream_name` is already in the shape. Nothing under `go/pkg/generated/` or `openapi.json` touched. No conformance case either: the wire behaviour is unchanged, this only stops throwing away a field the response already carried.

`make check` passes (153/153 conformance, all drift and freshness checks).

## Why now

hey-cli's TUI wants the Screener count to update live instead of only when you open or close it: basecamp/hey-cli#234 subscribes to that stream and re-reads the count behind each ring. That PR is pinned to a local `replace` of this repo until this ships.
