### PR TITLE
Bump the SDK to 0.9.0

### DIFF
--- a/go/pkg/hey/version.go
+++ b/go/pkg/hey/version.go
@@ -1,7 +1,7 @@
 package hey
 
 // Version is the current version of the HEY Go SDK.
-const Version = "0.8.0"
+const Version = "0.9.0"
 
 // APIVersion is the HEY API version this SDK targets.
 const APIVersion = "2026-08-21"


### PR DESCRIPTION
0.9.0 for #99: `Clearances().Summary`, an additive wrapper over the `GetClearances` operation the SDK already had. Nothing removed, nothing renamed, no generated code or spec touched — a minor.

hey-cli's TUI needs a released version to pin: basecamp/hey-cli#234 is on a local `replace` of this repo until this ships.

`make check` passes (153/153).