### PR TITLE
Keep root probes out of conformance request counts

### DIFF
--- a/conformance/runner/go/main.go
+++ b/conformance/runner/go/main.go
@@ -151,6 +151,12 @@ func runTest(tc TestCase) TestResult {
 	// Create mock server that serves responses in sequence
 	responseIndex := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// The conformance server serves API operation routes; HEY has no root operation.
+		if r.URL.Path == "/" {
+			http.NotFound(w, r)
+			return
+		}
+
 		mu.Lock()
 		requestCount++
 		requestTimes = append(requestTimes, time.Now())


### PR DESCRIPTION
The conformance runner treats every request to its loopback mock server as an SDK attempt. Localhost tooling also probes newly opened servers with `GET /`, so those unrelated requests consumed mock responses and made retry cases report six attempts or surface the mock’s fallback 500 response.

HEY has no root API operation. This returns 404 for `/` before request tracking, keeping conformance counts scoped to the operation routes the runner owns. SDK runtime behavior and API coverage are unchanged.

### Evidence

Before the change, repeated release-gate runs failed retry assertions such as `Expected 3 requests, got 6`; request instrumentation showed the extra requests used path `/` while SDK attempts used paths such as `/boxes.json`.

After the change:

- `mise exec -- env GOWORK=off make conformance-go` — 153/153 passed in five consecutive runs
- `mise exec -- env GOWORK=off make check` — MVP gate passed

This is required before the v0.8.0 release command can complete its mandatory local gate.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exclude root probes from conformance request counts to stabilize retry assertions. Previously the mock server counted every request, so localhost `GET /` probes consumed queued responses and inflated attempt counts; now `/` returns 404 before tracking, so only operation routes are counted.

- No SDK behavior or API coverage changes; only the conformance runner’s mock server logic is scoped.
- Verified locally: failures like “Expected 3 requests, got 6” no longer occur; conformance-go runs pass consistently (153/153) and the MVP gate passes.

<sup>Written for commit 9426c8577aa311bad1623fb2021db30230caaf98. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-sdk/pull/101?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

