### PR TITLE
Answer the next page on box, Screener and search reads

### DIFF
--- a/go/pkg/hey/boxes.go
+++ b/go/pkg/hey/boxes.go
@@ -2,6 +2,7 @@ package hey
 
 import (
 	"context"
+	"strconv"
 	"time"
 
 	"github.com/basecamp/hey-sdk/go/pkg/generated"
@@ -43,30 +44,45 @@ func (s *BoxesService) List(ctx context.Context) (result *generated.ListBoxesRes
 	return resp.JSON200, nil
 }
 
+// BoxPage contains one page of a box and its pagination state.
+type BoxPage struct {
+	Box        *generated.BoxShowResponse
+	NextPage   string
+	TotalCount int
+}
+
 // Get returns a specific mailbox by ID.
-func (s *BoxesService) Get(ctx context.Context, boxID int64, params *generated.GetBoxParams) (result *generated.BoxShowResponse, err error) {
+func (s *BoxesService) Get(ctx context.Context, boxID int64, params *generated.GetBoxParams) (*generated.BoxShowResponse, error) {
+	page, err := s.GetPage(ctx, boxID, params)
+	if err != nil || page == nil {
+		return nil, err
+	}
+	return page.Box, nil
+}
+
+// GetPage returns a box page with its next cursor and total posting count.
+func (s *BoxesService) GetPage(ctx context.Context, boxID int64, params *generated.GetBoxParams) (result *BoxPage, err error) {
 	op := OperationInfo{
 		Service: "Boxes", Operation: "GetBox",
 		ResourceType: "box", IsMutation: false, ResourceID: boxID,
 	}
-	if gater, ok := s.client.hooks.(GatingHooks); ok {
-		if ctx, err = gater.OnOperationGate(ctx, op); err != nil {
-			return
-		}
-	}
-	start := time.Now()
-	ctx = s.client.hooks.OnOperationStart(ctx, op)
-	defer func() { s.client.hooks.OnOperationEnd(ctx, op, err, time.Since(start)) }()
 
-	s.client.initGeneratedClient()
-	resp, err := s.client.gen.GetBoxWithResponse(ctx, boxID, params)
-	if err != nil {
-		return nil, err
-	}
-	if err = CheckResponse(resp.HTTPResponse); err != nil {
-		return nil, err
-	}
-	return resp.JSON200, nil
+	err = s.client.instrument(ctx, op, func(ctx context.Context) error {
+		resp, rerr := s.client.genClient().GetBoxWithResponse(ctx, boxID, params)
+		if rerr != nil {
+			return rerr
+		}
+		if cerr := CheckResponse(resp.HTTPResponse); cerr != nil {
+			return cerr
+		}
+		result = &BoxPage{Box: resp.JSON200}
+		if resp.HTTPResponse != nil {
+			result.TotalCount, _ = strconv.Atoi(resp.HTTPResponse.Header.Get("X-Total-Count"))
+			result.NextPage = gearedPageFromLink(resp.HTTPResponse.Header.Get("Link"))
+		}
+		return nil
+	})
+	return result, err
 }
 
 // GetImbox returns the Imbox.

--- a/go/pkg/hey/clearances.go
+++ b/go/pkg/hey/clearances.go
@@ -58,6 +58,14 @@ func (s *ClearancesService) Summary(ctx context.Context) (summary *generated.Cle
 	return summary, err
 }
 
+// ClearancePage contains one page of clearances and the cursor for the page after it.
+// PendingCount is what the Screener holds in total and is only answered by PendingPage.
+type ClearancePage struct {
+	Clearances   []generated.Clearance
+	PendingCount int
+	NextPage     string
+}
+
 // Pending answers the senders waiting to be screened, a page at a time.
 //
 // Each one carries the petitioner and the most recent entry they sent, so a caller can
@@ -70,13 +78,7 @@ func (s *ClearancesService) Pending(ctx context.Context, page string) (summary *
 	}
 
 	err = s.client.instrument(ctx, op, func(ctx context.Context) error {
-		include := true
-		params := &generated.GetClearancesParams{IncludeClearances: &include}
-		if page != "" {
-			params.Page = &page
-		}
-
-		resp, rerr := s.client.genClient().GetClearancesWithResponse(ctx, params)
+		resp, rerr := s.client.genClient().GetClearancesWithResponse(ctx, pendingClearancesParams(page))
 		if rerr != nil {
 			return rerr
 		}
@@ -87,6 +89,35 @@ func (s *ClearancesService) Pending(ctx context.Context, page string) (summary *
 		return nil
 	})
 	return summary, err
+}
+
+// PendingPage answers the same queue as Pending along with the cursor for the page after
+// it, so a caller walking the queue is told when it has reached the end of it.
+func (s *ClearancesService) PendingPage(ctx context.Context, page string) (result *ClearancePage, err error) {
+	op := OperationInfo{
+		Service: "Clearances", Operation: "GetClearances",
+		ResourceType: "clearance", IsMutation: false,
+	}
+
+	err = s.client.instrument(ctx, op, func(ctx context.Context) error {
+		resp, rerr := s.client.genClient().GetClearancesWithResponse(ctx, pendingClearancesParams(page))
+		if rerr != nil {
+			return rerr
+		}
+		if cerr := CheckResponse(resp.HTTPResponse); cerr != nil {
+			return cerr
+		}
+		result = &ClearancePage{}
+		if resp.JSON200 != nil {
+			result.Clearances = resp.JSON200.Clearances
+			result.PendingCount = int(resp.JSON200.PendingClearancesCount)
+		}
+		if resp.HTTPResponse != nil {
+			result.NextPage = gearedPageFromLink(resp.HTTPResponse.Header.Get("Link"))
+		}
+		return nil
+	})
+	return result, err
 }
 
 // Screen answers the Screener for one sender. Status is ClearanceApproved or
@@ -204,6 +235,16 @@ func (s *ClearancesService) Punt(ctx context.Context) error {
 // Screened answers the senders already screened in or out, newest decision first, a page
 // at a time.
 func (s *ClearancesService) Screened(ctx context.Context, page string) (clearances []generated.Clearance, err error) {
+	result, err := s.ScreenedPage(ctx, page)
+	if err != nil || result == nil {
+		return nil, err
+	}
+	return result.Clearances, nil
+}
+
+// ScreenedPage answers the same decisions as Screened along with the cursor for the page
+// after it.
+func (s *ClearancesService) ScreenedPage(ctx context.Context, page string) (result *ClearancePage, err error) {
 	op := OperationInfo{
 		Service: "Clearances", Operation: "GetMyClearances",
 		ResourceType: "clearance", IsMutation: false,
@@ -222,12 +263,16 @@ func (s *ClearancesService) Screened(ctx context.Context, page string) (clearanc
 		if cerr := CheckResponse(resp.HTTPResponse); cerr != nil {
 			return cerr
 		}
+		result = &ClearancePage{}
 		if resp.JSON200 != nil {
-			clearances = resp.JSON200.Clearances
+			result.Clearances = resp.JSON200.Clearances
+		}
+		if resp.HTTPResponse != nil {
+			result.NextPage = gearedPageFromLink(resp.HTTPResponse.Header.Get("Link"))
 		}
 		return nil
 	})
-	return clearances, err
+	return result, err
 }
 
 // Rescreen changes its mind about a sender already screened in or out.
@@ -257,6 +302,15 @@ func (s *ClearancesService) Rescreen(ctx context.Context, clearanceID int64, sta
 		return nil
 	})
 	return clearance, err
+}
+
+func pendingClearancesParams(page string) *generated.GetClearancesParams {
+	include := true
+	params := &generated.GetClearancesParams{IncludeClearances: &include}
+	if page != "" {
+		params.Page = &page
+	}
+	return params
 }
 
 func validateClearanceStatus(status string) error {

--- a/go/pkg/hey/clearances_test.go
+++ b/go/pkg/hey/clearances_test.go
@@ -112,6 +112,77 @@ func TestClearancesService_Pending(t *testing.T) {
 	}
 }
 
+func TestClearancesService_PendingPage(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if page := r.URL.Query().Get("page"); page != "eyJwYWdlIjoyfQ" {
+			t.Errorf("expected the page token to be passed through, got %q", page)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Link", `<http://`+r.Host+`/clearances.json?page=eyJwYWdlIjozfQ>; rel="next"`)
+		_, _ = w.Write([]byte(`{"pending_clearances_count":24,"clearances":[
+			{"id":91,"status":"pending","petitioner":{"id":51,"name":"Hollis Heimboch"}}]}`))
+	}))
+	t.Cleanup(srv.Close)
+	client := NewClient(&Config{BaseURL: srv.URL}, &StaticTokenProvider{Token: "t"}, WithMaxRetries(0))
+
+	page, err := client.Clearances().PendingPage(context.Background(), "eyJwYWdlIjoyfQ")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(page.Clearances) != 1 || page.Clearances[0].Id != 91 {
+		t.Errorf("expected clearance 91, got %+v", page.Clearances)
+	}
+	if page.PendingCount != 24 {
+		t.Errorf("expected 24 waiting, got %d", page.PendingCount)
+	}
+	if page.NextPage != "eyJwYWdlIjozfQ" {
+		t.Errorf("expected the cursor for the next page, got %q", page.NextPage)
+	}
+}
+
+// The queue's last page carries no Link header, which is how a caller walking it is told
+// it has reached the end.
+func TestClearancesService_PendingPageOnLastPage(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"pending_clearances_count":1,"clearances":[{"id":91,"status":"pending"}]}`))
+	}))
+	t.Cleanup(srv.Close)
+	client := NewClient(&Config{BaseURL: srv.URL}, &StaticTokenProvider{Token: "t"}, WithMaxRetries(0))
+
+	page, err := client.Clearances().PendingPage(context.Background(), "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if page.NextPage != "" {
+		t.Errorf("next page = %q, want none", page.NextPage)
+	}
+}
+
+func TestClearancesService_ScreenedPage(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/my/clearances.json" {
+			t.Errorf("expected GET /my/clearances.json, got %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Link", `<http://`+r.Host+`/my/clearances.json?page=eyJwYWdlIjoyfQ>; rel="next"`)
+		_, _ = w.Write([]byte(`{"clearances":[{"id":91,"status":"approved","petitioner":{"id":51,"name":"Glenn"}}]}`))
+	}))
+	t.Cleanup(srv.Close)
+	client := NewClient(&Config{BaseURL: srv.URL}, &StaticTokenProvider{Token: "t"}, WithMaxRetries(0))
+
+	page, err := client.Clearances().ScreenedPage(context.Background(), "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(page.Clearances) != 1 || page.Clearances[0].Petitioner.Name != "Glenn" {
+		t.Errorf("expected Glenn's decision, got %+v", page.Clearances)
+	}
+	if page.NextPage != "eyJwYWdlIjoyfQ" {
+		t.Errorf("expected the cursor for the next page, got %q", page.NextPage)
+	}
+}
+
 func TestClearancesService_Screen(t *testing.T) {
 	var gotBody map[string]any
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/go/pkg/hey/search.go
+++ b/go/pkg/hey/search.go
@@ -50,11 +50,30 @@ type SearchParams struct {
 	Attachment string
 }
 
+// SearchResults contains one page of matches and the number of the page after it, zero once
+// there is none. Search numbers its pages rather than cursoring them, so the next page is
+// followed by passing that number back as SearchParams.Page.
+type SearchResults struct {
+	Result   *generated.AdvancedSearchResult
+	NextPage int
+}
+
 // Search runs an advanced search and returns the matching threads, grouped by topic as
 // the search page shows them: the topic, your posting of it, and the entries that matched
 // (summaries; read a message with Messages().Get). The next page, if any, is followed
 // by passing Page.
-func (s *SearchService) Search(ctx context.Context, params SearchParams) (result *generated.AdvancedSearchResult, err error) {
+func (s *SearchService) Search(ctx context.Context, params SearchParams) (*generated.AdvancedSearchResult, error) {
+	results, err := s.SearchPage(ctx, params)
+	if err != nil || results == nil {
+		return nil, err
+	}
+	return results.Result, nil
+}
+
+// SearchPage runs the same search as Search and also answers which page comes next, so a
+// caller walking the results is told when it has reached the last of them rather than
+// having to ask for a page that turns out to be empty.
+func (s *SearchService) SearchPage(ctx context.Context, params SearchParams) (results *SearchResults, err error) {
 	op := OperationInfo{
 		Service: "Search", Operation: "AdvancedSearch",
 		ResourceType: "search", IsMutation: false,
@@ -67,10 +86,13 @@ func (s *SearchService) Search(ctx context.Context, params SearchParams) (result
 		if cerr := CheckResponse(resp.HTTPResponse); cerr != nil {
 			return cerr
 		}
-		result = resp.JSON200
+		results = &SearchResults{Result: resp.JSON200}
+		if resp.HTTPResponse != nil {
+			results.NextPage, _ = strconv.Atoi(gearedPageFromLink(resp.HTTPResponse.Header.Get("Link")))
+		}
 		return nil
 	})
-	return result, err
+	return results, err
 }
 
 // Filters returns the options the advanced search refine form offers: boxes, date ranges,

--- a/go/pkg/hey/services_test.go
+++ b/go/pkg/hey/services_test.go
@@ -994,6 +994,38 @@ func TestSearchService_Search(t *testing.T) {
 	}
 }
 
+func TestSearchService_SearchPage(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Query().Get("page") == "3" {
+			_, _ = w.Write([]byte(`{"matches":[{"topic":{"id":331,"name":"Kitchen remodel"},"posting_id":4471829}]}`))
+			return
+		}
+		w.Header().Set("Link", `<http://`+r.Host+`/advanced_search.json?q=cabinets&page=3>; rel="next"`)
+		_, _ = w.Write([]byte(`{"matches":[{"topic":{"id":332,"name":"Cabinet estimate"},"posting_id":4471830}]}`))
+	}))
+	t.Cleanup(srv.Close)
+	client := NewClient(&Config{BaseURL: srv.URL}, &StaticTokenProvider{Token: "t"}, WithMaxRetries(0))
+
+	results, err := client.Search().SearchPage(context.Background(), SearchParams{Query: "cabinets", Page: 2})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if results.NextPage != 3 {
+		t.Errorf("next page = %d, want 3", results.NextPage)
+	}
+
+	// The last page carries no Link header, which is how a caller walking the results is
+	// told to stop asking.
+	last, err := client.Search().SearchPage(context.Background(), SearchParams{Query: "cabinets", Page: 3})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if last.NextPage != 0 || len(last.Result.Matches) != 1 {
+		t.Errorf("last page = %+v", last)
+	}
+}
+
 func TestSearchService_Filters(t *testing.T) {
 	client := newServiceTestClient(t, map[string]string{
 		"/advanced_search_filters.json": `{"refine_in":[{"title":"Imbox","value":"imbox"}],"refine_labels":[{"title":"Receipts","value":"Receipts"}]}`,
@@ -1689,6 +1721,48 @@ func TestContactsService_Clearances(t *testing.T) {
 }
 
 // --- Boxes, groups and observation ---
+
+func TestBoxesService_GetPage(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/boxes/5.json" {
+			t.Errorf("path = %q, want /boxes/5.json", r.URL.Path)
+		}
+		if page := r.URL.Query().Get("page"); page != "current-cursor" {
+			t.Errorf("page = %q, want current-cursor", page)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Total-Count", "214")
+		w.Header().Set("Link", `<http://`+r.Host+`/boxes/5.json?page=next-cursor>; rel="next"`)
+		_, _ = io.WriteString(w, `{"id":5,"name":"Imbox","postings":[{"id":1,"kind":"topic"}]}`)
+	}))
+	t.Cleanup(server.Close)
+
+	client := NewClient(&Config{BaseURL: server.URL}, &StaticTokenProvider{Token: "test-token"}, WithMaxRetries(0))
+	cursor := "current-cursor"
+	page, err := client.Boxes().GetPage(context.Background(), 5, &generated.GetBoxParams{Page: &cursor})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if page.Box == nil || page.Box.Name != "Imbox" || len(page.Box.Postings) != 1 || page.TotalCount != 214 || page.NextPage != "next-cursor" {
+		t.Errorf("unexpected box page: %+v", page)
+	}
+}
+
+// The last page carries no Link header, which is how a caller walking a box is told to
+// stop asking for more.
+func TestBoxesService_GetPageOnLastPage(t *testing.T) {
+	client := newServiceTestClient(t, map[string]string{
+		"/boxes/%s": `{"id":5,"name":"Imbox","postings":[{"id":1,"kind":"topic"}]}`,
+	})
+
+	page, err := client.Boxes().GetPage(context.Background(), 5, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if page.NextPage != "" {
+		t.Errorf("next page = %q, want none", page.NextPage)
+	}
+}
 
 func TestBoxesService_ListGroups(t *testing.T) {
 	client := newServiceTestClient(t, map[string]string{

--- a/go/pkg/hey/version.go
+++ b/go/pkg/hey/version.go
@@ -1,7 +1,7 @@
 package hey
 
 // Version is the current version of the HEY Go SDK.
-const Version = "0.9.0"
+const Version = "0.10.0"
 
 // APIVersion is the HEY API version this SDK targets.
 const APIVersion = "2026-08-21"


### PR DESCRIPTION
Boxes, the Screener queue, the Screener's history and advanced search are all paginated by geared_pagination, so every one of them already answers a `Link` header whose `page` is the cursor for what comes next — and every one of these reads was throwing it away. A caller walking a box had no way to tell it had reached the end except by asking for another page and getting nothing back.

`Folders` and `Collections` already had the `GetPage` shape for exactly this. This gives the rest of them the same thing:

| | answers |
| --- | --- |
| `Boxes().GetPage` | the box page, the next cursor, the total count |
| `Clearances().PendingPage` | the queue, how much it holds, the next cursor |
| `Clearances().ScreenedPage` | the decisions, the next cursor |
| `Search().SearchPage` | the matches and the number of the next page |

`Get`, `Pending`, `Screened` and `Search` stay exactly as they were and delegate to these, so nothing that reads a page today has to change.

Search is the odd one out. `Search::Matches::Page` in haystack is a shim over geared's page rather than the real thing, and it numbers its pages, so `SearchResults` carries a `NextPage int` to be passed back as `SearchParams.Page` where the others carry an opaque cursor.

### Why

hey-cli's TUI is being changed so every mail list — boxes, labels, collections, search — and both of The Screener's panes grow as the reader scrolls, instead of stepping through pages with `n`/`p`. That needs to know when a list has run out, which is what this answers.

### Notes

- The version bump to 0.10.0 is the second commit, so it lands on main before the tag, as `CONTRIBUTING.md` requires.
- `make check` passes: drift gates, unit tests and all 153 conformance tests.
- Unit tests cover a page with a next cursor and a last page carrying no `Link` header, for each of the four reads.
