### PR TITLE
Walk a thread's entries with the cursor HEY serves

### DIFF
--- a/go/pkg/hey/topics.go
+++ b/go/pkg/hey/topics.go
@@ -46,6 +46,11 @@ func (s *TopicsService) Get(ctx context.Context, topicID int64) (result *generat
 }
 
 // GetEntries returns entries for a specific topic.
+//
+// The entry index is paginated by geared_pagination, so the page in params is a cursor out
+// of the previous answer's Link header rather than an offset — a number is ignored and
+// answered with the first page. This throws that header away; use GetEntriesPage to walk
+// the thread.
 func (s *TopicsService) GetEntries(ctx context.Context, topicID int64, params *generated.GetTopicEntriesParams) (result *generated.GetTopicEntriesResponseContent, err error) {
 	op := OperationInfo{
 		Service: "Topics", Operation: "GetTopicEntries",
@@ -69,6 +74,53 @@ func (s *TopicsService) GetEntries(ctx context.Context, topicID int64, params *g
 		return nil, err
 	}
 	return resp.JSON200, nil
+}
+
+// TopicEntryPage contains one page of a topic's entries and the cursor for the page after
+// it. NextPage is empty on the last page, which is how a caller walking a thread is told
+// it has read all of it.
+type TopicEntryPage struct {
+	Entries  []generated.Entry
+	NextPage string
+}
+
+// GetEntriesPage answers the same entries as GetEntries along with the cursor for the page
+// after it, so a caller walking a thread follows HEY's own ordering rather than guessing
+// page numbers geared_pagination does not understand.
+//
+// Pass an empty page for the first page, then the NextPage of each answer.
+func (s *TopicsService) GetEntriesPage(ctx context.Context, topicID int64, page string) (result *TopicEntryPage, err error) {
+	op := OperationInfo{
+		Service: "Topics", Operation: "GetTopicEntries",
+		ResourceType: "entry", IsMutation: false, ResourceID: topicID,
+	}
+
+	err = s.client.instrument(ctx, op, func(ctx context.Context) error {
+		resp, rerr := s.client.genClient().GetTopicEntriesWithResponse(ctx, topicID, topicEntriesParams(page))
+		if rerr != nil {
+			return rerr
+		}
+		if cerr := CheckResponse(resp.HTTPResponse); cerr != nil {
+			return cerr
+		}
+		result = &TopicEntryPage{}
+		if resp.JSON200 != nil {
+			result.Entries = *resp.JSON200
+		}
+		if resp.HTTPResponse != nil {
+			result.NextPage = gearedPageFromLink(resp.HTTPResponse.Header.Get("Link"))
+		}
+		return nil
+	})
+	return result, err
+}
+
+func topicEntriesParams(page string) *generated.GetTopicEntriesParams {
+	params := &generated.GetTopicEntriesParams{}
+	if page != "" {
+		params.Page = &page
+	}
+	return params
 }
 
 // GetSent returns sent topics.

--- a/go/pkg/hey/topics_test.go
+++ b/go/pkg/hey/topics_test.go
@@ -1,0 +1,74 @@
+package hey
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestTopicsService_GetEntriesPage(t *testing.T) {
+	var gotPage string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/topics/42/entries.json" {
+			t.Errorf("expected the entry index, got %q", r.URL.Path)
+		}
+		gotPage = r.URL.Query().Get("page")
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Link", `<http://`+r.Host+`/topics/42/entries.json?page=eyJwYWdlIjozfQ>; rel="next"`)
+		_, _ = w.Write([]byte(`[{"id":13,"kind":"message","summary":"Quarterly planning"}]`))
+	}))
+	t.Cleanup(srv.Close)
+	client := NewClient(&Config{BaseURL: srv.URL}, &StaticTokenProvider{Token: "t"}, WithMaxRetries(0))
+
+	page, err := client.Topics().GetEntriesPage(context.Background(), 42, "eyJwYWdlIjoyfQ")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotPage != "eyJwYWdlIjoyfQ" {
+		t.Errorf("expected the cursor to be passed through, got %q", gotPage)
+	}
+	if len(page.Entries) != 1 || page.Entries[0].Id != 13 {
+		t.Fatalf("expected entry 13, got %+v", page.Entries)
+	}
+	if page.NextPage != "eyJwYWdlIjozfQ" {
+		t.Errorf("expected the cursor for the next page, got %q", page.NextPage)
+	}
+}
+
+// The last page carries no Link header, which is how a caller walking a thread is told it
+// has read every entry.
+func TestTopicsService_GetEntriesPageOnLastPage(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Has("page") {
+			t.Errorf("expected no page on the first read, got %q", r.URL.RawQuery)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[{"id":13,"kind":"message"}]`))
+	}))
+	t.Cleanup(srv.Close)
+	client := NewClient(&Config{BaseURL: srv.URL}, &StaticTokenProvider{Token: "t"}, WithMaxRetries(0))
+
+	page, err := client.Topics().GetEntriesPage(context.Background(), 42, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(page.Entries) != 1 {
+		t.Fatalf("expected one entry, got %+v", page.Entries)
+	}
+	if page.NextPage != "" {
+		t.Errorf("expected no cursor past the last page, got %q", page.NextPage)
+	}
+}
+
+func TestTopicsService_GetEntriesPageError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	t.Cleanup(srv.Close)
+	client := NewClient(&Config{BaseURL: srv.URL}, &StaticTokenProvider{Token: "t"}, WithMaxRetries(0))
+
+	if _, err := client.Topics().GetEntriesPage(context.Background(), 42, ""); err == nil {
+		t.Fatal("expected an error for a topic that is not there")
+	}
+}

--- a/go/pkg/hey/version.go
+++ b/go/pkg/hey/version.go
@@ -1,7 +1,7 @@
 package hey
 
 // Version is the current version of the HEY Go SDK.
-const Version = "0.10.0"
+const Version = "0.11.0"
 
 // APIVersion is the HEY API version this SDK targets.
 const APIVersion = "2026-08-21"


### PR DESCRIPTION
`/topics/{id}/entries.json` is paginated by geared_pagination, so it answers a `Link` header whose `page` is the cursor for what comes next. `GetEntries` throws that header away, which leaves a caller walking a thread with nothing to ask for the next page with — and a page number is not it. Geared ignores a number and answers with the first page again.

That failure mode is nasty, because it doesn't look like a failure. A loop that counts pages reads the same page until it hits its own cap, and the usual empty-page exit never fires because no page is ever empty. hey-cli did exactly this: `hey threads` on a **3-entry thread returned 300 entries over 400 requests in 34 seconds**, and `hey attachments` reported truncation on every thread it was ever pointed at.

```
Topics().GetEntriesPage(ctx, topicID, page)   one page of entries, and the cursor after it
```

Folders, Collections, Boxes, the Screener and search all have this shape already — #102 gave it to the last four. This gives the entry index the same one, mirroring `Clearances().PendingPage`.

`GetEntries` is unchanged. Its doc comment now says what its `page` parameter actually is, since guessing wrong there doesn't read as an error, it reads as a thread that never ends.

No spec change: `GetTopicEntries` is already in the model, and this is a hand-written service method over it, same as the four in #102.

### Tests

`go/pkg/hey/topics_test.go` — the cursor is passed through and the next one comes back; the last page carries no `Link` and answers an empty cursor; a topic that isn't there is an error. `make check` passes (153/153).

### Downstream

hey-cli needs this to fix the paging bug above; it's on a `replace` directive until this releases.