### PR TITLE
Retry a 401 for credentials the SDK didn't issue, and stop reporting times nobody set

### DIFF
--- a/go/pkg/generated/client.gen.go
+++ b/go/pkg/generated/client.gen.go
@@ -34,7 +34,7 @@ type Account struct {
 	Readonly    bool       `json:"readonly,omitempty"`
 	Status      string     `json:"status,omitempty"`
 	Trial       bool       `json:"trial,omitempty"`
-	TrialEndsOn types.Date `json:"trial_ends_on,omitempty"`
+	TrialEndsOn types.Date `json:"trial_ends_on,omitempty,omitzero"`
 }
 
 // AddPostingsToBoxGroupRequestContent defines model for AddPostingsToBoxGroupRequestContent.
@@ -135,7 +135,7 @@ type BoxShowResponse struct {
 // BubbleUpSchedule BubbleUpSchedule
 type BubbleUpSchedule struct {
 	// BubbleUpAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
-	BubbleUpAt time.Time `json:"bubble_up_at,omitempty"`
+	BubbleUpAt time.Time `json:"bubble_up_at,omitempty,omitzero"`
 	SurpriseMe bool      `json:"surprise_me,omitempty"`
 }
 
@@ -192,7 +192,7 @@ type Calendar struct {
 	Color string `json:"color,omitempty"`
 
 	// CreatedAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
-	CreatedAt         time.Time `json:"created_at,omitempty"`
+	CreatedAt         time.Time `json:"created_at,omitempty,omitzero"`
 	External          bool      `json:"external,omitempty"`
 	Id                int64     `json:"id"`
 	Kind              string    `json:"kind,omitempty"`
@@ -204,7 +204,7 @@ type Calendar struct {
 	RecordingsUrl     string    `json:"recordings_url,omitempty"`
 
 	// UpdatedAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
-	UpdatedAt time.Time `json:"updated_at,omitempty"`
+	UpdatedAt time.Time `json:"updated_at,omitempty,omitzero"`
 	Url       string    `json:"url,omitempty"`
 }
 
@@ -220,7 +220,7 @@ type CalendarRecordingsResponse map[string][]Recording
 // CalendarTodoPayload defines model for CalendarTodoPayload.
 type CalendarTodoPayload struct {
 	// StartsAt Date string (YYYY-MM-DD). Defaults to today if omitted.
-	StartsAt *time.Time `json:"starts_at,omitempty"`
+	StartsAt *time.Time `json:"starts_at,omitempty,omitzero"`
 	Title    string     `json:"title"`
 }
 
@@ -237,7 +237,7 @@ type CalendarWithRecordingChangesUrl struct {
 // contact reads answer a clearance with nothing but its id and status.
 type Clearance struct {
 	// CreatedAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
-	CreatedAt time.Time `json:"created_at,omitempty"`
+	CreatedAt time.Time `json:"created_at,omitempty,omitzero"`
 	Id        int64     `json:"id"`
 
 	// MostRecentEntry Entry — a message entry within a topic
@@ -248,7 +248,7 @@ type Clearance struct {
 	Status     string  `json:"status,omitempty"`
 
 	// UpdatedAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
-	UpdatedAt time.Time `json:"updated_at,omitempty"`
+	UpdatedAt time.Time `json:"updated_at,omitempty,omitzero"`
 }
 
 // ClearanceListResponse ClearanceListResponse — wire format: {clearances: [...]}
@@ -271,7 +271,7 @@ type Clip struct {
 	Content string `json:"content,omitempty"`
 
 	// CreatedAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
-	CreatedAt time.Time `json:"created_at,omitempty"`
+	CreatedAt time.Time `json:"created_at,omitempty,omitzero"`
 	EntryId   int64     `json:"entry_id,omitempty"`
 	Id        int64     `json:"id"`
 
@@ -279,7 +279,7 @@ type Clip struct {
 	Topic ClipTopic `json:"topic,omitempty"`
 
 	// UpdatedAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
-	UpdatedAt time.Time `json:"updated_at,omitempty"`
+	UpdatedAt time.Time `json:"updated_at,omitempty,omitzero"`
 }
 
 // ClipTopic The topic a clip was taken from
@@ -294,12 +294,12 @@ type Collection struct {
 	AppUrl string `json:"app_url,omitempty"`
 
 	// CreatedAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
-	CreatedAt time.Time `json:"created_at,omitempty"`
+	CreatedAt time.Time `json:"created_at,omitempty,omitzero"`
 	Id        int64     `json:"id"`
 	Name      string    `json:"name,omitempty"`
 
 	// UpdatedAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
-	UpdatedAt time.Time `json:"updated_at,omitempty"`
+	UpdatedAt time.Time `json:"updated_at,omitempty,omitzero"`
 }
 
 // CollectionPayload defines model for CollectionPayload.
@@ -313,13 +313,13 @@ type CollectionWithPostings struct {
 	AppUrl string `json:"app_url,omitempty"`
 
 	// CreatedAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
-	CreatedAt time.Time `json:"created_at,omitempty"`
+	CreatedAt time.Time `json:"created_at,omitempty,omitzero"`
 	Id        int64     `json:"id"`
 	Name      string    `json:"name,omitempty"`
 	Postings  []Posting `json:"postings,omitempty"`
 
 	// UpdatedAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
-	UpdatedAt time.Time `json:"updated_at,omitempty"`
+	UpdatedAt time.Time `json:"updated_at,omitempty,omitzero"`
 }
 
 // CompleteCalendarTodoResponseContent Recording — polymorphic by `type` (CalendarEvent, CalendarTodo, etc.)
@@ -355,7 +355,7 @@ type Contact struct {
 	NameTag               string `json:"name_tag,omitempty"`
 
 	// UpdatedAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
-	UpdatedAt time.Time `json:"updated_at,omitempty"`
+	UpdatedAt time.Time `json:"updated_at,omitempty,omitzero"`
 }
 
 // ContactDetail ContactDetail — extended contact with additional show fields
@@ -382,7 +382,7 @@ type ContactDetail struct {
 	NameTag      string `json:"name_tag,omitempty"`
 
 	// UpdatedAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
-	UpdatedAt time.Time `json:"updated_at,omitempty"`
+	UpdatedAt time.Time `json:"updated_at,omitempty,omitzero"`
 }
 
 // ContactNote A contact's private note. Empty strings when there is no note.
@@ -495,7 +495,7 @@ type DeletedPosting struct {
 	BoxId int64 `json:"box_id,omitempty"`
 
 	// DeletedAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
-	DeletedAt time.Time `json:"deleted_at,omitempty"`
+	DeletedAt time.Time `json:"deleted_at,omitempty,omitzero"`
 	Id        int64     `json:"id"`
 }
 
@@ -543,12 +543,12 @@ type DraftMessage struct {
 	Id      int64   `json:"id"`
 
 	// ScheduledDeliveryAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
-	ScheduledDeliveryAt time.Time `json:"scheduled_delivery_at,omitempty"`
+	ScheduledDeliveryAt time.Time `json:"scheduled_delivery_at,omitempty,omitzero"`
 	Subject             string    `json:"subject,omitempty"`
 	Summary             string    `json:"summary,omitempty"`
 
 	// UpdatedAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
-	UpdatedAt time.Time `json:"updated_at,omitempty"`
+	UpdatedAt time.Time `json:"updated_at,omitempty,omitzero"`
 	Url       string    `json:"url,omitempty"`
 }
 
@@ -558,7 +558,7 @@ type Entry struct {
 	AppUrl                string `json:"app_url,omitempty"`
 
 	// CreatedAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
-	CreatedAt time.Time `json:"created_at,omitempty"`
+	CreatedAt time.Time `json:"created_at,omitempty,omitzero"`
 
 	// Creator Contact — the identity of someone in HEY
 	Creator Contact `json:"creator,omitempty"`
@@ -569,7 +569,7 @@ type Entry struct {
 	TopicId int64   `json:"topic_id,omitempty"`
 
 	// UpdatedAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
-	UpdatedAt time.Time `json:"updated_at,omitempty"`
+	UpdatedAt time.Time `json:"updated_at,omitempty,omitzero"`
 }
 
 // Extenzion Extenzion — external account extension
@@ -597,12 +597,12 @@ type Folder struct {
 	AppUrl string `json:"app_url,omitempty"`
 
 	// CreatedAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
-	CreatedAt time.Time `json:"created_at,omitempty"`
+	CreatedAt time.Time `json:"created_at,omitempty,omitzero"`
 	Id        int64     `json:"id"`
 	Name      string    `json:"name,omitempty"`
 
 	// UpdatedAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
-	UpdatedAt time.Time `json:"updated_at,omitempty"`
+	UpdatedAt time.Time `json:"updated_at,omitempty,omitzero"`
 }
 
 // FolderPayload defines model for FolderPayload.
@@ -616,13 +616,13 @@ type FolderWithPostings struct {
 	AppUrl string `json:"app_url,omitempty"`
 
 	// CreatedAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
-	CreatedAt time.Time `json:"created_at,omitempty"`
+	CreatedAt time.Time `json:"created_at,omitempty,omitzero"`
 	Id        int64     `json:"id"`
 	Name      string    `json:"name,omitempty"`
 	Postings  []Posting `json:"postings,omitempty"`
 
 	// UpdatedAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
-	UpdatedAt time.Time `json:"updated_at,omitempty"`
+	UpdatedAt time.Time `json:"updated_at,omitempty,omitzero"`
 }
 
 // ForbiddenErrorResponseContent defines model for ForbiddenErrorResponseContent.
@@ -834,7 +834,7 @@ type Message struct {
 	Content         string          `json:"content,omitempty"`
 
 	// CreatedAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
-	CreatedAt time.Time `json:"created_at,omitempty"`
+	CreatedAt time.Time `json:"created_at,omitempty,omitzero"`
 
 	// Creator Contact — the identity of someone in HEY
 	Creator Contact `json:"creator,omitempty"`
@@ -845,7 +845,7 @@ type Message struct {
 	Posting MessagePostingContext `json:"posting,omitempty"`
 
 	// ScheduledDeliveryAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
-	ScheduledDeliveryAt time.Time `json:"scheduled_delivery_at,omitempty"`
+	ScheduledDeliveryAt time.Time `json:"scheduled_delivery_at,omitempty,omitzero"`
 
 	// Sender Contact — the identity of someone in HEY
 	Sender                Contact `json:"sender,omitempty"`
@@ -853,7 +853,7 @@ type Message struct {
 	Subject               string  `json:"subject,omitempty"`
 
 	// UpdatedAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
-	UpdatedAt time.Time `json:"updated_at,omitempty"`
+	UpdatedAt time.Time `json:"updated_at,omitempty,omitzero"`
 	Url       string    `json:"url,omitempty"`
 }
 
@@ -967,7 +967,7 @@ type Posting struct {
 	AccountId int64 `json:"account_id,omitempty"`
 
 	// ActiveAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
-	ActiveAt              time.Time `json:"active_at,omitempty"`
+	ActiveAt              time.Time `json:"active_at,omitempty,omitzero"`
 	AddressedContacts     []Contact `json:"addressed_contacts,omitempty"`
 	AlternativeSenderName string    `json:"alternative_sender_name,omitempty"`
 	AppBundleUrl          string    `json:"app_bundle_url,omitempty"`
@@ -985,7 +985,7 @@ type Posting struct {
 	Contacts          []Contact        `json:"contacts,omitempty"`
 
 	// CreatedAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
-	CreatedAt time.Time `json:"created_at,omitempty"`
+	CreatedAt time.Time `json:"created_at,omitempty,omitzero"`
 
 	// Creator Contact — the identity of someone in HEY
 	Creator                 Contact     `json:"creator,omitempty"`
@@ -1005,13 +1005,13 @@ type Posting struct {
 	Note PostingNote `json:"note,omitempty"`
 
 	// ObservedAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
-	ObservedAt           time.Time `json:"observed_at,omitempty"`
+	ObservedAt           time.Time `json:"observed_at,omitempty,omitzero"`
 	PreapprovedClearance bool      `json:"preapproved_clearance,omitempty"`
 	Seen                 bool      `json:"seen,omitempty"`
 	Summary              string    `json:"summary,omitempty"`
 
 	// UpdatedAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
-	UpdatedAt         time.Time  `json:"updated_at,omitempty"`
+	UpdatedAt         time.Time  `json:"updated_at,omitempty,omitzero"`
 	VisibleEntryCount int32      `json:"visible_entry_count,omitempty"`
 	Workflows         []Workflow `json:"workflows,omitempty"`
 }
@@ -1038,7 +1038,7 @@ type Recording struct {
 	Color    string   `json:"color,omitempty"`
 
 	// CompletedAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
-	CompletedAt time.Time `json:"completed_at,omitempty"`
+	CompletedAt time.Time `json:"completed_at,omitempty,omitzero"`
 	Content     string    `json:"content,omitempty"`
 
 	// ContentHtml Full rich-text HTML of a journal entry (GetJournalEntry / UpdateJournalEntry only;
@@ -1046,13 +1046,13 @@ type Recording struct {
 	ContentHtml string `json:"content_html,omitempty"`
 
 	// CreatedAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
-	CreatedAt   time.Time `json:"created_at,omitempty"`
+	CreatedAt   time.Time `json:"created_at,omitempty,omitzero"`
 	Days        []int32   `json:"days,omitempty"`
 	Description string    `json:"description,omitempty"`
 	EditUrl     string    `json:"edit_url,omitempty"`
 
 	// EndsAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
-	EndsAt         time.Time `json:"ends_at,omitempty"`
+	EndsAt         time.Time `json:"ends_at,omitempty,omitzero"`
 	EndsAtTimeZone string    `json:"ends_at_time_zone,omitempty"`
 	Highlighted    bool      `json:"highlighted,omitempty"`
 	Icon           string    `json:"icon,omitempty"`
@@ -1084,11 +1084,11 @@ type Recording struct {
 	RemindersLabel     string             `json:"reminders_label,omitempty"`
 
 	// StartsAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
-	StartsAt         time.Time `json:"starts_at,omitempty"`
+	StartsAt         time.Time `json:"starts_at,omitempty,omitzero"`
 	StartsAtTimeZone string    `json:"starts_at_time_zone,omitempty"`
 
 	// StoppedAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
-	StoppedAt time.Time `json:"stopped_at,omitempty"`
+	StoppedAt time.Time `json:"stopped_at,omitempty,omitzero"`
 	Summary   string    `json:"summary,omitempty"`
 	Title     string    `json:"title,omitempty"`
 
@@ -1096,7 +1096,7 @@ type Recording struct {
 	Type string `json:"type"`
 
 	// UpdatedAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
-	UpdatedAt time.Time `json:"updated_at,omitempty"`
+	UpdatedAt time.Time `json:"updated_at,omitempty,omitzero"`
 	Url       string    `json:"url,omitempty"`
 }
 
@@ -1110,7 +1110,7 @@ type RecurrenceSchedule struct {
 // Reminder Reminder
 type Reminder struct {
 	// CreatedAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
-	CreatedAt       time.Time `json:"created_at,omitempty"`
+	CreatedAt       time.Time `json:"created_at,omitempty,omitzero"`
 	DefaultDuration bool      `json:"default_duration,omitempty"`
 	Delivered       bool      `json:"delivered,omitempty"`
 	Duration        int32     `json:"duration,omitempty"`
@@ -1119,11 +1119,11 @@ type Reminder struct {
 	Label           string    `json:"label,omitempty"`
 
 	// RemindAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
-	RemindAt time.Time `json:"remind_at,omitempty"`
+	RemindAt time.Time `json:"remind_at,omitempty,omitzero"`
 	Summary  string    `json:"summary,omitempty"`
 
 	// UpdatedAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
-	UpdatedAt time.Time `json:"updated_at,omitempty"`
+	UpdatedAt time.Time `json:"updated_at,omitempty,omitzero"`
 }
 
 // ReplyMessagePayload defines model for ReplyMessagePayload.
@@ -1177,12 +1177,12 @@ type Snippet struct {
 	ContentHtml string `json:"content_html,omitempty"`
 
 	// CreatedAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
-	CreatedAt time.Time `json:"created_at,omitempty"`
+	CreatedAt time.Time `json:"created_at,omitempty,omitzero"`
 	Id        int64     `json:"id"`
 	Name      string    `json:"name,omitempty"`
 
 	// UpdatedAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
-	UpdatedAt time.Time `json:"updated_at,omitempty"`
+	UpdatedAt time.Time `json:"updated_at,omitempty,omitzero"`
 }
 
 // StartTimeTrackResponseContent Recording — polymorphic by `type` (CalendarEvent, CalendarTodo, etc.)
@@ -1193,12 +1193,12 @@ type Sticky struct {
 	Body string `json:"body,omitempty"`
 
 	// CreatedAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
-	CreatedAt time.Time `json:"created_at,omitempty"`
+	CreatedAt time.Time `json:"created_at,omitempty,omitzero"`
 	Id        int64     `json:"id"`
 	Size      string    `json:"size,omitempty"`
 
 	// UpdatedAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
-	UpdatedAt time.Time `json:"updated_at,omitempty"`
+	UpdatedAt time.Time `json:"updated_at,omitempty,omitzero"`
 }
 
 // StickyPayload defines model for StickyPayload.
@@ -1215,12 +1215,12 @@ type StickyRequestContent struct {
 // TimeTrackCategory defines model for TimeTrackCategory.
 type TimeTrackCategory struct {
 	// CreatedAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
-	CreatedAt time.Time `json:"created_at,omitempty"`
+	CreatedAt time.Time `json:"created_at,omitempty,omitzero"`
 	Id        int64     `json:"id"`
 	Title     string    `json:"title,omitempty"`
 
 	// UpdatedAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
-	UpdatedAt time.Time `json:"updated_at,omitempty"`
+	UpdatedAt time.Time `json:"updated_at,omitempty,omitzero"`
 }
 
 // TimeTrackRequestContent defines model for TimeTrackRequestContent.
@@ -1236,13 +1236,13 @@ type Topic struct {
 	AccountId int64 `json:"account_id,omitempty"`
 
 	// ActiveAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
-	ActiveAt    time.Time    `json:"active_at,omitempty"`
+	ActiveAt    time.Time    `json:"active_at,omitempty,omitzero"`
 	AppUrl      string       `json:"app_url,omitempty"`
 	Collections []Collection `json:"collections,omitempty"`
 	Contacts    []Contact    `json:"contacts,omitempty"`
 
 	// CreatedAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
-	CreatedAt time.Time `json:"created_at,omitempty"`
+	CreatedAt time.Time `json:"created_at,omitempty,omitzero"`
 
 	// Creator Contact — the identity of someone in HEY
 	Creator Contact `json:"creator,omitempty"`
@@ -1260,7 +1260,7 @@ type Topic struct {
 	Status      string `json:"status,omitempty"`
 
 	// UpdatedAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
-	UpdatedAt time.Time `json:"updated_at,omitempty"`
+	UpdatedAt time.Time `json:"updated_at,omitempty,omitzero"`
 }
 
 // TopicListResponse TopicListResponse — wrapped topic list (sent, spam, trash, everything)
@@ -1365,11 +1365,11 @@ type UpdateTimeTrackPayload struct {
 	Category string `json:"category,omitempty"`
 
 	// EndsAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
-	EndsAt *time.Time `json:"ends_at,omitempty"`
+	EndsAt *time.Time `json:"ends_at,omitempty,omitzero"`
 	Notes  string     `json:"notes,omitempty"`
 
 	// StartsAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
-	StartsAt *time.Time `json:"starts_at,omitempty"`
+	StartsAt *time.Time `json:"starts_at,omitempty,omitzero"`
 	Title    string     `json:"title,omitempty"`
 }
 
@@ -1403,7 +1403,7 @@ type Workflow struct {
 	AppUrl string `json:"app_url,omitempty"`
 
 	// CreatedAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
-	CreatedAt time.Time `json:"created_at,omitempty"`
+	CreatedAt time.Time `json:"created_at,omitempty,omitzero"`
 	Id        int64     `json:"id"`
 	Name      string    `json:"name,omitempty"`
 
@@ -1411,7 +1411,7 @@ type Workflow struct {
 	Stages []WorkflowStage `json:"stages,omitempty"`
 
 	// UpdatedAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
-	UpdatedAt time.Time `json:"updated_at,omitempty"`
+	UpdatedAt time.Time `json:"updated_at,omitempty,omitzero"`
 }
 
 // WorkflowStage defines model for WorkflowStage.

--- a/go/pkg/hey/auth_strategy.go
+++ b/go/pkg/hey/auth_strategy.go
@@ -13,6 +13,15 @@ type AuthStrategy interface {
 	Authenticate(ctx context.Context, req *http.Request) error
 }
 
+// TokenRefresher renews the credentials a request is authenticated with, which is what
+// lets a 401 be retried rather than surfaced. AuthManager is one, and so is any
+// AuthStrategy or TokenProvider a caller brings that can renew what it hands out — a
+// client that keeps its credentials somewhere else is exactly the case that needs this,
+// since it has no AuthManager for the client to recognise.
+type TokenRefresher interface {
+	Refresh(ctx context.Context) error
+}
+
 // BearerAuth implements AuthStrategy using OAuth Bearer tokens.
 // This is the default authentication strategy.
 type BearerAuth struct {

--- a/go/pkg/hey/auth_strategy_test.go
+++ b/go/pkg/hey/auth_strategy_test.go
@@ -1,0 +1,76 @@
+package hey
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+)
+
+// refreshingAuth is a caller that keeps its credentials somewhere the SDK knows nothing
+// about, which is the case a *AuthManager check could never recognise.
+type refreshingAuth struct {
+	token     atomic.Value
+	refreshes atomic.Int64
+	refreshed string
+}
+
+func (a *refreshingAuth) Authenticate(_ context.Context, req *http.Request) error {
+	req.Header.Set("Authorization", "Bearer "+a.token.Load().(string))
+	return nil
+}
+
+func (a *refreshingAuth) Refresh(context.Context) error {
+	a.refreshes.Add(1)
+	a.token.Store(a.refreshed)
+	return nil
+}
+
+func TestUnauthorizedIsRetriedAfterTheStrategyRefreshes(t *testing.T) {
+	var seen []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen = append(seen, r.Header.Get("Authorization"))
+		if r.Header.Get("Authorization") != "Bearer fresh" {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	auth := &refreshingAuth{refreshed: "fresh"}
+	auth.token.Store("stale")
+	client := NewClient(&Config{BaseURL: srv.URL}, nil, WithAuthStrategy(auth), WithMaxRetries(1))
+
+	if _, err := client.Get(context.Background(), "/whatever.json"); err != nil {
+		t.Fatalf("expected the retry after a refresh to succeed: %v", err)
+	}
+	if refreshes := auth.refreshes.Load(); refreshes != 1 {
+		t.Errorf("expected one refresh, got %d", refreshes)
+	}
+	if len(seen) != 2 || seen[0] != "Bearer stale" || seen[1] != "Bearer fresh" {
+		t.Errorf("expected the stale token then the fresh one, got %v", seen)
+	}
+}
+
+// A strategy that cannot renew its credentials must not turn a 401 into a retry loop.
+func TestUnauthorizedIsSurfacedWhenNothingCanRefresh(t *testing.T) {
+	var requests atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+	}))
+	t.Cleanup(srv.Close)
+
+	client := NewClient(&Config{BaseURL: srv.URL}, &StaticTokenProvider{Token: "stale"}, WithMaxRetries(1))
+
+	_, err := client.Get(context.Background(), "/whatever.json")
+	if err == nil {
+		t.Fatal("expected an authentication error")
+	}
+	if requests.Load() != 1 {
+		t.Errorf("expected the 401 to be surfaced on the first request, got %d requests", requests.Load())
+	}
+}

--- a/go/pkg/hey/client.go
+++ b/go/pkg/hey/client.go
@@ -225,6 +225,20 @@ func NewClient(cfg *Config, tokenProvider TokenProvider, opts ...ClientOption) *
 }
 
 // initGeneratedClient initializes the generated OpenAPI client for this account scope.
+// refreshCredentials renews what the next request will authenticate with, and reports
+// whether anything was able to. The strategy is asked before the token provider because a
+// client given both is authenticated by the strategy, so the strategy is what holds the
+// credentials a 401 was about.
+func (c *Client) refreshCredentials(ctx context.Context) bool {
+	if refresher, ok := c.authStrategy.(TokenRefresher); ok {
+		return refresher.Refresh(ctx) == nil
+	}
+	if refresher, ok := c.tokenProvider.(TokenRefresher); ok {
+		return refresher.Refresh(ctx) == nil
+	}
+	return false
+}
+
 func (c *Client) initGeneratedClient() {
 	c.genOnce.Do(func() {
 		serverURL := strings.TrimSuffix(c.cfg.BaseURL, "/")
@@ -468,10 +482,8 @@ func (c *Client) doBodyRequest(ctx context.Context, method, path, contentType st
 
 	case resp.StatusCode == http.StatusUnauthorized:
 		// Try token refresh and retry once
-		if authMgr, ok := c.tokenProvider.(*AuthManager); ok {
-			if refreshErr := authMgr.Refresh(ctx); refreshErr == nil {
-				return c.doBodyRequest(ctx, method, path, contentType, body)
-			}
+		if c.refreshCredentials(ctx) {
+			return c.doBodyRequest(ctx, method, path, contentType, body)
 		}
 		return nil, ErrAuth("Authentication failed")
 
@@ -726,15 +738,11 @@ func (c *Client) singleRequest(ctx context.Context, method, url string, body any
 		return nil, &retryableError{err: rateErr, retryAfter: time.Duration(retryAfter) * time.Second}
 
 	case http.StatusUnauthorized:
-		if attempt == 1 {
-			if authMgr, ok := c.tokenProvider.(*AuthManager); ok {
-				if err := authMgr.Refresh(ctx); err == nil {
-					return nil, &Error{
-						Code:      CodeAuth,
-						Message:   "Token refreshed",
-						Retryable: true,
-					}
-				}
+		if attempt == 1 && c.refreshCredentials(ctx) {
+			return nil, &Error{
+				Code:      CodeAuth,
+				Message:   "Token refreshed",
+				Retryable: true,
 			}
 		}
 		return nil, ErrAuth("Authentication failed")

--- a/go/pkg/hey/timestamps_test.go
+++ b/go/pkg/hey/timestamps_test.go
@@ -1,0 +1,59 @@
+package hey
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/basecamp/hey-sdk/go/pkg/generated"
+)
+
+// A time track that is still running has no end, and a todo that is not done has no
+// completion. Marshalling one of those back out must not invent either: `omitempty` does
+// not omit a zero time.Time, so without `omitzero` on the generated timestamps an ongoing
+// track reports "ends_at":"0001-01-01T00:00:00Z" and reads as finished in year one.
+func TestAZeroTimestampIsNotMarshalled(t *testing.T) {
+	running := generated.Recording{
+		Id:       12,
+		Title:    "Reviewing the pagination fix",
+		StartsAt: time.Date(2026, 8, 21, 9, 0, 0, 0, time.UTC),
+	}
+
+	encoded, err := json.Marshal(running)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, absent := range []string{"ends_at", "stopped_at", "completed_at"} {
+		if strings.Contains(string(encoded), absent) {
+			t.Errorf("expected %q to be left out of a running time track, got %s", absent, encoded)
+		}
+	}
+	if !strings.Contains(string(encoded), `"starts_at":"2026-08-21T09:00:00Z"`) {
+		t.Errorf("expected the timestamp that was set to survive, got %s", encoded)
+	}
+}
+
+// The counterpart: a timestamp that carries a real time is still marshalled, so omitzero
+// omits nothing anyone set.
+func TestATimestampThatWasSetIsMarshalled(t *testing.T) {
+	finished := generated.Recording{
+		Id:        12,
+		StartsAt:  time.Date(2026, 8, 21, 9, 0, 0, 0, time.UTC),
+		EndsAt:    time.Date(2026, 8, 21, 11, 30, 0, 0, time.UTC),
+		StoppedAt: time.Date(2026, 8, 21, 11, 30, 0, 0, time.UTC),
+	}
+
+	encoded, err := json.Marshal(finished)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(string(encoded), `"ends_at":"2026-08-21T11:30:00Z"`) {
+		t.Errorf("expected the end of a finished track, got %s", encoded)
+	}
+	if !strings.Contains(string(encoded), `"stopped_at":"2026-08-21T11:30:00Z"`) {
+		t.Errorf("expected the stop of a finished track, got %s", encoded)
+	}
+}

--- a/openapi.json
+++ b/openapi.json
@@ -8452,7 +8452,8 @@
             "x-go-type": "types.Date",
             "x-go-type-import": {
               "path": "github.com/basecamp/hey-sdk/go/pkg/types"
-            }
+            },
+            "x-omitzero": true
           },
           "burner": {
             "type": "boolean"
@@ -8754,7 +8755,8 @@
             "x-go-type": "time.Time",
             "x-go-type-import": {
               "path": "time"
-            }
+            },
+            "x-omitzero": true
           },
           "surprise_me": {
             "type": "boolean"
@@ -8907,7 +8909,8 @@
             "x-go-type": "time.Time",
             "x-go-type-import": {
               "path": "time"
-            }
+            },
+            "x-omitzero": true
           },
           "updated_at": {
             "type": "string",
@@ -8916,7 +8919,8 @@
             "x-go-type": "time.Time",
             "x-go-type-import": {
               "path": "time"
-            }
+            },
+            "x-omitzero": true
           },
           "owned": {
             "type": "boolean"
@@ -8988,7 +8992,8 @@
             "x-go-type-import": {
               "path": "time"
             },
-            "x-go-type-skip-optional-pointer": false
+            "x-go-type-skip-optional-pointer": false,
+            "x-omitzero": true
           }
         },
         "required": [
@@ -9025,7 +9030,8 @@
             "x-go-type": "time.Time",
             "x-go-type-import": {
               "path": "time"
-            }
+            },
+            "x-omitzero": true
           },
           "updated_at": {
             "type": "string",
@@ -9034,7 +9040,8 @@
             "x-go-type": "time.Time",
             "x-go-type-import": {
               "path": "time"
-            }
+            },
+            "x-omitzero": true
           },
           "petitioner": {
             "$ref": "#/components/schemas/Contact"
@@ -9095,7 +9102,8 @@
             "x-go-type": "time.Time",
             "x-go-type-import": {
               "path": "time"
-            }
+            },
+            "x-omitzero": true
           },
           "updated_at": {
             "type": "string",
@@ -9104,7 +9112,8 @@
             "x-go-type": "time.Time",
             "x-go-type-import": {
               "path": "time"
-            }
+            },
+            "x-omitzero": true
           },
           "entry_id": {
             "type": "integer",
@@ -9155,7 +9164,8 @@
             "x-go-type": "time.Time",
             "x-go-type-import": {
               "path": "time"
-            }
+            },
+            "x-omitzero": true
           },
           "updated_at": {
             "type": "string",
@@ -9164,7 +9174,8 @@
             "x-go-type": "time.Time",
             "x-go-type-import": {
               "path": "time"
-            }
+            },
+            "x-omitzero": true
           },
           "app_url": {
             "type": "string"
@@ -9203,7 +9214,8 @@
             "x-go-type": "time.Time",
             "x-go-type-import": {
               "path": "time"
-            }
+            },
+            "x-omitzero": true
           },
           "updated_at": {
             "type": "string",
@@ -9212,7 +9224,8 @@
             "x-go-type": "time.Time",
             "x-go-type-import": {
               "path": "time"
-            }
+            },
+            "x-omitzero": true
           },
           "app_url": {
             "type": "string"
@@ -9280,7 +9293,8 @@
             "x-go-type": "time.Time",
             "x-go-type-import": {
               "path": "time"
-            }
+            },
+            "x-omitzero": true
           },
           "name": {
             "type": "string"
@@ -9330,7 +9344,8 @@
             "x-go-type": "time.Time",
             "x-go-type-import": {
               "path": "time"
-            }
+            },
+            "x-omitzero": true
           },
           "name": {
             "type": "string"
@@ -9626,7 +9641,8 @@
             "x-go-type": "time.Time",
             "x-go-type-import": {
               "path": "time"
-            }
+            },
+            "x-omitzero": true
           }
         },
         "required": [
@@ -9739,7 +9755,8 @@
             "x-go-type": "time.Time",
             "x-go-type-import": {
               "path": "time"
-            }
+            },
+            "x-omitzero": true
           },
           "creator": {
             "$ref": "#/components/schemas/Contact"
@@ -9773,7 +9790,8 @@
             "x-go-type": "time.Time",
             "x-go-type-import": {
               "path": "time"
-            }
+            },
+            "x-omitzero": true
           }
         },
         "required": [
@@ -9795,7 +9813,8 @@
             "x-go-type": "time.Time",
             "x-go-type-import": {
               "path": "time"
-            }
+            },
+            "x-omitzero": true
           },
           "updated_at": {
             "type": "string",
@@ -9804,7 +9823,8 @@
             "x-go-type": "time.Time",
             "x-go-type-import": {
               "path": "time"
-            }
+            },
+            "x-omitzero": true
           },
           "creator": {
             "$ref": "#/components/schemas/Contact"
@@ -9905,7 +9925,8 @@
             "x-go-type": "time.Time",
             "x-go-type-import": {
               "path": "time"
-            }
+            },
+            "x-omitzero": true
           },
           "updated_at": {
             "type": "string",
@@ -9914,7 +9935,8 @@
             "x-go-type": "time.Time",
             "x-go-type-import": {
               "path": "time"
-            }
+            },
+            "x-omitzero": true
           },
           "app_url": {
             "type": "string"
@@ -9956,7 +9978,8 @@
             "x-go-type": "time.Time",
             "x-go-type-import": {
               "path": "time"
-            }
+            },
+            "x-omitzero": true
           },
           "updated_at": {
             "type": "string",
@@ -9965,7 +9988,8 @@
             "x-go-type": "time.Time",
             "x-go-type-import": {
               "path": "time"
-            }
+            },
+            "x-omitzero": true
           },
           "app_url": {
             "type": "string"
@@ -10316,7 +10340,8 @@
             "x-go-type": "time.Time",
             "x-go-type-import": {
               "path": "time"
-            }
+            },
+            "x-omitzero": true
           },
           "updated_at": {
             "type": "string",
@@ -10325,7 +10350,8 @@
             "x-go-type": "time.Time",
             "x-go-type-import": {
               "path": "time"
-            }
+            },
+            "x-omitzero": true
           },
           "url": {
             "type": "string"
@@ -10358,7 +10384,8 @@
             "x-go-type": "time.Time",
             "x-go-type-import": {
               "path": "time"
-            }
+            },
+            "x-omitzero": true
           },
           "posting": {
             "$ref": "#/components/schemas/MessagePostingContext"
@@ -10615,7 +10642,8 @@
             "x-go-type": "time.Time",
             "x-go-type-import": {
               "path": "time"
-            }
+            },
+            "x-omitzero": true
           },
           "updated_at": {
             "type": "string",
@@ -10624,7 +10652,8 @@
             "x-go-type": "time.Time",
             "x-go-type-import": {
               "path": "time"
-            }
+            },
+            "x-omitzero": true
           },
           "observed_at": {
             "type": "string",
@@ -10633,7 +10662,8 @@
             "x-go-type": "time.Time",
             "x-go-type-import": {
               "path": "time"
-            }
+            },
+            "x-omitzero": true
           },
           "active_at": {
             "type": "string",
@@ -10642,7 +10672,8 @@
             "x-go-type": "time.Time",
             "x-go-type-import": {
               "path": "time"
-            }
+            },
+            "x-omitzero": true
           },
           "box_id": {
             "type": "integer",
@@ -10828,7 +10859,8 @@
             "x-go-type": "time.Time",
             "x-go-type-import": {
               "path": "time"
-            }
+            },
+            "x-omitzero": true
           },
           "ends_at": {
             "type": "string",
@@ -10837,7 +10869,8 @@
             "x-go-type": "time.Time",
             "x-go-type-import": {
               "path": "time"
-            }
+            },
+            "x-omitzero": true
           },
           "created_at": {
             "type": "string",
@@ -10846,7 +10879,8 @@
             "x-go-type": "time.Time",
             "x-go-type-import": {
               "path": "time"
-            }
+            },
+            "x-omitzero": true
           },
           "updated_at": {
             "type": "string",
@@ -10855,7 +10889,8 @@
             "x-go-type": "time.Time",
             "x-go-type-import": {
               "path": "time"
-            }
+            },
+            "x-omitzero": true
           },
           "type": {
             "type": "string",
@@ -10886,7 +10921,8 @@
             "x-go-type": "time.Time",
             "x-go-type-import": {
               "path": "time"
-            }
+            },
+            "x-omitzero": true
           },
           "highlighted": {
             "type": "boolean"
@@ -10976,7 +11012,8 @@
             "x-go-type": "time.Time",
             "x-go-type-import": {
               "path": "time"
-            }
+            },
+            "x-omitzero": true
           },
           "notes": {
             "type": "string"
@@ -11084,7 +11121,8 @@
             "x-go-type": "time.Time",
             "x-go-type-import": {
               "path": "time"
-            }
+            },
+            "x-omitzero": true
           },
           "created_at": {
             "type": "string",
@@ -11093,7 +11131,8 @@
             "x-go-type": "time.Time",
             "x-go-type-import": {
               "path": "time"
-            }
+            },
+            "x-omitzero": true
           },
           "updated_at": {
             "type": "string",
@@ -11102,7 +11141,8 @@
             "x-go-type": "time.Time",
             "x-go-type-import": {
               "path": "time"
-            }
+            },
+            "x-omitzero": true
           },
           "label": {
             "type": "string"
@@ -11240,7 +11280,8 @@
             "x-go-type": "time.Time",
             "x-go-type-import": {
               "path": "time"
-            }
+            },
+            "x-omitzero": true
           },
           "updated_at": {
             "type": "string",
@@ -11249,7 +11290,8 @@
             "x-go-type": "time.Time",
             "x-go-type-import": {
               "path": "time"
-            }
+            },
+            "x-omitzero": true
           }
         },
         "required": [
@@ -11280,7 +11322,8 @@
             "x-go-type": "time.Time",
             "x-go-type-import": {
               "path": "time"
-            }
+            },
+            "x-omitzero": true
           },
           "updated_at": {
             "type": "string",
@@ -11289,7 +11332,8 @@
             "x-go-type": "time.Time",
             "x-go-type-import": {
               "path": "time"
-            }
+            },
+            "x-omitzero": true
           }
         },
         "required": [
@@ -11336,7 +11380,8 @@
             "x-go-type": "time.Time",
             "x-go-type-import": {
               "path": "time"
-            }
+            },
+            "x-omitzero": true
           },
           "updated_at": {
             "type": "string",
@@ -11345,7 +11390,8 @@
             "x-go-type": "time.Time",
             "x-go-type-import": {
               "path": "time"
-            }
+            },
+            "x-omitzero": true
           }
         },
         "required": [
@@ -11401,7 +11447,8 @@
             "x-go-type": "time.Time",
             "x-go-type-import": {
               "path": "time"
-            }
+            },
+            "x-omitzero": true
           },
           "updated_at": {
             "type": "string",
@@ -11410,7 +11457,8 @@
             "x-go-type": "time.Time",
             "x-go-type-import": {
               "path": "time"
-            }
+            },
+            "x-omitzero": true
           },
           "active_at": {
             "type": "string",
@@ -11419,7 +11467,8 @@
             "x-go-type": "time.Time",
             "x-go-type-import": {
               "path": "time"
-            }
+            },
+            "x-omitzero": true
           },
           "status": {
             "type": "string"
@@ -11666,7 +11715,8 @@
             "x-go-type-import": {
               "path": "time"
             },
-            "x-go-type-skip-optional-pointer": false
+            "x-go-type-skip-optional-pointer": false,
+            "x-omitzero": true
           },
           "ends_at": {
             "type": "string",
@@ -11676,7 +11726,8 @@
             "x-go-type-import": {
               "path": "time"
             },
-            "x-go-type-skip-optional-pointer": false
+            "x-go-type-skip-optional-pointer": false,
+            "x-omitzero": true
           }
         }
       },
@@ -11754,7 +11805,8 @@
             "x-go-type": "time.Time",
             "x-go-type-import": {
               "path": "time"
-            }
+            },
+            "x-omitzero": true
           },
           "updated_at": {
             "type": "string",
@@ -11763,7 +11815,8 @@
             "x-go-type": "time.Time",
             "x-go-type-import": {
               "path": "time"
-            }
+            },
+            "x-omitzero": true
           },
           "app_url": {
             "type": "string"

--- a/scripts/enhance-openapi-go-types.sh
+++ b/scripts/enhance-openapi-go-types.sh
@@ -5,6 +5,7 @@
 #   - *_at fields → time.Time
 #   - *_on fields → types.Date
 #   - Optional booleans in request bodies → *bool (nil vs false distinction)
+#   - Optional timestamps → omitzero, so a time nobody set is not reported as one
 set -euo pipefail
 
 OPENAPI_FILE="${1:-openapi.json}"
@@ -134,6 +135,34 @@ jq '
       else .
       end
     )
+' "$OPENAPI_FILE" > "${OPENAPI_FILE}.tmp" && mv "${OPENAPI_FILE}.tmp" "$OPENAPI_FILE"
+
+# Pass 5: Optional timestamps everywhere → omitzero
+# Pass 2 keeps a zero time out of a request by making it a pointer, but a response shape is
+# read rather than sent, so its fields stay values for ergonomics — and marshalling one
+# back out then reports a time nobody set. `omitempty` does not omit a struct, so an
+# ongoing time track serializes "ends_at":"0001-01-01T00:00:00Z" and an incomplete todo
+# serializes a completed_at, which reads as finished. `omitzero` (Go 1.24+) omits the zero
+# time without changing the field's type, so reading r.EndsAt still works. Applies to every
+# non-required property pass 1 typed as a time or a date; on the request pointers from
+# pass 2 it is a no-op, a nil pointer being zero either way.
+jq '
+  (.components.schemas // {}) |= with_entries(
+    .value |= (
+      if .properties then
+        (.required // []) as $req
+        | .properties |= with_entries(
+            if ((.value["x-go-type"]? // "") | test("^(time\\.Time|types\\.Date)$"))
+               and ((.key as $p | $req | index($p)) | not)
+            then
+              .value += {"x-omitzero": true}
+            else .
+            end
+          )
+      else .
+      end
+    )
+  )
 ' "$OPENAPI_FILE" > "${OPENAPI_FILE}.tmp" && mv "${OPENAPI_FILE}.tmp" "$OPENAPI_FILE"
 
 # Self-referential types are fixed via post-codegen sed in go/Makefile.


### PR DESCRIPTION
Two independent fixes, one commit each, both found while wiring hey-cli against v0.10.0.

**No version bump here.** `version.go` is already at 0.11.0 from #103, which hasn't been released — v0.10.0 is still the latest tag. These changes join that pending release, so one `make release VERSION=0.11.0` ships all three.

## Retry a 401 for any credentials that can renew themselves

Both 401 paths already knew to refresh and retry once, but each asked `c.tokenProvider.(*AuthManager)` — a concrete type. So only a client keeping its credentials in the SDK's own store could ever take that path. A caller bringing its own credentials in through `WithAuthStrategy` has no token provider at all, the assertion failed, and the retry was dead code: a token expiring mid-session surfaced as a hard authentication error with a working refresh token sitting on disk.

`TokenRefresher` is that same `Refresh(ctx) error` as an interface. The strategy is asked before the token provider, because a client given both is authenticated by the strategy, so the strategy holds the credentials the 401 was about.

`AuthManager` satisfies it as it stands, so a client built the usual way behaves exactly as before. A client whose credentials *cannot* be renewed still surfaces the 401 on the first request rather than retrying into a loop — there's a test for each direction.

## Leave a time nobody set out of the JSON

`omitempty` does not omit a struct, and `time.Time` is one. Pass 2 of the type enhancement already handles this for requests, by making an optional timestamp a pointer so a partial update doesn't rewrite what it left alone. A response shape is read rather than sent, so its timestamps stay values for ergonomics — and marshalling one back out reports every time nobody set:

```json
{"id":12,"starts_at":"2026-08-21T09:00:00Z",
 "ends_at":"0001-01-01T00:00:00Z","stopped_at":"0001-01-01T00:00:00Z"}
```

That's a *running* time track, and anything reading the JSON concludes it ended in year one. An incomplete todo carries a `completed_at` the same way and reads as done. hey-cli hands these structs straight to its `--json` output, so this is what an agent reading `hey timetrack list` sees.

`omitzero` (Go 1.24; this module is on 1.26) omits the zero time without changing the field's type, so `r.EndsAt` goes on working and only the encoding moves. Pass 5 applies it to every non-required property pass 1 typed as a time or a date; on the request pointers from pass 2 it's a no-op, a nil pointer being zero either way.

Nothing hand-edited — the pass lives in `scripts/enhance-openapi-go-types.sh` and the tags follow from a regenerate, per AGENTS.md. **The diff to `client.gen.go` is 53 tags in, 53 out, and no field's type moved.** I checked `openapi.json` was reproducible from the spec before regenerating, so there's no unrelated churn here; `make url-routes`, `generate-shape-fingerprint` and `generate-route-coverage` all regenerate identically, since a tag change moves no routes.

## Checks

`make check` — 153/153. Note `make check-full` is broken in this repo (seed leftovers for languages that don't exist), as AGENTS.md says.