### PR TITLE
Cap JSON and HTML response bodies in the transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,12 @@ are configured with `WithResilience`, `WithCircuitBreaker`, `WithBulkhead` and
 `WithRateLimit`; HTTP caching with `WithCache`. Response caching is active for requests with
 an `Authorization` header, which gives each authenticated identity a stable cache partition.
 
+JSON and HTML answers are capped in the transport at `WithMaxResponseBodyBytes` (16 MiB of
+decompressed body by default; a negative value removes the cap). A body past it fails with an
+error that `errors.Is(err, hey.ErrResponseTooLarge)`, and is not retried. Blobs (`GetBlob`,
+`DownloadBlob`) and CSV exports are not capped there: the one buffers under
+`hey.MaxResponseBodyBytes`, the other streams.
+
 ### Errors
 
 Calls return `*hey.Error` with a stable `Code` (`hey.CodeNotFound`, `hey.CodeAuth`,

--- a/README.md
+++ b/README.md
@@ -106,10 +106,12 @@ are configured with `WithResilience`, `WithCircuitBreaker`, `WithBulkhead` and
 an `Authorization` header, which gives each authenticated identity a stable cache partition.
 
 JSON and HTML answers are capped in the transport at `WithMaxResponseBodyBytes` (16 MiB of
-decompressed body by default; a negative value removes the cap). A body past it fails with an
-error that `errors.Is(err, hey.ErrResponseTooLarge)`, and is not retried. Blobs (`GetBlob`,
-`DownloadBlob`) and CSV exports are not capped there: the one buffers under
-`hey.MaxResponseBodyBytes`, the other streams.
+decompressed body by default; the cap can be raised but not removed), success and error
+responses alike. A body past it fails with an error that `errors.Is(err,
+hey.ErrResponseTooLarge)`, and is not retried; a refused error response still carries its
+status in the `*hey.Error`. Buffered blobs and CSV exports (`GetBlob`, `GetCSV`) are bounded
+by the 50 MiB `hey.MaxResponseBodyBytes` constant instead; only `DownloadBlob` streams
+without a bound.
 
 ### Errors
 

--- a/go/pkg/hey/body_limit.go
+++ b/go/pkg/hey/body_limit.go
@@ -15,12 +15,15 @@ import (
 // and the generated client make: a RoundTripper that caps what a text-bearing response can
 // deliver, success and error alike, before a parser sees it.
 //
-// A success body past the limit is refused — its first read past the cap fails with
-// ErrResponseTooLarge — since a parser that buffers it would buffer it whole. An error body
-// past the limit is cut off at the cap instead: the status is what matters about an error,
-// and a refusal would hide it behind a read failure. Both happen at read time rather than at
-// the round trip: a round-trip error is one the retry loops, the SDK's and the generated
-// client's, treat as a network failure and try again, and the body would be too large again.
+// A body past the limit is refused — its first read past the cap fails with an error that
+// wraps ErrResponseTooLarge — since a parser that buffers it would buffer it whole. An error
+// body is refused the same way, but the refusal is the *Error CheckResponse would have built
+// for the status, with the refusal as its Cause: the generated parsers decode a modeled error
+// payload before a service wrapper reaches CheckResponse, so a body merely cut off at the
+// cap would surface as a JSON syntax error and the status would be lost with it. Both happen
+// at read time rather than at the round trip: a round-trip error is one the retry loops, the
+// SDK's and the generated client's, treat as a network failure and try again, and the body
+// would be too large again.
 //
 // Which responses are capped is decided by the request, not by what the server says it
 // answered with: the SDK asks for application/json where a generated parser or doRequest
@@ -43,23 +46,24 @@ func (t *bodyLimitTransport) RoundTrip(req *http.Request) (*http.Response, error
 	if err != nil || resp == nil || resp.Body == nil || !isParsedRequest(req) {
 		return resp, err
 	}
-	if resp.StatusCode >= 400 {
-		resp.Body = &truncatedBody{Reader: io.LimitReader(resp.Body, t.limit), closer: resp.Body}
-		return resp, nil
-	}
 	remaining := t.limit
 	if resp.ContentLength > t.limit {
 		// Declared past the limit: refused on its first read, the same failure a streamed
 		// body produces once it passes the cap, so neither retry loop sees a round-trip error.
 		remaining = -1
 	}
-	resp.Body = &cappedBody{
+	body := &cappedBody{
 		ReadCloser: resp.Body,
 		remaining:  remaining,
 		declared:   resp.ContentLength,
 		limit:      t.limit,
 		request:    req,
 	}
+	if resp.StatusCode >= 400 {
+		// The status is what matters about an error; the refusal carries it.
+		body.status, _ = CheckResponse(resp).(*Error)
+	}
+	resp.Body = body
 	return resp, nil
 }
 
@@ -83,23 +87,16 @@ func isParsedRequest(req *http.Request) bool {
 	return false
 }
 
-// truncatedBody is an error body cut off at the cap: what the server said, up to the limit,
-// with the status still standing.
-type truncatedBody struct {
-	io.Reader
-	closer io.Closer
-}
-
-func (b *truncatedBody) Close() error { return b.closer.Close() }
-
-// cappedBody is a success body that delivers up to the limit and fails on the first byte
-// past it.
+// cappedBody is a body that delivers up to the limit and fails on the first byte past it.
 type cappedBody struct {
 	io.ReadCloser
 	remaining int64
 	declared  int64
 	limit     int64
 	request   *http.Request
+	// status is the *Error CheckResponse built for an error response, which the refusal
+	// then carries; nil for a success.
+	status *Error
 }
 
 // Read delivers up to the limit and fails on the first byte past it. A body that is exactly
@@ -111,18 +108,36 @@ func (b *cappedBody) Read(p []byte) (int, error) {
 		return 0, nil
 	}
 	if b.remaining < 0 {
-		return 0, fmt.Errorf("%s %s: Content-Length %d: %w of %d bytes",
-			b.request.Method, b.request.URL.Path, b.declared, ErrResponseTooLarge, b.limit)
+		return 0, b.refuse(fmt.Errorf("%s %s: Content-Length %d: %w of %d bytes",
+			b.request.Method, b.request.URL.Path, b.declared, ErrResponseTooLarge, b.limit))
 	}
-	if int64(len(p)) > b.remaining+1 {
+	// Ask for one byte past what remains, so a body exactly at the limit reads to its EOF
+	// and one byte longer is caught. Compare before adding: a limit of math.MaxInt64 has
+	// no room for the extra byte.
+	if b.remaining < int64(len(p)) {
 		p = p[:b.remaining+1]
 	}
 	n, err := b.ReadCloser.Read(p)
 	if int64(n) > b.remaining {
 		n = int(b.remaining)
 		b.remaining = 0
-		return n, fmt.Errorf("%s %s: %w of %d bytes", b.request.Method, b.request.URL.Path, ErrResponseTooLarge, b.limit)
+		return n, b.refuse(fmt.Errorf("%s %s: %w of %d bytes", b.request.Method, b.request.URL.Path, ErrResponseTooLarge, b.limit))
 	}
 	b.remaining -= int64(n)
 	return n, err
+}
+
+// refuse is the error a read past the limit ends with: the refusal itself for a success,
+// and for an error response the status's own *Error with the refusal as its Cause, so
+// errors.As finds the status and errors.Is finds ErrResponseTooLarge.
+func (b *cappedBody) refuse(cause error) error {
+	if b.status == nil {
+		return cause
+	}
+	refused := *b.status
+	refused.Cause = cause
+	if refused.Hint == "" {
+		refused.Hint = cause.Error()
+	}
+	return &refused
 }

--- a/go/pkg/hey/body_limit.go
+++ b/go/pkg/hey/body_limit.go
@@ -1,0 +1,128 @@
+package hey
+
+import (
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"strings"
+)
+
+// The generated parsers read every response body with io.ReadAll before a service method
+// can apply a budget, so a server answering one entries page or one message with gigabytes
+// was a memory exhaustion for every consumer of the SDK. The bound lives in the transport
+// NewClient builds, where it covers every request the root client, an account-scoped client
+// and the generated client make: a RoundTripper that caps what a text-bearing response can
+// deliver, success and error alike, before a parser sees it.
+//
+// A success body past the limit is refused — its first read past the cap fails with
+// ErrResponseTooLarge — since a parser that buffers it would buffer it whole. An error body
+// past the limit is cut off at the cap instead: the status is what matters about an error,
+// and a refusal would hide it behind a read failure. Both happen at read time rather than at
+// the round trip: a round-trip error is one the retry loops, the SDK's and the generated
+// client's, treat as a network failure and try again, and the body would be too large again.
+//
+// Which responses are capped is decided by the request, not by what the server says it
+// answered with: the SDK asks for application/json where a generated parser or doRequest
+// will buffer the answer and for text/html where GetHTML will, and asks for */* for a blob,
+// which it streams to a destination of any size (DownloadBlob) or buffers under its own
+// MaxResponseBodyBytes (GetBlob), and for text/csv for an export. A server that labels a
+// JSON answer as a PNG is still capped; an attachment that happens to be a text file is
+// still streamed.
+
+// bodyLimitTransport wraps an http.RoundTripper so that JSON and HTML responses cannot
+// deliver more than limit decompressed bytes.
+type bodyLimitTransport struct {
+	inner http.RoundTripper
+	limit int64
+}
+
+// RoundTrip implements http.RoundTripper.
+func (t *bodyLimitTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := t.inner.RoundTrip(req)
+	if err != nil || resp == nil || resp.Body == nil || !isParsedRequest(req) {
+		return resp, err
+	}
+	if resp.StatusCode >= 400 {
+		resp.Body = &truncatedBody{Reader: io.LimitReader(resp.Body, t.limit), closer: resp.Body}
+		return resp, nil
+	}
+	remaining := t.limit
+	if resp.ContentLength > t.limit {
+		// Declared past the limit: refused on its first read, the same failure a streamed
+		// body produces once it passes the cap, so neither retry loop sees a round-trip error.
+		remaining = -1
+	}
+	resp.Body = &cappedBody{
+		ReadCloser: resp.Body,
+		remaining:  remaining,
+		declared:   resp.ContentLength,
+		limit:      t.limit,
+		request:    req,
+	}
+	return resp, nil
+}
+
+// isParsedRequest reports a request whose answer the SDK buffers and parses, by what the
+// request asked for. Anything it did not ask for as JSON or HTML — a blob's */*, an export's
+// text/csv — it handles by streaming or under its own bound.
+func isParsedRequest(req *http.Request) bool {
+	accept := req.Header.Get("Accept")
+	if accept == "" {
+		return true
+	}
+	for part := range strings.SplitSeq(accept, ",") {
+		mediaType, _, err := mime.ParseMediaType(strings.TrimSpace(part))
+		if err != nil {
+			continue
+		}
+		if mediaType == "application/json" || strings.HasSuffix(mediaType, "+json") || mediaType == "text/html" {
+			return true
+		}
+	}
+	return false
+}
+
+// truncatedBody is an error body cut off at the cap: what the server said, up to the limit,
+// with the status still standing.
+type truncatedBody struct {
+	io.Reader
+	closer io.Closer
+}
+
+func (b *truncatedBody) Close() error { return b.closer.Close() }
+
+// cappedBody is a success body that delivers up to the limit and fails on the first byte
+// past it.
+type cappedBody struct {
+	io.ReadCloser
+	remaining int64
+	declared  int64
+	limit     int64
+	request   *http.Request
+}
+
+// Read delivers up to the limit and fails on the first byte past it. A body that is exactly
+// the limit is read whole: with nothing remaining, the next read still asks the wrapped body
+// for one byte, and gets its EOF rather than a refusal. A body declared past the limit
+// starts with a negative remainder and fails on its first read.
+func (b *cappedBody) Read(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	if b.remaining < 0 {
+		return 0, fmt.Errorf("%s %s: Content-Length %d: %w of %d bytes",
+			b.request.Method, b.request.URL.Path, b.declared, ErrResponseTooLarge, b.limit)
+	}
+	if int64(len(p)) > b.remaining+1 {
+		p = p[:b.remaining+1]
+	}
+	n, err := b.ReadCloser.Read(p)
+	if int64(n) > b.remaining {
+		n = int(b.remaining)
+		b.remaining = 0
+		return n, fmt.Errorf("%s %s: %w of %d bytes", b.request.Method, b.request.URL.Path, ErrResponseTooLarge, b.limit)
+	}
+	b.remaining -= int64(n)
+	return n, err
+}

--- a/go/pkg/hey/body_limit_test.go
+++ b/go/pkg/hey/body_limit_test.go
@@ -1,0 +1,268 @@
+package hey
+
+import (
+	"compress/gzip"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// testBodyLimit caps JSON and HTML bodies at a kilobyte, which the tests overrun by a few.
+const testBodyLimit int64 = 1024
+
+// newCappedTestClient builds a client against handler with the cap at testBodyLimit and
+// the SDK's retries left on, so a refused body is shown not to be retried. The count is how
+// many requests the server saw.
+func newCappedTestClient(t *testing.T, handler http.HandlerFunc, opts ...ClientOption) (*Client, *atomic.Int32) {
+	t.Helper()
+	var hits atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		handler(w, r)
+	}))
+	t.Cleanup(server.Close)
+	opts = append([]ClientOption{
+		WithMaxResponseBodyBytes(testBodyLimit),
+		WithMaxRetries(3),
+		WithBaseDelay(time.Millisecond),
+		WithMaxJitter(time.Millisecond),
+	}, opts...)
+	return NewClient(&Config{BaseURL: server.URL}, &StaticTokenProvider{Token: "test-token"}, opts...), &hits
+}
+
+// cappedTransportClient is the transport on its own, for what the Client's own error
+// handling would otherwise hide: an error body's length, a blob's Content-Type.
+func cappedTransportClient() *http.Client {
+	return &http.Client{Transport: &bodyLimitTransport{inner: http.DefaultTransport, limit: testBodyLimit}}
+}
+
+func getAccepting(t *testing.T, client *http.Client, url, accept string) (status int, body []byte, err error) {
+	t.Helper()
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, url, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Accept", accept)
+	resp, err := client.Do(req)
+	if err != nil {
+		return 0, nil, err
+	}
+	defer resp.Body.Close()
+	body, err = io.ReadAll(resp.Body)
+	return resp.StatusCode, body, err
+}
+
+// serveOversizedJSON answers with 4 KiB of JSON, four times the test limit, declaring the
+// length or streaming it.
+func serveOversizedJSON(declare bool) http.HandlerFunc {
+	const size = 4096
+	return func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if declare {
+			w.Header().Set("Content-Length", strconv.Itoa(size))
+		}
+		flusher, _ := w.(http.Flusher)
+		body := `{"content":"` + strings.Repeat("x", size-14) + `"}`
+		for len(body) > 0 {
+			chunk := min(len(body), 64)
+			_, _ = io.WriteString(w, body[:chunk])
+			body = body[chunk:]
+			if flusher != nil && !declare {
+				flusher.Flush()
+			}
+		}
+	}
+}
+
+func TestBodyLimitPassesABodyWithinTheLimit(t *testing.T) {
+	client, hits := newCappedTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":1,"content":"short"}`)
+	})
+
+	resp, err := client.Get(context.Background(), "/messages/1.json")
+	if err != nil || string(resp.Data) != `{"id":1,"content":"short"}` {
+		t.Fatalf("data = %q, err = %v", resp.Data, err)
+	}
+	if hits.Load() != 1 {
+		t.Errorf("server saw %d requests, want 1", hits.Load())
+	}
+}
+
+// A body past the limit ends in ErrResponseTooLarge before a parser has it all, whether the
+// server declared its length or streamed it — and the request is not retried: the failure is
+// at the read, not the round trip, so the retry loop never sees a network error.
+func TestBodyLimitStopsAnOversizedBody(t *testing.T) {
+	for name, declare := range map[string]bool{"declared": true, "streamed": false} {
+		t.Run(name, func(t *testing.T) {
+			client, hits := newCappedTestClient(t, serveOversizedJSON(declare))
+
+			_, err := client.Get(context.Background(), "/messages/1.json")
+			if !errors.Is(err, ErrResponseTooLarge) {
+				t.Fatalf("err = %v, want ErrResponseTooLarge", err)
+			}
+			if hits.Load() != 1 {
+				t.Errorf("server saw %d requests, want 1: a refused body must not be retried", hits.Load())
+			}
+		})
+	}
+}
+
+// The generated parsers are what the cap exists for: they io.ReadAll a body before any
+// service method sees it. Their retry loop does not retry the refusal either.
+func TestBodyLimitStopsAnOversizedBodyBeforeTheGeneratedParser(t *testing.T) {
+	client, hits := newCappedTestClient(t, serveOversizedJSON(false))
+
+	_, err := client.Messages().Get(context.Background(), 1)
+	if !errors.Is(err, ErrResponseTooLarge) {
+		t.Fatalf("err = %v, want ErrResponseTooLarge through the generated client", err)
+	}
+	if hits.Load() != 1 {
+		t.Errorf("server saw %d requests, want 1", hits.Load())
+	}
+}
+
+// A body of exactly the limit is read whole; one byte more is refused.
+func TestBodyLimitAcceptsABodyExactlyAtTheLimit(t *testing.T) {
+	for _, size := range []int{int(testBodyLimit), int(testBodyLimit) + 1} {
+		client, _ := newCappedTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			flusher, _ := w.(http.Flusher)
+			_, _ = io.WriteString(w, strings.Repeat("x", size))
+			if flusher != nil {
+				flusher.Flush()
+			}
+		})
+		resp, err := client.Get(context.Background(), "/messages/1.json")
+		switch int64(size) {
+		case testBodyLimit:
+			if err != nil || int64(len(resp.Data)) != testBodyLimit {
+				t.Errorf("exactly at the limit: err = %v, want the whole body", err)
+			}
+		default:
+			if !errors.Is(err, ErrResponseTooLarge) {
+				t.Errorf("one past the limit: err = %v, want ErrResponseTooLarge", err)
+			}
+		}
+	}
+}
+
+// The limit counts decompressed bytes: a small gzip that inflates past it is refused.
+func TestBodyLimitCountsDecompressedBytes(t *testing.T) {
+	client, _ := newCappedTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Content-Encoding", "gzip")
+		zw := gzip.NewWriter(w)
+		_, _ = io.WriteString(zw, `{"content":"`+strings.Repeat("a", 8192)+`"}`)
+		_ = zw.Close()
+	})
+
+	_, err := client.Get(context.Background(), "/messages/1.json")
+	if !errors.Is(err, ErrResponseTooLarge) {
+		t.Fatalf("err = %v, want ErrResponseTooLarge for an inflated body", err)
+	}
+}
+
+// An error body past the limit is cut off at the limit, not refused: the status is what
+// matters about an error, and a read failure would hide it.
+func TestBodyLimitTruncatesErrorBodies(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = io.WriteString(w, `{"error":"`+strings.Repeat("e", 4096)+`"}`)
+	}))
+	t.Cleanup(server.Close)
+
+	status, body, err := getAccepting(t, cappedTransportClient(), server.URL, "application/json")
+	if err != nil {
+		t.Fatalf("err = %v, want the error body read without a refusal", err)
+	}
+	if status != http.StatusInternalServerError || int64(len(body)) != testBodyLimit {
+		t.Fatalf("status %d, %d bytes; want the status with the body cut at the limit", status, len(body))
+	}
+
+	// Through the client, the status is what the caller gets.
+	client, _ := newCappedTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_, _ = io.WriteString(w, `{"error":"`+strings.Repeat("e", 4096)+`"}`)
+	})
+	_, err = client.Get(context.Background(), "/messages/1.json")
+	var apiErr *Error
+	if !errors.As(err, &apiErr) || apiErr.HTTPStatus != http.StatusUnprocessableEntity || errors.Is(err, ErrResponseTooLarge) {
+		t.Fatalf("err = %v, want the 422 to stand", err)
+	}
+}
+
+// What is capped is decided by the request. A blob asked for with */* and an export asked
+// for with text/csv read whole whatever they turn out to be; a JSON or HTML answer is capped
+// whatever the server labels it.
+func TestBodyLimitDecidesByTheRequest(t *testing.T) {
+	serveLabelled := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", r.URL.Query().Get("type"))
+		_, _ = io.WriteString(w, strings.Repeat("%", 4096))
+	}
+
+	client, _ := newCappedTestClient(t, serveLabelled)
+	ctx := context.Background()
+	if resp, err := client.GetBlob(ctx, "/blobs/report.txt?type=text/plain"); err != nil || len(resp.Data) != 4096 {
+		t.Errorf("GetBlob: err = %v, want the whole blob", err)
+	}
+	if resp, err := client.GetCSV(ctx, "/contacts/export?type=text/csv"); err != nil || len(resp.Data) != 4096 {
+		t.Errorf("GetCSV: err = %v, want the whole export", err)
+	}
+	if _, err := client.GetHTML(ctx, "/topics/1?type=text/html"); !errors.Is(err, ErrResponseTooLarge) {
+		t.Errorf("GetHTML: err = %v, want ErrResponseTooLarge", err)
+	}
+	if _, err := client.Get(ctx, "/messages/1.json?type=image/png"); !errors.Is(err, ErrResponseTooLarge) {
+		t.Errorf("Get labelled as an image: err = %v, want ErrResponseTooLarge", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(serveLabelled))
+	t.Cleanup(server.Close)
+	for _, test := range []struct {
+		accept, contentType string
+		capped              bool
+	}{
+		{"*/*", "application/pdf", false},
+		{"*/*", "text/plain", false},
+		{"*/*", "application/json", false},
+		{"text/csv", "text/csv", false},
+		{"application/json", "application/json", true},
+		{"application/json", "image/png", true},
+		{"application/json", "application/octet-stream", true},
+		{"application/vnd.api+json", "application/json", true},
+		{"text/html", "text/html", true},
+		{"text/html, application/json;q=0.9", "text/html", true},
+		{"", "application/json", true},
+	} {
+		_, body, err := getAccepting(t, cappedTransportClient(), server.URL+"?type="+test.contentType, test.accept)
+		if capped := errors.Is(err, ErrResponseTooLarge); capped != test.capped {
+			t.Errorf("Accept %q, Content-Type %q: capped = %v (err %v, %d bytes), want %v", test.accept, test.contentType, capped, err, len(body), test.capped)
+		}
+	}
+}
+
+// 0 installs the default cap; a negative value installs none.
+func TestBodyLimitOptionDefaultsAndOptsOut(t *testing.T) {
+	defaulted, _ := newCappedTestClient(t, serveOversizedJSON(false), WithMaxResponseBodyBytes(0))
+	capped, ok := defaulted.httpClient.Transport.(*loggingTransport).inner.(*bodyLimitTransport)
+	if !ok || capped.limit != DefaultMaxResponseBodyBytes {
+		t.Fatalf("MaxResponseBodyBytes 0: transport %T, want the default cap of %d", defaulted.httpClient.Transport.(*loggingTransport).inner, DefaultMaxResponseBodyBytes)
+	}
+
+	uncapped, _ := newCappedTestClient(t, serveOversizedJSON(false), WithMaxResponseBodyBytes(-1))
+	if _, ok := uncapped.httpClient.Transport.(*loggingTransport).inner.(*bodyLimitTransport); ok {
+		t.Fatal("MaxResponseBodyBytes -1: a cap was installed")
+	}
+	if resp, err := uncapped.Get(context.Background(), "/messages/1.json"); err != nil || len(resp.Data) != 4096 {
+		t.Fatalf("uncapped: err = %v, want the whole body", err)
+	}
+}

--- a/go/pkg/hey/body_limit_test.go
+++ b/go/pkg/hey/body_limit_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -170,34 +171,80 @@ func TestBodyLimitCountsDecompressedBytes(t *testing.T) {
 	}
 }
 
-// An error body past the limit is cut off at the limit, not refused: the status is what
-// matters about an error, and a read failure would hide it.
-func TestBodyLimitTruncatesErrorBodies(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+// serveErrorJSON answers status with a JSON error body of the given size.
+func serveErrorJSON(status, size int) http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusInternalServerError)
-		_, _ = io.WriteString(w, `{"error":"`+strings.Repeat("e", 4096)+`"}`)
-	}))
-	t.Cleanup(server.Close)
-
-	status, body, err := getAccepting(t, cappedTransportClient(), server.URL, "application/json")
-	if err != nil {
-		t.Fatalf("err = %v, want the error body read without a refusal", err)
+		w.Header().Set("X-Request-Id", "req-7f3a")
+		w.WriteHeader(status)
+		_, _ = io.WriteString(w, `{"error":"`+strings.Repeat("e", size-12)+`"}`)
 	}
-	if status != http.StatusInternalServerError || int64(len(body)) != testBodyLimit {
-		t.Fatalf("status %d, %d bytes; want the status with the body cut at the limit", status, len(body))
-	}
+}
 
-	// Through the client, the status is what the caller gets.
-	client, _ := newCappedTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusUnprocessableEntity)
-		_, _ = io.WriteString(w, `{"error":"`+strings.Repeat("e", 4096)+`"}`)
-	})
-	_, err = client.Get(context.Background(), "/messages/1.json")
+// An error body past the limit is refused like a success body, but the refusal is the
+// status's own *Error with ErrResponseTooLarge as its cause. The generated parsers decode a
+// modeled error payload before a service wrapper reaches CheckResponse, so a body merely cut
+// off at the cap would reach the caller as a JSON syntax error with no status on it.
+func TestBodyLimitRefusesAnErrorBodyWithItsStatus(t *testing.T) {
+	client, hits := newCappedTestClient(t, serveErrorJSON(http.StatusUnauthorized, 4096))
+
+	_, err := client.Messages().Get(context.Background(), 1)
 	var apiErr *Error
-	if !errors.As(err, &apiErr) || apiErr.HTTPStatus != http.StatusUnprocessableEntity || errors.Is(err, ErrResponseTooLarge) {
-		t.Fatalf("err = %v, want the 422 to stand", err)
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("err = %v (%T), want a *Error through the generated client", err, err)
+	}
+	if apiErr.HTTPStatus != http.StatusUnauthorized || apiErr.Code != CodeAuth || apiErr.RequestID != "req-7f3a" {
+		t.Errorf("err = %+v, want the 401's code, status and request id", apiErr)
+	}
+	if !errors.Is(err, ErrResponseTooLarge) {
+		t.Errorf("err = %v, want ErrResponseTooLarge as the cause", err)
+	}
+	if hits.Load() != 1 {
+		t.Errorf("server saw %d requests, want 1", hits.Load())
+	}
+
+	// A 5xx is the same refusal, retryable as the status is; read through the transport
+	// alone, since both clients' retry loops would wait out their backoff on a 500 first.
+	server := httptest.NewServer(serveErrorJSON(http.StatusInternalServerError, 4096))
+	t.Cleanup(server.Close)
+	status, _, err := getAccepting(t, cappedTransportClient(), server.URL, "application/json")
+	if !errors.As(err, &apiErr) || apiErr.HTTPStatus != http.StatusInternalServerError || !apiErr.Retryable || !errors.Is(err, ErrResponseTooLarge) {
+		t.Errorf("status %d, err = %v, want the 500's *Error wrapping ErrResponseTooLarge", status, err)
+	}
+}
+
+// An error body within the limit reads whole and is handled as it always was: the generated
+// parser decodes it and CheckResponse reports the status, with no refusal in sight.
+func TestBodyLimitPassesAnErrorBodyWithinTheLimit(t *testing.T) {
+	client, _ := newCappedTestClient(t, serveErrorJSON(http.StatusNotFound, 64))
+
+	_, err := client.Messages().Get(context.Background(), 1)
+	var apiErr *Error
+	if !errors.As(err, &apiErr) || apiErr.HTTPStatus != http.StatusNotFound || apiErr.Code != CodeNotFound {
+		t.Fatalf("err = %v, want the 404", err)
+	}
+	if errors.Is(err, ErrResponseTooLarge) {
+		t.Errorf("err = %v, want no refusal for a body within the limit", err)
+	}
+
+	// The hand-written path reads what it can of an error body and reports the status
+	// either way, within the limit or past it.
+	for _, size := range []int{64, 4096} {
+		client, _ := newCappedTestClient(t, serveErrorJSON(http.StatusUnprocessableEntity, size))
+		_, err := client.Get(context.Background(), "/messages/1.json")
+		if !errors.As(err, &apiErr) || apiErr.HTTPStatus != http.StatusUnprocessableEntity {
+			t.Errorf("%d-byte 422 body: err = %v, want the 422 to stand", size, err)
+		}
+	}
+}
+
+// The largest cap an int64 holds must not overflow the one extra byte a read asks for.
+func TestBodyLimitAcceptsTheLargestCap(t *testing.T) {
+	client, _ := newCappedTestClient(t, serveOversizedJSON(false), WithMaxResponseBodyBytes(math.MaxInt64))
+
+	resp, err := client.Get(context.Background(), "/messages/1.json")
+	if err != nil || len(resp.Data) != 4096 {
+		t.Fatalf("err = %v, %d bytes; want the whole body under a cap of math.MaxInt64", err, len(resp.Data))
 	}
 }
 
@@ -250,19 +297,71 @@ func TestBodyLimitDecidesByTheRequest(t *testing.T) {
 	}
 }
 
-// 0 installs the default cap; a negative value installs none.
-func TestBodyLimitOptionDefaultsAndOptsOut(t *testing.T) {
-	defaulted, _ := newCappedTestClient(t, serveOversizedJSON(false), WithMaxResponseBodyBytes(0))
-	capped, ok := defaulted.httpClient.Transport.(*loggingTransport).inner.(*bodyLimitTransport)
-	if !ok || capped.limit != DefaultMaxResponseBodyBytes {
-		t.Fatalf("MaxResponseBodyBytes 0: transport %T, want the default cap of %d", defaulted.httpClient.Transport.(*loggingTransport).inner, DefaultMaxResponseBodyBytes)
+// 0 and a negative value both install the default cap: there is no opting out.
+func TestBodyLimitOptionDefaults(t *testing.T) {
+	for _, configured := range []int64{0, -1} {
+		client, _ := newCappedTestClient(t, serveOversizedJSON(false), WithMaxResponseBodyBytes(configured))
+		inner := client.httpClient.Transport.(*loggingTransport).inner
+		capped, ok := inner.(*bodyLimitTransport)
+		if !ok || capped.limit != DefaultMaxResponseBodyBytes {
+			t.Errorf("MaxResponseBodyBytes %d: transport %T, want the default cap of %d", configured, inner, DefaultMaxResponseBodyBytes)
+		}
+	}
+}
+
+// What singleRequest buffers is bounded by the request's kind: a parsed answer at the
+// configured cap the transport already holds it to, so no second bound refuses it below
+// that; anything else at the 50 MiB constant.
+func TestBufferBoundFollowsTheRequest(t *testing.T) {
+	client, _ := newCappedTestClient(t, serveOversizedJSON(false))
+	for accept, want := range map[string]int64{
+		"application/json":         testBodyLimit,
+		"application/vnd.api+json": testBodyLimit,
+		"text/html":                testBodyLimit,
+		"":                         testBodyLimit,
+		"*/*":                      MaxResponseBodyBytes,
+		"text/csv":                 MaxResponseBodyBytes,
+	} {
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://app.hey.com/messages/1.json", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if accept != "" {
+			req.Header.Set("Accept", accept)
+		}
+		if got := client.bufferBound(req); got != want {
+			t.Errorf("Accept %q: bound %d, want %d", accept, got, want)
+		}
+	}
+}
+
+// A cached body is held to the cap too. The transport never saw it — a client with a
+// higher cap, or an older SDK with none, wrote it — so a 304 that would hand it back is
+// refused the same way the live answer would have been.
+func TestBodyLimitRefusesACachedBodyPastTheCap(t *testing.T) {
+	const etag = `"v1"`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("If-None-Match") == etag {
+			w.WriteHeader(http.StatusNotModified)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("ETag", etag)
+		_, _ = io.WriteString(w, `{"content":"`+strings.Repeat("x", 4096)+`"}`)
+	}))
+	t.Cleanup(server.Close)
+
+	cache := NewCache(t.TempDir())
+	newClient := func(limit int64) *Client {
+		return NewClient(&Config{BaseURL: server.URL}, &StaticTokenProvider{Token: "test-token"},
+			WithMaxRetries(0), WithCache(cache), WithMaxResponseBodyBytes(limit))
+	}
+	if resp, err := newClient(1<<20).Get(context.Background(), "/messages/1.json"); err != nil || resp.FromCache {
+		t.Fatalf("seeding the cache: err = %v, from cache %v", err, resp != nil && resp.FromCache)
 	}
 
-	uncapped, _ := newCappedTestClient(t, serveOversizedJSON(false), WithMaxResponseBodyBytes(-1))
-	if _, ok := uncapped.httpClient.Transport.(*loggingTransport).inner.(*bodyLimitTransport); ok {
-		t.Fatal("MaxResponseBodyBytes -1: a cap was installed")
-	}
-	if resp, err := uncapped.Get(context.Background(), "/messages/1.json"); err != nil || len(resp.Data) != 4096 {
-		t.Fatalf("uncapped: err = %v, want the whole body", err)
+	_, err := newClient(testBodyLimit).Get(context.Background(), "/messages/1.json")
+	if !errors.Is(err, ErrResponseTooLarge) {
+		t.Fatalf("err = %v, want ErrResponseTooLarge for a cached body past the cap", err)
 	}
 }

--- a/go/pkg/hey/client.go
+++ b/go/pkg/hey/client.go
@@ -190,9 +190,7 @@ func NewClient(cfg *Config, tokenProvider TokenProvider, opts ...ClientOption) *
 		// The cap sits inside the logging transport, so logging and hooks see every round
 		// trip, and outside the transport that negotiated the encoding, so it counts the
 		// decompressed bytes a parser would buffer.
-		if limit := c.httpOpts.responseBodyLimit(); limit > 0 {
-			transport = &bodyLimitTransport{inner: transport, limit: limit}
-		}
+		transport = &bodyLimitTransport{inner: transport, limit: c.httpOpts.responseBodyLimit()}
 		transport = &loggingTransport{inner: transport, client: c}
 
 		c.httpClient = &http.Client{
@@ -703,6 +701,12 @@ func (c *Client) singleRequest(ctx context.Context, method, url string, body any
 			c.logger.Debug("cache hit", "status", 304)
 			cached := c.cache.GetBody(cacheKey)
 			if cached != nil {
+				// Written by a client with a higher cap, or an older SDK with none: the
+				// transport never saw it, so it is held to the bound here.
+				if bound := c.bufferBound(req); int64(len(cached)) > bound {
+					return nil, fmt.Errorf("%s %s: cached response of %d bytes: %w of %d bytes",
+						method, req.URL.Path, len(cached), ErrResponseTooLarge, bound)
+				}
 				return &Response{
 					Data:       cached,
 					StatusCode: http.StatusOK,
@@ -721,7 +725,7 @@ func (c *Client) singleRequest(ctx context.Context, method, url string, body any
 			}
 			return &Response{StatusCode: resp.StatusCode, Headers: resp.Header}, nil
 		}
-		respBody, err := limitedReadAll(resp.Body, MaxResponseBodyBytes)
+		respBody, err := limitedReadAll(resp.Body, c.bufferBound(req))
 		if err != nil {
 			return nil, fmt.Errorf("failed to read response: %w", err)
 		}
@@ -795,6 +799,19 @@ func (c *Client) singleRequest(ctx context.Context, method, url string, body any
 		}
 		return nil, ErrAPI(resp.StatusCode, fmt.Sprintf("Request failed (HTTP %d)", resp.StatusCode))
 	}
+}
+
+// bufferBound is the most singleRequest buffers of an answer to req. A parsed request —
+// JSON, HTML — is already capped in the transport at the configured limit, so the bound here
+// is that same limit: a second, smaller one would refuse an answer below the cap the caller
+// configured, and the same number still holds for a client built with WithHTTPClient, which
+// has no transport cap. Anything else — a blob, an export — is bounded at the 50 MiB
+// MaxResponseBodyBytes constant.
+func (c *Client) bufferBound(req *http.Request) int64 {
+	if isParsedRequest(req) {
+		return c.httpOpts.responseBodyLimit()
+	}
+	return MaxResponseBodyBytes
 }
 
 func (c *Client) buildURL(path string) (string, error) {

--- a/go/pkg/hey/client.go
+++ b/go/pkg/hey/client.go
@@ -121,7 +121,10 @@ func (r *Response) UnmarshalData(v any) error {
 // ClientOption configures a Client.
 type ClientOption func(*Client)
 
-// WithHTTPClient sets a custom HTTP client.
+// WithHTTPClient sets a custom HTTP client. It replaces the one NewClient would build, so
+// none of what that one carries — the request timeout, credential stripping on cross-origin
+// redirects, the response body cap, logging and hooks — applies to it. WithTransport keeps
+// all of that and swaps only the transport underneath.
 func WithHTTPClient(c *http.Client) ClientOption {
 	return func(client *Client) {
 		client.httpClient = c
@@ -184,6 +187,12 @@ func NewClient(cfg *Config, tokenProvider TokenProvider, opts ...ClientOption) *
 			transport = newDefaultTransport()
 		}
 
+		// The cap sits inside the logging transport, so logging and hooks see every round
+		// trip, and outside the transport that negotiated the encoding, so it counts the
+		// decompressed bytes a parser would buffer.
+		if limit := c.httpOpts.responseBodyLimit(); limit > 0 {
+			transport = &bodyLimitTransport{inner: transport, limit: limit}
+		}
 		transport = &loggingTransport{inner: transport, client: c}
 
 		c.httpClient = &http.Client{
@@ -474,7 +483,9 @@ func (c *Client) doBodyRequest(ctx context.Context, method, path, contentType st
 		}, nil
 
 	case resp.StatusCode >= 200 && resp.StatusCode < 300:
-		responseBody, err := io.ReadAll(resp.Body)
+		// Asked for with */*, so the transport's cap does not apply; bound it here as
+		// singleRequest bounds its own reads.
+		responseBody, err := limitedReadAll(resp.Body, MaxResponseBodyBytes)
 		if err != nil {
 			return nil, ErrNetwork(err)
 		}

--- a/go/pkg/hey/doc.go
+++ b/go/pkg/hey/doc.go
@@ -102,9 +102,12 @@
 //	    }
 //	}
 //
-// JSON and HTML response bodies are capped at [WithMaxResponseBodyBytes] (16 MiB of
-// decompressed body by default). A body past the cap fails with an error that wraps
-// [ErrResponseTooLarge], and is not retried; blobs and CSV exports are not capped.
+// JSON and HTML response bodies are capped in the transport at [WithMaxResponseBodyBytes]
+// (16 MiB of decompressed body by default), success and error responses alike. A body past
+// the cap fails with an error that wraps [ErrResponseTooLarge] and is not retried; a refused
+// error response still carries its status in the [Error] the read fails with. Buffered blob
+// and CSV answers ([Client.GetBlob], [Client.GetCSV]) are bounded by the 50 MiB
+// [MaxResponseBodyBytes] constant instead; only [Client.DownloadBlob] reads without a bound.
 //
 // # Thread Safety
 //

--- a/go/pkg/hey/doc.go
+++ b/go/pkg/hey/doc.go
@@ -102,6 +102,10 @@
 //	    }
 //	}
 //
+// JSON and HTML response bodies are capped at [WithMaxResponseBodyBytes] (16 MiB of
+// decompressed body by default). A body past the cap fails with an error that wraps
+// [ErrResponseTooLarge], and is not retried; blobs and CSV exports are not capped.
+//
 // # Thread Safety
 //
 // The Client is safe for concurrent use after construction.

--- a/go/pkg/hey/errors.go
+++ b/go/pkg/hey/errors.go
@@ -22,7 +22,11 @@ var (
 // form or multipart answer at the 50 MiB MaxResponseBodyBytes constant. It reaches the
 // caller wrapped, so test for it with errors.Is. An error response refused this way still
 // carries its status: the error is the *Error CheckResponse builds for the status, with the
-// refusal as its Cause, so errors.As finds the HTTPStatus and errors.Is finds this.
+// refusal as its Cause, so errors.As finds the HTTPStatus and errors.Is finds this. The
+// refusal reaches whoever reads the body. The generated parsers read every body, so a
+// service method answers with it; the raw Get and GetHTML answer an error status without
+// reading its body, so there the status error stands alone and the oversized body is simply
+// never buffered — which is what the bound is for.
 var ErrResponseTooLarge = errors.New("response body exceeded the size limit")
 
 // Error codes for API responses.

--- a/go/pkg/hey/errors.go
+++ b/go/pkg/hey/errors.go
@@ -16,9 +16,13 @@ var (
 	ErrRateLimited = errors.New("rate limit exceeded")
 )
 
-// ErrResponseTooLarge is the error a JSON or HTML response body ends with once it passes
-// the client's MaxResponseBodyBytes. It reaches the caller wrapped, so test for it with
-// errors.Is.
+// ErrResponseTooLarge is the error a response body ends with once it passes the bound it
+// reads under: a JSON or HTML body, success or error alike, at the client's configured
+// MaxResponseBodyBytes (HTTPOptions, WithMaxResponseBodyBytes), and a buffered blob, export,
+// form or multipart answer at the 50 MiB MaxResponseBodyBytes constant. It reaches the
+// caller wrapped, so test for it with errors.Is. An error response refused this way still
+// carries its status: the error is the *Error CheckResponse builds for the status, with the
+// refusal as its Cause, so errors.As finds the HTTPStatus and errors.Is finds this.
 var ErrResponseTooLarge = errors.New("response body exceeded the size limit")
 
 // Error codes for API responses.

--- a/go/pkg/hey/errors.go
+++ b/go/pkg/hey/errors.go
@@ -16,6 +16,11 @@ var (
 	ErrRateLimited = errors.New("rate limit exceeded")
 )
 
+// ErrResponseTooLarge is the error a JSON or HTML response body ends with once it passes
+// the client's MaxResponseBodyBytes. It reaches the caller wrapped, so test for it with
+// errors.Is.
+var ErrResponseTooLarge = errors.New("response body exceeded the size limit")
+
 // Error codes for API responses.
 const (
 	CodeUsage      = "usage"

--- a/go/pkg/hey/http.go
+++ b/go/pkg/hey/http.go
@@ -13,6 +13,12 @@ const (
 	DefaultMaxJitter  = 100 * time.Millisecond
 	DefaultTimeout    = 30 * time.Second
 	DefaultMaxPages   = 10000
+
+	// DefaultMaxResponseBodyBytes is the most a JSON or HTML response may deliver, in
+	// decompressed bytes: 16 MiB, which is a message with a very large HTML body several
+	// times over, and small enough that a server answering one page with gigabytes is
+	// refused long before it exhausts memory.
+	DefaultMaxResponseBodyBytes int64 = 16 << 20
 )
 
 // HTTPOptions configures the HTTP client behavior.
@@ -35,16 +41,37 @@ type HTTPOptions struct {
 	// Transport is the HTTP transport to use. If nil, a default transport
 	// with sensible connection pooling is created.
 	Transport http.RoundTripper
+
+	// MaxResponseBodyBytes is the most a JSON or HTML response body may deliver, in
+	// decompressed bytes, before its read fails with ErrResponseTooLarge (default:
+	// DefaultMaxResponseBodyBytes). 0 means the default; a negative value disables the
+	// cap, for consumers that bound their reads themselves. Blob (*/*) and CSV answers are
+	// never capped: GetBlob buffers under MaxResponseBodyBytes and DownloadBlob streams.
+	MaxResponseBodyBytes int64
 }
 
 // DefaultHTTPOptions returns HTTPOptions with sensible defaults.
 func DefaultHTTPOptions() HTTPOptions {
 	return HTTPOptions{
-		Timeout:    DefaultTimeout,
-		MaxRetries: DefaultMaxRetries,
-		BaseDelay:  DefaultBaseDelay,
-		MaxJitter:  DefaultMaxJitter,
-		MaxPages:   DefaultMaxPages,
+		Timeout:              DefaultTimeout,
+		MaxRetries:           DefaultMaxRetries,
+		BaseDelay:            DefaultBaseDelay,
+		MaxJitter:            DefaultMaxJitter,
+		MaxPages:             DefaultMaxPages,
+		MaxResponseBodyBytes: DefaultMaxResponseBodyBytes,
+	}
+}
+
+// responseBodyLimit is the cap NewClient installs: the configured MaxResponseBodyBytes,
+// the default when it is 0, and 0 — no cap — when it is negative.
+func (o HTTPOptions) responseBodyLimit() int64 {
+	switch {
+	case o.MaxResponseBodyBytes == 0:
+		return DefaultMaxResponseBodyBytes
+	case o.MaxResponseBodyBytes < 0:
+		return 0
+	default:
+		return o.MaxResponseBodyBytes
 	}
 }
 
@@ -83,10 +110,21 @@ func WithMaxPages(n int) ClientOption {
 	}
 }
 
-// WithTransport sets a custom HTTP transport.
+// WithTransport sets a custom HTTP transport. The SDK still wraps it with its own
+// response body cap, logging and hooks; WithHTTPClient is the option that replaces all of
+// that.
 func WithTransport(t http.RoundTripper) ClientOption {
 	return func(c *Client) {
 		c.httpOpts.Transport = t
+	}
+}
+
+// WithMaxResponseBodyBytes sets the most a JSON or HTML response body may deliver, in
+// decompressed bytes, before its read fails with ErrResponseTooLarge. 0 restores
+// DefaultMaxResponseBodyBytes; a negative value disables the cap.
+func WithMaxResponseBodyBytes(n int64) ClientOption {
+	return func(c *Client) {
+		c.httpOpts.MaxResponseBodyBytes = n
 	}
 }
 

--- a/go/pkg/hey/http.go
+++ b/go/pkg/hey/http.go
@@ -43,10 +43,16 @@ type HTTPOptions struct {
 	Transport http.RoundTripper
 
 	// MaxResponseBodyBytes is the most a JSON or HTML response body may deliver, in
-	// decompressed bytes, before its read fails with ErrResponseTooLarge (default:
-	// DefaultMaxResponseBodyBytes). 0 means the default; a negative value disables the
-	// cap, for consumers that bound their reads themselves. Blob (*/*) and CSV answers are
-	// never capped: GetBlob buffers under MaxResponseBodyBytes and DownloadBlob streams.
+	// decompressed bytes, before its read fails with an error wrapping ErrResponseTooLarge —
+	// success and error responses alike; a refused error body still carries its status. 0
+	// or a negative value means DefaultMaxResponseBodyBytes: the cap is always installed.
+	// The transport applies it; a client built with WithHTTPClient keeps it only on Get and
+	// GetHTML, which bound their own buffering at the same number, not on the service
+	// methods.
+	//
+	// Blob (*/*) and CSV answers are not capped here: GetBlob and GetCSV buffer under the
+	// 50 MiB MaxResponseBodyBytes constant instead, and only DownloadBlob streams without
+	// a bound.
 	MaxResponseBodyBytes int64
 }
 
@@ -62,17 +68,14 @@ func DefaultHTTPOptions() HTTPOptions {
 	}
 }
 
-// responseBodyLimit is the cap NewClient installs: the configured MaxResponseBodyBytes,
-// the default when it is 0, and 0 — no cap — when it is negative.
+// responseBodyLimit is the cap NewClient installs: the configured MaxResponseBodyBytes, or
+// the default when that is 0 or negative. There is no opting out — a consumer that wants
+// more raises the cap.
 func (o HTTPOptions) responseBodyLimit() int64 {
-	switch {
-	case o.MaxResponseBodyBytes == 0:
+	if o.MaxResponseBodyBytes <= 0 {
 		return DefaultMaxResponseBodyBytes
-	case o.MaxResponseBodyBytes < 0:
-		return 0
-	default:
-		return o.MaxResponseBodyBytes
 	}
+	return o.MaxResponseBodyBytes
 }
 
 // WithTimeout sets the HTTP request timeout.
@@ -120,8 +123,8 @@ func WithTransport(t http.RoundTripper) ClientOption {
 }
 
 // WithMaxResponseBodyBytes sets the most a JSON or HTML response body may deliver, in
-// decompressed bytes, before its read fails with ErrResponseTooLarge. 0 restores
-// DefaultMaxResponseBodyBytes; a negative value disables the cap.
+// decompressed bytes, before its read fails with an error wrapping ErrResponseTooLarge. 0
+// or a negative value restores DefaultMaxResponseBodyBytes; the cap cannot be removed.
 func WithMaxResponseBodyBytes(n int64) ClientOption {
 	return func(c *Client) {
 		c.httpOpts.MaxResponseBodyBytes = n

--- a/go/pkg/hey/http_test.go
+++ b/go/pkg/hey/http_test.go
@@ -28,9 +28,9 @@ func TestDefaultHTTPOptions(t *testing.T) {
 	}
 }
 
-// 0 asks for the default cap and a negative value for none; anything else is the cap.
+// 0 and a negative value ask for the default cap; anything else is the cap.
 func TestHTTPOptionsResponseBodyLimit(t *testing.T) {
-	for configured, want := range map[int64]int64{0: DefaultMaxResponseBodyBytes, -1: 0, 4 << 20: 4 << 20} {
+	for configured, want := range map[int64]int64{0: DefaultMaxResponseBodyBytes, -1: DefaultMaxResponseBodyBytes, 4 << 20: 4 << 20} {
 		if got := (HTTPOptions{MaxResponseBodyBytes: configured}).responseBodyLimit(); got != want {
 			t.Errorf("MaxResponseBodyBytes %d: limit %d, want %d", configured, got, want)
 		}

--- a/go/pkg/hey/http_test.go
+++ b/go/pkg/hey/http_test.go
@@ -23,6 +23,18 @@ func TestDefaultHTTPOptions(t *testing.T) {
 	if opts.MaxPages != 10000 {
 		t.Fatalf("expected 10000 max pages, got %d", opts.MaxPages)
 	}
+	if opts.MaxResponseBodyBytes != DefaultMaxResponseBodyBytes {
+		t.Fatalf("expected %d max response body bytes, got %d", DefaultMaxResponseBodyBytes, opts.MaxResponseBodyBytes)
+	}
+}
+
+// 0 asks for the default cap and a negative value for none; anything else is the cap.
+func TestHTTPOptionsResponseBodyLimit(t *testing.T) {
+	for configured, want := range map[int64]int64{0: DefaultMaxResponseBodyBytes, -1: 0, 4 << 20: 4 << 20} {
+		if got := (HTTPOptions{MaxResponseBodyBytes: configured}).responseBodyLimit(); got != want {
+			t.Errorf("MaxResponseBodyBytes %d: limit %d, want %d", configured, got, want)
+		}
+	}
 }
 
 func TestRetryableError(t *testing.T) {
@@ -61,8 +73,12 @@ func TestClientOptions(t *testing.T) {
 		WithBaseDelay(2*time.Second),
 		WithMaxJitter(50*time.Millisecond),
 		WithMaxPages(100),
+		WithMaxResponseBodyBytes(4<<20),
 	)
 
+	if c.httpOpts.MaxResponseBodyBytes != 4<<20 {
+		t.Fatalf("expected 4 MiB max response body bytes, got %d", c.httpOpts.MaxResponseBodyBytes)
+	}
 	if c.httpOpts.Timeout != 10*time.Second {
 		t.Fatalf("expected 10s timeout, got %v", c.httpOpts.Timeout)
 	}

--- a/go/pkg/hey/security.go
+++ b/go/pkg/hey/security.go
@@ -3,18 +3,26 @@ package hey
 import (
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"net/url"
 	"strings"
 )
 
 // Response body size limits. JSON and HTML answers are capped in the transport, at the
-// client's MaxResponseBodyBytes (HTTPOptions, WithMaxResponseBodyBytes; 16 MiB by default),
-// before any of these apply.
+// client's configured limit (HTTPOptions.MaxResponseBodyBytes, WithMaxResponseBodyBytes;
+// DefaultMaxResponseBodyBytes, 16 MiB, by default), before any of these apply.
 const (
 	// MaxResponseBodyBytes is the most the client buffers of a successful body the
-	// transport cap leaves alone — a blob read with GetBlob, a mutation answered to a */*
-	// request, a form or multipart answer — 50 MiB.
+	// transport cap leaves alone — a blob read with GetBlob, an export read with GetCSV, a
+	// mutation answered to a */* request, a form or multipart answer — 50 MiB. Only
+	// DownloadBlob, which streams to the caller's writer, reads without a bound. A body
+	// past it fails with an error wrapping ErrResponseTooLarge.
+	//
+	// This constant shares its name with the HTTPOptions.MaxResponseBodyBytes field and is
+	// not the same limit: the field is the configurable cap on JSON and HTML, this is the
+	// fixed bound on everything else. The name predates the field and is kept for
+	// compatibility.
 	MaxResponseBodyBytes int64 = 50 * 1024 * 1024
 	// MaxErrorBodyBytes is the maximum size for error response bodies (1 MB).
 	MaxErrorBodyBytes int64 = 1 * 1024 * 1024
@@ -22,15 +30,21 @@ const (
 	MaxErrorMessageBytes = 500
 )
 
-// limitedReadAll reads up to maxBytes from r.
+// limitedReadAll reads up to maxBytes from r, and fails with an error wrapping
+// ErrResponseTooLarge on a body longer than that.
 func limitedReadAll(r io.Reader, maxBytes int64) ([]byte, error) {
-	lr := io.LimitReader(r, maxBytes+1)
-	data, err := io.ReadAll(lr)
+	// One byte past the bound is what tells a body over it from one exactly at it. A bound
+	// of math.MaxInt64 has no room for that byte, and nothing can exceed it anyway.
+	past := maxBytes
+	if past < math.MaxInt64 {
+		past++
+	}
+	data, err := io.ReadAll(io.LimitReader(r, past))
 	if err != nil {
 		return nil, err
 	}
 	if int64(len(data)) > maxBytes {
-		return nil, fmt.Errorf("response body exceeds %d byte limit", maxBytes)
+		return nil, fmt.Errorf("%w of %d bytes", ErrResponseTooLarge, maxBytes)
 	}
 	return data, nil
 }

--- a/go/pkg/hey/security.go
+++ b/go/pkg/hey/security.go
@@ -8,9 +8,13 @@ import (
 	"strings"
 )
 
-// Response body size limits.
+// Response body size limits. JSON and HTML answers are capped in the transport, at the
+// client's MaxResponseBodyBytes (HTTPOptions, WithMaxResponseBodyBytes; 16 MiB by default),
+// before any of these apply.
 const (
-	// MaxResponseBodyBytes is the maximum size for successful API response bodies (50 MB).
+	// MaxResponseBodyBytes is the most the client buffers of a successful body the
+	// transport cap leaves alone — a blob read with GetBlob, a mutation answered to a */*
+	// request, a form or multipart answer — 50 MiB.
 	MaxResponseBodyBytes int64 = 50 * 1024 * 1024
 	// MaxErrorBodyBytes is the maximum size for error response bodies (1 MB).
 	MaxErrorBodyBytes int64 = 1 * 1024 * 1024

--- a/go/pkg/hey/security_test.go
+++ b/go/pkg/hey/security_test.go
@@ -205,8 +205,8 @@ func TestLimitedReadAll(t *testing.T) {
 
 	r2 := strings.NewReader("too long")
 	_, err = limitedReadAll(r2, 3)
-	if err == nil {
-		t.Fatal("expected error for exceeding limit")
+	if !errors.Is(err, ErrResponseTooLarge) {
+		t.Fatalf("err = %v, want ErrResponseTooLarge for exceeding the limit", err)
 	}
 }
 


### PR DESCRIPTION
SDK side of basecamp/hey-cli#248.

## What

The generated parsers read every response body with `io.ReadAll` before a service method can apply a budget, so a server answering one entries page or one message with gigabytes was a memory exhaustion for every consumer. hey-cli has been carrying an interim `RoundTripper` (`internal/cmd/sdk_transport.go`) to bound this from outside; this moves the bound into the SDK so every consumer gets it and hey-cli can drop its wrapper.

## How

`NewClient` installs a `bodyLimitTransport` inside the logging transport (logging and hooks still see every round trip) and outside the transport that negotiated the encoding (the cap counts decompressed bytes). Root, `ForAccount`-derived and generated clients all share it. `WithHTTPClient` replaces the SDK's client wholesale and so bypasses it, as documented.

- Decided by the **request's** Accept, not the response's Content-Type: `application/json`, `*+json` and `text/html` are capped; `*/*` (`GetBlob`, `DownloadBlob`, `PostMutation`/`PatchMutation`, forms) and `text/csv` are not.
- A **success** body past the limit fails on its first read past it with an error wrapping `ErrResponseTooLarge` (`errors.Is` works through the hand-written and generated paths). The failure is at read time rather than at `RoundTrip`, so neither the SDK's GET retry loop nor the generated client's `doWithRetry` treats it as a network error and fetches the same body again — the tests count server hits with retries left on. A body declared past the limit via Content-Length is refused the same way; a body of exactly the limit reads whole.
- An **error** body (status >= 400) past the limit is refused the same way, but the refusal is the `*Error` `CheckResponse` builds for the status (same Code/HTTPStatus/Retryable/RequestID) with the `ErrResponseTooLarge` error as its `Cause`, so `errors.As` finds the status and `errors.Is` finds the sentinel. The generated parsers decode a modeled error payload before a wrapper reaches `CheckResponse`, so a body merely cut off at the cap would reach the caller as a JSON syntax error with no status on it.
- `singleRequest` bounds what it buffers by the request's kind: a parsed (JSON/HTML) answer at the configured cap the transport already holds it to, so no second, smaller bound refuses below it; blobs, exports and form answers at the 50 MiB `MaxResponseBodyBytes` constant. A cached body handed back on a 304 is held to the same bound, since the transport never saw it.
- `doBodyRequest`'s 2xx form/multipart answers (asked for with `*/*`) now read under `MaxResponseBodyBytes` instead of a bare `io.ReadAll`, and `limitedReadAll`'s own refusal wraps `ErrResponseTooLarge`, so every bound a body can hit answers the same `errors.Is`.

## API

- `HTTPOptions.MaxResponseBodyBytes int64` and `WithMaxResponseBodyBytes(n int64) ClientOption`
- `DefaultMaxResponseBodyBytes int64 = 16 << 20` — the hey-cli value: a message with a very large HTML body several times over. `0` or a negative value means the default; the cap can be raised but not removed.
- `ErrResponseTooLarge` sentinel (wrapped; test with `errors.Is`).
- The existing `MaxResponseBodyBytes` (50 MiB) constant is kept and re-documented as the buffer bound for what the transport leaves alone (`GetBlob`, `GetCSV`, forms; only `DownloadBlob` is unbounded). Its name collides with the new option's and it is not the same limit; the doc says so rather than renaming a public constant.

## Tests

`body_limit_test.go` goes through a real `Client` + `httptest.Server`: within-limit passes; oversized streamed and declared bodies fail with the sentinel and are not retried (hand-written `Get` and generated `Messages().Get`); exactly-at-limit reads whole and +1 is refused; a cap of `math.MaxInt64` does not overflow; gzip inflation counts decompressed bytes; an oversized error body through `Messages().Get` yields the status-bearing `*Error` wrapping `ErrResponseTooLarge`, and a small one parses as before; `GetBlob`/`GetCSV` are uncapped in the transport while `Get`/`GetHTML` are capped, and `bufferBound` picks the bound by request kind; a cached body past the cap is refused on a 304; an Accept × Content-Type table at the transport level; `0`/negative both install the default cap. `make check` passes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps JSON and HTML response bodies in the SDK transport to prevent unbounded reads from exhausting memory. Previously reads were unbounded; now JSON/HTML bodies are capped (16 MiB default) and fail at read time when exceeding the limit; error bodies are refused with the status error carrying `ErrResponseTooLarge`.

- Installed as `bodyLimitTransport` inside logging and outside content-encoding; the cap counts decompressed bytes and logging/hooks see all traffic.
- Decided by the request Accept: `application/json`, `*+json`, `text/html` are capped; `*/*` (e.g., `GetBlob`, `DownloadBlob`, mutations/forms) and `text/csv` are not.
- Declared oversize (`Content-Length` > limit) fails on first read; exactly-at-limit reads fully; gzip counts after inflation.
- Success over the cap errors with `ErrResponseTooLarge`; the failure is at read time, so neither SDK nor generated retries re-fetch.
- Error responses (>=400) over the cap are refused with the status’s `*Error` carrying `ErrResponseTooLarge` as its Cause; on the raw `Get`/`GetHTML` paths we do not read error bodies, so callers receive the status error alone and the oversized body is never buffered.
- Buffered blobs/CSV are bounded by the 50 MiB `MaxResponseBodyBytes` constant; only `DownloadBlob` streams unbounded.
- Cached bodies returned on 304 are held to the same cap; oversize cached entries are refused. Internal buffering now follows the request: parsed answers at the configured cap; everything else at the 50 MiB constant. All bounds report `ErrResponseTooLarge`.

- Migration
  - Configure via `HTTPOptions.MaxResponseBodyBytes` or `WithMaxResponseBodyBytes(n)`. Default is 16 MiB; 0 or negative uses the default; the cap cannot be removed.
  - If you rely on larger JSON/HTML responses, raise the limit explicitly.
  - `WithHTTPClient` replaces the SDK’s client and bypasses the transport cap (and logging/hooks) for generated service methods; use `WithTransport` to keep SDK wrapping.
  - `hey-cli` can remove its interim response-size limiting `RoundTripper`.

<sup>Written for commit 232dbe7dbbdac2d52ff28e35d14597cef6b45560. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-sdk/pull/105?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

