### PR TITLE
Move topics to requested workflow stages

### DIFF
--- a/behavior-model.json
+++ b/behavior-model.json
@@ -253,6 +253,13 @@
         ]
       }
     },
+    "CreateWorkflowStaging": {
+      "idempotent": false,
+      "readonly": false,
+      "retry": {
+        "max": 0
+      }
+    },
     "DeleteBoxDesignation": {
       "idempotent": true,
       "readonly": false,
@@ -1080,6 +1087,13 @@
           429,
           503
         ]
+      }
+    },
+    "MoveWorkflowStaging": {
+      "idempotent": true,
+      "readonly": false,
+      "retry": {
+        "max": 0
       }
     },
     "MutePostings": {

--- a/behavior-model.json
+++ b/behavior-model.json
@@ -1090,7 +1090,7 @@
       }
     },
     "MoveWorkflowStaging": {
-      "idempotent": true,
+      "idempotent": false,
       "readonly": false,
       "retry": {
         "max": 0

--- a/conformance/runner/go/main.go
+++ b/conformance/runner/go/main.go
@@ -1095,6 +1095,24 @@ func executeOperation(client *generated.Client, ctx context.Context, tc TestCase
 		return client.ListSnippets(ctx)
 	case "GetWorkflow":
 		return client.GetWorkflow(ctx, getInt64Param(tc.PathParams, "workflowId"))
+	case "CreateWorkflowStaging":
+		return client.CreateWorkflowStaging(
+			ctx,
+			getInt64Param(tc.PathParams, "topicId"),
+			getInt64Param(tc.PathParams, "workflowId"),
+		)
+	case "MoveWorkflowStaging":
+		body := generated.MoveWorkflowStagingJSONRequestBody{
+			WorkflowStaging: generated.WorkflowStagingPayload{
+				WorkflowStageId: getInt64Param(tc.RequestBody, "workflow_stage_id"),
+			},
+		}
+		return client.MoveWorkflowStaging(
+			ctx,
+			getInt64Param(tc.PathParams, "topicId"),
+			getInt64Param(tc.PathParams, "workflowId"),
+			body,
+		)
 	case "ListTimeTrackCategories":
 		return client.ListTimeTrackCategories(ctx)
 	case "GetTopicPublication":

--- a/conformance/tests/paths.json
+++ b/conformance/tests/paths.json
@@ -3391,6 +3391,85 @@
     ]
   },
   {
+    "name": "CreateWorkflowStaging uses the topic workflow stagings path",
+    "description": "Verifies that CreateWorkflowStaging adds a topic through its workflow staging resource",
+    "operation": "CreateWorkflowStaging",
+    "method": "POST",
+    "path": "/topics/{topicId}/workflows/{workflowId}/stagings",
+    "pathParams": {
+      "topicId": 4471829,
+      "workflowId": 8801
+    },
+    "mockResponses": [
+      {
+        "status": 204,
+        "body": {}
+      }
+    ],
+    "assertions": [
+      {
+        "type": "requestPath",
+        "expected": "/topics/4471829/workflows/8801/stagings"
+      },
+      {
+        "type": "requestMethod",
+        "expected": "POST"
+      },
+      {
+        "type": "noError"
+      }
+    ],
+    "tags": [
+      "path",
+      "workflows",
+      "writes"
+    ]
+  },
+  {
+    "name": "MoveWorkflowStaging uses the topic workflow stagings path",
+    "description": "Verifies that MoveWorkflowStaging sends the selected stage to the topic's workflow staging resource",
+    "operation": "MoveWorkflowStaging",
+    "method": "PATCH",
+    "path": "/topics/{topicId}/workflows/{workflowId}/stagings",
+    "pathParams": {
+      "topicId": 4471829,
+      "workflowId": 8801
+    },
+    "requestBody": {
+      "workflow_stage_id": 5513
+    },
+    "mockResponses": [
+      {
+        "status": 204,
+        "body": {}
+      }
+    ],
+    "assertions": [
+      {
+        "type": "requestPath",
+        "expected": "/topics/4471829/workflows/8801/stagings"
+      },
+      {
+        "type": "requestMethod",
+        "expected": "PATCH"
+      },
+      {
+        "type": "requestBody",
+        "expected": {
+          "workflow_staging.workflow_stage_id": 5513
+        }
+      },
+      {
+        "type": "noError"
+      }
+    ],
+    "tags": [
+      "path",
+      "workflows",
+      "writes"
+    ]
+  },
+  {
     "name": "ListTimeTrackCategories uses /calendar/time_tracks/categories.json path",
     "description": "Verifies that ListTimeTrackCategories constructs the URL path /calendar/time_tracks/categories.json",
     "operation": "ListTimeTrackCategories",

--- a/go/pkg/generated/client.gen.go
+++ b/go/pkg/generated/client.gen.go
@@ -919,6 +919,11 @@ type MoveTopicRequestContent struct {
 	BoxId int64 `json:"box_id"`
 }
 
+// MoveWorkflowStagingRequestContent defines model for MoveWorkflowStagingRequestContent.
+type MoveWorkflowStagingRequestContent struct {
+	WorkflowStaging WorkflowStagingPayload `json:"workflow_staging"`
+}
+
 // NavigationIcon NavigationIcon
 type NavigationIcon struct {
 	AndroidUrl string `json:"android_url,omitempty"`
@@ -1420,6 +1425,11 @@ type WorkflowStage struct {
 	Name string `json:"name,omitempty"`
 }
 
+// WorkflowStagingPayload defines model for WorkflowStagingPayload.
+type WorkflowStagingPayload struct {
+	WorkflowStageId int64 `json:"workflow_stage_id"`
+}
+
 // SensitiveString is a string type that redacts its value in logs.
 // Used for fields marked with x-hey-sensitive in the OpenAPI spec.
 type SensitiveString string
@@ -1718,6 +1728,9 @@ type UpdateStickyJSONRequestBody = StickyRequestContent
 
 // MoveTopicJSONRequestBody defines body for MoveTopic for application/json ContentType.
 type MoveTopicJSONRequestBody = MoveTopicRequestContent
+
+// MoveWorkflowStagingJSONRequestBody defines body for MoveWorkflowStaging for application/json ContentType.
+type MoveWorkflowStagingJSONRequestBody = MoveWorkflowStagingRequestContent
 
 // RequestEditorFn is the function signature for the RequestEditor callback function
 type RequestEditorFn func(ctx context.Context, req *http.Request) error
@@ -2329,6 +2342,14 @@ type ClientInterface interface {
 
 	// TrashTopic request
 	TrashTopic(ctx context.Context, topicId int64, params *TrashTopicParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// MoveWorkflowStagingWithBody request with any body
+	MoveWorkflowStagingWithBody(ctx context.Context, topicId int64, workflowId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	MoveWorkflowStaging(ctx context.Context, topicId int64, workflowId int64, body MoveWorkflowStagingJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// CreateWorkflowStaging request
+	CreateWorkflowStaging(ctx context.Context, topicId int64, workflowId int64, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetWorkflow request
 	GetWorkflow(ctx context.Context, workflowId int64, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -4085,6 +4106,52 @@ func (c *Client) TrashTopic(ctx context.Context, topicId int64, params *TrashTop
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewTrashTopicRequest(c.Server, topicId, params)
 	}, true, "TrashTopic", reqEditors...)
+
+}
+
+// MoveWorkflowStagingWithBody executes the MoveWorkflowStaging operation.
+
+func (c *Client) MoveWorkflowStagingWithBody(ctx context.Context, topicId int64, workflowId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+
+	req, err := NewMoveWorkflowStagingRequestWithBody(c.Server, topicId, workflowId, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+
+}
+
+func (c *Client) MoveWorkflowStaging(ctx context.Context, topicId int64, workflowId int64, body MoveWorkflowStagingJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+
+	req, err := NewMoveWorkflowStagingRequest(c.Server, topicId, workflowId, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+
+}
+
+// CreateWorkflowStaging executes the CreateWorkflowStaging operation.
+
+func (c *Client) CreateWorkflowStaging(ctx context.Context, topicId int64, workflowId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
+
+	req, err := NewCreateWorkflowStagingRequest(c.Server, topicId, workflowId)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
 
 }
 
@@ -8671,6 +8738,101 @@ func NewTrashTopicRequest(server string, topicId int64, params *TrashTopicParams
 	return req, nil
 }
 
+// NewMoveWorkflowStagingRequest calls the generic MoveWorkflowStaging builder with application/json body
+func NewMoveWorkflowStagingRequest(server string, topicId int64, workflowId int64, body MoveWorkflowStagingJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewMoveWorkflowStagingRequestWithBody(server, topicId, workflowId, "application/json", bodyReader)
+}
+
+// NewMoveWorkflowStagingRequestWithBody generates requests for MoveWorkflowStaging with any type of body
+func NewMoveWorkflowStagingRequestWithBody(server string, topicId int64, workflowId int64, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "topicId", runtime.ParamLocationPath, topicId)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "workflowId", runtime.ParamLocationPath, workflowId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/topics/%s/workflows/%s/stagings", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("PATCH", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewCreateWorkflowStagingRequest generates requests for CreateWorkflowStaging
+func NewCreateWorkflowStagingRequest(server string, topicId int64, workflowId int64) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "topicId", runtime.ParamLocationPath, topicId)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "workflowId", runtime.ParamLocationPath, workflowId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/topics/%s/workflows/%s/stagings", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewGetWorkflowRequest generates requests for GetWorkflow
 func NewGetWorkflowRequest(server string, workflowId int64) (*http.Request, error) {
 	var err error
@@ -8836,6 +8998,8 @@ var operationMetadata = map[string]OperationMetadata{
 	"RestoreTopic":               {Idempotent: true, HasSensitiveParams: false},
 	"MarkTopicHam":               {Idempotent: true, HasSensitiveParams: false},
 	"TrashTopic":                 {Idempotent: true, HasSensitiveParams: false},
+	"MoveWorkflowStaging":        {Idempotent: false, HasSensitiveParams: false},
+	"CreateWorkflowStaging":      {Idempotent: false, HasSensitiveParams: false},
 	"GetWorkflow":                {Idempotent: true, HasSensitiveParams: false},
 }
 
@@ -10487,6 +10651,27 @@ type ClientWithResponsesInterface interface {
 	//
 	// Returns a wrapper object for the known response body format(s).
 	TrashTopicWithResponse(ctx context.Context, topicId int64, params *TrashTopicParams, reqEditors ...RequestEditorFn) (*TrashTopicResponse, error)
+
+	// MoveWorkflowStagingWithBodyWithResponse performs a PATCH /topics/{topicId}/workflows/{workflowId}/stagings (the `MoveWorkflowStaging` operationId) request,
+	// with any type of body and a specified content type.
+	//
+	// Move a staged topic to a workflow stage.
+	//
+	// Returns a wrapper object for the known response body format(s).
+	MoveWorkflowStagingWithBodyWithResponse(ctx context.Context, topicId int64, workflowId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*MoveWorkflowStagingResponse, error)
+
+	// MoveWorkflowStagingWithResponse performs a PATCH /topics/{topicId}/workflows/{workflowId}/stagings (the `MoveWorkflowStaging` operationId) request.
+	// Takes a body of the `application/json` content type, and returns a wrapper object for the known response body format(s).
+	//
+	// Move a staged topic to a workflow stage.
+	MoveWorkflowStagingWithResponse(ctx context.Context, topicId int64, workflowId int64, body MoveWorkflowStagingJSONRequestBody, reqEditors ...RequestEditorFn) (*MoveWorkflowStagingResponse, error)
+
+	// CreateWorkflowStagingWithResponse performs a POST /topics/{topicId}/workflows/{workflowId}/stagings (the `CreateWorkflowStaging` operationId) request.
+	//
+	// Add a topic to a workflow. HEY places it in the first stage.
+	//
+	// Returns a wrapper object for the known response body format(s).
+	CreateWorkflowStagingWithResponse(ctx context.Context, topicId int64, workflowId int64, reqEditors ...RequestEditorFn) (*CreateWorkflowStagingResponse, error)
 
 	// GetWorkflowWithResponse performs a GET /workflows/{workflowId} (the `GetWorkflow` operationId) request.
 	//
@@ -17370,6 +17555,158 @@ func (r TrashTopicResponse) ContentType() string {
 	return ""
 }
 
+type MoveWorkflowStagingResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	// JSON401 the response for an HTTP 401 `application/json` response
+	JSON401 *UnauthorizedErrorResponseContent
+	// JSON403 the response for an HTTP 403 `application/json` response
+	JSON403 *ForbiddenErrorResponseContent
+	// JSON404 the response for an HTTP 404 `application/json` response
+	JSON404 *NotFoundErrorResponseContent
+	// JSON422 the response for an HTTP 422 `application/json` response
+	JSON422 *UnprocessableEntityErrorResponseContent
+	// JSON500 the response for an HTTP 500 `application/json` response
+	JSON500 *InternalServerErrorResponseContent
+	// JSON503 the response for an HTTP 503 `application/json` response
+	JSON503 *ServiceUnavailableErrorResponseContent
+}
+
+// GetJSON401 returns the response for an HTTP 401 `application/json` response
+func (r MoveWorkflowStagingResponse) GetJSON401() *UnauthorizedErrorResponseContent {
+	return r.JSON401
+}
+
+// GetJSON403 returns the response for an HTTP 403 `application/json` response
+func (r MoveWorkflowStagingResponse) GetJSON403() *ForbiddenErrorResponseContent {
+	return r.JSON403
+}
+
+// GetJSON404 returns the response for an HTTP 404 `application/json` response
+func (r MoveWorkflowStagingResponse) GetJSON404() *NotFoundErrorResponseContent {
+	return r.JSON404
+}
+
+// GetJSON422 returns the response for an HTTP 422 `application/json` response
+func (r MoveWorkflowStagingResponse) GetJSON422() *UnprocessableEntityErrorResponseContent {
+	return r.JSON422
+}
+
+// GetJSON500 returns the response for an HTTP 500 `application/json` response
+func (r MoveWorkflowStagingResponse) GetJSON500() *InternalServerErrorResponseContent {
+	return r.JSON500
+}
+
+// GetJSON503 returns the response for an HTTP 503 `application/json` response
+func (r MoveWorkflowStagingResponse) GetJSON503() *ServiceUnavailableErrorResponseContent {
+	return r.JSON503
+}
+
+// GetBody returns the raw response body bytes
+func (r MoveWorkflowStagingResponse) GetBody() []byte {
+	return r.Body
+}
+
+// Status returns HTTPResponse.Status
+func (r MoveWorkflowStagingResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r MoveWorkflowStagingResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r MoveWorkflowStagingResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type CreateWorkflowStagingResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	// JSON401 the response for an HTTP 401 `application/json` response
+	JSON401 *UnauthorizedErrorResponseContent
+	// JSON403 the response for an HTTP 403 `application/json` response
+	JSON403 *ForbiddenErrorResponseContent
+	// JSON404 the response for an HTTP 404 `application/json` response
+	JSON404 *NotFoundErrorResponseContent
+	// JSON422 the response for an HTTP 422 `application/json` response
+	JSON422 *UnprocessableEntityErrorResponseContent
+	// JSON500 the response for an HTTP 500 `application/json` response
+	JSON500 *InternalServerErrorResponseContent
+	// JSON503 the response for an HTTP 503 `application/json` response
+	JSON503 *ServiceUnavailableErrorResponseContent
+}
+
+// GetJSON401 returns the response for an HTTP 401 `application/json` response
+func (r CreateWorkflowStagingResponse) GetJSON401() *UnauthorizedErrorResponseContent {
+	return r.JSON401
+}
+
+// GetJSON403 returns the response for an HTTP 403 `application/json` response
+func (r CreateWorkflowStagingResponse) GetJSON403() *ForbiddenErrorResponseContent {
+	return r.JSON403
+}
+
+// GetJSON404 returns the response for an HTTP 404 `application/json` response
+func (r CreateWorkflowStagingResponse) GetJSON404() *NotFoundErrorResponseContent {
+	return r.JSON404
+}
+
+// GetJSON422 returns the response for an HTTP 422 `application/json` response
+func (r CreateWorkflowStagingResponse) GetJSON422() *UnprocessableEntityErrorResponseContent {
+	return r.JSON422
+}
+
+// GetJSON500 returns the response for an HTTP 500 `application/json` response
+func (r CreateWorkflowStagingResponse) GetJSON500() *InternalServerErrorResponseContent {
+	return r.JSON500
+}
+
+// GetJSON503 returns the response for an HTTP 503 `application/json` response
+func (r CreateWorkflowStagingResponse) GetJSON503() *ServiceUnavailableErrorResponseContent {
+	return r.JSON503
+}
+
+// GetBody returns the raw response body bytes
+func (r CreateWorkflowStagingResponse) GetBody() []byte {
+	return r.Body
+}
+
+// Status returns HTTPResponse.Status
+func (r CreateWorkflowStagingResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r CreateWorkflowStagingResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r CreateWorkflowStagingResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
 type GetWorkflowResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -19317,6 +19654,45 @@ func (c *ClientWithResponses) TrashTopicWithResponse(ctx context.Context, topicI
 		return nil, err
 	}
 	return ParseTrashTopicResponse(rsp)
+}
+
+// MoveWorkflowStagingWithBodyWithResponse performs a PATCH /topics/{topicId}/workflows/{workflowId}/stagings (the `MoveWorkflowStaging` operationId) request,
+// with any type of body and a specified content type.
+//
+// Move a staged topic to a workflow stage.
+//
+// Returns a wrapper object for the known response body format(s).
+func (c *ClientWithResponses) MoveWorkflowStagingWithBodyWithResponse(ctx context.Context, topicId int64, workflowId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*MoveWorkflowStagingResponse, error) {
+	rsp, err := c.MoveWorkflowStagingWithBody(ctx, topicId, workflowId, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseMoveWorkflowStagingResponse(rsp)
+}
+
+// MoveWorkflowStagingWithResponse performs a PATCH /topics/{topicId}/workflows/{workflowId}/stagings (the `MoveWorkflowStaging` operationId) request.
+// Takes a body of the `application/json` content type, and returns a wrapper object for the known response body format(s).
+//
+// Move a staged topic to a workflow stage.
+func (c *ClientWithResponses) MoveWorkflowStagingWithResponse(ctx context.Context, topicId int64, workflowId int64, body MoveWorkflowStagingJSONRequestBody, reqEditors ...RequestEditorFn) (*MoveWorkflowStagingResponse, error) {
+	rsp, err := c.MoveWorkflowStaging(ctx, topicId, workflowId, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseMoveWorkflowStagingResponse(rsp)
+}
+
+// CreateWorkflowStagingWithResponse performs a POST /topics/{topicId}/workflows/{workflowId}/stagings (the `CreateWorkflowStaging` operationId) request.
+//
+// Add a topic to a workflow. HEY places it in the first stage.
+//
+// Returns a wrapper object for the known response body format(s).
+func (c *ClientWithResponses) CreateWorkflowStagingWithResponse(ctx context.Context, topicId int64, workflowId int64, reqEditors ...RequestEditorFn) (*CreateWorkflowStagingResponse, error) {
+	rsp, err := c.CreateWorkflowStaging(ctx, topicId, workflowId, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateWorkflowStagingResponse(rsp)
 }
 
 // GetWorkflowWithResponse performs a GET /workflows/{workflowId} (the `GetWorkflow` operationId) request.
@@ -24734,6 +25110,134 @@ func ParseTrashTopicResponse(rsp *http.Response) (*TrashTopicResponse, error) {
 			return nil, err
 		}
 		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalServerErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 503:
+		var dest ServiceUnavailableErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON503 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseMoveWorkflowStagingResponse parses an HTTP response from a MoveWorkflowStagingWithResponse call
+func ParseMoveWorkflowStagingResponse(rsp *http.Response) (*MoveWorkflowStagingResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &MoveWorkflowStagingResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case rsp.StatusCode == 200:
+		break // No content-type
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest UnauthorizedErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest ForbiddenErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFoundErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest UnprocessableEntityErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalServerErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 503:
+		var dest ServiceUnavailableErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON503 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseCreateWorkflowStagingResponse parses an HTTP response from a CreateWorkflowStagingWithResponse call
+func ParseCreateWorkflowStagingResponse(rsp *http.Response) (*CreateWorkflowStagingResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &CreateWorkflowStagingResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case rsp.StatusCode == 200:
+		break // No content-type
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest UnauthorizedErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest ForbiddenErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFoundErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest UnprocessableEntityErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest InternalServerErrorResponseContent

--- a/go/pkg/hey/client.go
+++ b/go/pkg/hey/client.go
@@ -281,6 +281,13 @@ func withJSONExtension(path string) string {
 	return path + ".json"
 }
 
+// useFormRepresentation selects the HTML representation used by form-backed operations.
+func useFormRepresentation(_ context.Context, req *http.Request) error {
+	req.URL.Path = strings.TrimSuffix(req.URL.Path, ".json")
+	req.Header.Set("Accept", "*/*")
+	return nil
+}
+
 // discardHandler is a slog.Handler that discards all log records.
 type discardHandler struct{}
 

--- a/go/pkg/hey/services_test.go
+++ b/go/pkg/hey/services_test.go
@@ -2687,14 +2687,82 @@ func TestWorkflowsService_Writes(t *testing.T) {
 		t.Fatalf("unexpected error renaming a stage: %v", err)
 	}
 
-	filer := newFormTestClient(t, "POST", "/topics/%s/workflows/%s/stagings", func(t *testing.T, values url.Values) {
+	mover := newFormTestClient(t, "PATCH", "/topics/%s/workflows/%s/stagings", func(t *testing.T, values url.Values) {
 		t.Helper()
-		if values.Get("workflow_stage_id") != "5512" {
-			t.Errorf("expected the stage id, got %q", values.Get("workflow_stage_id"))
+		if values.Get("workflow_staging[workflow_stage_id]") != "5513" {
+			t.Errorf("expected the destination stage id, got %q", values.Get("workflow_staging[workflow_stage_id]"))
 		}
-	}, "/topics/4471829")
-	if err := filer.Workflows().StageTopic(context.Background(), 4471829, 8801, 5512); err != nil {
+	}, "")
+	if err := mover.Workflows().MoveTopic(context.Background(), 4471829, 8801, 5513); err != nil {
+		t.Fatalf("unexpected error moving a staged topic: %v", err)
+	}
+}
+
+func TestWorkflowsService_StageTopicMovesToRequestedStage(t *testing.T) {
+	const stagingPath = "/topics/4471829/workflows/8801/stagings"
+	requestCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if r.URL.Path != stagingPath {
+			t.Errorf("expected path %s, got %s", stagingPath, r.URL.Path)
+		}
+		if got := r.Header.Get("Accept"); got != "*/*" {
+			t.Errorf("expected the form representation, got Accept %q", got)
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("failed to parse form: %v", err)
+		}
+
+		switch requestCount {
+		case 1:
+			if r.Method != http.MethodPost {
+				t.Errorf("expected the staging request to use POST, got %s", r.Method)
+			}
+			if len(r.PostForm) != 0 {
+				t.Errorf("expected the staging request body to be empty, got %v", r.PostForm)
+			}
+		case 2:
+			if r.Method != http.MethodPatch {
+				t.Errorf("expected the move request to use PATCH, got %s", r.Method)
+			}
+			if got := r.PostForm.Get("workflow_staging[workflow_stage_id]"); got != "5512" {
+				t.Errorf("expected the destination stage id, got %q", got)
+			}
+		default:
+			t.Errorf("unexpected request %d", requestCount)
+		}
+
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(server.Close)
+
+	client := NewClient(&Config{BaseURL: server.URL}, &StaticTokenProvider{Token: "test-token"}, WithMaxRetries(0))
+	if err := client.Workflows().StageTopic(context.Background(), 4471829, 8801, 5512); err != nil {
 		t.Fatalf("unexpected error staging a topic: %v", err)
+	}
+	if requestCount != 2 {
+		t.Fatalf("expected staging and move requests, got %d requests", requestCount)
+	}
+}
+
+func TestWorkflowsService_StageTopicSurfacesStageSelectionError(t *testing.T) {
+	requestCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		w.WriteHeader(http.StatusUnprocessableEntity)
+	}))
+	t.Cleanup(server.Close)
+
+	client := NewClient(&Config{BaseURL: server.URL}, &StaticTokenProvider{Token: "test-token"}, WithMaxRetries(0))
+	if err := client.Workflows().StageTopic(context.Background(), 4471829, 8801, 9999); err == nil {
+		t.Fatal("expected the stage-selection error to surface")
+	}
+	if requestCount != 2 {
+		t.Fatalf("expected staging and move requests, got %d requests", requestCount)
 	}
 }
 
@@ -2733,6 +2801,9 @@ func TestWorkflowsService_WriteErrorsSurface(t *testing.T) {
 	c := NewClient(&Config{BaseURL: srv.URL}, &StaticTokenProvider{Token: "t"}, WithMaxRetries(0))
 	if err := c.Workflows().Delete(context.Background(), 8801); err == nil {
 		t.Fatal("expected a 403 to surface as an error")
+	}
+	if err := c.Workflows().MoveTopic(context.Background(), 4471829, 8801, 5513); err == nil {
+		t.Fatal("expected a 403 moving a staged topic to surface as an error")
 	}
 	if err := c.Workflows().UnstageTopic(context.Background(), 4471829, 8801); err == nil {
 		t.Fatal("expected a 403 to surface as an error")

--- a/go/pkg/hey/url-routes.json
+++ b/go/pkg/hey/url-routes.json
@@ -896,6 +896,24 @@
       }
     },
     {
+      "pattern": "/topics/{topicId}/workflows/{workflowId}/stagings",
+      "resource": "Workflows",
+      "operations": {
+        "PATCH": "MoveWorkflowStaging",
+        "POST": "CreateWorkflowStaging"
+      },
+      "params": {
+        "topicId": {
+          "role": "parent",
+          "type": "int64"
+        },
+        "workflowId": {
+          "role": "parent",
+          "type": "int64"
+        }
+      }
+    },
+    {
       "pattern": "/workflows/{workflowId}",
       "resource": "Workflows",
       "operations": {

--- a/go/pkg/hey/workflows.go
+++ b/go/pkg/hey/workflows.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/url"
 	"strconv"
+	"strings"
 
 	"github.com/basecamp/hey-sdk/go/pkg/generated"
 )
@@ -190,7 +191,9 @@ func (s *WorkflowsService) DeleteStage(ctx context.Context, workflowID, stageID 
 	})
 }
 
-// StageTopic files a topic into a workflow stage.
+// StageTopic adds a topic to a workflow in the selected stage. HEY creates the workflow
+// membership before selecting the stage, so a stage-selection error leaves the topic in the
+// workflow's first stage.
 func (s *WorkflowsService) StageTopic(ctx context.Context, topicID, workflowID, stageID int64) error {
 	op := OperationInfo{
 		Service: "Workflows", Operation: "CreateWorkflowStaging",
@@ -198,12 +201,40 @@ func (s *WorkflowsService) StageTopic(ctx context.Context, topicID, workflowID, 
 	}
 
 	return s.client.instrument(ctx, op, func(ctx context.Context) error {
-		values := url.Values{}
-		values.Set("workflow_stage_id", strconv.FormatInt(stageID, 10))
-
-		_, err := s.client.PostForm(ctx, fmt.Sprintf("/topics/%d/workflows/%d/stagings", topicID, workflowID), values)
-		return err
+		resp, err := s.client.genClient().CreateWorkflowStagingWithResponse(ctx, topicID, workflowID, useFormRepresentation)
+		if err != nil {
+			return err
+		}
+		if err := CheckResponse(resp.HTTPResponse); err != nil {
+			return err
+		}
+		return s.moveTopic(ctx, topicID, workflowID, stageID)
 	})
+}
+
+// MoveTopic moves a staged topic to another workflow stage.
+func (s *WorkflowsService) MoveTopic(ctx context.Context, topicID, workflowID, stageID int64) error {
+	op := OperationInfo{
+		Service: "Workflows", Operation: "MoveWorkflowStaging",
+		ResourceType: "workflow_staging", IsMutation: true, ResourceID: topicID,
+	}
+
+	return s.client.instrument(ctx, op, func(ctx context.Context) error {
+		return s.moveTopic(ctx, topicID, workflowID, stageID)
+	})
+}
+
+func (s *WorkflowsService) moveTopic(ctx context.Context, topicID, workflowID, stageID int64) error {
+	values := url.Values{}
+	values.Set("workflow_staging[workflow_stage_id]", strconv.FormatInt(stageID, 10))
+
+	resp, err := s.client.genClient().MoveWorkflowStagingWithBodyWithResponse(
+		ctx, topicID, workflowID, "application/x-www-form-urlencoded", strings.NewReader(values.Encode()), useFormRepresentation,
+	)
+	if err != nil {
+		return err
+	}
+	return CheckResponse(resp.HTTPResponse)
 }
 
 // UnstageTopic takes a topic back off a workflow.

--- a/openapi.json
+++ b/openapi.json
@@ -8340,6 +8340,202 @@
         }
       }
     },
+    "/topics/{topicId}/workflows/{workflowId}/stagings": {
+      "patch": {
+        "description": "Move a staged topic to a workflow stage.",
+        "operationId": "MoveWorkflowStaging",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MoveWorkflowStagingRequestContent"
+              }
+            }
+          },
+          "required": true
+        },
+        "parameters": [
+          {
+            "name": "topicId",
+            "in": "path",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "required": true
+          },
+          {
+            "name": "workflowId",
+            "in": "path",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "MoveWorkflowStaging 200 response"
+          },
+          "401": {
+            "description": "UnauthorizedError 401 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedErrorResponseContent"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "ForbiddenError 403 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ForbiddenErrorResponseContent"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFoundError 404 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundErrorResponseContent"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "UnprocessableEntityError 422 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnprocessableEntityErrorResponseContent"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "InternalServerError 500 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerErrorResponseContent"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "ServiceUnavailableError 503 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceUnavailableErrorResponseContent"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Workflows"
+        ]
+      },
+      "post": {
+        "description": "Add a topic to a workflow. HEY places it in the first stage.",
+        "operationId": "CreateWorkflowStaging",
+        "parameters": [
+          {
+            "name": "topicId",
+            "in": "path",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "required": true
+          },
+          {
+            "name": "workflowId",
+            "in": "path",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "CreateWorkflowStaging 200 response"
+          },
+          "401": {
+            "description": "UnauthorizedError 401 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedErrorResponseContent"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "ForbiddenError 403 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ForbiddenErrorResponseContent"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFoundError 404 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundErrorResponseContent"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "UnprocessableEntityError 422 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnprocessableEntityErrorResponseContent"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "InternalServerError 500 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerErrorResponseContent"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "ServiceUnavailableError 503 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceUnavailableErrorResponseContent"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Workflows"
+        ]
+      }
+    },
     "/workflows/{workflowId}": {
       "get": {
         "description": "A workflow with its stages",
@@ -10535,6 +10731,17 @@
           "box_id"
         ]
       },
+      "MoveWorkflowStagingRequestContent": {
+        "type": "object",
+        "properties": {
+          "workflow_staging": {
+            "$ref": "#/components/schemas/WorkflowStagingPayload"
+          }
+        },
+        "required": [
+          "workflow_staging"
+        ]
+      },
       "NavigationIcon": {
         "type": "object",
         "description": "NavigationIcon",
@@ -11846,6 +12053,18 @@
         },
         "required": [
           "id"
+        ]
+      },
+      "WorkflowStagingPayload": {
+        "type": "object",
+        "properties": {
+          "workflow_stage_id": {
+            "type": "integer",
+            "format": "int64"
+          }
+        },
+        "required": [
+          "workflow_stage_id"
         ]
       }
     }

--- a/spec/excluded-routes.json
+++ b/spec/excluded-routes.json
@@ -3555,16 +3555,6 @@
     "reason": "phase-2: topic workflows"
   },
   {
-    "method": "PATCH",
-    "path": "/topics/{topic_id}/workflows/{workflow_id}/stagings",
-    "reason": "phase-2: topic workflows"
-  },
-  {
-    "method": "POST",
-    "path": "/topics/{topic_id}/workflows/{workflow_id}/stagings",
-    "reason": "phase-2: topic workflows"
-  },
-  {
     "method": "PUT",
     "path": "/topics/{topic_id}/workflows/{workflow_id}/stagings",
     "reason": "phase-2: topic workflows"

--- a/spec/hey.smithy
+++ b/spec/hey.smithy
@@ -3715,7 +3715,6 @@ structure CreateWorkflowStagingInput {
 }
 
 /// Move a staged topic to a workflow stage.
-@idempotent
 @http(method: "PATCH", uri: "/topics/{topicId}/workflows/{workflowId}/stagings")
 @tags(["Workflows"])
 operation MoveWorkflowStaging {

--- a/spec/hey.smithy
+++ b/spec/hey.smithy
@@ -223,6 +223,8 @@ service HEY {
         ListClips
         ListSnippets
         GetWorkflow
+        CreateWorkflowStaging
+        MoveWorkflowStaging
         GetTopicPublication
     ]
 }
@@ -3692,6 +3694,57 @@ structure GetWorkflowInput {
 structure GetWorkflowOutput {
     @required
     workflow: Workflow
+}
+
+/// Add a topic to a workflow. HEY places it in the first stage.
+@http(method: "POST", uri: "/topics/{topicId}/workflows/{workflowId}/stagings")
+@tags(["Workflows"])
+operation CreateWorkflowStaging {
+    input: CreateWorkflowStagingInput
+    errors: [UnauthorizedError, ForbiddenError, NotFoundError, UnprocessableEntityError, InternalServerError, ServiceUnavailableError]
+}
+
+structure CreateWorkflowStagingInput {
+    @httpLabel
+    @required
+    topicId: Long
+
+    @httpLabel
+    @required
+    workflowId: Long
+}
+
+/// Move a staged topic to a workflow stage.
+@idempotent
+@http(method: "PATCH", uri: "/topics/{topicId}/workflows/{workflowId}/stagings")
+@tags(["Workflows"])
+operation MoveWorkflowStaging {
+    input: MoveWorkflowStagingInput
+    errors: [UnauthorizedError, ForbiddenError, NotFoundError, UnprocessableEntityError, InternalServerError, ServiceUnavailableError]
+}
+
+structure MoveWorkflowStagingInput {
+    @httpLabel
+    @required
+    topicId: Long
+
+    @httpLabel
+    @required
+    workflowId: Long
+
+    @httpPayload
+    @required
+    body: MoveWorkflowStagingRequestContent
+}
+
+structure MoveWorkflowStagingRequestContent {
+    @required
+    workflow_staging: WorkflowStagingPayload
+}
+
+structure WorkflowStagingPayload {
+    @required
+    workflow_stage_id: Long
 }
 
 /// Whether a thread is shared with a public link, and the link

--- a/spec/route-coverage.json
+++ b/spec/route-coverage.json
@@ -100,6 +100,11 @@
     "path": "/calendar/time_tracks.json"
   },
   {
+    "method": "POST",
+    "operationId": "CreateWorkflowStaging",
+    "path": "/topics/{topicId}/workflows/{workflowId}/stagings"
+  },
+  {
     "method": "DELETE",
     "operationId": "DeleteBoxDesignation",
     "path": "/boxes/{boxId}/designations/{designationId}"
@@ -393,6 +398,11 @@
     "method": "POST",
     "operationId": "MoveTopic",
     "path": "/topics/{topicId}/moves.json"
+  },
+  {
+    "method": "PATCH",
+    "operationId": "MoveWorkflowStaging",
+    "path": "/topics/{topicId}/workflows/{workflowId}/stagings"
   },
   {
     "method": "POST",


### PR DESCRIPTION
<!-- pr-review-readiness-head: 5e3bf88de7a8cd738ff5c94c8389bf0af8ec7774 -->

Make workflow staging honor the requested stage and expose a direct move operation, so the CLI can add a thread to a chosen workflow stage and move it later. This models the form-backed POST/PATCH routes while preserving HEY’s two-step create-then-select behavior.

**Review readiness:** ✅ Yes  
**Risk:** 🟡 Medium — staging a new topic requires two server mutations, so a failed stage selection leaves the topic in the workflow’s first stage.  
**Decision:** Confirm the documented partial-failure behavior is the right SDK guarantee for HEY’s two-step endpoint.

<details>
<summary>✅ Change — workflow staging now selects and moves to the requested stage</summary>

### Before

```text
StageTopic(topic, workflow, requested stage)
└── POST workflow staging with an ignored field
    └── ❌ topic remains in the workflow’s first stage
```

### After

```text
StageTopic(topic, workflow, requested stage)
├── POST workflow staging
└── PATCH staging with workflow_staging[workflow_stage_id]
    └── ✅ topic lands in the requested stage  ← CHANGED

MoveTopic(topic, workflow, requested stage)
└── PATCH the existing staging
    └── ✅ topic moves directly
```

The Smithy model now owns both routes. The wrapper uses generated request builders and selects the HTML/form representation required by Haystack. Workflow stage moves remain explicitly non-retryable so arbitrary form-body readers are never replayed after consumption.

</details>

<details>
<summary>✅ Evidence — generated contracts, regression tests, and a real dev-server cycle pass</summary>

- ✅ The regression test asserts `StageTopic` performs POST then PATCH, sends an empty create body, and nests the destination stage field correctly.
- ✅ Conformance cases verify the generated POST/PATCH methods, paths, methods, and PATCH payload.
- ✅ A Haystack development-server smoke cycle staged a fixture topic into the second stage, verified the database stage ID, moved it to the first stage, verified again, and removed it. The temporary workflow was deleted afterward.

```text
GOWORK=off make check
# MVP gate passed — 155 conformance checks

GOWORK=off go test -race ./pkg/hey ./pkg/hey/oauth ./pkg/types
# pass
```

</details>

<details>
<summary>✅ Scope — SDK workflow staging only; no CLI behavior ships here</summary>

Included: Smithy operations, generated OpenAPI/Go artifacts, route coverage, conformance coverage, `StageTopic` correction, and the new `MoveTopic` wrapper.

Not included: workflow CLI commands, workflow/stage CRUD changes, or a server-side atomic create-in-stage endpoint.

</details>

<details>
<summary>➖ Delivery — no migration, configuration, or runtime dependency</summary>

Release this SDK change before the CLI consumes `MoveTopic`. Rollback is a normal SDK version rollback; there are no data migrations or persistent configuration changes.

</details>

<details>
<summary>⚠️ Review decision — focus on form representation and two-step failure semantics</summary>

1. Confirm generated requests correctly opt out of the global JSON representation for these HTML-form endpoints.
2. Confirm the documented partial-failure behavior is preferable to unsafe automatic rollback, since the create endpoint may find an existing staging.

</details>

<details>
<summary>✅ Review path — model, wrapper, then behavioral proof</summary>

1. [`spec/hey.smithy`](https://github.com/basecamp/hey-sdk/blob/5e3bf88de7a8cd738ff5c94c8389bf0af8ec7774/spec/hey.smithy) — operation contracts and payload shape.
2. [`go/pkg/hey/workflows.go`](https://github.com/basecamp/hey-sdk/blob/5e3bf88de7a8cd738ff5c94c8389bf0af8ec7774/go/pkg/hey/workflows.go) — create/move behavior and partial-failure guarantee.
3. [`go/pkg/hey/services_test.go`](https://github.com/basecamp/hey-sdk/blob/5e3bf88de7a8cd738ff5c94c8389bf0af8ec7774/go/pkg/hey/services_test.go) and [`conformance/tests/paths.json`](https://github.com/basecamp/hey-sdk/blob/5e3bf88de7a8cd738ff5c94c8389bf0af8ec7774/conformance/tests/paths.json) — focused and generated-contract evidence.
4. Generated artifacts and route inventories are regenerated from the Smithy additions.

**Origin and supporting links:** [HEY CLI workflow card](https://app.basecamp.com/2914079/buckets/48521764/card_tables/cards/10206892855)

</details>
