### PR TITLE
Bump the SDK to 0.12.0

### DIFF
--- a/go/pkg/hey/version.go
+++ b/go/pkg/hey/version.go
@@ -1,7 +1,7 @@
 package hey
 
 // Version is the current version of the HEY Go SDK.
-const Version = "0.11.0"
+const Version = "0.12.0"
 
 // APIVersion is the HEY API version this SDK targets.
 const APIVersion = "2026-08-21"


### PR DESCRIPTION
<!-- pr-review-readiness-head: 1018ca6ca8fa06a50f0a905783685de1f7b97c3d -->

Prepare HEY SDK v0.12.0 so the workflow-stage operations merged in #106 can be tagged and consumed by hey-cli. Runtime behavior is unchanged by this PR; it aligns the SDK’s reported version with the upcoming release tag.

**Review readiness:** ✅ Yes  
**Risk:** 🟢 Low — this changes only the SDK version constant required by the release gate.  
**Decision:** None

<details>
<summary>✅ Change — Version advances from 0.11.0 to 0.12.0</summary>

```text
SDK User-Agent version
├── Before: 0.11.0
└── After:  0.12.0  ← CHANGED
```

The API contract version remains `2026-08-21`.

</details>

<details>
<summary>✅ Evidence — release gate prerequisites and full SDK checks pass</summary>

```text
GOWORK=off make check
# MVP gate passed — 155 conformance checks
```

`go/pkg/hey/version.go` now matches the intended `v0.12.0` and `go/v0.12.0` tags.

</details>

<details>
<summary>✅ Scope — release metadata only</summary>

Included: the Go SDK version constant.

Not included: API contract changes, generated artifacts, dependencies, migrations, or configuration.

</details>

<details>
<summary>✅ Delivery — merge before creating both release tags</summary>

After merge, run `make release VERSION=0.12.0`. That gate verifies the version and pushes both tags. Rollback is publishing a corrective patch release if needed.

</details>

<details>
<summary>✅ Review path — verify the version and release intent</summary>

1. [`go/pkg/hey/version.go`](https://github.com/basecamp/hey-sdk/blob/1018ca6ca8fa06a50f0a905783685de1f7b97c3d/go/pkg/hey/version.go) — the only changed file.
2. [Workflow-stage SDK PR #106](https://github.com/basecamp/hey-sdk/pull/106) — capability included in this release.

**Origin:** [HEY CLI workflow card](https://app.basecamp.com/2914079/buckets/48521764/card_tables/cards/10206892855)

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps the HEY Go SDK version from 0.11.0 to 0.12.0 to align with the release tag so workflow-stage operations can be consumed by hey-cli. Runtime behavior is unchanged; only the reported SDK version changes.

- Only change: update Version in go/pkg/hey/version.go; APIVersion remains 2026-08-21.
- After merge, run make release VERSION=0.12.0 to publish tags.
- No API, dependency, or migration changes.

<sup>Written for commit 1018ca6ca8fa06a50f0a905783685de1f7b97c3d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-sdk/pull/107?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

