### PR TITLE
Bump the SDK to 0.13.0

### DIFF
--- a/go/pkg/hey/version.go
+++ b/go/pkg/hey/version.go
@@ -1,7 +1,7 @@
 package hey
 
 // Version is the current version of the HEY Go SDK.
-const Version = "0.12.0"
+const Version = "0.13.0"
 
 // APIVersion is the HEY API version this SDK targets.
 const APIVersion = "2026-08-21"


### PR DESCRIPTION
Release prep for v0.13.0, carrying the response-body cap from #105.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps the `hey` Go SDK version to 0.13.0 to ship the response-body cap introduced in #105. Earlier versions did not cap captured response bodies; 0.13.0 enforces a cap with no API changes.

- Rollout
  - Tag and publish v0.13.0.
  - Consumers should update to 0.13.0 to pick up the cap; no migration required.

<sup>Written for commit 4818cd293e1137ecf988c700c7445011fc976da9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-sdk/pull/108?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

