### PR TITLE
Edit a calendar todo

### DIFF
--- a/behavior-model.json
+++ b/behavior-model.json
@@ -1317,6 +1317,19 @@
         ]
       }
     },
+    "UpdateCalendarTodo": {
+      "idempotent": true,
+      "readonly": false,
+      "retry": {
+        "backoff": "exponential",
+        "base_delay_ms": 1000,
+        "max": 2,
+        "retry_on": [
+          429,
+          503
+        ]
+      }
+    },
     "UpdateClearance": {
       "idempotent": true,
       "readonly": false,

--- a/go/pkg/generated/client.gen.go
+++ b/go/pkg/generated/client.gen.go
@@ -217,6 +217,15 @@ type CalendarListPayload struct {
 // CalendarRecordingsResponse CalendarRecordingsResponse — recordings grouped by type
 type CalendarRecordingsResponse map[string][]Recording
 
+// CalendarTodoChanges Nothing here is required: a rename sends a title and leaves the day alone.
+type CalendarTodoChanges struct {
+	Focused *bool `json:"focused,omitempty"`
+
+	// StartsAt Date string (YYYY-MM-DD). The day the todo is filed on.
+	StartsAt *time.Time `json:"starts_at,omitempty,omitzero"`
+	Title    string     `json:"title,omitempty"`
+}
+
 // CalendarTodoPayload defines model for CalendarTodoPayload.
 type CalendarTodoPayload struct {
 	// StartsAt Date string (YYYY-MM-DD). Defaults to today if omitted.
@@ -1310,6 +1319,15 @@ type UnprocessableEntityErrorResponseContent struct {
 	Message string   `json:"message,omitempty"`
 }
 
+// UpdateCalendarTodoRequestContent Wire format: {calendar_todo: {title, starts_at, focused}}
+type UpdateCalendarTodoRequestContent struct {
+	// CalendarTodo Nothing here is required: a rename sends a title and leaves the day alone.
+	CalendarTodo CalendarTodoChanges `json:"calendar_todo"`
+}
+
+// UpdateCalendarTodoResponseContent Recording — polymorphic by `type` (CalendarEvent, CalendarTodo, etc.)
+type UpdateCalendarTodoResponseContent = Recording
+
 // UpdateClearanceRequestContent Wire format: {status: "approved"|"denied"} — top level, not nested under a clearance key.
 type UpdateClearanceRequestContent struct {
 	DesignationBoxId int64  `json:"designation_box_id,omitempty"`
@@ -1653,6 +1671,9 @@ type UpdateTimeTrackJSONRequestBody = UpdateTimeTrackRequestContent
 
 // CreateCalendarTodoJSONRequestBody defines body for CreateCalendarTodo for application/json ContentType.
 type CreateCalendarTodoJSONRequestBody = CreateCalendarTodoRequestContent
+
+// UpdateCalendarTodoJSONRequestBody defines body for UpdateCalendarTodo for application/json ContentType.
+type UpdateCalendarTodoJSONRequestBody = UpdateCalendarTodoRequestContent
 
 // BulkUpdateClearancesJSONRequestBody defines body for BulkUpdateClearances for application/json ContentType.
 type BulkUpdateClearancesJSONRequestBody = BulkUpdateClearancesRequestContent
@@ -2070,6 +2091,11 @@ type ClientInterface interface {
 
 	// DeleteCalendarTodo request
 	DeleteCalendarTodo(ctx context.Context, todoId int64, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UpdateCalendarTodoWithBody request with any body
+	UpdateCalendarTodoWithBody(ctx context.Context, todoId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	UpdateCalendarTodo(ctx context.Context, todoId int64, body UpdateCalendarTodoJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// UncompleteCalendarTodo request
 	UncompleteCalendarTodo(ctx context.Context, todoId int64, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -2848,6 +2874,36 @@ func (c *Client) DeleteCalendarTodo(ctx context.Context, todoId int64, reqEditor
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewDeleteCalendarTodoRequest(c.Server, todoId)
 	}, true, "DeleteCalendarTodo", reqEditors...)
+
+}
+
+// UpdateCalendarTodoWithBody executes the UpdateCalendarTodo operation.
+
+func (c *Client) UpdateCalendarTodoWithBody(ctx context.Context, todoId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+
+	req, err := NewUpdateCalendarTodoRequestWithBody(c.Server, todoId, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+
+}
+
+func (c *Client) UpdateCalendarTodo(ctx context.Context, todoId int64, body UpdateCalendarTodoJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+
+	req, err := NewUpdateCalendarTodoRequest(c.Server, todoId, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
 
 }
 
@@ -5618,6 +5674,53 @@ func NewDeleteCalendarTodoRequest(server string, todoId int64) (*http.Request, e
 	if err != nil {
 		return nil, err
 	}
+
+	return req, nil
+}
+
+// NewUpdateCalendarTodoRequest calls the generic UpdateCalendarTodo builder with application/json body
+func NewUpdateCalendarTodoRequest(server string, todoId int64, body UpdateCalendarTodoJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewUpdateCalendarTodoRequestWithBody(server, todoId, "application/json", bodyReader)
+}
+
+// NewUpdateCalendarTodoRequestWithBody generates requests for UpdateCalendarTodo with any type of body
+func NewUpdateCalendarTodoRequestWithBody(server string, todoId int64, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "todoId", runtime.ParamLocationPath, todoId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/calendar/todos/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("PATCH", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
 
 	return req, nil
 }
@@ -8924,6 +9027,7 @@ var operationMetadata = map[string]OperationMetadata{
 	"UpdateTimeTrack":            {Idempotent: true, HasSensitiveParams: false},
 	"CreateCalendarTodo":         {Idempotent: false, HasSensitiveParams: false},
 	"DeleteCalendarTodo":         {Idempotent: true, HasSensitiveParams: false},
+	"UpdateCalendarTodo":         {Idempotent: false, HasSensitiveParams: false},
 	"UncompleteCalendarTodo":     {Idempotent: true, HasSensitiveParams: false},
 	"CompleteCalendarTodo":       {Idempotent: true, HasSensitiveParams: false},
 	"ListCalendars":              {Idempotent: true, HasSensitiveParams: false},
@@ -9914,6 +10018,24 @@ type ClientWithResponsesInterface interface {
 	//
 	// Returns a wrapper object for the known response body format(s).
 	DeleteCalendarTodoWithResponse(ctx context.Context, todoId int64, reqEditors ...RequestEditorFn) (*DeleteCalendarTodoResponse, error)
+
+	// UpdateCalendarTodoWithBodyWithResponse performs a PATCH /calendar/todos/{todoId} (the `UpdateCalendarTodo` operationId) request,
+	// with any type of body and a specified content type.
+	//
+	// Edit a calendar todo. todoId is the recording's id, and every field of the payload
+	// is optional: haystack's `wrap_parameters` accepts title, focused and starts_at, and
+	// changes only what is sent.
+	//
+	// Returns a wrapper object for the known response body format(s).
+	UpdateCalendarTodoWithBodyWithResponse(ctx context.Context, todoId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateCalendarTodoResponse, error)
+
+	// UpdateCalendarTodoWithResponse performs a PATCH /calendar/todos/{todoId} (the `UpdateCalendarTodo` operationId) request.
+	// Takes a body of the `application/json` content type, and returns a wrapper object for the known response body format(s).
+	//
+	// Edit a calendar todo. todoId is the recording's id, and every field of the payload
+	// is optional: haystack's `wrap_parameters` accepts title, focused and starts_at, and
+	// changes only what is sent.
+	UpdateCalendarTodoWithResponse(ctx context.Context, todoId int64, body UpdateCalendarTodoJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateCalendarTodoResponse, error)
 
 	// UncompleteCalendarTodoWithResponse performs a DELETE /calendar/todos/{todoId}/completions (the `UncompleteCalendarTodo` operationId) request.
 	//
@@ -12758,6 +12880,82 @@ func (r DeleteCalendarTodoResponse) StatusCode() int {
 
 // ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
 func (r DeleteCalendarTodoResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type UpdateCalendarTodoResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	// JSON200 the response for an HTTP 200 `application/json` response
+	JSON200 *UpdateCalendarTodoResponseContent
+	// JSON401 the response for an HTTP 401 `application/json` response
+	JSON401 *UnauthorizedErrorResponseContent
+	// JSON404 the response for an HTTP 404 `application/json` response
+	JSON404 *NotFoundErrorResponseContent
+	// JSON422 the response for an HTTP 422 `application/json` response
+	JSON422 *UnprocessableEntityErrorResponseContent
+	// JSON500 the response for an HTTP 500 `application/json` response
+	JSON500 *InternalServerErrorResponseContent
+	// JSON503 the response for an HTTP 503 `application/json` response
+	JSON503 *ServiceUnavailableErrorResponseContent
+}
+
+// GetJSON200 returns the response for an HTTP 200 `application/json` response
+func (r UpdateCalendarTodoResponse) GetJSON200() *UpdateCalendarTodoResponseContent {
+	return r.JSON200
+}
+
+// GetJSON401 returns the response for an HTTP 401 `application/json` response
+func (r UpdateCalendarTodoResponse) GetJSON401() *UnauthorizedErrorResponseContent {
+	return r.JSON401
+}
+
+// GetJSON404 returns the response for an HTTP 404 `application/json` response
+func (r UpdateCalendarTodoResponse) GetJSON404() *NotFoundErrorResponseContent {
+	return r.JSON404
+}
+
+// GetJSON422 returns the response for an HTTP 422 `application/json` response
+func (r UpdateCalendarTodoResponse) GetJSON422() *UnprocessableEntityErrorResponseContent {
+	return r.JSON422
+}
+
+// GetJSON500 returns the response for an HTTP 500 `application/json` response
+func (r UpdateCalendarTodoResponse) GetJSON500() *InternalServerErrorResponseContent {
+	return r.JSON500
+}
+
+// GetJSON503 returns the response for an HTTP 503 `application/json` response
+func (r UpdateCalendarTodoResponse) GetJSON503() *ServiceUnavailableErrorResponseContent {
+	return r.JSON503
+}
+
+// GetBody returns the raw response body bytes
+func (r UpdateCalendarTodoResponse) GetBody() []byte {
+	return r.Body
+}
+
+// Status returns HTTPResponse.Status
+func (r UpdateCalendarTodoResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UpdateCalendarTodoResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r UpdateCalendarTodoResponse) ContentType() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Header.Get("Content-Type")
 	}
@@ -18325,6 +18523,36 @@ func (c *ClientWithResponses) DeleteCalendarTodoWithResponse(ctx context.Context
 	return ParseDeleteCalendarTodoResponse(rsp)
 }
 
+// UpdateCalendarTodoWithBodyWithResponse performs a PATCH /calendar/todos/{todoId} (the `UpdateCalendarTodo` operationId) request,
+// with any type of body and a specified content type.
+//
+// Edit a calendar todo. todoId is the recording's id, and every field of the payload
+// is optional: haystack's `wrap_parameters` accepts title, focused and starts_at, and
+// changes only what is sent.
+//
+// Returns a wrapper object for the known response body format(s).
+func (c *ClientWithResponses) UpdateCalendarTodoWithBodyWithResponse(ctx context.Context, todoId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateCalendarTodoResponse, error) {
+	rsp, err := c.UpdateCalendarTodoWithBody(ctx, todoId, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateCalendarTodoResponse(rsp)
+}
+
+// UpdateCalendarTodoWithResponse performs a PATCH /calendar/todos/{todoId} (the `UpdateCalendarTodo` operationId) request.
+// Takes a body of the `application/json` content type, and returns a wrapper object for the known response body format(s).
+//
+// Edit a calendar todo. todoId is the recording's id, and every field of the payload
+// is optional: haystack's `wrap_parameters` accepts title, focused and starts_at, and
+// changes only what is sent.
+func (c *ClientWithResponses) UpdateCalendarTodoWithResponse(ctx context.Context, todoId int64, body UpdateCalendarTodoJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateCalendarTodoResponse, error) {
+	rsp, err := c.UpdateCalendarTodo(ctx, todoId, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateCalendarTodoResponse(rsp)
+}
+
 // UncompleteCalendarTodoWithResponse performs a DELETE /calendar/todos/{todoId}/completions (the `UncompleteCalendarTodo` operationId) request.
 //
 // Uncomplete a calendar todo.
@@ -21333,6 +21561,67 @@ func ParseDeleteCalendarTodoResponse(rsp *http.Response) (*DeleteCalendarTodoRes
 			return nil, err
 		}
 		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalServerErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 503:
+		var dest ServiceUnavailableErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON503 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUpdateCalendarTodoResponse parses an HTTP response from a UpdateCalendarTodoWithResponse call
+func ParseUpdateCalendarTodoResponse(rsp *http.Response) (*UpdateCalendarTodoResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UpdateCalendarTodoResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest UpdateCalendarTodoResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest UnauthorizedErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFoundErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest UnprocessableEntityErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest InternalServerErrorResponseContent

--- a/go/pkg/hey/calendar_todos.go
+++ b/go/pkg/hey/calendar_todos.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"time"
 
 	"github.com/basecamp/hey-sdk/go/pkg/generated"
@@ -64,6 +65,69 @@ func (s *CalendarTodosService) Create(ctx context.Context, title string, startsA
 		return nil, err
 	}
 	return resp.JSON200, nil
+}
+
+// TodoChanges is what an edit changes about a todo. A zero field is left alone: the
+// server applies what it is sent and keeps the rest, so a rename carries a title and
+// says nothing about the day.
+type TodoChanges struct {
+	Title    string
+	StartsAt string // Date string (YYYY-MM-DD)
+	Focused  *bool
+}
+
+// body renders the changes as HEY takes them, wrapped under calendar_todo. As in Create,
+// starts_at goes on the wire as a bare date rather than through the generated payload,
+// which types it as a time.Time: an RFC 3339 instant at UTC midnight can land on the
+// previous day once the server casts it in the user's time zone.
+func (c TodoChanges) body() map[string]any {
+	changes := map[string]any{}
+	if c.Title != "" {
+		changes["title"] = c.Title
+	}
+	if c.StartsAt != "" {
+		changes["starts_at"] = c.StartsAt
+	}
+	if c.Focused != nil {
+		changes["focused"] = *c.Focused
+	}
+	return map[string]any{"calendar_todo": changes}
+}
+
+func (c TodoChanges) empty() bool {
+	return c.Title == "" && c.StartsAt == "" && c.Focused == nil
+}
+
+// Update edits a calendar todo. todoID is the recording's id.
+//
+// Changing nothing is refused rather than sent: an empty payload asks the server to do
+// nothing and answers as though it had done something.
+func (s *CalendarTodosService) Update(ctx context.Context, todoID int64, changes TodoChanges) (result *generated.Recording, err error) {
+	if changes.empty() {
+		return nil, fmt.Errorf("hey: update calendar todo %d: nothing to change", todoID)
+	}
+
+	op := OperationInfo{
+		Service: "CalendarTodos", Operation: "UpdateCalendarTodo",
+		ResourceType: "calendar_todo", IsMutation: true, ResourceID: todoID,
+	}
+
+	err = s.client.instrument(ctx, op, func(ctx context.Context) error {
+		payload, merr := json.Marshal(changes.body())
+		if merr != nil {
+			return merr
+		}
+		resp, rerr := s.client.genClient().UpdateCalendarTodoWithBodyWithResponse(ctx, todoID, "application/json", bytes.NewReader(payload))
+		if rerr != nil {
+			return rerr
+		}
+		if cerr := CheckResponse(resp.HTTPResponse); cerr != nil {
+			return cerr
+		}
+		result = resp.JSON200
+		return nil
+	})
+	return result, err
 }
 
 // Complete marks a calendar todo as complete.

--- a/go/pkg/hey/services_test.go
+++ b/go/pkg/hey/services_test.go
@@ -670,6 +670,79 @@ func TestCalendarTodosService_Create(t *testing.T) {
 	}
 }
 
+func TestCalendarTodosService_Update(t *testing.T) {
+	client := newMutationTestClientWithValidation(t, "PATCH", "/calendar/todos/1.json",
+		func(t *testing.T, body map[string]any) {
+			t.Helper()
+			todo, ok := body["calendar_todo"].(map[string]any)
+			if !ok {
+				t.Fatal("missing calendar_todo wrapper")
+			}
+			if todo["title"] != "Renew the passport" {
+				t.Errorf("expected title 'Renew the passport', got %v", todo["title"])
+			}
+			// A rename says nothing about the day or the focus, so the server keeps them.
+			if _, ok := todo["starts_at"]; ok {
+				t.Errorf("a rename sent starts_at: %v", todo)
+			}
+			if _, ok := todo["focused"]; ok {
+				t.Errorf("a rename sent focused: %v", todo)
+			}
+		},
+		`{"id":1,"type":"CalendarTodo","title":"Renew the passport"}`,
+	)
+
+	result, err := client.CalendarTodos().Update(context.Background(), 1, TodoChanges{Title: "Renew the passport"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+}
+
+// starts_at goes out as the bare date it was given: sent as an RFC 3339 instant at UTC
+// midnight it can land on the day before once the server reads it in the user's zone.
+func TestCalendarTodosService_UpdateSendsABareDate(t *testing.T) {
+	focused := true
+	client := newMutationTestClientWithValidation(t, "PATCH", "/calendar/todos/1.json",
+		func(t *testing.T, body map[string]any) {
+			t.Helper()
+			todo, ok := body["calendar_todo"].(map[string]any)
+			if !ok {
+				t.Fatal("missing calendar_todo wrapper")
+			}
+			if todo["starts_at"] != "2026-03-13" {
+				t.Errorf("starts_at = %v, want the bare date", todo["starts_at"])
+			}
+			if todo["focused"] != true {
+				t.Errorf("focused = %v", todo["focused"])
+			}
+		},
+		`{"id":1,"type":"CalendarTodo"}`,
+	)
+
+	if _, err := client.CalendarTodos().Update(context.Background(), 1, TodoChanges{
+		StartsAt: "2026-03-13",
+		Focused:  &focused,
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestCalendarTodosService_UpdateRefusesAnEmptyChange(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("an update that changes nothing reached the server: %s %s", r.Method, r.URL.Path)
+		w.WriteHeader(200)
+	}))
+	defer server.Close()
+
+	client := NewClient(&Config{BaseURL: server.URL}, &StaticTokenProvider{Token: "test-token"})
+	if _, err := client.CalendarTodos().Update(context.Background(), 1, TodoChanges{}); err == nil {
+		t.Fatal("an update that changes nothing was accepted")
+	}
+}
+
 func TestCalendarTodosService_Complete(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/go/pkg/hey/url-routes.json
+++ b/go/pkg/hey/url-routes.json
@@ -270,7 +270,8 @@
       "pattern": "/calendar/todos/{todoId}",
       "resource": "Calendar Todos",
       "operations": {
-        "DELETE": "DeleteCalendarTodo"
+        "DELETE": "DeleteCalendarTodo",
+        "PATCH": "UpdateCalendarTodo"
       },
       "params": {
         "todoId": {

--- a/go/pkg/hey/version.go
+++ b/go/pkg/hey/version.go
@@ -1,7 +1,7 @@
 package hey
 
 // Version is the current version of the HEY Go SDK.
-const Version = "0.13.0"
+const Version = "0.14.0"
 
 // APIVersion is the HEY API version this SDK targets.
 const APIVersion = "2026-08-21"

--- a/openapi.json
+++ b/openapi.json
@@ -2628,6 +2628,105 @@
             503
           ]
         }
+      },
+      "patch": {
+        "description": "Edit a calendar todo. todoId is the recording's id, and every field of the payload\nis optional: haystack's `wrap_parameters` accepts title, focused and starts_at, and\nchanges only what is sent.",
+        "operationId": "UpdateCalendarTodo",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateCalendarTodoRequestContent"
+              }
+            }
+          },
+          "required": true
+        },
+        "parameters": [
+          {
+            "name": "todoId",
+            "in": "path",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "UpdateCalendarTodo 200 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateCalendarTodoResponseContent"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "UnauthorizedError 401 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedErrorResponseContent"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFoundError 404 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundErrorResponseContent"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "UnprocessableEntityError 422 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnprocessableEntityErrorResponseContent"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "InternalServerError 500 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerErrorResponseContent"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "ServiceUnavailableError 503 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceUnavailableErrorResponseContent"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Calendar Todos"
+        ],
+        "x-hey-retry": {
+          "maxAttempts": 2,
+          "baseDelayMs": 1000,
+          "backoff": "exponential",
+          "retryOn": [
+            429,
+            503
+          ]
+        }
       }
     },
     "/calendar/todos/{todoId}/completions": {
@@ -9175,6 +9274,29 @@
         },
         "description": "CalendarRecordingsResponse — recordings grouped by type"
       },
+      "CalendarTodoChanges": {
+        "type": "object",
+        "description": "Nothing here is required: a rename sends a title and leaves the day alone.",
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "starts_at": {
+            "type": "string",
+            "description": "Date string (YYYY-MM-DD). The day the todo is filed on.",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": false,
+            "x-omitzero": true
+          },
+          "focused": {
+            "type": "boolean",
+            "x-go-type-skip-optional-pointer": false
+          }
+        }
+      },
       "CalendarTodoPayload": {
         "type": "object",
         "properties": {
@@ -11809,6 +11931,21 @@
             "type": "string"
           }
         }
+      },
+      "UpdateCalendarTodoRequestContent": {
+        "type": "object",
+        "description": "Wire format: {calendar_todo: {title, starts_at, focused}}",
+        "properties": {
+          "calendar_todo": {
+            "$ref": "#/components/schemas/CalendarTodoChanges"
+          }
+        },
+        "required": [
+          "calendar_todo"
+        ]
+      },
+      "UpdateCalendarTodoResponseContent": {
+        "$ref": "#/components/schemas/Recording"
       },
       "UpdateClearanceRequestContent": {
         "type": "object",

--- a/spec/excluded-routes.json
+++ b/spec/excluded-routes.json
@@ -1040,11 +1040,6 @@
     "reason": "phase-2: calendar todo management"
   },
   {
-    "method": "PATCH",
-    "path": "/calendar/todos/{id}",
-    "reason": "phase-2: calendar todo management"
-  },
-  {
     "method": "PUT",
     "path": "/calendar/todos/{id}",
     "reason": "phase-2: calendar todo management"

--- a/spec/hey.smithy
+++ b/spec/hey.smithy
@@ -102,8 +102,9 @@ service HEY {
         ListCalendars
         GetCalendarRecordings
 
-        // Calendar Todos (4 MVP)
+        // Calendar Todos (5 MVP)
         CreateCalendarTodo
+        UpdateCalendarTodo
         CompleteCalendarTodo
         UncompleteCalendarTodo
         DeleteCalendarTodo
@@ -1870,6 +1871,51 @@ structure CalendarTodoPayload {
 }
 
 structure CreateCalendarTodoOutput {
+    @required
+    recording: Recording
+}
+
+/// Edit a calendar todo. todoId is the recording's id, and every field of the payload
+/// is optional: haystack's `wrap_parameters` accepts title, focused and starts_at, and
+/// changes only what is sent.
+@idempotent
+@http(method: "PATCH", uri: "/calendar/todos/{todoId}")
+@tags(["Calendar Todos"])
+@heyRetry(maxAttempts: 2, baseDelayMs: 1000, backoff: "exponential", retryOn: [429, 503])
+operation UpdateCalendarTodo {
+    input: UpdateCalendarTodoInput
+    output: UpdateCalendarTodoOutput
+    errors: [UnauthorizedError, NotFoundError, UnprocessableEntityError, InternalServerError, ServiceUnavailableError]
+}
+
+structure UpdateCalendarTodoInput {
+    @httpLabel
+    @required
+    todoId: Long
+
+    @httpPayload
+    @required
+    body: UpdateCalendarTodoRequestContent
+}
+
+/// Wire format: {calendar_todo: {title, starts_at, focused}}
+structure UpdateCalendarTodoRequestContent {
+    @required
+    calendar_todo: CalendarTodoChanges
+}
+
+/// Nothing here is required: a rename sends a title and leaves the day alone.
+structure CalendarTodoChanges {
+    title: String
+
+    /// Date string (YYYY-MM-DD). The day the todo is filed on.
+    starts_at: String
+
+    focused: Boolean
+}
+
+/// The edited todo as a recording (haystack renders calendar/recordings/_recording).
+structure UpdateCalendarTodoOutput {
     @required
     recording: Recording
 }

--- a/spec/route-coverage.json
+++ b/spec/route-coverage.json
@@ -491,6 +491,11 @@
   },
   {
     "method": "PATCH",
+    "operationId": "UpdateCalendarTodo",
+    "path": "/calendar/todos/{todoId}"
+  },
+  {
+    "method": "PATCH",
     "operationId": "UpdateClearance",
     "path": "/clearances/{clearanceId}"
   },

--- a/spec/shape-fingerprint.json
+++ b/spec/shape-fingerprint.json
@@ -56,6 +56,7 @@
   "StartTimeTrack": "631c6e31e91d56c667db4f53df609e0006de3787de580f1f52366f8da283ec91",
   "UncompleteCalendarTodo": "2034f18325d4021bdf67313966275d25c100b11e77bcacfbcddfd3f2ab551783",
   "UncompleteHabit": "d6cbfd918a4f869bf812a29ebc40aeeb203fe88736c424701274b15c94041c43",
+  "UpdateCalendarTodo": "eefec392bce3e8bb9907f00d018fc300c5195172c0c205bf8bfdad588a5a6d5d",
   "UpdateClearance": "c1597f10d3d5f9fabcf67ee69776dfedfe3f67752799276cda904caa9440b502",
   "UpdateContact": "e02333bf4001ecc7ef74a7fef1df25e15d77cf692f31a4e61e314a0446240aaf",
   "UpdateContactNote": "8333012b045fd6fef793cc5e757cbca113eda36bc1d592a3e91a8b60abe6f2b6",


### PR DESCRIPTION
haystack has served `PATCH /calendar/todos/:id` since the todo controller was written — `wrap_parameters` takes `title`, `focused` and `starts_at`, and `changing` applies what it is sent — but the route sat on the excluded list as phase-2. So the SDK could create, complete, uncomplete and delete a todo and never rename one, and a client wanting a rename had to delete and recreate, which changes the todo's identity.

`UpdateCalendarTodo` models it, and `CalendarTodos().Update` takes a `TodoChanges` whose zero fields are left alone:

```go
_, err := client.CalendarTodos().Update(ctx, todoID, hey.TodoChanges{Title: "Renew the passport"})
```

A rename carries a title and says nothing about the day or the focus, so the server keeps them. Changing nothing is refused rather than sent — an empty payload asks the server to do nothing and answers as though it had done something.

`starts_at` goes on the wire as the bare date it was given, for the reason `Create` already documents: the generated payload types it as a `time.Time`, and an RFC 3339 instant at UTC midnight can land on the previous day once the server casts it in the user's zone.

**Version.** Bumped to 0.14.0 — 0.13.0 is already tagged and released, so this needs its own.

## Notes for review

- `PATCH /calendar/todos/{id}` came off `spec/excluded-routes.json`; the reverse drift check catches a route that is both modelled and excluded, which is how I found it. `GET` and `PUT` on the same path stay excluded.
- Regenerated per AGENTS.md: `make smithy-build`, `make url-routes`, `./scripts/generate-shape-fingerprint`, `./scripts/generate-route-coverage`, `make go-generate`.
- `make check` passes (155 conformance checks, MVP gate).

## Why now

hey-cli's TUI is growing a to-dos modal on the calendar's "Sometime this week" section — check, uncheck, add, delete and rename. Rename is the one thing it cannot do without this.