### PR TITLE
List journal entries

### DIFF
--- a/behavior-model.json
+++ b/behavior-model.json
@@ -933,6 +933,22 @@
         ]
       }
     },
+    "ListJournalEntries": {
+      "idempotent": false,
+      "pagination": {
+        "style": "link"
+      },
+      "readonly": true,
+      "retry": {
+        "backoff": "exponential",
+        "base_delay_ms": 1000,
+        "max": 3,
+        "retry_on": [
+          429,
+          503
+        ]
+      }
+    },
     "ListSnippets": {
       "idempotent": false,
       "readonly": true,

--- a/conformance/runner/go/main.go
+++ b/conformance/runner/go/main.go
@@ -1063,6 +1063,8 @@ func executeOperation(client *generated.Client, ctx context.Context, tc TestCase
 		return client.UpdateTimeTrack(ctx, timeTrackId, body)
 
 	// Journal
+	case "ListJournalEntries":
+		return client.ListJournalEntries(ctx, nil)
 	case "GetJournalEntry":
 		day := getStringParam(tc.PathParams, "day")
 		return client.GetJournalEntry(ctx, day)

--- a/conformance/tests/paths.json
+++ b/conformance/tests/paths.json
@@ -851,6 +851,38 @@
     ]
   },
   {
+    "name": "ListJournalEntries uses /calendar/journal_entries path",
+    "description": "Verifies that ListJournalEntries reads the journal feed from /calendar/journal_entries",
+    "operation": "ListJournalEntries",
+    "method": "GET",
+    "path": "/calendar/journal_entries",
+    "mockResponses": [
+      {
+        "status": 200,
+        "body": [
+          {
+            "id": 123,
+            "type": "CalendarJournalEntry",
+            "content": "Quarterly planning"
+          }
+        ]
+      }
+    ],
+    "assertions": [
+      {
+        "type": "requestPath",
+        "expected": "/calendar/journal_entries"
+      },
+      {
+        "type": "noError"
+      }
+    ],
+    "tags": [
+      "path",
+      "calendar-journal"
+    ]
+  },
+  {
     "name": "ListCalendars uses /calendars.json path",
     "description": "Verifies that ListCalendars constructs the URL path /calendars.json",
     "operation": "ListCalendars",

--- a/go/pkg/generated/client.gen.go
+++ b/go/pkg/generated/client.gen.go
@@ -819,6 +819,9 @@ type ListContactsResponseContent = []Contact
 // ListDraftsResponseContent defines model for ListDraftsResponseContent.
 type ListDraftsResponseContent = []DraftMessage
 
+// ListJournalEntriesResponseContent defines model for ListJournalEntriesResponseContent.
+type ListJournalEntriesResponseContent = []Recording
+
 // ListSnippetsResponseContent defines model for ListSnippetsResponseContent.
 type ListSnippetsResponseContent = []Snippet
 
@@ -1516,6 +1519,12 @@ type NewBulkReplyParams struct {
 	PostingIds string `form:"posting_ids" json:"posting_ids"`
 }
 
+// ListJournalEntriesParams defines parameters for ListJournalEntries.
+type ListJournalEntriesParams struct {
+	Page *string `form:"page,omitempty" json:"page,omitempty"`
+	Q    *string `form:"q,omitempty" json:"q,omitempty"`
+}
+
 // GetCalendarRecordingsParams defines parameters for GetCalendarRecordings.
 type GetCalendarRecordingsParams struct {
 	StartsOn *string `form:"starts_on,omitempty" json:"starts_on,omitempty"`
@@ -2061,6 +2070,9 @@ type ClientInterface interface {
 
 	// StopHabit request
 	StopHabit(ctx context.Context, habitId int64, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ListJournalEntries request
+	ListJournalEntries(ctx context.Context, params *ListJournalEntriesParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetOngoingTimeTrack request
 	GetOngoingTimeTrack(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -2740,6 +2752,16 @@ func (c *Client) StopHabit(ctx context.Context, habitId int64, reqEditors ...Req
 		return nil, err
 	}
 	return c.Client.Do(req)
+
+}
+
+// ListJournalEntries is marked as idempotent and will be retried on transient failures.
+
+func (c *Client) ListJournalEntries(ctx context.Context, params *ListJournalEntriesParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		return NewListJournalEntriesRequest(c.Server, params)
+	}, true, "ListJournalEntries", reqEditors...)
 
 }
 
@@ -5395,6 +5417,71 @@ func NewStopHabitRequest(server string, habitId int64) (*http.Request, error) {
 	}
 
 	req, err := http.NewRequest("POST", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewListJournalEntriesRequest generates requests for ListJournalEntries
+func NewListJournalEntriesRequest(server string, params *ListJournalEntriesParams) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/calendar/journal_entries")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.Page != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "page", runtime.ParamLocationQuery, *params.Page); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Q != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "q", runtime.ParamLocationQuery, *params.Q); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -9019,6 +9106,7 @@ var operationMetadata = map[string]OperationMetadata{
 	"UpdateHabit":                {Idempotent: false, HasSensitiveParams: false},
 	"ResumeHabit":                {Idempotent: true, HasSensitiveParams: false},
 	"StopHabit":                  {Idempotent: false, HasSensitiveParams: false},
+	"ListJournalEntries":         {Idempotent: true, HasSensitiveParams: false},
 	"GetOngoingTimeTrack":        {Idempotent: true, HasSensitiveParams: false},
 	"StartTimeTrack":             {Idempotent: false, HasSensitiveParams: false},
 	"CreateTimeTrack":            {Idempotent: false, HasSensitiveParams: false},
@@ -9935,6 +10023,14 @@ type ClientWithResponsesInterface interface {
 	//
 	// Returns a wrapper object for the known response body format(s).
 	StopHabitWithResponse(ctx context.Context, habitId int64, reqEditors ...RequestEditorFn) (*StopHabitResponse, error)
+
+	// ListJournalEntriesWithResponse performs a GET /calendar/journal_entries (the `ListJournalEntries` operationId) request.
+	//
+	// List journal entries newest first. The next page, if any, is a Link header.
+	// Pass q to search journal entry content.
+	//
+	// Returns a wrapper object for the known response body format(s).
+	ListJournalEntriesWithResponse(ctx context.Context, params *ListJournalEntriesParams, reqEditors ...RequestEditorFn) (*ListJournalEntriesResponse, error)
 
 	// GetOngoingTimeTrackWithResponse performs a GET /calendar/ongoing_time_track.json (the `GetOngoingTimeTrack` operationId) request.
 	//
@@ -12335,6 +12431,68 @@ func (r StopHabitResponse) StatusCode() int {
 
 // ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
 func (r StopHabitResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type ListJournalEntriesResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	// JSON200 the response for an HTTP 200 `application/json` response
+	JSON200 *ListJournalEntriesResponseContent
+	// JSON401 the response for an HTTP 401 `application/json` response
+	JSON401 *UnauthorizedErrorResponseContent
+	// JSON500 the response for an HTTP 500 `application/json` response
+	JSON500 *InternalServerErrorResponseContent
+	// JSON503 the response for an HTTP 503 `application/json` response
+	JSON503 *ServiceUnavailableErrorResponseContent
+}
+
+// GetJSON200 returns the response for an HTTP 200 `application/json` response
+func (r ListJournalEntriesResponse) GetJSON200() *ListJournalEntriesResponseContent {
+	return r.JSON200
+}
+
+// GetJSON401 returns the response for an HTTP 401 `application/json` response
+func (r ListJournalEntriesResponse) GetJSON401() *UnauthorizedErrorResponseContent {
+	return r.JSON401
+}
+
+// GetJSON500 returns the response for an HTTP 500 `application/json` response
+func (r ListJournalEntriesResponse) GetJSON500() *InternalServerErrorResponseContent {
+	return r.JSON500
+}
+
+// GetJSON503 returns the response for an HTTP 503 `application/json` response
+func (r ListJournalEntriesResponse) GetJSON503() *ServiceUnavailableErrorResponseContent {
+	return r.JSON503
+}
+
+// GetBody returns the raw response body bytes
+func (r ListJournalEntriesResponse) GetBody() []byte {
+	return r.Body
+}
+
+// Status returns HTTPResponse.Status
+func (r ListJournalEntriesResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListJournalEntriesResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r ListJournalEntriesResponse) ContentType() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Header.Get("Content-Type")
 	}
@@ -18374,6 +18532,20 @@ func (c *ClientWithResponses) StopHabitWithResponse(ctx context.Context, habitId
 	return ParseStopHabitResponse(rsp)
 }
 
+// ListJournalEntriesWithResponse performs a GET /calendar/journal_entries (the `ListJournalEntries` operationId) request.
+//
+// List journal entries newest first. The next page, if any, is a Link header.
+// Pass q to search journal entry content.
+//
+// Returns a wrapper object for the known response body format(s).
+func (c *ClientWithResponses) ListJournalEntriesWithResponse(ctx context.Context, params *ListJournalEntriesParams, reqEditors ...RequestEditorFn) (*ListJournalEntriesResponse, error) {
+	rsp, err := c.ListJournalEntries(ctx, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListJournalEntriesResponse(rsp)
+}
+
 // GetOngoingTimeTrackWithResponse performs a GET /calendar/ongoing_time_track.json (the `GetOngoingTimeTrack` operationId) request.
 //
 // Get the ongoing time track (404 = no active track; see ADR-004)
@@ -21130,6 +21302,53 @@ func ParseStopHabitResponse(rsp *http.Response) (*StopHabitResponse, error) {
 			return nil, err
 		}
 		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalServerErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 503:
+		var dest ServiceUnavailableErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON503 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseListJournalEntriesResponse parses an HTTP response from a ListJournalEntriesWithResponse call
+func ParseListJournalEntriesResponse(rsp *http.Response) (*ListJournalEntriesResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListJournalEntriesResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest ListJournalEntriesResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest UnauthorizedErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest InternalServerErrorResponseContent

--- a/go/pkg/hey/journal.go
+++ b/go/pkg/hey/journal.go
@@ -20,6 +20,51 @@ func NewJournalService(client *Client) *JournalService {
 	return &JournalService{client: client}
 }
 
+// JournalPage contains one page of journal entries and the cursor for the page after it.
+// NextPage is empty on the last page.
+type JournalPage struct {
+	Entries  []generated.Recording
+	NextPage string
+}
+
+// ListPage returns journal entries newest first, optionally filtered by a search query.
+// Pass an empty page for the first page, then the NextPage of each answer.
+func (s *JournalService) ListPage(ctx context.Context, page, query string) (result *JournalPage, err error) {
+	op := OperationInfo{
+		Service: "Journal", Operation: "ListJournalEntries",
+		ResourceType: "journal_entry", IsMutation: false,
+	}
+	err = s.client.instrument(ctx, op, func(ctx context.Context) error {
+		resp, rerr := s.client.genClient().ListJournalEntriesWithResponse(ctx, journalListParams(page, query))
+		if rerr != nil {
+			return rerr
+		}
+		if cerr := CheckResponse(resp.HTTPResponse); cerr != nil {
+			return cerr
+		}
+		result = &JournalPage{}
+		if resp.JSON200 != nil {
+			result.Entries = *resp.JSON200
+		}
+		if resp.HTTPResponse != nil {
+			result.NextPage = gearedPageFromLink(resp.HTTPResponse.Header.Get("Link"))
+		}
+		return nil
+	})
+	return result, err
+}
+
+func journalListParams(page, query string) *generated.ListJournalEntriesParams {
+	params := &generated.ListJournalEntriesParams{}
+	if page != "" {
+		params.Page = &page
+	}
+	if query != "" {
+		params.Q = &query
+	}
+	return params
+}
+
 // Get returns the journal entry for a day (YYYY-MM-DD), or nil when the day has none.
 func (s *JournalService) Get(ctx context.Context, day string) (result *generated.Recording, err error) {
 	op := OperationInfo{

--- a/go/pkg/hey/journal_test.go
+++ b/go/pkg/hey/journal_test.go
@@ -1,0 +1,64 @@
+package hey
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestJournalServiceListPage(t *testing.T) {
+	var gotPage, gotQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/calendar/journal_entries.json" {
+			t.Errorf("expected the journal entry index, got %q", r.URL.Path)
+		}
+		gotPage = r.URL.Query().Get("page")
+		gotQuery = r.URL.Query().Get("q")
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Link", `<http://`+r.Host+`/calendar/journal_entries.json?page=eyJwYWdlIjozfQ&q=meetings+%26+notes>; rel="next"`)
+		_, _ = w.Write([]byte(`[{"id":13,"type":"CalendarJournalEntry","content":"Quarterly planning","starts_at":"2026-08-19T00:00:00Z"}]`))
+	}))
+	t.Cleanup(srv.Close)
+	client := NewClient(&Config{BaseURL: srv.URL}, &StaticTokenProvider{Token: "t"}, WithMaxRetries(0))
+
+	page, err := client.Journal().ListPage(context.Background(), "eyJwYWdlIjoyfQ", "meetings & notes")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotPage != "eyJwYWdlIjoyfQ" {
+		t.Errorf("expected the cursor to be passed through, got %q", gotPage)
+	}
+	if gotQuery != "meetings & notes" {
+		t.Errorf("expected the search query to be passed through, got %q", gotQuery)
+	}
+	if len(page.Entries) != 1 || page.Entries[0].Id != 13 || page.Entries[0].Content != "Quarterly planning" {
+		t.Fatalf("expected journal entry 13, got %+v", page.Entries)
+	}
+	if page.NextPage != "eyJwYWdlIjozfQ" {
+		t.Errorf("expected the cursor for the next page, got %q", page.NextPage)
+	}
+}
+
+func TestJournalServiceListPageOnLastPage(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Has("page") || r.URL.Query().Has("q") {
+			t.Errorf("expected no empty query parameters on the first unfiltered read, got %q", r.URL.RawQuery)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[{"id":13,"type":"CalendarJournalEntry","content":"Quarterly planning"}]`))
+	}))
+	t.Cleanup(srv.Close)
+	client := NewClient(&Config{BaseURL: srv.URL}, &StaticTokenProvider{Token: "t"}, WithMaxRetries(0))
+
+	page, err := client.Journal().ListPage(context.Background(), "", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(page.Entries) != 1 {
+		t.Fatalf("expected one journal entry, got %+v", page.Entries)
+	}
+	if page.NextPage != "" {
+		t.Errorf("expected no cursor past the last page, got %q", page.NextPage)
+	}
+}

--- a/go/pkg/hey/url-routes.json
+++ b/go/pkg/hey/url-routes.json
@@ -220,6 +220,14 @@
       }
     },
     {
+      "pattern": "/calendar/journal_entries",
+      "resource": "Calendar Journal",
+      "operations": {
+        "GET": "ListJournalEntries"
+      },
+      "params": {}
+    },
+    {
       "pattern": "/calendar/ongoing_time_track",
       "resource": "Calendar Time Tracks",
       "operations": {

--- a/openapi.json
+++ b/openapi.json
@@ -2010,6 +2010,87 @@
         }
       }
     },
+    "/calendar/journal_entries": {
+      "get": {
+        "description": "List journal entries newest first. The next page, if any, is a Link header.\nPass q to search journal entry content.",
+        "operationId": "ListJournalEntries",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "x-go-type-skip-optional-pointer": false
+            }
+          },
+          {
+            "name": "q",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "x-go-type-skip-optional-pointer": false
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ListJournalEntries 200 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListJournalEntriesResponseContent"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "UnauthorizedError 401 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedErrorResponseContent"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "InternalServerError 500 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerErrorResponseContent"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "ServiceUnavailableError 503 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceUnavailableErrorResponseContent"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Calendar Journal"
+        ],
+        "x-hey-pagination": {
+          "style": "link"
+        },
+        "x-hey-retry": {
+          "maxAttempts": 3,
+          "baseDelayMs": 1000,
+          "backoff": "exponential",
+          "retryOn": [
+            429,
+            503
+          ]
+        }
+      }
+    },
     "/calendar/ongoing_time_track.json": {
       "get": {
         "description": "Get the ongoing time track (404 = no active track; see ADR-004)",
@@ -10608,6 +10689,12 @@
         "type": "array",
         "items": {
           "$ref": "#/components/schemas/DraftMessage"
+        }
+      },
+      "ListJournalEntriesResponseContent": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/Recording"
         }
       },
       "ListSnippetsResponseContent": {

--- a/spec/excluded-routes.json
+++ b/spec/excluded-routes.json
@@ -6,11 +6,6 @@
   },
   {
     "method": "GET",
-    "path": "/calendar/journal_entries.json",
-    "reason": "broken: returns 406 (hey-cli PR #2)"
-  },
-  {
-    "method": "GET",
     "path": "/calendar/time_tracks.json",
     "reason": "broken: returns 406 (hey-cli PR #2)"
   },

--- a/spec/hey.smithy
+++ b/spec/hey.smithy
@@ -125,7 +125,8 @@ service HEY {
         StartTimeTrack
         UpdateTimeTrack
 
-        // Calendar Journal (2 MVP)
+        // Calendar Journal (3 MVP)
+        ListJournalEntries
         GetJournalEntry
         UpdateJournalEntry
 
@@ -2093,6 +2094,32 @@ structure UpdateTimeTrackOutput {
 // =============================================================================
 // CALENDAR JOURNAL OPERATIONS
 // =============================================================================
+
+/// List journal entries newest first. The next page, if any, is a Link header.
+/// Pass q to search journal entry content.
+@readonly
+@http(method: "GET", uri: "/calendar/journal_entries")
+@tags(["Calendar Journal"])
+@heyRetry(maxAttempts: 3, baseDelayMs: 1000, backoff: "exponential", retryOn: [429, 503])
+@heyPagination(style: "link")
+operation ListJournalEntries {
+    input: ListJournalEntriesInput
+    output: ListJournalEntriesOutput
+    errors: [UnauthorizedError, InternalServerError, ServiceUnavailableError]
+}
+
+structure ListJournalEntriesInput {
+    @httpQuery("page")
+    page: String
+
+    @httpQuery("q")
+    q: String
+}
+
+structure ListJournalEntriesOutput {
+    @required
+    entries: RecordingList
+}
 
 /// Get journal entry for a day
 @readonly

--- a/spec/route-coverage.json
+++ b/spec/route-coverage.json
@@ -341,6 +341,11 @@
   },
   {
     "method": "GET",
+    "operationId": "ListJournalEntries",
+    "path": "/calendar/journal_entries"
+  },
+  {
+    "method": "GET",
     "operationId": "ListSnippets",
     "path": "/snippets.json"
   },

--- a/spec/shape-fingerprint.json
+++ b/spec/shape-fingerprint.json
@@ -47,6 +47,7 @@
   "ListCollections": "de091eba7293db6990eb112c27141105abc651ca931f111f77ad403d8b26fdba",
   "ListContacts": "993b719c97f2ca524b10b6fbd70dcbfd6c01eede6faee8d5168303d03b7d5a53",
   "ListDrafts": "da0cce2ba7163fdf23d92f9c2bcfa2646945969f26d81a8ba878b8a1303ee89e",
+  "ListJournalEntries": "2b06e6bd41caccc48f7bc6fa52dc2b5865aa3a5468990bb61424ee613a8f5354",
   "ListSnippets": "023552e610add5f2f2bef591c9d626a74ebd86ff1e2e8566ec390c4180be45cf",
   "ListStickies": "cc287c996f7305a4bedb0c851ec1db200db2eebf575e22e22921fd753ec88aa9",
   "ListTimeTrackCategories": "3b0754dbc1b1c8d49f5f681ef99a0fb6e1c9c66be2614543060507a891f2419f",


### PR DESCRIPTION
<!-- pr-review-readiness-head: f7b418e4b7b1a5aaa0b54d0186801ecc7631782f -->

Give Go SDK consumers typed, cursor-based access to personal Journal history and scoped search. The server contract is merged and verified in production; existing per-day Journal reads and mutations remain unchanged.

**Review readiness:** ✅ Yes — generated contract, wrapper coverage, CI, and production availability are verified  
**Risk:** 🟡 Medium — this adds a generated API surface and cursor parsing consumed by the dependent TUI  
**Decision:** None

<details>
<summary>✅ Change — Go callers can list, page, and search Journal entries</summary>

### Before

```text
Go SDK consumer
└── Journal service
    ├── read one known day
    └── ❌ cannot discover or search Journal history
```

### After

```text
Go SDK consumer
└── Journal.ListPage(page, query)
    ├── ✅ receive newest-first entries  ← CHANGED
    ├── ✅ pass NextPage to read older entries  ← CHANGED
    └── ✅ provide q to search Journal content  ← CHANGED
```

`JournalPage` returns typed recordings plus the geared cursor parsed from HEY's `Link` header. The caller starts with an empty page and decides whether to follow `NextPage`.

</details>

<details>
<summary>✅ Evidence — generation, conformance, wrapper behavior, and production compatibility are verified</summary>

- ✅ `make check` passed at this head, including 156 conformance checks.
- ✅ Unit coverage verifies query encoding, typed decoding, next-page extraction, and an empty cursor on the final page.
- ✅ Current-head GitHub checks cover Smithy verification, spec drift, API compatibility, Go tests/lint, conformance, CodeQL, Trivy, govulncheck, and gosec.
- ✅ A read-only production probe using this exact SDK head called `JournalService.ListPage(ctx, "", "")` successfully after the Haystack deployment.

```text
make check
passed — 156 conformance checks

GOWORK=off go test ./pkg/hey -run Journal
passed

production JournalService.ListPage(ctx, "", "")
journal feed: ok entries=3 has_next=false
```

Behavioral proof: [Journal wrapper tests](https://github.com/basecamp/hey-sdk/blob/f7b418e4b7b1a5aaa0b54d0186801ecc7631782f/go/pkg/hey/journal_test.go) · [path conformance cases](https://github.com/basecamp/hey-sdk/blob/f7b418e4b7b1a5aaa0b54d0186801ecc7631782f/conformance/tests/paths.json)

</details>

<details>
<summary>✅ Scope — additive Journal listing only; existing SDK operations remain compatible</summary>

Included:
- Smithy `ListJournalEntries` operation with `page` and `q`
- OpenAPI and Go client generation
- `JournalService.ListPage` and `JournalPage`
- route, behavior, shape, coverage, and conformance artifacts

Preserved:
- `JournalService.Get`, `GetContent`, and `Update`
- existing authentication, account scope, retries, and response limits
- every existing generated client operation

Not included:
- automatic all-page collection
- a separate search method; search is the optional `query` argument
- server-side search pagination, which is outside this SDK PR

</details>

<details>
<summary>✅ Delivery — Haystack is merged and responding in production; no SDK runtime prerequisite remains</summary>

The server dependency, [haystack#8655](https://github.com/basecamp/haystack/pull/8655), is merged. A non-mutating call from this SDK head to production returned a valid `JournalPage`, confirming deploy ordering before review.

There are no migrations, backfills, feature flags, credentials, configuration changes, or new runtime dependencies. Rollback is removal of the additive operation before publishing, or a subsequent SDK release if already published.

</details>

<details>
<summary>⚠️ Review decision — focus on generated contract fidelity and cursor boundaries</summary>

Please begin with:
1. whether the Smithy operation accurately models HEY's query parameters, response, and retry behavior
2. whether `JournalService.ListPage` handles the first, intermediate, and final page without hiding pagination policy from callers

The deliberate boundary is one page per call. Search results use the server's bounded, unpaginated response and therefore return no `NextPage`.

</details>

<details>
<summary>✅ Review path — model, generated surface, wrapper, then drift/conformance artifacts</summary>

1. [Smithy model](https://github.com/basecamp/hey-sdk/blob/f7b418e4b7b1a5aaa0b54d0186801ecc7631782f/spec/hey.smithy) — operation, inputs, output, pagination, and retry contract.
2. [OpenAPI](https://github.com/basecamp/hey-sdk/blob/f7b418e4b7b1a5aaa0b54d0186801ecc7631782f/openapi.json), [behavior model](https://github.com/basecamp/hey-sdk/blob/f7b418e4b7b1a5aaa0b54d0186801ecc7631782f/behavior-model.json), and [generated Go client](https://github.com/basecamp/hey-sdk/blob/f7b418e4b7b1a5aaa0b54d0186801ecc7631782f/go/pkg/generated/client.gen.go) — generated contract surfaces.
3. [Journal wrapper](https://github.com/basecamp/hey-sdk/blob/f7b418e4b7b1a5aaa0b54d0186801ecc7631782f/go/pkg/hey/journal.go) and [tests](https://github.com/basecamp/hey-sdk/blob/f7b418e4b7b1a5aaa0b54d0186801ecc7631782f/go/pkg/hey/journal_test.go) — public Go API and cursor behavior.
4. [Conformance runner](https://github.com/basecamp/hey-sdk/blob/f7b418e4b7b1a5aaa0b54d0186801ecc7631782f/conformance/runner/go/main.go), [path cases](https://github.com/basecamp/hey-sdk/blob/f7b418e4b7b1a5aaa0b54d0186801ecc7631782f/conformance/tests/paths.json), [URL routes](https://github.com/basecamp/hey-sdk/blob/f7b418e4b7b1a5aaa0b54d0186801ecc7631782f/go/pkg/hey/url-routes.json), [excluded routes](https://github.com/basecamp/hey-sdk/blob/f7b418e4b7b1a5aaa0b54d0186801ecc7631782f/spec/excluded-routes.json), [route coverage](https://github.com/basecamp/hey-sdk/blob/f7b418e4b7b1a5aaa0b54d0186801ecc7631782f/spec/route-coverage.json), and [shape fingerprint](https://github.com/basecamp/hey-sdk/blob/f7b418e4b7b1a5aaa0b54d0186801ecc7631782f/spec/shape-fingerprint.json) — generated drift and behavioral proof.

**Origin and supporting links:** [Basecamp concept card](https://app.basecamp.com/2914079/buckets/48521764/card_tables/cards/10228996495) · [merged Haystack endpoint](https://github.com/basecamp/haystack/pull/8655) · [dependent hey-cli draft and demo](https://github.com/basecamp/hey-cli/pull/275)

</details>
