### PR TITLE
Bump the SDK to 0.15.0

### DIFF
--- a/go/pkg/hey/version.go
+++ b/go/pkg/hey/version.go
@@ -1,7 +1,7 @@
 package hey
 
 // Version is the current version of the HEY Go SDK.
-const Version = "0.14.0"
+const Version = "0.15.0"
 
 // APIVersion is the HEY API version this SDK targets.
 const APIVersion = "2026-08-21"


### PR DESCRIPTION
Release prep for v0.15.0, carrying the Journal feed and search API from #110.

## Change

- bump the Go SDK from 0.14.0 to 0.15.0
- keep the API contract date unchanged

## Validation

- `GOWORK=off make check`
- 156 conformance checks passed
- production accepted a read-only `JournalService.ListPage` call from the merged SDK implementation

## Delivery

After this lands on `main`, run `make release VERSION=0.15.0` to create and push both `v0.15.0` and `go/v0.15.0`.

Related work:
- https://github.com/basecamp/hey-sdk/pull/110
- https://github.com/basecamp/haystack/pull/8655
- https://app.basecamp.com/2914079/buckets/48521764/card_tables/cards/10228996495


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps the HEY Go SDK from 0.14.0 to 0.15.0 to release the Journal feed and search API from #110. The API contract date stays the same, so existing endpoints behave the same.

- Only change in code: update the `Version` constant; `APIVersion` remains "2026-08-21".
- No migration required; new Journal feed and search APIs are available to consumers.
- Validation: 156 conformance checks passed; production accepted a read-only `JournalService.ListPage` call.
- Rollout: after merge to main, run `make release VERSION=0.15.0` to publish `v0.15.0` and `go/v0.15.0`.

<sup>Written for commit 6981f7da9b824ca8b435b409133f57aa9e9bcd3c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-sdk/pull/111?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

