### PR TITLE
Answer which calendars are selected on the list

### DIFF
--- a/go/pkg/generated/client.gen.go
+++ b/go/pkg/generated/client.gen.go
@@ -217,6 +217,11 @@ type CalendarDayListPayload struct {
 type CalendarListPayload struct {
 	CalendarChangesUrl string                            `json:"calendar_changes_url,omitempty"`
 	Calendars          []CalendarWithRecordingChangesUrl `json:"calendars,omitempty"`
+
+	// SelectedCalendarIds The calendars every period read is drawn from. ToggleCalendar changes this and
+	// answers the new one, so a client reads it here once — to open on what is already
+	// on — and takes it from the toggle after that.
+	SelectedCalendarIds []int64 `json:"selected_calendar_ids,omitempty"`
 }
 
 // CalendarPeriod CalendarPeriod — a day or a week: its bounds and everything in it, grouped by type.

--- a/go/pkg/hey/calendar_periods_test.go
+++ b/go/pkg/hey/calendar_periods_test.go
@@ -240,6 +240,32 @@ func TestCalendarsToggleAnswersTheSelection(t *testing.T) {
 	}
 }
 
+// The calendar list carries the selection too, so a client can open on what is already on
+// without a toggle to tell it.
+func TestCalendarsListCarriesTheSelection(t *testing.T) {
+	client := periodsClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+		  "calendars": [
+		    { "calendar": { "id": 41, "name": "Design Team", "color": "teal", "personal": false } },
+		    { "calendar": { "id": 42, "name": "", "personal": true } }
+		  ],
+		  "selected_calendar_ids": [42]
+		}`))
+	})
+
+	payload, err := client.Calendars().List(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(payload.SelectedCalendarIds) != 1 || payload.SelectedCalendarIds[0] != 42 {
+		t.Errorf("selected ids = %v, want [42]", payload.SelectedCalendarIds)
+	}
+	if payload.Calendars[0].Calendar.Color != "teal" {
+		t.Errorf("color = %q, want teal", payload.Calendars[0].Calendar.Color)
+	}
+}
+
 func TestCalendarPeriodsReportNotFound(t *testing.T) {
 	client := periodsClient(t, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/go/pkg/hey/version.go
+++ b/go/pkg/hey/version.go
@@ -1,7 +1,7 @@
 package hey
 
 // Version is the current version of the HEY Go SDK.
-const Version = "0.16.0"
+const Version = "0.17.0"
 
 // APIVersion is the HEY API version this SDK targets.
 const APIVersion = "2026-08-21"

--- a/openapi.json
+++ b/openapi.json
@@ -9832,6 +9832,14 @@
           },
           "calendar_changes_url": {
             "type": "string"
+          },
+          "selected_calendar_ids": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "description": "The calendars every period read is drawn from. ToggleCalendar changes this and\nanswers the new one, so a client reads it here once — to open on what is already\non — and takes it from the toggle after that."
           }
         }
       },

--- a/spec/hey.smithy
+++ b/spec/hey.smithy
@@ -822,6 +822,11 @@ list CalendarWithRecordingChangesUrlList {
 structure CalendarListPayload {
     calendars: CalendarWithRecordingChangesUrlList
     calendar_changes_url: String
+
+    /// The calendars every period read is drawn from. ToggleCalendar changes this and
+    /// answers the new one, so a client reads it here once — to open on what is already
+    /// on — and takes it from the toggle after that.
+    selected_calendar_ids: CalendarIdList
 }
 
 /// RecurrenceSchedule


### PR DESCRIPTION
`ToggleCalendar` answers the selection it left behind, which is enough to follow the selection but not to open on it: a client that has toggled nothing has never been told what is on.

HEY already serves `selected_calendar_ids` on the calendar list for exactly that reason — #112 added it to the response but never modelled it on `CalendarListPayload`, so the field went nowhere. One read at startup, and the toggle from then on.

Bumped to 0.17.0. Caught while wiring the multi-select calendar picker in hey-cli, which could read the toggle's answer but had nothing to open on.