### PR TITLE
Set a calendar event's time zones, and let an update move it between calendars

### DIFF
--- a/go/pkg/hey/calendar_events.go
+++ b/go/pkg/hey/calendar_events.go
@@ -47,6 +47,11 @@ type CreateCalendarEventParams struct {
 	// as its own form offers, so an event can start in one and finish in another.
 	StartTimeZone string
 	EndTimeZone   string
+	// TimeZone names one zone for both ends.
+	//
+	// Deprecated: use StartTimeZone and EndTimeZone. It stands in for whichever of them is
+	// empty, so a caller that only ever wanted one zone keeps working.
+	TimeZone string
 	// Reminders is a list of durations before the event to send reminders.
 	// The API accepts any duration, not just the presets in the web UI.
 	Reminders []time.Duration
@@ -77,7 +82,12 @@ type UpdateCalendarEventParams struct {
 	// with; nil leaves them out of the request, which HEY also reads as clearing them.
 	StartTimeZone *string
 	EndTimeZone   *string
-	Reminders     []time.Duration
+	// TimeZone names one zone for both ends.
+	//
+	// Deprecated: use StartTimeZone and EndTimeZone. It stands in for whichever of them is
+	// nil, so a caller that only ever wanted one zone keeps working.
+	TimeZone  *string
+	Reminders []time.Duration
 }
 
 // setTimeZones writes the zones a timed event's clock times are written in, and the flag that
@@ -86,6 +96,22 @@ type UpdateCalendarEventParams struct {
 //
 // Naming no zone is a complete answer rather than an omission — convert to UTC and say nothing.
 // An all-day event does not come through here at all, since a date has no zone.
+// timeZoneOr and timeZonePointerOr let the deprecated TimeZone stand in for an end the caller
+// did not name.
+func timeZoneOr(zone, both string) string {
+	if zone == "" {
+		return both
+	}
+	return zone
+}
+
+func timeZonePointerOr(zone, both *string) *string {
+	if zone == nil {
+		return both
+	}
+	return zone
+}
+
 func setTimeZones(values url.Values, start, end string) {
 	if start == "" && end == "" {
 		values.Set("calendar_event[set_time_zone]", "0")
@@ -140,7 +166,9 @@ func (s *CalendarEventsService) Create(ctx context.Context, params CreateCalenda
 		values.Set("calendar_event[all_day]", "0")
 		values.Set("calendar_event[starts_at_time]", params.StartTime+":00")
 		values.Set("calendar_event[ends_at_time]", params.EndTime+":00")
-		setTimeZones(values, params.StartTimeZone, params.EndTimeZone)
+		setTimeZones(values,
+			timeZoneOr(params.StartTimeZone, params.TimeZone),
+			timeZoneOr(params.EndTimeZone, params.TimeZone))
 		for _, r := range params.Reminders {
 			values.Add("timed_reminder_durations[]", fmt.Sprintf("%d", int64(r.Seconds())))
 		}
@@ -215,13 +243,15 @@ func (s *CalendarEventsService) Update(ctx context.Context, eventID int64, param
 	if params.CalendarID != nil {
 		values.Set("calendar_event[calendar_id]", fmt.Sprintf("%d", *params.CalendarID))
 	}
-	if params.StartTimeZone != nil || params.EndTimeZone != nil {
+	startZone := timeZonePointerOr(params.StartTimeZone, params.TimeZone)
+	endZone := timeZonePointerOr(params.EndTimeZone, params.TimeZone)
+	if startZone != nil || endZone != nil {
 		var start, end string
-		if params.StartTimeZone != nil {
-			start = *params.StartTimeZone
+		if startZone != nil {
+			start = *startZone
 		}
-		if params.EndTimeZone != nil {
-			end = *params.EndTimeZone
+		if endZone != nil {
+			end = *endZone
 		}
 		setTimeZones(values, start, end)
 	}

--- a/go/pkg/hey/calendar_events.go
+++ b/go/pkg/hey/calendar_events.go
@@ -41,9 +41,12 @@ type CreateCalendarEventParams struct {
 	StartTime string
 	// EndTime is the end time in HH:MM format (required if not all-day).
 	EndTime string
-	// TimeZone is the IANA timezone name (e.g., "America/New_York").
-	// Required for timed events.
-	TimeZone string
+	// StartTimeZone and EndTimeZone are the IANA names of the zones the clock times above are
+	// written in — "Europe/Zagreb", "America/New_York". Leave them empty and the times are
+	// read in UTC, which is the zone HEY parses an API request in. HEY keeps a zone per end,
+	// as its own form offers, so an event can start in one and finish in another.
+	StartTimeZone string
+	EndTimeZone   string
 	// Reminders is a list of durations before the event to send reminders.
 	// The API accepts any duration, not just the presets in the web UI.
 	Reminders []time.Duration
@@ -51,15 +54,53 @@ type CreateCalendarEventParams struct {
 
 // UpdateCalendarEventParams contains the parameters for updating a calendar event.
 // Only non-nil fields are updated.
+//
+// The zones are the exception, and the reason is on HEY's side: it reads the pair out of the
+// submitted parameters or nils both, so an update that says nothing about them clears whatever
+// the event had. A caller keeping a zoned event's zones has to send them again.
 type UpdateCalendarEventParams struct {
-	Title     *string
-	StartsAt  *string
-	EndsAt    *string
-	AllDay    *bool
-	StartTime *string
-	EndTime   *string
-	TimeZone  *string
-	Reminders []time.Duration
+	// CalendarID moves the event to another calendar. An update takes the same calendar as a
+	// create does, which is how the web app's calendar select relocates an event.
+	//
+	// It has to be a calendar the identity can file on — one it owns or shares, and not a
+	// subscription. The personal calendar is the one that catches you out: it is in the list
+	// Identity serves, and filing on it answers 404 all the same.
+	CalendarID *int64
+	Title      *string
+	StartsAt   *string
+	EndsAt     *string
+	AllDay     *bool
+	StartTime  *string
+	EndTime    *string
+	// StartTimeZone and EndTimeZone are the zones the clock times are written in, as on a
+	// create. Empty strings say the times are UTC and clear the zones the event was saved
+	// with; nil leaves them out of the request, which HEY also reads as clearing them.
+	StartTimeZone *string
+	EndTimeZone   *string
+	Reminders     []time.Duration
+}
+
+// setTimeZones writes the zones a timed event's clock times are written in, and the flag that
+// makes HEY honour them. The flag is not decoration: without it both names are dropped and the
+// times are read in UTC, so 08:00 sent from Zagreb is stored as 08:00Z.
+//
+// Naming no zone is a complete answer rather than an omission — convert to UTC and say nothing.
+// An all-day event does not come through here at all, since a date has no zone.
+func setTimeZones(values url.Values, start, end string) {
+	if start == "" && end == "" {
+		values.Set("calendar_event[set_time_zone]", "0")
+		return
+	}
+	// An empty name is read as no name, which lands that end back in UTC.
+	if start == "" {
+		start = end
+	}
+	if end == "" {
+		end = start
+	}
+	values.Set("calendar_event[set_time_zone]", "1")
+	values.Set("calendar_event[starts_at_time_zone_name]", start)
+	values.Set("calendar_event[ends_at_time_zone_name]", end)
 }
 
 // Create creates a new calendar event and returns it as a recording.
@@ -99,8 +140,7 @@ func (s *CalendarEventsService) Create(ctx context.Context, params CreateCalenda
 		values.Set("calendar_event[all_day]", "0")
 		values.Set("calendar_event[starts_at_time]", params.StartTime+":00")
 		values.Set("calendar_event[ends_at_time]", params.EndTime+":00")
-		values.Set("calendar_event[starts_at_time_zone_name]", params.TimeZone)
-		values.Set("calendar_event[ends_at_time_zone_name]", params.TimeZone)
+		setTimeZones(values, params.StartTimeZone, params.EndTimeZone)
 		for _, r := range params.Reminders {
 			values.Add("timed_reminder_durations[]", fmt.Sprintf("%d", int64(r.Seconds())))
 		}
@@ -172,9 +212,18 @@ func (s *CalendarEventsService) Update(ctx context.Context, eventID int64, param
 	if params.EndTime != nil {
 		values.Set("calendar_event[ends_at_time]", *params.EndTime+":00")
 	}
-	if params.TimeZone != nil {
-		values.Set("calendar_event[starts_at_time_zone_name]", *params.TimeZone)
-		values.Set("calendar_event[ends_at_time_zone_name]", *params.TimeZone)
+	if params.CalendarID != nil {
+		values.Set("calendar_event[calendar_id]", fmt.Sprintf("%d", *params.CalendarID))
+	}
+	if params.StartTimeZone != nil || params.EndTimeZone != nil {
+		var start, end string
+		if params.StartTimeZone != nil {
+			start = *params.StartTimeZone
+		}
+		if params.EndTimeZone != nil {
+			end = *params.EndTimeZone
+		}
+		setTimeZones(values, start, end)
 	}
 	if params.Reminders != nil {
 		allDay := params.AllDay != nil && *params.AllDay

--- a/go/pkg/hey/services_test.go
+++ b/go/pkg/hey/services_test.go
@@ -1162,7 +1162,9 @@ func TestCalendarEventsService_Create(t *testing.T) {
 		StartsAt:   "2026-04-06",
 		StartTime:  "10:00",
 		EndTime:    "11:00",
-		TimeZone:   "America/New_York",
+
+		StartTimeZone: "America/New_York",
+		EndTimeZone:   "America/New_York",
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -1191,7 +1193,9 @@ func TestCalendarEventsService_Create_OnAServerWithoutTheJSONBranch(t *testing.T
 		StartsAt:   "2026-04-06",
 		StartTime:  "10:00",
 		EndTime:    "11:00",
-		TimeZone:   "America/New_York",
+
+		StartTimeZone: "America/New_York",
+		EndTimeZone:   "America/New_York",
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -1263,6 +1267,59 @@ func TestCalendarEventsService_Update(t *testing.T) {
 	}
 	if recording.Title != "Updated Meeting" {
 		t.Errorf("expected the new title, got %q", recording.Title)
+	}
+}
+
+// An event can start in one zone and finish in another, which is what a flight is.
+func TestCalendarEventsService_Update_WithAZonePerEnd(t *testing.T) {
+	departs, arrives := "Europe/Zagreb", "America/New_York"
+	client := newFormJSONTestClient(t, "PATCH", "/calendar/events/%s",
+		func(t *testing.T, values url.Values) {
+			t.Helper()
+			for field, want := range map[string]string{
+				"calendar_event[set_time_zone]":            "1",
+				"calendar_event[starts_at_time_zone_name]": "Europe/Zagreb",
+				"calendar_event[ends_at_time_zone_name]":   "America/New_York",
+			} {
+				if got := values.Get(field); got != want {
+					t.Errorf("%s = %q, want %q", field, got, want)
+				}
+			}
+		},
+		200, `{"id": 99, "type": "Calendar::Event"}`,
+	)
+
+	_, err := client.CalendarEvents().Update(context.Background(), 99, UpdateCalendarEventParams{
+		StartTimeZone: &departs,
+		EndTimeZone:   &arrives,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// Empty zones say the times are UTC, and put the event back to having no zones of its own.
+func TestCalendarEventsService_Update_ClearingTheZones(t *testing.T) {
+	none := ""
+	client := newFormJSONTestClient(t, "PATCH", "/calendar/events/%s",
+		func(t *testing.T, values url.Values) {
+			t.Helper()
+			if got := values.Get("calendar_event[set_time_zone]"); got != "0" {
+				t.Errorf("set_time_zone = %q, want 0", got)
+			}
+			if got := values.Get("calendar_event[starts_at_time_zone_name]"); got != "" {
+				t.Errorf("a zone was named anyway: %q", got)
+			}
+		},
+		200, `{"id": 99, "type": "Calendar::Event"}`,
+	)
+
+	_, err := client.CalendarEvents().Update(context.Background(), 99, UpdateCalendarEventParams{
+		StartTimeZone: &none,
+		EndTimeZone:   &none,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/go/pkg/hey/services_test.go
+++ b/go/pkg/hey/services_test.go
@@ -1298,6 +1298,38 @@ func TestCalendarEventsService_Update_WithAZonePerEnd(t *testing.T) {
 	}
 }
 
+// The deprecated single TimeZone still names both ends, and now carries the flag that makes
+// HEY read it — which it never did before.
+func TestCalendarEventsService_Create_WithTheDeprecatedTimeZone(t *testing.T) {
+	client := newFormJSONTestClient(t, "POST", "/calendar/events.json",
+		func(t *testing.T, values url.Values) {
+			t.Helper()
+			for field, want := range map[string]string{
+				"calendar_event[set_time_zone]":            "1",
+				"calendar_event[starts_at_time_zone_name]": "America/New_York",
+				"calendar_event[ends_at_time_zone_name]":   "America/New_York",
+			} {
+				if got := values.Get(field); got != want {
+					t.Errorf("%s = %q, want %q", field, got, want)
+				}
+			}
+		},
+		201, calendarEventJSON,
+	)
+
+	_, err := client.CalendarEvents().Create(context.Background(), CreateCalendarEventParams{
+		CalendarID: 1,
+		Title:      "Meeting",
+		StartsAt:   "2026-04-06",
+		StartTime:  "10:00",
+		EndTime:    "11:00",
+		TimeZone:   "America/New_York",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 // Empty zones say the times are UTC, and put the event back to having no zones of its own.
 func TestCalendarEventsService_Update_ClearingTheZones(t *testing.T) {
 	none := ""


### PR DESCRIPTION
Two writes the SDK could not express, both of them things the web form does.

### Time zones

An event's clock times are read in UTC unless the request names the zones they were written in, and naming them takes a flag. Without `calendar_event[set_time_zone]` both names are dropped, so `09:00` sent from Zagreb is stored as `09:00Z` — an hour or two out, depending on the season, and out again on every subsequent save.

`Create` was already sending the names without the flag, so they were being thrown away.

`StartTimeZone` and `EndTimeZone` replace the single `TimeZone`, because HEY keeps a zone per end and an event can start in one and finish in another — which is what a flight is. `TimeZone` stays, deprecated, standing in for whichever end the caller did not name: dropping it fails the API compatibility check, and keeping it costs nothing. Worth removing in a breaking release.

Empty zones are a complete answer rather than an omission: they say the clock times are UTC, which is what a caller with no dependable name for the local zone should send.

### Clearing them

On an update the pair is read out of the submitted parameters or nilled, so **an update that says nothing about the zones clears whatever the event had**. That is worth knowing before you write an update: a caller that means to keep a zoned event's zones has to send them again. `nil` and `""` therefore both clear, and the doc comment says so.

### A calendar on update

An update takes a calendar the same way a create does, which is how the web app's calendar select relocates an event. `CalendarID` is no longer create-only.

It has to be a calendar the identity can file on — one it owns or shares, and not a subscription. The personal calendar is the one that catches you out: it is in the list `Identity` serves, and filing on it answers 404 all the same.

### Verified

Against production, creating and then deleting a throwaway event:

```
asking for 09:00 CEST → 2026-08-25T07:00:00Z
created  starts_at=2026-08-25T07:00:00Z → Madrid 09:00  zones="Europe/Madrid"/"Europe/Madrid"
edited   starts_at=2026-08-25T07:00:00Z → Madrid 09:00  zones="Europe/Madrid"/"Europe/Madrid"
cleared  starts_at=2026-08-25T07:00:00Z → Madrid 09:00  zones=""/""
```

Tests cover a zone per end and clearing the pair. `make drift-check` is clean — the read side needed nothing, since `Recording` already carries `starts_at_time_zone` and `ends_at_time_zone`.

No version bump here, since those land on their own.
