### PR TITLE
Write one day of a repeating event, and everything else an event carries

### DIFF
--- a/go/pkg/hey/calendar_events.go
+++ b/go/pkg/hey/calendar_events.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/basecamp/hey-sdk/go/pkg/generated"
@@ -23,6 +25,181 @@ type CalendarEventsService struct {
 // NewCalendarEventsService creates a new CalendarEventsService.
 func NewCalendarEventsService(client *Client) *CalendarEventsService {
 	return &CalendarEventsService{client: client}
+}
+
+// EventContentParams is an event's content, and it is a replacement rather than a patch.
+//
+// HEY reads these four out of the submitted parameters and then defaults every one of them to
+// nil, so a write that says nothing about a field clears it. There is no way to send a subset:
+// the fields left out of the struct are the fields the event loses. An update therefore has to
+// read the event first and pass back whatever it means to keep — including through
+// UpdateOccurrence, which takes the same parameters.
+//
+// Title is not in here, and that is not an oversight: HEY leaves the summary alone when it is
+// not submitted, so it stays a *string on an update like the rest of a partial write.
+type EventContentParams struct {
+	// Notes is HEY's calendar_event[description] — Trix rich text, so HTML going in.
+	//
+	// It does not round-trip. HEY serves the notes back as plain text and omits the key
+	// entirely when they are blank, so echoing a read back flattens the markup rather than
+	// preserving it. Keeping formatted notes through an update means holding the HTML the
+	// caller sent, not the text HEY answered.
+	Notes string
+	// Location is a plain string. HEY truncates it at 3900 characters rather than refusing it.
+	Location string
+	// Link is validated as a URL and capped at 2500 characters, so a malformed one is a 422
+	// rather than a silent drop.
+	//
+	// It is not the join_link on a read. HEY derives that by scanning the notes, the location
+	// and this for a known meeting service, and it is response-only — there is nothing to
+	// submit it with.
+	Link string
+	// EntryID attaches an email to the event, HEY's calendar_event[entry_id]. A read serves the
+	// attachment back as attached_entry, so a caller keeping one passes attached_entry.id here.
+	EntryID int64
+}
+
+// CountdownUnit is one countdown unit as a number of seconds, which is the form HEY's own form
+// submits and the only one it reads.
+type CountdownUnit int
+
+const (
+	CountdownUnitDays   CountdownUnit = 86400
+	CountdownUnitWeeks  CountdownUnit = 604800
+	CountdownUnitMonths CountdownUnit = 2629746
+)
+
+// CountdownParams is the countdown HEY runs up to an event, and like EventContentParams it is
+// resend-or-lose-it: HEY reads the pair on every editable write and a missing value deletes the
+// countdown. The zero value therefore means the event has no countdown once the write lands.
+//
+// A countdown is a child recording of its own rather than a field on the event, so it is not on
+// the event's JSON and cannot be read back from one. Value 1–30 is what the web app offers.
+type CountdownParams struct {
+	Value int
+	Unit  CountdownUnit
+}
+
+// RepeatFrequency is how often an event repeats. HEY has no day-of-week parameter, so
+// RepeatEveryWeekday — a hardcoded Monday to Friday — is the only weekday set expressible.
+type RepeatFrequency string
+
+const (
+	RepeatEveryDay        RepeatFrequency = "every_day"
+	RepeatEveryWeekday    RepeatFrequency = "every_weekday"
+	RepeatEveryWeek       RepeatFrequency = "every_week"
+	RepeatEveryOtherWeek  RepeatFrequency = "every_other_week"
+	RepeatEveryDayOfMonth RepeatFrequency = "every_day_of_month"
+	RepeatEveryYear       RepeatFrequency = "every_year"
+	// RepeatCustom keeps whatever schedule the event already has instead of naming a new one.
+	// It is how a write says the recurrence is none of its business.
+	RepeatCustom RepeatFrequency = "custom"
+)
+
+// RepeatUntil says when a recurrence stops.
+type RepeatUntil string
+
+const (
+	RepeatUntilForever RepeatUntil = "forever"
+	RepeatUntilDate    RepeatUntil = "date"
+	RepeatUntilCount   RepeatUntil = "count"
+)
+
+// RepeatParams is an event's recurrence.
+type RepeatParams struct {
+	Frequency RepeatFrequency
+	Until     RepeatUntil
+	// UntilDate is YYYY-MM-DD and is read only when Until is RepeatUntilDate.
+	UntilDate string
+	// Count is read only when Until is RepeatUntilCount.
+	Count int
+}
+
+// setEventContent writes the content fields. All four go out every time, because HEY clears the
+// ones it is not sent — see EventContentParams.
+func setEventContent(values url.Values, content EventContentParams) {
+	values.Set("calendar_event[description]", content.Notes)
+	values.Set("calendar_event[location]", content.Location)
+	values.Set("calendar_event[url]", content.Link)
+	if content.EntryID == 0 {
+		values.Set("calendar_event[entry_id]", "")
+	} else {
+		values.Set("calendar_event[entry_id]", fmt.Sprintf("%d", content.EntryID))
+	}
+}
+
+// setAttendees writes the guest list, which HEY replaces wholesale rather than merging. Existing
+// guests are matched by address and keep the status they answered with; an address HEY cannot
+// parse is dropped without comment. Submitting the list at all also makes the caller the event's
+// organizer and sends iCal invitations, and a read's manage_attendance says whether the caller
+// may submit it in the first place.
+//
+// A nil list leaves the roster alone — HEY only touches it when the parameter is present. An
+// empty one clears it, and needs a blank value on the wire to say so, since a form carries no
+// empty array. That blank is what HEY's own form posts.
+func setAttendees(values url.Values, attendees []string) {
+	if attendees == nil {
+		return
+	}
+	if len(attendees) == 0 {
+		values.Add("calendar_event[attendance_email_addresses][]", "")
+		return
+	}
+	for _, address := range attendees {
+		values.Add("calendar_event[attendance_email_addresses][]", address)
+	}
+}
+
+// setHighlighted circles or uncircles the event. HEY reads the flag only when it is submitted, so
+// nil leaves the circle as it was.
+//
+// The empty highlight_id is what makes "off" mean off. HEY builds a new highlight when the flag
+// is off and that key is absent — turning the circle on — and destroys the existing one when the
+// key is there and empty. It is never served on a read, so a caller could not construct the
+// right form from one; sending it unconditionally is how this stays a bool.
+func setHighlighted(values url.Values, highlighted *bool) {
+	if highlighted == nil {
+		return
+	}
+	if *highlighted {
+		values.Set("calendar_event[highlighted]", "1")
+	} else {
+		values.Set("calendar_event[highlighted]", "0")
+	}
+	values.Set("calendar_event[highlight_id]", "")
+}
+
+// setCountdown writes the countdown pair. A zero value sends no value at all, which is how HEY
+// is told to delete the countdown — there is no "leave it alone".
+func setCountdown(values url.Values, countdown CountdownParams) {
+	if countdown.Value <= 0 {
+		return
+	}
+	unit := countdown.Unit
+	if unit == 0 {
+		unit = CountdownUnitDays
+	}
+	values.Set("countdown_interval_duration_value", fmt.Sprintf("%d", countdown.Value))
+	values.Set("countdown_interval_duration_unit", fmt.Sprintf("%d", int(unit)))
+}
+
+// setRepeat writes the recurrence. Nothing is written for a nil one, which on a whole-event
+// update leaves the recurrence untouched — unlike the occurrence update, where HEY reads the
+// same silence as "stop repeating".
+func setRepeat(values url.Values, repeat *RepeatParams) {
+	if repeat == nil {
+		return
+	}
+	values.Set("repeat_frequency", string(repeat.Frequency))
+	if repeat.Until != "" {
+		values.Set("calendar_recurrence_schedule[recurs_until_type]", string(repeat.Until))
+	}
+	if repeat.Until == RepeatUntilDate {
+		values.Set("calendar_recurrence_schedule[recurs_until_date]", repeat.UntilDate)
+	}
+	if repeat.Until == RepeatUntilCount {
+		values.Set("calendar_recurrence_schedule[recurs_count]", fmt.Sprintf("%d", repeat.Count))
+	}
 }
 
 // CreateCalendarEventParams contains the parameters for creating a calendar event.
@@ -52,17 +229,35 @@ type CreateCalendarEventParams struct {
 	// Deprecated: use StartTimeZone and EndTimeZone. It stands in for whichever of them is
 	// empty, so a caller that only ever wanted one zone keeps working.
 	TimeZone string
-	// Reminders is a list of durations before the event to send reminders.
-	// The API accepts any duration, not just the presets in the web UI.
+	// Reminders is a list of durations before the event to send reminders. HEY takes several in
+	// one write and de-duplicates them, and accepts any duration rather than only the presets
+	// the web app offers. Only the list matching the event's all-day flag is read.
+	//
+	// Empty means no reminders. On an update that is not "leave them alone" but "remove them",
+	// so a partial update that forgets them silently unschedules every one.
 	Reminders []time.Duration
+	// Content is the notes, location, link and attached entry. Nothing exists to lose on a
+	// create, so the zero value is simply an event with none of them.
+	Content EventContentParams
+	// Attendees is the guest list. Submitting one makes the caller the organizer and sends
+	// invitations.
+	Attendees []string
+	// Highlighted circles the event. HEY reads it only when it is submitted, so nil is "not
+	// circled" on a create.
+	Highlighted *bool
+	// Countdown counts down to the event. The zero value creates none.
+	Countdown CountdownParams
+	// Repeat makes the event recurring. A nil one is a one-off.
+	Repeat *RepeatParams
 }
 
-// UpdateCalendarEventParams contains the parameters for updating a calendar event.
-// Only non-nil fields are updated.
+// UpdateCalendarEventParams contains the parameters for updating a calendar event. The pointer
+// fields are a partial update: only the non-nil ones are sent, and the rest are left as they are.
 //
-// The zones are the exception, and the reason is on HEY's side: it reads the pair out of the
-// submitted parameters or nils both, so an update that says nothing about them clears whatever
-// the event had. A caller keeping a zoned event's zones has to send them again.
+// The value fields are not, and the reason is on HEY's side. It reads the zones, the content
+// fields, the reminders and the countdown out of the submitted parameters on every write and
+// defaults each of them to nothing, so an update saying nothing about one clears it. Those are
+// marked below; a caller keeping any of them has to read the event and send them back.
 type UpdateCalendarEventParams struct {
 	// CalendarID moves the event to another calendar. An update takes the same calendar as a
 	// create does, which is how the web app's calendar select relocates an event.
@@ -86,8 +281,28 @@ type UpdateCalendarEventParams struct {
 	//
 	// Deprecated: use StartTimeZone and EndTimeZone. It stands in for whichever of them is
 	// nil, so a caller that only ever wanted one zone keeps working.
-	TimeZone  *string
+	TimeZone *string
+	// Reminders is resend-or-lose-it, like the zones. HEY reads the list on every write and
+	// unschedules everything when it is empty, so an update that leaves it out removes the
+	// reminders the event had. Several durations go in one write and HEY de-duplicates them;
+	// only the list matching the event's all-day flag is read.
 	Reminders []time.Duration
+	// Content is the notes, location, link and attached entry, and it is a replacement rather
+	// than a patch — every field left empty is cleared on the event. See EventContentParams
+	// before using it: keeping any of the four means reading the event and passing it back.
+	Content EventContentParams
+	// Attendees replaces the guest list. Nil leaves it alone; an empty non-nil slice removes
+	// every guest. See setAttendees for what submitting it commits the caller to.
+	Attendees []string
+	// Highlighted circles or uncircles the event, HEY's "Circle event". Nil leaves it as it is.
+	Highlighted *bool
+	// Countdown is resend-or-lose-it too: the zero value deletes the event's countdown, because
+	// that is what HEY does with a write that names no countdown value.
+	Countdown CountdownParams
+	// Repeat changes the recurrence. Nil leaves it untouched on a whole-event update — but not
+	// on an occurrence update, where HEY reads silence as "stop repeating"; see
+	// UpdateCalendarEventOccurrenceParams.
+	Repeat *RepeatParams
 }
 
 // setTimeZones writes the zones a timed event's clock times are written in, and the flag that
@@ -156,6 +371,11 @@ func (s *CalendarEventsService) Create(ctx context.Context, params CreateCalenda
 	values.Set("calendar_event[summary]", params.Title)
 	values.Set("calendar_event[starts_at]", params.StartsAt)
 	values.Set("calendar_event[ends_at]", params.EndsAt)
+	setEventContent(values, params.Content)
+	setAttendees(values, params.Attendees)
+	setHighlighted(values, params.Highlighted)
+	setCountdown(values, params.Countdown)
+	setRepeat(values, params.Repeat)
 
 	if params.AllDay {
 		values.Set("calendar_event[all_day]", "1")
@@ -217,6 +437,16 @@ func (s *CalendarEventsService) Update(ctx context.Context, eventID int64, param
 	ctx = s.client.hooks.OnOperationStart(ctx, op)
 	defer func() { s.client.hooks.OnOperationEnd(ctx, op, err, time.Since(start)) }()
 
+	resp, err := s.client.PatchForm(ctx, fmt.Sprintf("/calendar/events/%d.json", eventID), updateEventValues(params))
+	if err != nil {
+		return nil, err
+	}
+	return recordingFromFormResponse(resp)
+}
+
+// updateEventValues form-encodes an update. The occurrence update takes the same fields, so it
+// builds its body from here and adds the two parameters that only mean something to a series.
+func updateEventValues(params UpdateCalendarEventParams) url.Values {
 	values := url.Values{}
 	if params.Title != nil {
 		values.Set("calendar_event[summary]", *params.Title)
@@ -243,6 +473,11 @@ func (s *CalendarEventsService) Update(ctx context.Context, eventID int64, param
 	if params.CalendarID != nil {
 		values.Set("calendar_event[calendar_id]", fmt.Sprintf("%d", *params.CalendarID))
 	}
+	setEventContent(values, params.Content)
+	setAttendees(values, params.Attendees)
+	setHighlighted(values, params.Highlighted)
+	setCountdown(values, params.Countdown)
+	setRepeat(values, params.Repeat)
 	startZone := timeZonePointerOr(params.StartTimeZone, params.TimeZone)
 	endZone := timeZonePointerOr(params.EndTimeZone, params.TimeZone)
 	if startZone != nil || endZone != nil {
@@ -266,11 +501,7 @@ func (s *CalendarEventsService) Update(ctx context.Context, eventID int64, param
 		}
 	}
 
-	resp, err := s.client.PatchForm(ctx, fmt.Sprintf("/calendar/events/%d.json", eventID), values)
-	if err != nil {
-		return nil, err
-	}
-	return recordingFromFormResponse(resp)
+	return values
 }
 
 // Delete deletes a calendar event.
@@ -289,5 +520,148 @@ func (s *CalendarEventsService) Delete(ctx context.Context, eventID int64) (err 
 	defer func() { s.client.hooks.OnOperationEnd(ctx, op, err, time.Since(start)) }()
 
 	_, err = s.client.DeleteForm(ctx, fmt.Sprintf("/calendar/events/%d", eventID))
+	return err
+}
+
+const occurrenceDateLayout = "2006-01-02"
+
+// EventOccurrence names one day of a repeating calendar event.
+//
+// A repeating event's days are served as virtual occurrences: they carry an id of 0, the series
+// in parent_id, and their only handle in occurrence_id, which reads "<event id>_<YYYY-MM-DD>".
+// So an occurrence is addressed by the series it belongs to plus the day it falls on, and
+// Update and Delete — which take an id — cannot touch one.
+type EventOccurrence struct {
+	// EventID is the repeating event the occurrence belongs to, HEY's parent_id.
+	EventID int64
+	// Date is the day the occurrence falls on. Only the calendar date is read.
+	Date time.Time
+}
+
+// ParseOccurrenceID reads the occurrence_id HEY serves for a virtual occurrence.
+func ParseOccurrenceID(occurrenceID string) (EventOccurrence, error) {
+	event, day, split := strings.Cut(occurrenceID, "_")
+	if !split {
+		return EventOccurrence{}, fmt.Errorf("occurrence id %q is not <event id>_<YYYY-MM-DD>", occurrenceID)
+	}
+
+	eventID, err := strconv.ParseInt(event, 10, 64)
+	if err != nil || eventID <= 0 {
+		return EventOccurrence{}, fmt.Errorf("occurrence id %q names no event", occurrenceID)
+	}
+
+	date, err := time.Parse(occurrenceDateLayout, day)
+	if err != nil {
+		return EventOccurrence{}, fmt.Errorf("occurrence id %q names no date: %w", occurrenceID, err)
+	}
+
+	return EventOccurrence{EventID: eventID, Date: date}, nil
+}
+
+// String is the occurrence_id again, so an occurrence read out of one can be handed back as one.
+func (o EventOccurrence) String() string {
+	return fmt.Sprintf("%d_%s", o.EventID, o.DateParam())
+}
+
+// DateParam is the date as the occurrence routes take it.
+func (o EventOccurrence) DateParam() string {
+	return o.Date.Format(occurrenceDateLayout)
+}
+
+func (o EventOccurrence) path() string {
+	return fmt.Sprintf("/calendar/events/%d/occurrences/%s.json", o.EventID, o.DateParam())
+}
+
+// OccurrenceScope says how much of a repeating event a write to one of its occurrences reaches.
+// Whichever is chosen, the series' earlier days are left alone; the whole series is reached by
+// Update and Delete on the event id instead.
+type OccurrenceScope string
+
+const (
+	// OccurrenceScopeThisEvent changes or removes the named day alone. It is the zero value's
+	// meaning too, so a caller who says nothing gets the narrower of the two.
+	OccurrenceScopeThisEvent OccurrenceScope = "this_event"
+	// OccurrenceScopeThisAndFollowing changes or removes the named day and every one after it.
+	// On an update HEY does this by splitting the series: it records a new repeating event
+	// starting at this day, cancels the occurrences from here on, and either truncates the old
+	// series to the day before or destroys it if this was its first day. The response is still
+	// the old occurrence, not the new series, so a caller wanting the new event has to read the
+	// period again.
+	OccurrenceScopeThisAndFollowing OccurrenceScope = "this_and_following"
+)
+
+func (s OccurrenceScope) applyToFuture() string {
+	if s == OccurrenceScopeThisAndFollowing {
+		return "1"
+	}
+	return "0"
+}
+
+// UpdateCalendarEventOccurrenceParams contains the parameters for updating one occurrence of a
+// repeating event. They are a whole-event update's, read the same way but for Repeat.
+//
+// A nil Repeat leaves a whole event's recurrence alone. Here it would end it: HEY reads an
+// occurrence update that names no frequency as "stop repeating", drops the series' schedule and
+// cancels every other occurrence. So UpdateOccurrence sends RepeatCustom for a nil one, which
+// keeps the schedule the series already has — the recurrence is not usually the business of an
+// update to one day of it. Naming a Repeat means changing the series' schedule on purpose.
+type UpdateCalendarEventOccurrenceParams struct {
+	UpdateCalendarEventParams
+}
+
+// UpdateOccurrence updates one day of a repeating event and returns it as a recording.
+//
+// PATCH /calendar/events/{event id}/occurrences/{YYYY-MM-DD}.json. A date that is not an
+// occurrence of that series is a 404, as is an event the caller cannot edit — the occurrence
+// routes want edit rights on both the day and the series, which is stricter than the
+// whole-event update.
+func (s *CalendarEventsService) UpdateOccurrence(ctx context.Context, occurrence EventOccurrence, scope OccurrenceScope, params UpdateCalendarEventOccurrenceParams) (recording *generated.Recording, err error) {
+	op := OperationInfo{
+		Service: "CalendarEvents", Operation: "UpdateCalendarEventOccurrence",
+		ResourceType: "calendar_event", IsMutation: true, ResourceID: occurrence.EventID,
+	}
+	if gater, ok := s.client.hooks.(GatingHooks); ok {
+		if ctx, err = gater.OnOperationGate(ctx, op); err != nil {
+			return
+		}
+	}
+	start := time.Now()
+	ctx = s.client.hooks.OnOperationStart(ctx, op)
+	defer func() { s.client.hooks.OnOperationEnd(ctx, op, err, time.Since(start)) }()
+
+	values := updateEventValues(params.UpdateCalendarEventParams)
+	values.Set("apply_to_future", scope.applyToFuture())
+	if params.Repeat == nil {
+		values.Set("repeat_frequency", string(RepeatCustom))
+	}
+
+	resp, err := s.client.PatchForm(ctx, occurrence.path(), values)
+	if err != nil {
+		return nil, err
+	}
+	return recordingFromFormResponse(resp)
+}
+
+// DeleteOccurrence removes one day of a repeating event, or that day and every one after it.
+//
+// DELETE /calendar/events/{event id}/occurrences/{YYYY-MM-DD}.json, with the scope in the
+// query string because a delete carries no body. HEY answers 204, so there is nothing to read
+// back: a single day becomes an exception in the series' schedule, and the wider scope
+// truncates the series at the day before — or destroys it, if this was its first day.
+func (s *CalendarEventsService) DeleteOccurrence(ctx context.Context, occurrence EventOccurrence, scope OccurrenceScope) (err error) {
+	op := OperationInfo{
+		Service: "CalendarEvents", Operation: "DeleteCalendarEventOccurrence",
+		ResourceType: "calendar_event", IsMutation: true, ResourceID: occurrence.EventID,
+	}
+	if gater, ok := s.client.hooks.(GatingHooks); ok {
+		if ctx, err = gater.OnOperationGate(ctx, op); err != nil {
+			return
+		}
+	}
+	start := time.Now()
+	ctx = s.client.hooks.OnOperationStart(ctx, op)
+	defer func() { s.client.hooks.OnOperationEnd(ctx, op, err, time.Since(start)) }()
+
+	_, err = s.client.DeleteForm(ctx, occurrence.path()+"?apply_to_future="+scope.applyToFuture())
 	return err
 }

--- a/go/pkg/hey/services_test.go
+++ b/go/pkg/hey/services_test.go
@@ -1383,6 +1383,416 @@ func TestCalendarEventsService_Delete(t *testing.T) {
 	}
 }
 
+func TestParseOccurrenceID(t *testing.T) {
+	occurrence, err := ParseOccurrenceID("153688907_2026-08-21")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if occurrence.EventID != 153688907 {
+		t.Errorf("EventID = %d, want 153688907", occurrence.EventID)
+	}
+	if got := occurrence.Date.Format("2006-01-02"); got != "2026-08-21" {
+		t.Errorf("Date = %s, want 2026-08-21", got)
+	}
+	if got := occurrence.String(); got != "153688907_2026-08-21" {
+		t.Errorf("String() = %q, want the occurrence id back", got)
+	}
+	if got := occurrence.DateParam(); got != "2026-08-21" {
+		t.Errorf("DateParam() = %q, want 2026-08-21", got)
+	}
+}
+
+func TestParseOccurrenceID_Malformed(t *testing.T) {
+	for _, occurrenceID := range []string{
+		"",
+		"153688907",
+		"153688907_",
+		"153688907_2026-08",
+		"153688907_2026-13-40",
+		"153688907_20260821",
+		"_2026-08-21",
+		"0_2026-08-21",
+		"summer_2026-08-21",
+		"153688907_2026-08-21_extra",
+	} {
+		if _, err := ParseOccurrenceID(occurrenceID); err == nil {
+			t.Errorf("%q was accepted as an occurrence id", occurrenceID)
+		}
+	}
+}
+
+func TestCalendarEventsService_UpdateOccurrence(t *testing.T) {
+	newTitle := "Summer Friday"
+	client := newFormJSONTestClient(t, "PATCH", "/calendar/events/153688907/occurrences/2026-08-21.json",
+		func(t *testing.T, values url.Values) {
+			t.Helper()
+			for field, want := range map[string]string{
+				"calendar_event[summary]": "Summer Friday",
+				"apply_to_future":         "0",
+				"repeat_frequency":        "custom",
+			} {
+				if got := values.Get(field); got != want {
+					t.Errorf("%s = %q, want %q", field, got, want)
+				}
+			}
+		},
+		200, `{"id": 153688908, "title": "Summer Friday", "type": "Calendar::Event"}`,
+	)
+
+	occurrence, err := ParseOccurrenceID("153688907_2026-08-21")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	recording, err := client.CalendarEvents().UpdateOccurrence(context.Background(), occurrence, OccurrenceScopeThisEvent,
+		UpdateCalendarEventOccurrenceParams{
+			UpdateCalendarEventParams: UpdateCalendarEventParams{Title: &newTitle},
+		})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if recording.Id != 153688908 {
+		t.Errorf("expected the realized occurrence, got %d", recording.Id)
+	}
+}
+
+// Naming no frequency has to mean "leave the series alone", because HEY reads a silent update as
+// "stop repeating" and cancels every other occurrence.
+func TestCalendarEventsService_UpdateOccurrence_KeepsTheSeriesRepeating(t *testing.T) {
+	client := newFormJSONTestClient(t, "PATCH", "/calendar/events/%s/occurrences/%s",
+		func(t *testing.T, values url.Values) {
+			t.Helper()
+			if got := values.Get("repeat_frequency"); got != "custom" {
+				t.Errorf("repeat_frequency = %q, want custom", got)
+			}
+		},
+		200, `{"id": 153688908, "type": "Calendar::Event"}`,
+	)
+
+	_, err := client.CalendarEvents().UpdateOccurrence(context.Background(),
+		EventOccurrence{EventID: 153688907, Date: time.Date(2026, 8, 21, 0, 0, 0, 0, time.UTC)},
+		OccurrenceScopeThisEvent, UpdateCalendarEventOccurrenceParams{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestCalendarEventsService_UpdateOccurrence_ThisAndFollowing(t *testing.T) {
+	startTime := "10:30"
+	client := newFormJSONTestClient(t, "PATCH", "/calendar/events/%s/occurrences/%s",
+		func(t *testing.T, values url.Values) {
+			t.Helper()
+			for field, want := range map[string]string{
+				"apply_to_future":                "1",
+				"repeat_frequency":               "every_week",
+				"calendar_event[starts_at_time]": "10:30:00",
+			} {
+				if got := values.Get(field); got != want {
+					t.Errorf("%s = %q, want %q", field, got, want)
+				}
+			}
+		},
+		200, `{"id": 153688908, "type": "Calendar::Event"}`,
+	)
+
+	_, err := client.CalendarEvents().UpdateOccurrence(context.Background(),
+		EventOccurrence{EventID: 153688907, Date: time.Date(2026, 8, 21, 0, 0, 0, 0, time.UTC)},
+		OccurrenceScopeThisAndFollowing, UpdateCalendarEventOccurrenceParams{
+			UpdateCalendarEventParams: UpdateCalendarEventParams{
+				StartTime: &startTime,
+				Repeat:    &RepeatParams{Frequency: RepeatEveryWeek},
+			},
+		})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// assertFormFields checks the fields a write is expected to carry, and that the ones it is
+// expected to leave out are absent — for the content and countdown parameters an absent key and
+// an empty one mean different things to HEY.
+func assertFormFields(t *testing.T, values url.Values, want map[string]string, absent ...string) {
+	t.Helper()
+	for field, wanted := range want {
+		if got := values.Get(field); got != wanted {
+			t.Errorf("%s = %q, want %q", field, got, wanted)
+		}
+	}
+	for _, field := range absent {
+		if values.Has(field) {
+			t.Errorf("%s was sent as %q, want it left out", field, values.Get(field))
+		}
+	}
+}
+
+func TestCalendarEventsService_Create_WithContentAndGuests(t *testing.T) {
+	client := newFormJSONTestClient(t, "POST", "/calendar/events.json",
+		func(t *testing.T, values url.Values) {
+			t.Helper()
+			assertFormFields(t, values, map[string]string{
+				"calendar_event[description]":                     "<div>Bring the <strong>roadmap</strong>.</div>",
+				"calendar_event[location]":                        "Meeting Room 2",
+				"calendar_event[url]":                             "https://meet.google.com/abc-defg-hij",
+				"calendar_event[entry_id]":                        "884213",
+				"calendar_event[highlighted]":                     "1",
+				"calendar_event[highlight_id]":                    "",
+				"countdown_interval_duration_value":               "2",
+				"countdown_interval_duration_unit":                "604800",
+				"repeat_frequency":                                "every_other_week",
+				"calendar_recurrence_schedule[recurs_until_type]": "date",
+				"calendar_recurrence_schedule[recurs_until_date]": "2026-12-18",
+			}, "calendar_recurrence_schedule[recurs_count]")
+
+			guests := values["calendar_event[attendance_email_addresses][]"]
+			if len(guests) != 2 || guests[0] != "marta.kowalska@example.com" || guests[1] != "yusuf.demir@example.org" {
+				t.Errorf("guest list = %v", guests)
+			}
+		},
+		201, calendarEventJSON,
+	)
+
+	circled := true
+	_, err := client.CalendarEvents().Create(context.Background(), CreateCalendarEventParams{
+		CalendarID: 1,
+		Title:      "Quarterly roadmap review",
+		StartsAt:   "2026-09-10",
+		AllDay:     true,
+		Content: EventContentParams{
+			Notes:    "<div>Bring the <strong>roadmap</strong>.</div>",
+			Location: "Meeting Room 2",
+			Link:     "https://meet.google.com/abc-defg-hij",
+			EntryID:  884213,
+		},
+		Attendees:   []string{"marta.kowalska@example.com", "yusuf.demir@example.org"},
+		Highlighted: &circled,
+		Countdown:   CountdownParams{Value: 2, Unit: CountdownUnitWeeks},
+		Repeat: &RepeatParams{
+			Frequency: RepeatEveryOtherWeek,
+			Until:     RepeatUntilDate,
+			UntilDate: "2026-12-18",
+			Count:     9,
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// HEY defaults all four content fields to nothing on every write, so an update that only means to
+// move an event still has to say what its notes are. Sending them empty is the SDK being honest
+// about that rather than pretending the fields were left alone.
+func TestCalendarEventsService_Update_SendsTheWholeContentEveryTime(t *testing.T) {
+	client := newFormJSONTestClient(t, "PATCH", "/calendar/events/%s",
+		func(t *testing.T, values url.Values) {
+			t.Helper()
+			assertFormFields(t, values, map[string]string{
+				"calendar_event[starts_at]":   "2026-09-11",
+				"calendar_event[description]": "",
+				"calendar_event[location]":    "",
+				"calendar_event[url]":         "",
+				"calendar_event[entry_id]":    "",
+			})
+		},
+		200, `{"id": 99, "type": "Calendar::Event"}`,
+	)
+
+	startsAt := "2026-09-11"
+	_, err := client.CalendarEvents().Update(context.Background(), 99, UpdateCalendarEventParams{
+		StartsAt: &startsAt,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// Turning the circle off needs the empty highlight_id: without it HEY reads highlighted=0 as a
+// request to build a highlight, which turns the circle on. It goes out with the flag either way.
+func TestCalendarEventsService_Update_Highlighted(t *testing.T) {
+	for circled, wantFlag := range map[bool]string{true: "1", false: "0"} {
+		client := newFormJSONTestClient(t, "PATCH", "/calendar/events/%s",
+			func(t *testing.T, values url.Values) {
+				t.Helper()
+				assertFormFields(t, values, map[string]string{
+					"calendar_event[highlighted]":  wantFlag,
+					"calendar_event[highlight_id]": "",
+				})
+			},
+			200, `{"id": 99, "type": "Calendar::Event"}`,
+		)
+
+		_, err := client.CalendarEvents().Update(context.Background(), 99, UpdateCalendarEventParams{
+			Highlighted: &circled,
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}
+}
+
+// Nothing is sent for the circle when nobody asked about it, because HEY only reads the flag when
+// it is submitted.
+func TestCalendarEventsService_Update_LeavesTheCircleAloneUnasked(t *testing.T) {
+	client := newFormJSONTestClient(t, "PATCH", "/calendar/events/%s",
+		func(t *testing.T, values url.Values) {
+			t.Helper()
+			assertFormFields(t, values, nil,
+				"calendar_event[highlighted]", "calendar_event[highlight_id]")
+		},
+		200, `{"id": 99, "type": "Calendar::Event"}`,
+	)
+
+	_, err := client.CalendarEvents().Update(context.Background(), 99, UpdateCalendarEventParams{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// The zero countdown sends no countdown at all, which is how HEY is told to delete it. There is no
+// third state, so this is the same request as one that never had a countdown in mind.
+func TestCalendarEventsService_Update_ZeroCountdownSendsNothing(t *testing.T) {
+	client := newFormJSONTestClient(t, "PATCH", "/calendar/events/%s",
+		func(t *testing.T, values url.Values) {
+			t.Helper()
+			assertFormFields(t, values, nil,
+				"countdown_interval_duration_value", "countdown_interval_duration_unit")
+		},
+		200, `{"id": 99, "type": "Calendar::Event"}`,
+	)
+
+	_, err := client.CalendarEvents().Update(context.Background(), 99, UpdateCalendarEventParams{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// A countdown with no unit named is counted in days, which is the web app's own default.
+func TestCalendarEventsService_Update_CountdownDefaultsToDays(t *testing.T) {
+	client := newFormJSONTestClient(t, "PATCH", "/calendar/events/%s",
+		func(t *testing.T, values url.Values) {
+			t.Helper()
+			assertFormFields(t, values, map[string]string{
+				"countdown_interval_duration_value": "10",
+				"countdown_interval_duration_unit":  "86400",
+			})
+		},
+		200, `{"id": 99, "type": "Calendar::Event"}`,
+	)
+
+	_, err := client.CalendarEvents().Update(context.Background(), 99, UpdateCalendarEventParams{
+		Countdown: CountdownParams{Value: 10},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// A nil guest list leaves the roster alone; an empty one clears it, and needs a blank value on
+// the wire to say so, since a form cannot carry an empty array.
+func TestCalendarEventsService_Update_Attendees(t *testing.T) {
+	client := newFormJSONTestClient(t, "PATCH", "/calendar/events/%s",
+		func(t *testing.T, values url.Values) {
+			t.Helper()
+			assertFormFields(t, values, nil, "calendar_event[attendance_email_addresses][]")
+		},
+		200, `{"id": 99, "type": "Calendar::Event"}`,
+	)
+
+	_, err := client.CalendarEvents().Update(context.Background(), 99, UpdateCalendarEventParams{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	client = newFormJSONTestClient(t, "PATCH", "/calendar/events/%s",
+		func(t *testing.T, values url.Values) {
+			t.Helper()
+			guests := values["calendar_event[attendance_email_addresses][]"]
+			if len(guests) != 1 || guests[0] != "" {
+				t.Errorf("guest list = %v, want a single blank so HEY sees the key", guests)
+			}
+		},
+		200, `{"id": 99, "type": "Calendar::Event"}`,
+	)
+
+	_, err = client.CalendarEvents().Update(context.Background(), 99, UpdateCalendarEventParams{
+		Attendees: []string{},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// A count-limited recurrence sends the count and no until-date, since HEY reads only the one
+// matching the type.
+func TestCalendarEventsService_Update_RepeatUntilCount(t *testing.T) {
+	client := newFormJSONTestClient(t, "PATCH", "/calendar/events/%s",
+		func(t *testing.T, values url.Values) {
+			t.Helper()
+			assertFormFields(t, values, map[string]string{
+				"repeat_frequency": "every_weekday",
+				"calendar_recurrence_schedule[recurs_until_type]": "count",
+				"calendar_recurrence_schedule[recurs_count]":      "12",
+			}, "calendar_recurrence_schedule[recurs_until_date]")
+		},
+		200, `{"id": 99, "type": "Calendar::Event"}`,
+	)
+
+	_, err := client.CalendarEvents().Update(context.Background(), 99, UpdateCalendarEventParams{
+		Repeat: &RepeatParams{Frequency: RepeatEveryWeekday, Until: RepeatUntilCount, Count: 12},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// A whole-event update that says nothing about the recurrence leaves it alone — the one place
+// where the occurrence update reads the same silence differently.
+func TestCalendarEventsService_Update_WithoutRepeatLeavesTheScheduleAlone(t *testing.T) {
+	client := newFormJSONTestClient(t, "PATCH", "/calendar/events/%s",
+		func(t *testing.T, values url.Values) {
+			t.Helper()
+			assertFormFields(t, values, nil, "repeat_frequency")
+		},
+		200, `{"id": 99, "type": "Calendar::Event"}`,
+	)
+
+	_, err := client.CalendarEvents().Update(context.Background(), 99, UpdateCalendarEventParams{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// A delete carries no body, so the scope rides in the query string, as it does in HEY's own
+// occurrence links.
+func TestCalendarEventsService_DeleteOccurrence(t *testing.T) {
+	for scope, wantApplyToFuture := range map[OccurrenceScope]string{
+		OccurrenceScopeThisEvent:        "0",
+		OccurrenceScopeThisAndFollowing: "1",
+	} {
+		var gotPath, gotApplyToFuture, gotMethod string
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotMethod, gotPath = r.Method, r.URL.Path
+			gotApplyToFuture = r.URL.Query().Get("apply_to_future")
+			w.WriteHeader(204)
+		}))
+		t.Cleanup(server.Close)
+		client := NewClient(&Config{BaseURL: server.URL}, &StaticTokenProvider{Token: "test-token"}, WithMaxRetries(0))
+
+		err := client.CalendarEvents().DeleteOccurrence(context.Background(),
+			EventOccurrence{EventID: 153688907, Date: time.Date(2026, 8, 21, 0, 0, 0, 0, time.UTC)}, scope)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if gotMethod != "DELETE" {
+			t.Errorf("expected DELETE, got %s", gotMethod)
+		}
+		if gotPath != "/calendar/events/153688907/occurrences/2026-08-21.json" {
+			t.Errorf("path = %q", gotPath)
+		}
+		if gotApplyToFuture != wantApplyToFuture {
+			t.Errorf("apply_to_future = %q, want %q for %s", gotApplyToFuture, wantApplyToFuture, scope)
+		}
+	}
+}
+
 // --- Designations ---
 
 func TestDesignationsService_Create(t *testing.T) {


### PR DESCRIPTION
Two additions, both driven by a terminal calendar that could not do things the web app can.

## Writing one day of a repeating event

A repeating event's individual days are served as virtual occurrences. Reading a calendar period gives you, for such a day:

```
id: 0
occurrence_id: "153688907_2026-08-21"
parent_id: 153688907
edit_url: ".../calendar/events/153688907/occurrences/2026-08-21/edit"
```

No id of its own. `Update` and `Delete` take an event id, so a client following them would have addressed `/calendar/events/0` — and a client keying its selection on the id could not so much as *point* at one. That is the bug that started this: a weekly all-day event was unselectable in every view of the CLI's calendar.

```go
type EventOccurrence struct { EventID int64; Date time.Time }
func ParseOccurrenceID(occurrenceID string) (EventOccurrence, error)

type OccurrenceScope string
const (
    OccurrenceScopeThisEvent        OccurrenceScope = "this_event"
    OccurrenceScopeThisAndFollowing OccurrenceScope = "this_and_following"
)

func (s *CalendarEventsService) UpdateOccurrence(ctx, occurrence, scope, params) (*generated.Recording, error)
func (s *CalendarEventsService) DeleteOccurrence(ctx, occurrence, scope) error
```

A two-value scope rather than a bool, because "not the future" is not what a caller means — they mean *this day*. `ParseOccurrenceID` exists so the `"<series>_<date>"` split lives in one place instead of being re-derived by every caller.

One guard is baked in: on an occurrence update, **omitting the repeat frequency does not mean "leave the recurrence alone"** — it is read as *stop repeating*, which drops the series' schedule and cancels every occurrence. `UpdateOccurrence` sends `custom` ("keep the schedule verbatim") when the caller says nothing, and the field says why.

## Everything else an event carries

Notes, location, link, attached entry, invites, the circle, a countdown, a repeat — on create and update both.

These needed a decision rather than a field each, because **some of them are cleared by any write that leaves them out**. A `*string` where nil means "leave alone" would be a lie about those. So the type says which semantics apply:

- **Pointer** — a genuine partial. `Title`, `StartsAt`, `Highlighted`, `Repeat`. Nil leaves it.
- **Value struct or slice** — a replacement. `Content`, `Countdown`, `Reminders`. There is no leave-alone to model, so there is no nil to offer.
- **Nil versus empty** — `Attendees` only, where both states are real: nil leaves the roster alone, an empty list clears it.

The four cleared-by-omission fields are grouped into `EventContentParams` so a call site reads as setting a whole object, not as four independent optional fields. `Title` deliberately stays outside it: the summary really is preserved on omission, and the grouping is exactly the set that is not.

Two traps are handled here rather than pushed at callers:

- **Turning the circle off** needs an empty `highlight_id` sent alongside the flag. Without it the write *turns it on*. And the id is never served on a read, so a caller could not have constructed the right form from one — the SDK sends it unconditionally and `Highlighted` stays a plain `*bool`.
- **A zero countdown is how a countdown is deleted.** Documented as that, rather than dressed up as "unchanged".

## Still not expressible

**A repeat cannot be stopped.** The whole-event write takes no parameter for it: omitting the frequency leaves the schedule alone and an empty one is a 500. And the date a series runs until is not served — only its kind — so re-sending a frequency would turn a series that ends in December into one that never ends. A client can replace a repeat or keep it, and can do neither of the two useful things: remove it, or preserve a bounded one while changing something else. That wants an API change, not an SDK one.

## Checks

- `apidiff -incompatible` against main: **exit 0**, all 37 changes additive.
- `make check`: **156 passed, 0 failed**.
- `make drift-check`: coverage fresh, 116 modelled routes present, 845 JSON-capable routes accounted for, fingerprints up to date. No Smithy regeneration — both occurrence routes were already in `spec/excluded-routes.json` alongside the whole-event writes these sit next to.
- `go test ./...`, `gofmt -l` clean.

Fifteen new tests, asserting the form-encoded bodies — including the absent keys, since for these parameters an absent key and an empty one mean different things.

No version bump; that lands on its own.
