### PR TITLE
Bump the SDK to 0.19.0

### DIFF
--- a/go/pkg/hey/version.go
+++ b/go/pkg/hey/version.go
@@ -1,7 +1,7 @@
 package hey
 
 // Version is the current version of the HEY Go SDK.
-const Version = "0.18.0"
+const Version = "0.19.0"
 
 // APIVersion is the HEY API version this SDK targets.
 const APIVersion = "2026-08-21"


### PR DESCRIPTION
Releases the repeating-event occurrence writes and the rest of the event write surface from #116.