### PR TITLE
Follow calendar changes: the two feeds, and each calendar's stream name

### DIFF
--- a/go/pkg/hey/calendar_changes.go
+++ b/go/pkg/hey/calendar_changes.go
@@ -1,0 +1,340 @@
+package hey
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"net/http"
+	"net/url"
+	"slices"
+	"time"
+
+	"github.com/basecamp/hey-sdk/go/pkg/generated"
+)
+
+// CalendarChangesCursor is where a read of a calendar changes feed starts — either the
+// calendar-level feed behind a CalendarList's CalendarChangesURL or a calendar's own
+// recording feed behind its RecordingChangesURL; both speak the same cursor. Since is an
+// ISO 8601 timestamp with milliseconds and is exclusive; Version is the contract version
+// the caller speaks. The two server-issued URLs differ: a recording_changes_url carries
+// v=1, which the recording feed requires, while a calendar_changes_url carries no version
+// at all. The server issues the pair in those URLs to begin with — read them with
+// CalendarChangesCursorFrom rather than picking the query apart.
+type CalendarChangesCursor struct {
+	Since   string
+	Version string
+	Page    string
+	PerPage string
+}
+
+// CalendarChangesCursorFrom reads a cursor out of a changes URL the server issued: a
+// CalendarList's CalendarChangesURL, a calendar's RecordingChangesURL, or a Link header
+// either feed answered with. The recording feed refuses a cursor without the version the
+// server put in its URL, so this is the only sound way to build one for it.
+func CalendarChangesCursorFrom(changesURL string) (CalendarChangesCursor, error) {
+	parsed, err := url.Parse(changesURL)
+	if err != nil {
+		return CalendarChangesCursor{}, fmt.Errorf("failed to read changes URL %q: %w", changesURL, err)
+	}
+
+	query := parsed.Query()
+	return CalendarChangesCursor{
+		Since:   query.Get("since"),
+		Version: query.Get("v"),
+		Page:    query.Get("page"),
+		PerPage: query.Get("per_page"),
+	}, nil
+}
+
+// query renders the cursor for a request path. The version is never invented here: a
+// cursor read from a server-issued URL carries whichever version the server speaks.
+func (c CalendarChangesCursor) query() string {
+	values := url.Values{}
+	values.Set("since", c.Since)
+	if c.Version != "" {
+		values.Set("v", c.Version)
+	}
+	if c.Page != "" {
+		values.Set("page", c.Page)
+	}
+	if c.PerPage != "" {
+		values.Set("per_page", c.PerPage)
+	}
+	return values.Encode()
+}
+
+// DeletedCalendar is a calendar the changes feed reports gone.
+type DeletedCalendar struct {
+	ID        int64     `json:"id"`
+	DeletedAt time.Time `json:"deleted_at"`
+}
+
+// CalendarChanges is everything that happened to the calendar list since a cursor.
+// Added calendars arrive as ListedCalendar, so a new calendar comes with the changes URL
+// and signed stream name a live follower needs.
+//
+// NextPage is set while this increment has more pages to read now. NextCursor is set on
+// the last page and is where the next read should resume; it is nil when nothing changed,
+// in which case the cursor that produced this page still stands. Unlike the recording
+// feed, this feed never falls too far behind, so there is no FullSyncRequired here.
+type CalendarChanges struct {
+	Added      []ListedCalendar
+	Updated    []generated.Calendar
+	Deleted    []DeletedCalendar
+	NextPage   *CalendarChangesCursor
+	NextCursor *CalendarChangesCursor
+}
+
+// AllCalendarChanges reads the calendar changes feed from a cursor to its end.
+func (s *CalendarsService) AllCalendarChanges(ctx context.Context, cursor CalendarChangesCursor) (*CalendarChanges, error) {
+	all := &CalendarChanges{}
+
+	for page := 1; page <= s.client.httpOpts.MaxPages; page++ {
+		changes, err := s.CalendarChanges(ctx, cursor)
+		if err != nil {
+			return nil, err
+		}
+
+		all.Added = append(all.Added, changes.Added...)
+		all.Updated = append(all.Updated, changes.Updated...)
+		all.Deleted = append(all.Deleted, changes.Deleted...)
+		all.NextCursor = changes.NextCursor
+
+		if changes.NextPage == nil {
+			return all, nil
+		}
+		cursor = *changes.NextPage
+	}
+
+	s.client.logger.Warn("calendar changes pagination capped", "maxPages", s.client.httpOpts.MaxPages)
+	return all, nil
+}
+
+// CalendarChanges returns one page of the calendar changes feed.
+func (s *CalendarsService) CalendarChanges(ctx context.Context, cursor CalendarChangesCursor) (result *CalendarChanges, err error) {
+	if cursor.Since == "" {
+		return nil, ErrUsage("a since cursor is required — start from the list's calendar_changes_url")
+	}
+
+	op := OperationInfo{
+		Service: "Calendars", Operation: "GetCalendarChanges",
+		ResourceType: "calendar", IsMutation: false,
+	}
+
+	err = s.client.instrument(ctx, op, func(ctx context.Context) error {
+		path := "/calendar/changes.json?" + cursor.query()
+		requested, berr := s.client.buildURL(path)
+		if berr != nil {
+			return berr
+		}
+
+		// Cursor URLs never repeat, so a cached response would never be revalidated —
+		// a long-running watch would grow the cache one dead entry per read.
+		resp, rerr := s.client.Get(contextWithoutCache(ctx), path)
+		if rerr != nil {
+			return rerr
+		}
+
+		var payload struct {
+			Added   []ListedCalendar     `json:"added"`
+			Updated []generated.Calendar `json:"updated"`
+			Deleted []DeletedCalendar    `json:"deleted"`
+		}
+		if derr := resp.UnmarshalData(&payload); derr != nil {
+			return fmt.Errorf("failed to decode the calendar changes: %w", derr)
+		}
+
+		changes := &CalendarChanges{
+			Added:   payload.Added,
+			Updated: payload.Updated,
+			Deleted: payload.Deleted,
+		}
+
+		var nerr error
+		changes.NextPage, changes.NextCursor, nerr = nextCalendarChangesCursor(requested, resp.Headers)
+		if nerr != nil {
+			return nerr
+		}
+
+		result = changes
+		return nil
+	})
+	return result, err
+}
+
+// DeletedRecording is a recording the changes feed reports gone. Type is the recordable
+// type key the recording was grouped under while it existed.
+type DeletedRecording struct {
+	ID        int64     `json:"id"`
+	DeletedAt time.Time `json:"deleted_at"`
+	Type      string    `json:"type"`
+}
+
+// RecordingChanges is everything that happened to a calendar's recordings since a cursor.
+// Added and Updated keep the wire's grouping by recordable type key — "Calendar::Event",
+// "Calendar::Habit", "Calendar::Habit::Completion", "Calendar::DayTitle",
+// "Calendar::DayBackground", "Calendar::TimeTrack", "Calendar::Todo",
+// "Calendar::Countdown", "Calendar::JournalEntry" — the server owns that vocabulary.
+// Deleted is one deduplicated slice: the wire groups deletions by type key too, but it
+// repeats the whole deleted collection under every key it groups, so the map shape carries
+// no information beyond each record's own Type — which is authoritative here.
+//
+// NextPage is set while this increment has more pages to read now. NextCursor is set on
+// the last page and is where the next read should resume; it is nil when nothing changed,
+// in which case the cursor that produced this page still stands. FullSyncRequired is set
+// when the cursor is too far behind for an increment to carry the difference — or speaks
+// a version the feed no longer does — and the calendar has to be read in full instead.
+type RecordingChanges struct {
+	Added            map[string][]generated.Recording
+	Updated          map[string][]generated.Recording
+	Deleted          []DeletedRecording
+	NextPage         *CalendarChangesCursor
+	NextCursor       *CalendarChangesCursor
+	FullSyncRequired bool
+}
+
+// AllRecordingChanges reads a calendar's recording changes feed from a cursor to its end.
+func (s *CalendarsService) AllRecordingChanges(ctx context.Context, calendarID int64, cursor CalendarChangesCursor) (*RecordingChanges, error) {
+	all := &RecordingChanges{}
+
+	for page := 1; page <= s.client.httpOpts.MaxPages; page++ {
+		changes, err := s.RecordingChanges(ctx, calendarID, cursor)
+		if err != nil {
+			return nil, err
+		}
+		if changes.FullSyncRequired {
+			return changes, nil
+		}
+
+		all.Added = mergeRecordingBuckets(all.Added, changes.Added)
+		all.Updated = mergeRecordingBuckets(all.Updated, changes.Updated)
+		all.Deleted = append(all.Deleted, changes.Deleted...)
+		all.NextCursor = changes.NextCursor
+
+		if changes.NextPage == nil {
+			return all, nil
+		}
+		cursor = *changes.NextPage
+	}
+
+	s.client.logger.Warn("recording changes pagination capped", "maxPages", s.client.httpOpts.MaxPages)
+	return all, nil
+}
+
+// RecordingChanges returns one page of a calendar's recording changes feed.
+func (s *CalendarsService) RecordingChanges(ctx context.Context, calendarID int64, cursor CalendarChangesCursor) (result *RecordingChanges, err error) {
+	if cursor.Since == "" {
+		return nil, ErrUsage("a since cursor is required — start from the calendar's recording_changes_url")
+	}
+	// Without the version the server answers 409 forever, which would read as an endless
+	// full-sync loop rather than the usage error it is.
+	if cursor.Version == "" {
+		return nil, ErrUsage("a feed version is required — parse the calendar's recording_changes_url with CalendarChangesCursorFrom")
+	}
+
+	op := OperationInfo{
+		Service: "Calendars", Operation: "GetCalendarRecordingChanges",
+		ResourceType: "recording", IsMutation: false, ResourceID: calendarID,
+	}
+
+	err = s.client.instrument(ctx, op, func(ctx context.Context) error {
+		path := fmt.Sprintf("/calendars/%d/recording/changes.json?%s", calendarID, cursor.query())
+		requested, berr := s.client.buildURL(path)
+		if berr != nil {
+			return berr
+		}
+
+		// Cursor URLs never repeat, so a cached response would never be revalidated —
+		// a long-running watch would grow the cache one dead entry per read.
+		resp, rerr := s.client.Get(contextWithoutCache(ctx), path)
+		if rerr != nil {
+			// Too far behind for an increment, or a feed version mismatch: the server says
+			// so with a 409, and the answer to both is a full read and a fresh cursor.
+			if AsError(rerr).HTTPStatus == http.StatusConflict {
+				result = &RecordingChanges{FullSyncRequired: true}
+				return nil
+			}
+			return rerr
+		}
+
+		var payload struct {
+			Added   map[string][]generated.Recording `json:"added"`
+			Updated map[string][]generated.Recording `json:"updated"`
+			Deleted map[string][]DeletedRecording    `json:"deleted"`
+		}
+		if derr := resp.UnmarshalData(&payload); derr != nil {
+			return fmt.Errorf("failed to decode the recording changes: %w", derr)
+		}
+
+		changes := &RecordingChanges{
+			Added:   payload.Added,
+			Updated: payload.Updated,
+			Deleted: flattenDeletedRecordings(payload.Deleted),
+		}
+
+		var nerr error
+		changes.NextPage, changes.NextCursor, nerr = nextCalendarChangesCursor(requested, resp.Headers)
+		if nerr != nil {
+			return nerr
+		}
+
+		result = changes
+		return nil
+	})
+	return result, err
+}
+
+func mergeRecordingBuckets(into, from map[string][]generated.Recording) map[string][]generated.Recording {
+	if len(from) == 0 {
+		return into
+	}
+	if into == nil {
+		into = map[string][]generated.Recording{}
+	}
+	for key, recordings := range from {
+		into[key] = append(into[key], recordings...)
+	}
+	return into
+}
+
+// flattenDeletedRecordings folds the wire's per-type deleted buckets into one slice. The
+// server repeats the whole deleted collection under every type key it groups, so the same
+// deletion arrives once per key; the ID dedupe removes the repeats, and each record's own
+// Type says what it was.
+func flattenDeletedRecordings(buckets map[string][]DeletedRecording) []DeletedRecording {
+	var deleted []DeletedRecording
+	seen := map[int64]bool{}
+	for _, key := range slices.Sorted(maps.Keys(buckets)) {
+		for _, record := range buckets[key] {
+			if !seen[record.ID] {
+				seen[record.ID] = true
+				deleted = append(deleted, record)
+			}
+		}
+	}
+	return deleted
+}
+
+// nextCalendarChangesCursor reads the feed's Link header: while an increment has more
+// pages the link carries a page cursor, and the last page carries a fresh since cursor
+// instead. Both are nil when there is no link — the caller's cursor still stands.
+func nextCalendarChangesCursor(requestedURL string, headers http.Header) (page, since *CalendarChangesCursor, err error) {
+	link := parseNextLink(headers.Get("Link"))
+	if link == "" {
+		return nil, nil, nil
+	}
+
+	next := resolveURL(requestedURL, link)
+	if !isSameOrigin(next, requestedURL) {
+		return nil, nil, fmt.Errorf("changes Link header points to a different origin: %s", next)
+	}
+
+	cursor, cerr := CalendarChangesCursorFrom(next)
+	if cerr != nil {
+		return nil, nil, cerr
+	}
+	if cursor.Page != "" {
+		return &cursor, nil, nil
+	}
+	return nil, &cursor, nil
+}

--- a/go/pkg/hey/calendar_changes_test.go
+++ b/go/pkg/hey/calendar_changes_test.go
@@ -1,0 +1,370 @@
+package hey
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// newCalendarChangesTestClient serves the calendar changes feeds with the given handler,
+// and answers with the cursors the calendars list would carry.
+func newCalendarChangesTestClient(t *testing.T, handler http.HandlerFunc) (c *Client, calendarCursor, recordingCursor CalendarChangesCursor) {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	c = NewClient(&Config{BaseURL: server.URL}, &StaticTokenProvider{Token: "test-token"},
+		WithMaxRetries(0), WithBaseDelay(time.Millisecond), WithMaxJitter(time.Millisecond))
+
+	calendarCursor, err := CalendarChangesCursorFrom(server.URL + "/calendar/changes.json?since=2026-08-18T09%3A00%3A00.000Z")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	recordingCursor, err = CalendarChangesCursorFrom(server.URL + "/calendars/512/recording/changes.json?since=2026-08-18T09%3A00%3A00.000Z&v=1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	return c, calendarCursor, recordingCursor
+}
+
+func TestCalendarChangesCursorFrom(t *testing.T) {
+	cursor, err := CalendarChangesCursorFrom("https://app.hey.com/calendars/512/recording/changes.json?since=2026-08-18T09%3A00%3A00.000Z&v=1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cursor.Since != "2026-08-18T09:00:00.000Z" {
+		t.Errorf("since = %q, want it decoded", cursor.Since)
+	}
+	if cursor.Version != "1" || cursor.Page != "" {
+		t.Errorf("cursor = %+v, want v 1 and no page", cursor)
+	}
+
+	cursor, err = CalendarChangesCursorFrom("https://app.hey.com/calendar/changes.json?since=2026-08-18T09%3A00%3A00.000Z&page=2")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cursor.Since != "2026-08-18T09:00:00.000Z" || cursor.Page != "2" || cursor.Version != "" {
+		t.Errorf("cursor = %+v, want the since and page with no version", cursor)
+	}
+
+	if _, err = CalendarChangesCursorFrom("://not a url"); err == nil {
+		t.Error("expected an error for a garbage URL")
+	}
+}
+
+func TestCalendarsService_ListWithChanges(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"calendars": [
+				{"calendar": {"id": 512, "name": "Personal", "personal": true},
+				 "recording_changes_url": "https://app.hey.com/calendars/512/recording/changes.json?since=2026-08-18T09%3A00%3A00.000Z&v=1",
+				 "signed_stream_name": "IloybGtPaTh2YUdWNUwwTmhiR1Z1WkdGeUx6VXhNZyJ9--personal"},
+				{"calendar": {"id": 513, "name": "Family"},
+				 "recording_changes_url": "https://app.hey.com/calendars/513/recording/changes.json?since=2026-08-18T09%3A00%3A00.000Z&v=1",
+				 "signed_stream_name": "IloybGtPaTh2YUdWNUwwTmhiR1Z1WkdGeUx6VXhNdyJ9--family"}
+			],
+			"calendar_changes_url": "https://app.hey.com/calendar/changes.json?since=2026-08-18T09%3A00%3A00.000Z",
+			"selected_calendar_ids": [512, 513]
+		}`))
+	}))
+	t.Cleanup(server.Close)
+	c := NewClient(&Config{BaseURL: server.URL}, &StaticTokenProvider{Token: "test-token"},
+		WithMaxRetries(0), WithBaseDelay(time.Millisecond), WithMaxJitter(time.Millisecond))
+
+	list, err := c.Calendars().ListWithChanges(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(list.Calendars) != 2 {
+		t.Fatalf("calendars = %+v, want two", list.Calendars)
+	}
+	personal := list.Calendars[0]
+	if personal.Calendar.Id != 512 || personal.Calendar.Name != "Personal" || !personal.Calendar.Personal {
+		t.Errorf("calendar = %+v, want the personal calendar", personal.Calendar)
+	}
+	if personal.SignedStreamName != "IloybGtPaTh2YUdWNUwwTmhiR1Z1WkdGeUx6VXhNZyJ9--personal" {
+		t.Errorf("signed stream name = %q, want the wrapper's", personal.SignedStreamName)
+	}
+	if !strings.Contains(personal.RecordingChangesURL, "/calendars/512/recording/changes.json") {
+		t.Errorf("recording changes URL = %q, want the calendar's own feed", personal.RecordingChangesURL)
+	}
+	if !strings.Contains(list.CalendarChangesURL, "/calendar/changes.json") {
+		t.Errorf("calendar changes URL = %q, want the list-level feed", list.CalendarChangesURL)
+	}
+	if len(list.SelectedCalendarIDs) != 2 || list.SelectedCalendarIDs[0] != 512 {
+		t.Errorf("selected calendar ids = %v, want both calendars", list.SelectedCalendarIDs)
+	}
+}
+
+func TestCalendarsService_CalendarChanges(t *testing.T) {
+	var requested string
+	c, cursor, _ := newCalendarChangesTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		requested = r.URL.String()
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Link", `<`+r.URL.Path+`?since=2026-08-18T09%3A14%3A22.031Z>; rel="next"`)
+		_, _ = w.Write([]byte(`{
+			"added": [{"calendar": {"id": 514, "name": "Book Club"},
+			           "recording_changes_url": "https://app.hey.com/calendars/514/recording/changes.json?since=2026-08-18T09%3A14%3A00.000Z&v=1",
+			           "signed_stream_name": "IloybGtPaTh2YUdWNUwwTmhiR1Z1WkdGeUx6VXhOQSJ9--bookclub"}],
+			"updated": [{"id": 512, "name": "Personal", "personal": true}],
+			"deleted": [{"id": 511, "deleted_at": "2026-08-18T09:14:00.000Z"}]
+		}`))
+	})
+
+	changes, err := c.Calendars().CalendarChanges(context.Background(), cursor)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if requested != "/calendar/changes.json?since=2026-08-18T09%3A00%3A00.000Z" {
+		t.Errorf("requested %q, want the feed with the cursor and nothing the cursor lacks", requested)
+	}
+	if len(changes.Added) != 1 || changes.Added[0].Calendar.Id != 514 {
+		t.Fatalf("added = %+v, want calendar 514", changes.Added)
+	}
+	if changes.Added[0].SignedStreamName != "IloybGtPaTh2YUdWNUwwTmhiR1Z1WkdGeUx6VXhOQSJ9--bookclub" {
+		t.Errorf("signed stream name = %q, want the added calendar subscribable", changes.Added[0].SignedStreamName)
+	}
+	if !strings.Contains(changes.Added[0].RecordingChangesURL, "/calendars/514/recording/changes.json") {
+		t.Errorf("recording changes URL = %q, want the added calendar's feed", changes.Added[0].RecordingChangesURL)
+	}
+	if len(changes.Updated) != 1 || changes.Updated[0].Id != 512 {
+		t.Errorf("updated = %+v, want calendar 512", changes.Updated)
+	}
+	wantDeletedAt := time.Date(2026, 8, 18, 9, 14, 0, 0, time.UTC)
+	if len(changes.Deleted) != 1 || changes.Deleted[0].ID != 511 || !changes.Deleted[0].DeletedAt.Equal(wantDeletedAt) {
+		t.Errorf("deleted = %+v, want calendar 511 deleted at %v", changes.Deleted, wantDeletedAt)
+	}
+	if changes.NextPage != nil {
+		t.Errorf("next page = %+v, want none: a since link is a cursor, not a page", changes.NextPage)
+	}
+	if changes.NextCursor == nil || changes.NextCursor.Since != "2026-08-18T09:14:22.031Z" {
+		t.Errorf("cursor = %+v, want the since from the Link header", changes.NextCursor)
+	}
+}
+
+func TestCalendarsService_AllCalendarChangesFollowsPages(t *testing.T) {
+	var requested []string
+	c, cursor, _ := newCalendarChangesTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		requested = append(requested, r.URL.String())
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Query().Get("page") == "" {
+			w.Header().Set("Link", `<`+r.URL.Path+`?since=2026-08-18T09%3A00%3A00.000Z&page=2>; rel="next"`)
+			_, _ = w.Write([]byte(`{"updated":[{"id":512,"name":"Personal"}]}`))
+		} else {
+			w.Header().Set("Link", `<`+r.URL.Path+`?since=2026-08-18T09%3A30%3A00.000Z>; rel="next"`)
+			_, _ = w.Write([]byte(`{"updated":[{"id":513,"name":"Family"}]}`))
+		}
+	})
+
+	changes, err := c.Calendars().AllCalendarChanges(context.Background(), cursor)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(requested) != 2 {
+		t.Fatalf("requests = %v, want two pages", requested)
+	}
+	if !strings.Contains(requested[1], "page=2") {
+		t.Errorf("second request = %q, want the page from the Link header", requested[1])
+	}
+	if len(changes.Updated) != 2 || changes.Updated[0].Id != 512 || changes.Updated[1].Id != 513 {
+		t.Errorf("updated = %+v, want both pages", changes.Updated)
+	}
+	if changes.NextCursor == nil || changes.NextCursor.Since != "2026-08-18T09:30:00.000Z" {
+		t.Errorf("cursor = %+v, want the last page's since", changes.NextCursor)
+	}
+}
+
+func TestCalendarsService_RecordingChanges(t *testing.T) {
+	var requested string
+	c, _, cursor := newCalendarChangesTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		requested = r.URL.String()
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Link", `<`+r.URL.Path+`?since=2026-08-18T09%3A14%3A22.031Z&v=1>; rel="next"`)
+		_, _ = w.Write([]byte(`{
+			"added": {"Calendar::Event": [{"id": 88001, "title": "Dentist appointment"}]},
+			"updated": {"Calendar::JournalEntry": [{"id": 88002}]},
+			"deleted": {
+				"Calendar::Habit": [
+					{"id": 88005, "deleted_at": "2026-08-18T09:12:00.000Z", "type": "Calendar::Habit"},
+					{"id": 88003, "deleted_at": "2026-08-18T09:14:00.000Z", "type": "Calendar::Todo"}
+				],
+				"Calendar::Todo": [
+					{"id": 88005, "deleted_at": "2026-08-18T09:12:00.000Z", "type": "Calendar::Habit"},
+					{"id": 88003, "deleted_at": "2026-08-18T09:14:00.000Z", "type": "Calendar::Todo"}
+				]
+			}
+		}`))
+	})
+
+	changes, err := c.Calendars().RecordingChanges(context.Background(), 512, cursor)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if requested != "/calendars/512/recording/changes.json?since=2026-08-18T09%3A00%3A00.000Z&v=1" {
+		t.Errorf("requested %q, want the calendar's own feed with the cursor's since and version", requested)
+	}
+	added := changes.Added["Calendar::Event"]
+	if len(added) != 1 || added[0].Id != 88001 || added[0].Title != "Dentist appointment" {
+		t.Errorf("added = %+v, want event 88001 under its type key", changes.Added)
+	}
+	updated := changes.Updated["Calendar::JournalEntry"]
+	if len(updated) != 1 || updated[0].Id != 88002 {
+		t.Errorf("updated = %+v, want journal entry 88002 under its type key", changes.Updated)
+	}
+	if len(changes.Deleted) != 2 {
+		t.Fatalf("deleted = %+v, want the wire's repeats deduped down to two", changes.Deleted)
+	}
+	if changes.Deleted[0].ID != 88005 || changes.Deleted[0].Type != "Calendar::Habit" {
+		t.Errorf("deleted[0] = %+v, want habit 88005 with its own type", changes.Deleted[0])
+	}
+	if changes.Deleted[1].ID != 88003 || changes.Deleted[1].Type != "Calendar::Todo" {
+		t.Errorf("deleted[1] = %+v, want todo 88003 with its own type", changes.Deleted[1])
+	}
+	if changes.NextPage != nil {
+		t.Errorf("next page = %+v, want none: a since link is a cursor, not a page", changes.NextPage)
+	}
+	if changes.NextCursor == nil || changes.NextCursor.Since != "2026-08-18T09:14:22.031Z" {
+		t.Errorf("cursor = %+v, want the since from the Link header", changes.NextCursor)
+	}
+}
+
+func TestCalendarsService_AllRecordingChangesFollowsPages(t *testing.T) {
+	var requested []string
+	c, _, cursor := newCalendarChangesTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		requested = append(requested, r.URL.String())
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Query().Get("page") == "" {
+			w.Header().Set("Link", `<`+r.URL.Path+`?since=2026-08-18T09%3A00%3A00.000Z&v=1&page=2>; rel="next"`)
+			_, _ = w.Write([]byte(`{
+				"added": {"Calendar::Event": [{"id": 88001, "title": "Dentist appointment"}]},
+				"deleted": {"Calendar::Todo": [{"id": 88003, "deleted_at": "2026-08-18T09:14:00.000Z", "type": "Calendar::Todo"}]}
+			}`))
+		} else {
+			w.Header().Set("Link", `<`+r.URL.Path+`?since=2026-08-18T09%3A30%3A00.000Z&v=1>; rel="next"`)
+			_, _ = w.Write([]byte(`{
+				"added": {"Calendar::Event": [{"id": 88004, "title": "Parent-teacher conference"}]},
+				"deleted": {"Calendar::Habit": [{"id": 88005, "deleted_at": "2026-08-18T09:20:00.000Z", "type": "Calendar::Habit"}]}
+			}`))
+		}
+	})
+
+	changes, err := c.Calendars().AllRecordingChanges(context.Background(), 512, cursor)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(requested) != 2 {
+		t.Fatalf("requests = %v, want two pages", requested)
+	}
+	if !strings.Contains(requested[1], "page=2") {
+		t.Errorf("second request = %q, want the page from the Link header", requested[1])
+	}
+	added := changes.Added["Calendar::Event"]
+	if len(added) != 2 || added[0].Id != 88001 || added[1].Id != 88004 {
+		t.Errorf("added = %+v, want both pages merged under the type key", changes.Added)
+	}
+	if len(changes.Deleted) != 2 || changes.Deleted[0].ID != 88003 || changes.Deleted[1].ID != 88005 {
+		t.Errorf("deleted = %+v, want both pages in read order", changes.Deleted)
+	}
+	if changes.NextCursor == nil || changes.NextCursor.Since != "2026-08-18T09:30:00.000Z" {
+		t.Errorf("cursor = %+v, want the last page's since", changes.NextCursor)
+	}
+}
+
+func TestCalendarsService_RecordingChangesOnLastPage(t *testing.T) {
+	c, _, cursor := newCalendarChangesTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	})
+
+	changes, err := c.Calendars().RecordingChanges(context.Background(), 512, cursor)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if changes.NextPage != nil || changes.NextCursor != nil {
+		t.Errorf("changes = %+v, want no cursors so the caller keeps the one it has", changes)
+	}
+}
+
+func TestCalendarsService_RecordingChangesTooFarBehind(t *testing.T) {
+	var requests int
+	c, _, cursor := newCalendarChangesTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		w.WriteHeader(http.StatusConflict)
+	})
+
+	changes, err := c.Calendars().RecordingChanges(context.Background(), 512, cursor)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !changes.FullSyncRequired {
+		t.Error("a 409 should ask for a full sync rather than error")
+	}
+	if len(changes.Added)+len(changes.Updated)+len(changes.Deleted) != 0 {
+		t.Errorf("changes = %+v, want empty buckets next to the flag", changes)
+	}
+
+	changes, err = c.Calendars().AllRecordingChanges(context.Background(), 512, cursor)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !changes.FullSyncRequired {
+		t.Error("AllRecordingChanges should surface the full-sync flag")
+	}
+	if requests != 2 {
+		t.Errorf("requests = %d, want the loop to stop on the first 409", requests)
+	}
+}
+
+func TestCalendarsService_ChangesRefusesForeignLink(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Link", `<https://evil.example.com/calendar/changes.json?since=2026-08-18T09%3A14%3A22.031Z>; rel="next"`)
+		_, _ = w.Write([]byte(`{}`))
+	}
+
+	t.Run("calendar feed", func(t *testing.T) {
+		c, cursor, _ := newCalendarChangesTestClient(t, handler)
+		if _, err := c.Calendars().CalendarChanges(context.Background(), cursor); err == nil || !strings.Contains(err.Error(), "different origin") {
+			t.Fatalf("err = %v, want a refusal naming the origin", err)
+		}
+	})
+
+	t.Run("recording feed", func(t *testing.T) {
+		c, _, cursor := newCalendarChangesTestClient(t, handler)
+		if _, err := c.Calendars().RecordingChanges(context.Background(), 512, cursor); err == nil || !strings.Contains(err.Error(), "different origin") {
+			t.Fatalf("err = %v, want a refusal naming the origin", err)
+		}
+	})
+}
+
+func TestCalendarsService_ChangesRequiresSince(t *testing.T) {
+	c, _, _ := newCalendarChangesTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("no request should be sent without a cursor")
+	})
+
+	if _, err := c.Calendars().CalendarChanges(context.Background(), CalendarChangesCursor{}); err == nil {
+		t.Fatal("expected error for a calendar cursor with no since")
+	}
+	if _, err := c.Calendars().RecordingChanges(context.Background(), 512, CalendarChangesCursor{}); err == nil {
+		t.Fatal("expected error for a recording cursor with no since")
+	}
+}
+
+func TestCalendarsService_RecordingChangesRequiresVersion(t *testing.T) {
+	c, _, _ := newCalendarChangesTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("no request should be sent without a version — the server would answer 409 forever")
+	})
+
+	cursor := CalendarChangesCursor{Since: "2026-08-18T09:00:00.000Z"}
+	_, err := c.Calendars().RecordingChanges(context.Background(), 512, cursor)
+	if err == nil || !strings.Contains(err.Error(), "recording_changes_url") {
+		t.Fatalf("err = %v, want a usage error pointing at the server-issued URL", err)
+	}
+
+	if _, err := c.Calendars().AllRecordingChanges(context.Background(), 512, cursor); err == nil {
+		t.Fatal("expected AllRecordingChanges to refuse a version-less cursor too")
+	}
+}

--- a/go/pkg/hey/calendars.go
+++ b/go/pkg/hey/calendars.go
@@ -2,6 +2,7 @@ package hey
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/basecamp/hey-sdk/go/pkg/generated"
@@ -66,6 +67,53 @@ func (s *CalendarsService) Toggle(ctx context.Context, calendarID int64) (select
 		return nil
 	})
 	return selectedIDs, err
+}
+
+// ListedCalendar is a calendar as the calendars list serves it, wrapped with what a live
+// follower needs: RecordingChangesURL is where the calendar's recording changes feed
+// starts (read it with CalendarChangesCursorFrom), and SignedStreamName subscribes the
+// calendar's stream over Action Cable — a frame arriving there means the calendar
+// changed, and the name is stable for the calendar's life. The level-1 changes feed's
+// added bucket carries the same shape, so a calendar learned of either way arrives
+// subscribable.
+type ListedCalendar struct {
+	Calendar            generated.Calendar `json:"calendar"`
+	RecordingChangesURL string             `json:"recording_changes_url"`
+	SignedStreamName    string             `json:"signed_stream_name"`
+}
+
+// CalendarList is the full calendars index: every calendar with its changes URL and
+// signed stream name, the calendar-level changes feed's own URL, and which calendars the
+// user has selected for display.
+type CalendarList struct {
+	Calendars           []ListedCalendar `json:"calendars"`
+	CalendarChangesURL  string           `json:"calendar_changes_url"`
+	SelectedCalendarIDs []int64          `json:"selected_calendar_ids"`
+}
+
+// ListWithChanges returns all calendars along with everything List throws away: each
+// calendar's recording changes URL and signed stream name, the calendar changes URL,
+// and the selected calendar IDs.
+func (s *CalendarsService) ListWithChanges(ctx context.Context) (result *CalendarList, err error) {
+	op := OperationInfo{
+		Service: "Calendars", Operation: "ListCalendars",
+		ResourceType: "calendar", IsMutation: false,
+	}
+
+	err = s.client.instrument(ctx, op, func(ctx context.Context) error {
+		resp, rerr := s.client.Get(ctx, "/calendars.json")
+		if rerr != nil {
+			return rerr
+		}
+
+		list := &CalendarList{}
+		if derr := resp.UnmarshalData(list); derr != nil {
+			return fmt.Errorf("failed to decode the calendar list: %w", derr)
+		}
+		result = list
+		return nil
+	})
+	return result, err
 }
 
 // GetRecordings returns recordings for a specific calendar.

--- a/go/pkg/hey/version.go
+++ b/go/pkg/hey/version.go
@@ -1,7 +1,7 @@
 package hey
 
 // Version is the current version of the HEY Go SDK.
-const Version = "0.20.0"
+const Version = "0.21.0"
 
 // APIVersion is the HEY API version this SDK targets.
 const APIVersion = "2026-08-21"


### PR DESCRIPTION
hey-cli is growing live calendar updates (TUI sections that stay current, calendar events in `hey watch`), and this is the SDK half.

## The calendars index, in full

`Calendars().ListWithChanges` reads what `List` throws away: each calendar's `recording_changes_url` and `signed_stream_name` (new in HEY's JSON — the name subscribes the calendar's update stream over Action Cable, and it is stable for the calendar's life), plus the index-level `calendar_changes_url` and `selected_calendar_ids`. `List` stays the plain list it was.

## The two changes feeds

Modeled after `Postings().AllChanges`/`PostingChangesCursor`:

- `CalendarChangesCursorFrom` parses the cursor out of the URL HEY serves (`since`, `page`, `v`), and refuses a `Link` pointing at a different origin.
- `CalendarChanges`/`AllCalendarChanges` read the calendar-level feed: added, updated and deleted calendars. Added ones arrive as `ListedCalendar` — changes URL and stream name included — so a calendar learned of this way is immediately followable. This feed never asks for a full sync.
- `RecordingChanges`/`AllRecordingChanges` read one calendar's recording feed: added and updated recordings keyed by their type (`Calendar::Event`, `Calendar::JournalEntry`, …), deletions as `{id, deleted_at, type}`. A 409 answers `FullSyncRequired` instead of an error, and a cursor missing the `v` parameter is refused up front — the server would answer 409 forever.
- Paging follows the `Link` header: `NextPage` while the increment has more pages now, `NextCursor` from the last page; an empty read answers neither and the caller keeps the cursor it has.

One wire quirk absorbed here: the recording feed can currently repeat each deletion under every type key present, so the deleted bucket is flattened and deduplicated by ID, each entry keeping the type it names for itself. That stays correct if the duplication is fixed server-side.

All hand-written in `go/pkg/hey/`; nothing generated changed. Tests cover both feeds, paging, the 409 path, cursor parsing and refusals.