### PR TITLE
Bump the SDK to 0.22.0

### DIFF
--- a/go/pkg/hey/version.go
+++ b/go/pkg/hey/version.go
@@ -1,7 +1,7 @@
 package hey
 
 // Version is the current version of the HEY Go SDK.
-const Version = "0.21.0"
+const Version = "0.22.0"
 
 // APIVersion is the HEY API version this SDK targets.
 const APIVersion = "2026-08-21"


### PR DESCRIPTION
Minor release: the draft lifecycle (#121) — CreateDraft/UpdateDraft/SendDraft/GetEdit on Messages, CreateReplyDraft/DeleteDraft/ListDraftsPage/NewReply on Entries, and the UpdateMessage no-retry guard. New surface only; nothing existing changed in code, wire, or behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps the HEY Go SDK to 0.22.0 to expose the draft lifecycle surface and an UpdateMessage no-retry guard. Earlier versions lacked these methods; clients now have CreateDraft/UpdateDraft/SendDraft/GetEdit on Messages and CreateReplyDraft/DeleteDraft/ListDraftsPage/NewReply on Entries, with no changes to existing code, wire, or behavior.

- Only updates the `hey` Version constant; no functional diffs to review.
- No migrations required; upgrade to v0.22.0 to use the new methods.

<sup>Written for commit 0429fb865de60a008127179c52a77a8c4dd7c5f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-sdk/pull/122?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

