### PR TITLE
Model the identity calendar preferences: UpdateFirstWeekDay and UpdateTimeFormat

### DIFF
--- a/behavior-model.json
+++ b/behavior-model.json
@@ -1544,6 +1544,19 @@
         ]
       }
     },
+    "UpdateFirstWeekDay": {
+      "idempotent": true,
+      "readonly": false,
+      "retry": {
+        "backoff": "exponential",
+        "base_delay_ms": 1000,
+        "max": 3,
+        "retry_on": [
+          429,
+          503
+        ]
+      }
+    },
     "UpdateHabit": {
       "idempotent": true,
       "readonly": false,
@@ -1603,6 +1616,19 @@
         "backoff": "exponential",
         "base_delay_ms": 1000,
         "max": 2,
+        "retry_on": [
+          429,
+          503
+        ]
+      }
+    },
+    "UpdateTimeFormat": {
+      "idempotent": true,
+      "readonly": false,
+      "retry": {
+        "backoff": "exponential",
+        "base_delay_ms": 1000,
+        "max": 3,
         "retry_on": [
           429,
           503

--- a/go/pkg/generated/client.gen.go
+++ b/go/pkg/generated/client.gen.go
@@ -668,6 +668,18 @@ type FilePostingsRequestContent struct {
 	PostingIds []int64 `json:"posting_ids"`
 }
 
+// FirstWeekDayParams defines model for FirstWeekDayParams.
+type FirstWeekDayParams struct {
+	// FirstWeekDay Lowercase day name, sunday through saturday.
+	FirstWeekDay string `json:"first_week_day"`
+}
+
+// FirstWeekDayPreference defines model for FirstWeekDayPreference.
+type FirstWeekDayPreference struct {
+	// FirstWeekDay 0 is Sunday through 6 Saturday, as GetIdentity serves it.
+	FirstWeekDay int32 `json:"first_week_day"`
+}
+
 // Folder Folder — email folder
 type Folder struct {
 	AppUrl string `json:"app_url,omitempty"`
@@ -1379,6 +1391,12 @@ type StickyRequestContent struct {
 	Sticky StickyPayload `json:"sticky"`
 }
 
+// TimeFormatPreference defines model for TimeFormatPreference.
+type TimeFormatPreference struct {
+	// TimeFormat "twelve_hour" or "twenty_four_hour", as GetIdentity serves it.
+	TimeFormat string `json:"time_format"`
+}
+
 // TimeTrackCategory defines model for TimeTrackCategory.
 type TimeTrackCategory struct {
 	// CreatedAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
@@ -1521,6 +1539,14 @@ type UpdateContactNoteResponseContent = ContactNote
 // UpdateContactResponseContent Contact — the identity of someone in HEY
 type UpdateContactResponseContent = Contact
 
+// UpdateFirstWeekDayRequestContent Wire format: {identity_preference: {first_week_day: "monday"}}
+type UpdateFirstWeekDayRequestContent struct {
+	IdentityPreference FirstWeekDayParams `json:"identity_preference"`
+}
+
+// UpdateFirstWeekDayResponseContent defines model for UpdateFirstWeekDayResponseContent.
+type UpdateFirstWeekDayResponseContent = FirstWeekDayPreference
+
 // UpdateHabitResponseContent Recording — polymorphic by `type` (CalendarEvent, CalendarTodo, etc.)
 type UpdateHabitResponseContent = Recording
 
@@ -1545,6 +1571,14 @@ type UpdateMyClearanceResponseContent = Clearance
 
 // UpdateStickyResponseContent Sticky — a note on the stickies board
 type UpdateStickyResponseContent = Sticky
+
+// UpdateTimeFormatRequestContent defines model for UpdateTimeFormatRequestContent.
+type UpdateTimeFormatRequestContent struct {
+	TwentyFourHourTimeFormat bool `json:"twenty_four_hour_time_format"`
+}
+
+// UpdateTimeFormatResponseContent defines model for UpdateTimeFormatResponseContent.
+type UpdateTimeFormatResponseContent = TimeFormatPreference
 
 // UpdateTimeTrackPayload defines model for UpdateTimeTrackPayload.
 type UpdateTimeTrackPayload struct {
@@ -1864,6 +1898,9 @@ type CreateHabitJSONRequestBody = HabitRequestContent
 // UpdateHabitJSONRequestBody defines body for UpdateHabit for application/json ContentType.
 type UpdateHabitJSONRequestBody = HabitRequestContent
 
+// UpdateFirstWeekDayJSONRequestBody defines body for UpdateFirstWeekDay for application/json ContentType.
+type UpdateFirstWeekDayJSONRequestBody = UpdateFirstWeekDayRequestContent
+
 // CreateTimeTrackJSONRequestBody defines body for CreateTimeTrack for application/json ContentType.
 type CreateTimeTrackJSONRequestBody = TimeTrackRequestContent
 
@@ -1899,6 +1936,9 @@ type UpdateContactNoteJSONRequestBody = ContactNoteRequestContent
 
 // CreateReplyJSONRequestBody defines body for CreateReply for application/json ContentType.
 type CreateReplyJSONRequestBody = CreateReplyRequestContent
+
+// UpdateTimeFormatJSONRequestBody defines body for UpdateTimeFormat for application/json ContentType.
+type UpdateTimeFormatJSONRequestBody = UpdateTimeFormatRequestContent
 
 // CreateMessageJSONRequestBody defines body for CreateMessage for application/json ContentType.
 type CreateMessageJSONRequestBody = CreateMessageRequestContent
@@ -2272,6 +2312,11 @@ type ClientInterface interface {
 	// StopHabit request
 	StopHabit(ctx context.Context, habitId int64, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// UpdateFirstWeekDayWithBody request with any body
+	UpdateFirstWeekDayWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	UpdateFirstWeekDay(ctx context.Context, body UpdateFirstWeekDayJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// ListJournalEntries request
 	ListJournalEntries(ctx context.Context, params *ListJournalEntriesParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -2439,6 +2484,11 @@ type ClientInterface interface {
 
 	// GetIdentity request
 	GetIdentity(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UpdateTimeFormatWithBody request with any body
+	UpdateTimeFormatWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	UpdateTimeFormat(ctx context.Context, body UpdateTimeFormatJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetImbox request
 	GetImbox(ctx context.Context, params *GetImboxParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -3002,6 +3052,24 @@ func (c *Client) StopHabit(ctx context.Context, habitId int64, reqEditors ...Req
 		return nil, err
 	}
 	return c.Client.Do(req)
+
+}
+
+// UpdateFirstWeekDayWithBody is marked as idempotent and will be retried on transient failures.
+
+func (c *Client) UpdateFirstWeekDayWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		return NewUpdateFirstWeekDayRequestWithBody(c.Server, contentType, body)
+	}, true, "UpdateFirstWeekDay", reqEditors...)
+
+}
+
+func (c *Client) UpdateFirstWeekDay(ctx context.Context, body UpdateFirstWeekDayJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		return NewUpdateFirstWeekDayRequest(c.Server, body)
+	}, true, "UpdateFirstWeekDay", reqEditors...)
 
 }
 
@@ -3740,6 +3808,24 @@ func (c *Client) GetIdentity(ctx context.Context, reqEditors ...RequestEditorFn)
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewGetIdentityRequest(c.Server)
 	}, true, "GetIdentity", reqEditors...)
+
+}
+
+// UpdateTimeFormatWithBody is marked as idempotent and will be retried on transient failures.
+
+func (c *Client) UpdateTimeFormatWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		return NewUpdateTimeFormatRequestWithBody(c.Server, contentType, body)
+	}, true, "UpdateTimeFormat", reqEditors...)
+
+}
+
+func (c *Client) UpdateTimeFormat(ctx context.Context, body UpdateTimeFormatJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		return NewUpdateTimeFormatRequest(c.Server, body)
+	}, true, "UpdateTimeFormat", reqEditors...)
 
 }
 
@@ -5873,6 +5959,46 @@ func NewStopHabitRequest(server string, habitId int64) (*http.Request, error) {
 	return req, nil
 }
 
+// NewUpdateFirstWeekDayRequest calls the generic UpdateFirstWeekDay builder with application/json body
+func NewUpdateFirstWeekDayRequest(server string, body UpdateFirstWeekDayJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewUpdateFirstWeekDayRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewUpdateFirstWeekDayRequestWithBody generates requests for UpdateFirstWeekDay with any type of body
+func NewUpdateFirstWeekDayRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/calendar/identity/first_week_day")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("PUT", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
 // NewListJournalEntriesRequest generates requests for ListJournalEntries
 func NewListJournalEntriesRequest(server string, params *ListJournalEntriesParams) (*http.Request, error) {
 	var err error
@@ -7862,6 +7988,46 @@ func NewGetIdentityRequest(server string) (*http.Request, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	return req, nil
+}
+
+// NewUpdateTimeFormatRequest calls the generic UpdateTimeFormat builder with application/json body
+func NewUpdateTimeFormatRequest(server string, body UpdateTimeFormatJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewUpdateTimeFormatRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewUpdateTimeFormatRequestWithBody generates requests for UpdateTimeFormat with any type of body
+func NewUpdateTimeFormatRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/identity/time_format")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("PUT", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
 
 	return req, nil
 }
@@ -9938,6 +10104,7 @@ var operationMetadata = map[string]OperationMetadata{
 	"UpdateHabit":                {Idempotent: false, HasSensitiveParams: false},
 	"ResumeHabit":                {Idempotent: true, HasSensitiveParams: false},
 	"StopHabit":                  {Idempotent: false, HasSensitiveParams: false},
+	"UpdateFirstWeekDay":         {Idempotent: true, HasSensitiveParams: false},
 	"ListJournalEntries":         {Idempotent: true, HasSensitiveParams: false},
 	"GetOngoingTimeTrack":        {Idempotent: true, HasSensitiveParams: false},
 	"StartTimeTrack":             {Idempotent: false, HasSensitiveParams: false},
@@ -9986,6 +10153,7 @@ var operationMetadata = map[string]OperationMetadata{
 	"GetFeedbox":                 {Idempotent: true, HasSensitiveParams: false},
 	"GetFolder":                  {Idempotent: true, HasSensitiveParams: false},
 	"GetIdentity":                {Idempotent: true, HasSensitiveParams: false},
+	"UpdateTimeFormat":           {Idempotent: true, HasSensitiveParams: false},
 	"GetImbox":                   {Idempotent: true, HasSensitiveParams: false},
 	"CreateMessage":              {Idempotent: false, HasSensitiveParams: false},
 	"GetMessage":                 {Idempotent: true, HasSensitiveParams: false},
@@ -10888,6 +11056,24 @@ type ClientWithResponsesInterface interface {
 	// Returns a wrapper object for the known response body format(s).
 	StopHabitWithResponse(ctx context.Context, habitId int64, reqEditors ...RequestEditorFn) (*StopHabitResponse, error)
 
+	// UpdateFirstWeekDayWithBodyWithResponse performs a PUT /calendar/identity/first_week_day (the `UpdateFirstWeekDay` operationId) request,
+	// with any type of body and a specified content type.
+	//
+	// Set which day the identity's calendar weeks start on. Answers the stored
+	// preference. The write reaches every HEY client — web, mobile and this SDK
+	// read the same identity preference.
+	//
+	// Returns a wrapper object for the known response body format(s).
+	UpdateFirstWeekDayWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateFirstWeekDayResponse, error)
+
+	// UpdateFirstWeekDayWithResponse performs a PUT /calendar/identity/first_week_day (the `UpdateFirstWeekDay` operationId) request.
+	// Takes a body of the `application/json` content type, and returns a wrapper object for the known response body format(s).
+	//
+	// Set which day the identity's calendar weeks start on. Answers the stored
+	// preference. The write reaches every HEY client — web, mobile and this SDK
+	// read the same identity preference.
+	UpdateFirstWeekDayWithResponse(ctx context.Context, body UpdateFirstWeekDayJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateFirstWeekDayResponse, error)
+
 	// ListJournalEntriesWithResponse performs a GET /calendar/journal_entries (the `ListJournalEntries` operationId) request.
 	//
 	// List journal entries newest first. The next page, if any, is a Link header.
@@ -11357,6 +11543,24 @@ type ClientWithResponsesInterface interface {
 	//
 	// Returns a wrapper object for the known response body format(s).
 	GetIdentityWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetIdentityResponse, error)
+
+	// UpdateTimeFormatWithBodyWithResponse performs a PUT /identity/time_format (the `UpdateTimeFormat` operationId) request,
+	// with any type of body and a specified content type.
+	//
+	// Set whether HEY renders times on a 12-hour or a 24-hour clock. Answers the
+	// stored preference. The parameter is the web toggle's, said honestly: true
+	// for the 24-hour clock, false for the 12-hour one.
+	//
+	// Returns a wrapper object for the known response body format(s).
+	UpdateTimeFormatWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateTimeFormatResponse, error)
+
+	// UpdateTimeFormatWithResponse performs a PUT /identity/time_format (the `UpdateTimeFormat` operationId) request.
+	// Takes a body of the `application/json` content type, and returns a wrapper object for the known response body format(s).
+	//
+	// Set whether HEY renders times on a 12-hour or a 24-hour clock. Answers the
+	// stored preference. The parameter is the web toggle's, said honestly: true
+	// for the 24-hour clock, false for the 12-hour one.
+	UpdateTimeFormatWithResponse(ctx context.Context, body UpdateTimeFormatJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateTimeFormatResponse, error)
 
 	// GetImboxWithResponse performs a GET /imbox.json (the `GetImbox` operationId) request.
 	//
@@ -13549,6 +13753,75 @@ func (r StopHabitResponse) StatusCode() int {
 
 // ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
 func (r StopHabitResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type UpdateFirstWeekDayResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	// JSON200 the response for an HTTP 200 `application/json` response
+	JSON200 *UpdateFirstWeekDayResponseContent
+	// JSON400 the response for an HTTP 400 `application/json` response
+	JSON400 *BadRequestErrorResponseContent
+	// JSON401 the response for an HTTP 401 `application/json` response
+	JSON401 *UnauthorizedErrorResponseContent
+	// JSON500 the response for an HTTP 500 `application/json` response
+	JSON500 *InternalServerErrorResponseContent
+	// JSON503 the response for an HTTP 503 `application/json` response
+	JSON503 *ServiceUnavailableErrorResponseContent
+}
+
+// GetJSON200 returns the response for an HTTP 200 `application/json` response
+func (r UpdateFirstWeekDayResponse) GetJSON200() *UpdateFirstWeekDayResponseContent {
+	return r.JSON200
+}
+
+// GetJSON400 returns the response for an HTTP 400 `application/json` response
+func (r UpdateFirstWeekDayResponse) GetJSON400() *BadRequestErrorResponseContent {
+	return r.JSON400
+}
+
+// GetJSON401 returns the response for an HTTP 401 `application/json` response
+func (r UpdateFirstWeekDayResponse) GetJSON401() *UnauthorizedErrorResponseContent {
+	return r.JSON401
+}
+
+// GetJSON500 returns the response for an HTTP 500 `application/json` response
+func (r UpdateFirstWeekDayResponse) GetJSON500() *InternalServerErrorResponseContent {
+	return r.JSON500
+}
+
+// GetJSON503 returns the response for an HTTP 503 `application/json` response
+func (r UpdateFirstWeekDayResponse) GetJSON503() *ServiceUnavailableErrorResponseContent {
+	return r.JSON503
+}
+
+// GetBody returns the raw response body bytes
+func (r UpdateFirstWeekDayResponse) GetBody() []byte {
+	return r.Body
+}
+
+// Status returns HTTPResponse.Status
+func (r UpdateFirstWeekDayResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UpdateFirstWeekDayResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r UpdateFirstWeekDayResponse) ContentType() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Header.Get("Content-Type")
 	}
@@ -16784,6 +17057,68 @@ func (r GetIdentityResponse) StatusCode() int {
 
 // ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
 func (r GetIdentityResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type UpdateTimeFormatResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	// JSON200 the response for an HTTP 200 `application/json` response
+	JSON200 *UpdateTimeFormatResponseContent
+	// JSON401 the response for an HTTP 401 `application/json` response
+	JSON401 *UnauthorizedErrorResponseContent
+	// JSON500 the response for an HTTP 500 `application/json` response
+	JSON500 *InternalServerErrorResponseContent
+	// JSON503 the response for an HTTP 503 `application/json` response
+	JSON503 *ServiceUnavailableErrorResponseContent
+}
+
+// GetJSON200 returns the response for an HTTP 200 `application/json` response
+func (r UpdateTimeFormatResponse) GetJSON200() *UpdateTimeFormatResponseContent {
+	return r.JSON200
+}
+
+// GetJSON401 returns the response for an HTTP 401 `application/json` response
+func (r UpdateTimeFormatResponse) GetJSON401() *UnauthorizedErrorResponseContent {
+	return r.JSON401
+}
+
+// GetJSON500 returns the response for an HTTP 500 `application/json` response
+func (r UpdateTimeFormatResponse) GetJSON500() *InternalServerErrorResponseContent {
+	return r.JSON500
+}
+
+// GetJSON503 returns the response for an HTTP 503 `application/json` response
+func (r UpdateTimeFormatResponse) GetJSON503() *ServiceUnavailableErrorResponseContent {
+	return r.JSON503
+}
+
+// GetBody returns the raw response body bytes
+func (r UpdateTimeFormatResponse) GetBody() []byte {
+	return r.Body
+}
+
+// Status returns HTTPResponse.Status
+func (r UpdateTimeFormatResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UpdateTimeFormatResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r UpdateTimeFormatResponse) ContentType() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Header.Get("Content-Type")
 	}
@@ -20291,6 +20626,36 @@ func (c *ClientWithResponses) StopHabitWithResponse(ctx context.Context, habitId
 	return ParseStopHabitResponse(rsp)
 }
 
+// UpdateFirstWeekDayWithBodyWithResponse performs a PUT /calendar/identity/first_week_day (the `UpdateFirstWeekDay` operationId) request,
+// with any type of body and a specified content type.
+//
+// Set which day the identity's calendar weeks start on. Answers the stored
+// preference. The write reaches every HEY client — web, mobile and this SDK
+// read the same identity preference.
+//
+// Returns a wrapper object for the known response body format(s).
+func (c *ClientWithResponses) UpdateFirstWeekDayWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateFirstWeekDayResponse, error) {
+	rsp, err := c.UpdateFirstWeekDayWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateFirstWeekDayResponse(rsp)
+}
+
+// UpdateFirstWeekDayWithResponse performs a PUT /calendar/identity/first_week_day (the `UpdateFirstWeekDay` operationId) request.
+// Takes a body of the `application/json` content type, and returns a wrapper object for the known response body format(s).
+//
+// Set which day the identity's calendar weeks start on. Answers the stored
+// preference. The write reaches every HEY client — web, mobile and this SDK
+// read the same identity preference.
+func (c *ClientWithResponses) UpdateFirstWeekDayWithResponse(ctx context.Context, body UpdateFirstWeekDayJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateFirstWeekDayResponse, error) {
+	rsp, err := c.UpdateFirstWeekDay(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateFirstWeekDayResponse(rsp)
+}
+
 // ListJournalEntriesWithResponse performs a GET /calendar/journal_entries (the `ListJournalEntries` operationId) request.
 //
 // List journal entries newest first. The next page, if any, is a Link header.
@@ -21119,6 +21484,36 @@ func (c *ClientWithResponses) GetIdentityWithResponse(ctx context.Context, reqEd
 		return nil, err
 	}
 	return ParseGetIdentityResponse(rsp)
+}
+
+// UpdateTimeFormatWithBodyWithResponse performs a PUT /identity/time_format (the `UpdateTimeFormat` operationId) request,
+// with any type of body and a specified content type.
+//
+// Set whether HEY renders times on a 12-hour or a 24-hour clock. Answers the
+// stored preference. The parameter is the web toggle's, said honestly: true
+// for the 24-hour clock, false for the 12-hour one.
+//
+// Returns a wrapper object for the known response body format(s).
+func (c *ClientWithResponses) UpdateTimeFormatWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateTimeFormatResponse, error) {
+	rsp, err := c.UpdateTimeFormatWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateTimeFormatResponse(rsp)
+}
+
+// UpdateTimeFormatWithResponse performs a PUT /identity/time_format (the `UpdateTimeFormat` operationId) request.
+// Takes a body of the `application/json` content type, and returns a wrapper object for the known response body format(s).
+//
+// Set whether HEY renders times on a 12-hour or a 24-hour clock. Answers the
+// stored preference. The parameter is the web toggle's, said honestly: true
+// for the 24-hour clock, false for the 12-hour one.
+func (c *ClientWithResponses) UpdateTimeFormatWithResponse(ctx context.Context, body UpdateTimeFormatJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateTimeFormatResponse, error) {
+	rsp, err := c.UpdateTimeFormat(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateTimeFormatResponse(rsp)
 }
 
 // GetImboxWithResponse performs a GET /imbox.json (the `GetImbox` operationId) request.
@@ -23345,6 +23740,60 @@ func ParseStopHabitResponse(rsp *http.Response) (*StopHabitResponse, error) {
 			return nil, err
 		}
 		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalServerErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 503:
+		var dest ServiceUnavailableErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON503 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUpdateFirstWeekDayResponse parses an HTTP response from a UpdateFirstWeekDayWithResponse call
+func ParseUpdateFirstWeekDayResponse(rsp *http.Response) (*UpdateFirstWeekDayResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UpdateFirstWeekDayResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest UpdateFirstWeekDayResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequestErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest UnauthorizedErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest InternalServerErrorResponseContent
@@ -25885,6 +26334,53 @@ func ParseGetIdentityResponse(rsp *http.Response) (*GetIdentityResponse, error) 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest GetIdentityResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest UnauthorizedErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalServerErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 503:
+		var dest ServiceUnavailableErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON503 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUpdateTimeFormatResponse parses an HTTP response from a UpdateTimeFormatWithResponse call
+func ParseUpdateTimeFormatResponse(rsp *http.Response) (*UpdateTimeFormatResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UpdateTimeFormatResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest UpdateTimeFormatResponseContent
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/go/pkg/hey/identity.go
+++ b/go/pkg/hey/identity.go
@@ -2,9 +2,18 @@ package hey
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"github.com/basecamp/hey-sdk/go/pkg/generated"
+)
+
+// TimeFormat is the clock HEY renders times in.
+type TimeFormat string
+
+const (
+	TimeFormatTwelveHour     TimeFormat = "twelve_hour"
+	TimeFormatTwentyFourHour TimeFormat = "twenty_four_hour"
 )
 
 // IdentityService handles identity and navigation operations.
@@ -41,6 +50,54 @@ func (s *IdentityService) GetIdentity(ctx context.Context) (result *generated.Id
 		return nil, err
 	}
 	return resp.JSON200, nil
+}
+
+// UpdateFirstWeekDay sets which day the current identity's calendar weeks start on, and
+// returns the day HEY stored.
+func (s *IdentityService) UpdateFirstWeekDay(ctx context.Context, day time.Weekday) (result time.Weekday, err error) {
+	op := OperationInfo{
+		Service: "Identity", Operation: "UpdateFirstWeekDay",
+		ResourceType: "identity", IsMutation: true,
+	}
+	err = s.client.instrument(ctx, op, func(ctx context.Context) error {
+		body := generated.UpdateFirstWeekDayJSONRequestBody{
+			IdentityPreference: generated.FirstWeekDayParams{FirstWeekDay: strings.ToLower(day.String())},
+		}
+		resp, rerr := s.client.genClient().UpdateFirstWeekDayWithResponse(ctx, body)
+		if rerr != nil {
+			return rerr
+		}
+		if cerr := CheckResponse(resp.HTTPResponse); cerr != nil {
+			return cerr
+		}
+		result = time.Weekday(resp.JSON200.FirstWeekDay)
+		return nil
+	})
+	return result, err
+}
+
+// UpdateTimeFormat sets whether HEY renders times on a 12-hour or 24-hour clock, and
+// returns the format HEY stored.
+func (s *IdentityService) UpdateTimeFormat(ctx context.Context, format TimeFormat) (result TimeFormat, err error) {
+	op := OperationInfo{
+		Service: "Identity", Operation: "UpdateTimeFormat",
+		ResourceType: "identity", IsMutation: true,
+	}
+	err = s.client.instrument(ctx, op, func(ctx context.Context) error {
+		body := generated.UpdateTimeFormatJSONRequestBody{
+			TwentyFourHourTimeFormat: format == TimeFormatTwentyFourHour,
+		}
+		resp, rerr := s.client.genClient().UpdateTimeFormatWithResponse(ctx, body)
+		if rerr != nil {
+			return rerr
+		}
+		if cerr := CheckResponse(resp.HTTPResponse); cerr != nil {
+			return cerr
+		}
+		result = TimeFormat(resp.JSON200.TimeFormat)
+		return nil
+	})
+	return result, err
 }
 
 // GetNavigation returns the navigation structure for the current user.

--- a/go/pkg/hey/services_test.go
+++ b/go/pkg/hey/services_test.go
@@ -220,6 +220,59 @@ func TestIdentityService_GetNavigation(t *testing.T) {
 	}
 }
 
+func TestIdentityService_UpdateFirstWeekDay(t *testing.T) {
+	client := newMutationTestClientWithValidation(t, "PUT", "/calendar/identity/first_week_day.json",
+		func(t *testing.T, body map[string]any) {
+			t.Helper()
+			preference, _ := body["identity_preference"].(map[string]any)
+			if preference["first_week_day"] != "monday" {
+				t.Errorf("expected monday, got %v", preference["first_week_day"])
+			}
+		}, `{"first_week_day":1}`)
+
+	stored, err := client.Identity().UpdateFirstWeekDay(context.Background(), time.Monday)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if stored != time.Monday {
+		t.Errorf("stored day = %v, want Monday", stored)
+	}
+}
+
+func TestIdentityService_UpdateTimeFormat(t *testing.T) {
+	twentyFour := newMutationTestClientWithValidation(t, "PUT", "/identity/time_format.json",
+		func(t *testing.T, body map[string]any) {
+			t.Helper()
+			if body["twenty_four_hour_time_format"] != true {
+				t.Errorf("expected true, got %v", body["twenty_four_hour_time_format"])
+			}
+		}, `{"time_format":"twenty_four_hour"}`)
+
+	stored, err := twentyFour.Identity().UpdateTimeFormat(context.Background(), TimeFormatTwentyFourHour)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if stored != TimeFormatTwentyFourHour {
+		t.Errorf("stored format = %v, want twenty_four_hour", stored)
+	}
+
+	twelve := newMutationTestClientWithValidation(t, "PUT", "/identity/time_format.json",
+		func(t *testing.T, body map[string]any) {
+			t.Helper()
+			if body["twenty_four_hour_time_format"] != false {
+				t.Errorf("expected false, got %v", body["twenty_four_hour_time_format"])
+			}
+		}, `{"time_format":"twelve_hour"}`)
+
+	stored, err = twelve.Identity().UpdateTimeFormat(context.Background(), TimeFormatTwelveHour)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if stored != TimeFormatTwelveHour {
+		t.Errorf("stored format = %v, want twelve_hour", stored)
+	}
+}
+
 func TestIdentityService_GetIdentity_Error(t *testing.T) {
 	client := newServiceTestClient(t, map[string]string{})
 	_, err := client.Identity().GetIdentity(context.Background())

--- a/go/pkg/hey/url-routes.json
+++ b/go/pkg/hey/url-routes.json
@@ -241,6 +241,14 @@
       }
     },
     {
+      "pattern": "/calendar/identity/first_week_day",
+      "resource": "Identity",
+      "operations": {
+        "PUT": "UpdateFirstWeekDay"
+      },
+      "params": {}
+    },
+    {
       "pattern": "/calendar/journal_entries",
       "resource": "Calendar Journal",
       "operations": {
@@ -637,6 +645,14 @@
       "resource": "Identity",
       "operations": {
         "GET": "GetIdentity"
+      },
+      "params": {}
+    },
+    {
+      "pattern": "/identity/time_format",
+      "resource": "Identity",
+      "operations": {
+        "PUT": "UpdateTimeFormat"
       },
       "params": {}
     },

--- a/go/pkg/hey/version.go
+++ b/go/pkg/hey/version.go
@@ -1,7 +1,7 @@
 package hey
 
 // Version is the current version of the HEY Go SDK.
-const Version = "0.22.0"
+const Version = "0.23.0"
 
 // APIVersion is the HEY API version this SDK targets.
 const APIVersion = "2026-08-21"

--- a/openapi.json
+++ b/openapi.json
@@ -2162,6 +2162,86 @@
         }
       }
     },
+    "/calendar/identity/first_week_day": {
+      "put": {
+        "description": "Set which day the identity's calendar weeks start on. Answers the stored\npreference. The write reaches every HEY client — web, mobile and this SDK\nread the same identity preference.",
+        "operationId": "UpdateFirstWeekDay",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateFirstWeekDayRequestContent"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "UpdateFirstWeekDay 200 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateFirstWeekDayResponseContent"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "BadRequestError 400 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestErrorResponseContent"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "UnauthorizedError 401 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedErrorResponseContent"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "InternalServerError 500 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerErrorResponseContent"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "ServiceUnavailableError 503 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceUnavailableErrorResponseContent"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Identity"
+        ],
+        "x-hey-retry": {
+          "maxAttempts": 3,
+          "baseDelayMs": 1000,
+          "backoff": "exponential",
+          "retryOn": [
+            429,
+            503
+          ]
+        }
+      }
+    },
     "/calendar/journal_entries": {
       "get": {
         "description": "List journal entries newest first. The next page, if any, is a Link header.\nPass q to search journal entry content.",
@@ -6014,6 +6094,76 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/GetIdentityResponseContent"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "UnauthorizedError 401 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedErrorResponseContent"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "InternalServerError 500 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerErrorResponseContent"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "ServiceUnavailableError 503 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceUnavailableErrorResponseContent"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Identity"
+        ],
+        "x-hey-retry": {
+          "maxAttempts": 3,
+          "baseDelayMs": 1000,
+          "backoff": "exponential",
+          "retryOn": [
+            429,
+            503
+          ]
+        }
+      }
+    },
+    "/identity/time_format": {
+      "put": {
+        "description": "Set whether HEY renders times on a 12-hour or a 24-hour clock. Answers the\nstored preference. The parameter is the web toggle's, said honestly: true\nfor the 24-hour clock, false for the 12-hour one.",
+        "operationId": "UpdateTimeFormat",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateTimeFormatRequestContent"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "UpdateTimeFormat 200 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateTimeFormatResponseContent"
                 }
               }
             }
@@ -11380,6 +11530,31 @@
           "posting_ids"
         ]
       },
+      "FirstWeekDayParams": {
+        "type": "object",
+        "properties": {
+          "first_week_day": {
+            "type": "string",
+            "description": "Lowercase day name, sunday through saturday."
+          }
+        },
+        "required": [
+          "first_week_day"
+        ]
+      },
+      "FirstWeekDayPreference": {
+        "type": "object",
+        "properties": {
+          "first_week_day": {
+            "type": "integer",
+            "description": "0 is Sunday through 6 Saturday, as GetIdentity serves it.",
+            "format": "int32"
+          }
+        },
+        "required": [
+          "first_week_day"
+        ]
+      },
       "Folder": {
         "type": "object",
         "description": "Folder — email folder",
@@ -12966,6 +13141,18 @@
           "sticky"
         ]
       },
+      "TimeFormatPreference": {
+        "type": "object",
+        "properties": {
+          "time_format": {
+            "type": "string",
+            "description": "\"twelve_hour\" or \"twenty_four_hour\", as GetIdentity serves it."
+          }
+        },
+        "required": [
+          "time_format"
+        ]
+      },
       "TimeTrackCategory": {
         "type": "object",
         "properties": {
@@ -13299,6 +13486,21 @@
       "UpdateContactResponseContent": {
         "$ref": "#/components/schemas/Contact"
       },
+      "UpdateFirstWeekDayRequestContent": {
+        "type": "object",
+        "description": "Wire format: {identity_preference: {first_week_day: \"monday\"}}",
+        "properties": {
+          "identity_preference": {
+            "$ref": "#/components/schemas/FirstWeekDayParams"
+          }
+        },
+        "required": [
+          "identity_preference"
+        ]
+      },
+      "UpdateFirstWeekDayResponseContent": {
+        "$ref": "#/components/schemas/FirstWeekDayPreference"
+      },
       "UpdateHabitResponseContent": {
         "$ref": "#/components/schemas/Recording"
       },
@@ -13333,6 +13535,21 @@
       },
       "UpdateStickyResponseContent": {
         "$ref": "#/components/schemas/Sticky"
+      },
+      "UpdateTimeFormatRequestContent": {
+        "type": "object",
+        "properties": {
+          "twenty_four_hour_time_format": {
+            "type": "boolean",
+            "x-go-type-skip-optional-pointer": false
+          }
+        },
+        "required": [
+          "twenty_four_hour_time_format"
+        ]
+      },
+      "UpdateTimeFormatResponseContent": {
+        "$ref": "#/components/schemas/TimeFormatPreference"
       },
       "UpdateTimeTrackPayload": {
         "type": "object",

--- a/spec/excluded-routes.json
+++ b/spec/excluded-routes.json
@@ -672,12 +672,7 @@
   {
     "method": "PATCH",
     "path": "/calendar/identity/first_week_day",
-    "reason": "phase-2: calendar identity settings"
-  },
-  {
-    "method": "PUT",
-    "path": "/calendar/identity/first_week_day",
-    "reason": "phase-2: calendar identity settings"
+    "reason": "modelled as PUT UpdateFirstWeekDay; PATCH is the same Rails route"
   },
   {
     "method": "PATCH",
@@ -1987,12 +1982,7 @@
   {
     "method": "PATCH",
     "path": "/identity/time_format",
-    "reason": "phase-2: mobile triage surface"
-  },
-  {
-    "method": "PUT",
-    "path": "/identity/time_format",
-    "reason": "phase-2: mobile triage surface"
+    "reason": "modelled as PUT UpdateTimeFormat; PATCH is the same Rails route"
   },
   {
     "method": "PATCH",

--- a/spec/hey.smithy
+++ b/spec/hey.smithy
@@ -61,9 +61,11 @@ timestamp DateTime
 service HEY {
     version: "2026-08-21"
     operations: [
-        // Identity (2 MVP)
+        // Identity (4 MVP)
         GetIdentity
         GetNavigation
+        UpdateFirstWeekDay
+        UpdateTimeFormat
 
         // Boxes (8 MVP)
         ListBoxes
@@ -1176,6 +1178,83 @@ operation GetNavigation {
 structure GetNavigationOutput {
     @required
     navigation: NavigationResponse
+}
+
+/// Set which day the identity's calendar weeks start on. Answers the stored
+/// preference. The write reaches every HEY client — web, mobile and this SDK
+/// read the same identity preference.
+@idempotent
+@http(method: "PUT", uri: "/calendar/identity/first_week_day")
+@tags(["Identity"])
+@heyRetry(maxAttempts: 3, baseDelayMs: 1000, backoff: "exponential", retryOn: [429, 503])
+operation UpdateFirstWeekDay {
+    input: UpdateFirstWeekDayInput
+    output: UpdateFirstWeekDayOutput
+    errors: [UnauthorizedError, BadRequestError, InternalServerError, ServiceUnavailableError]
+}
+
+structure UpdateFirstWeekDayInput {
+    @httpPayload
+    @required
+    body: UpdateFirstWeekDayRequestContent
+}
+
+/// Wire format: {identity_preference: {first_week_day: "monday"}}
+structure UpdateFirstWeekDayRequestContent {
+    @required
+    identity_preference: FirstWeekDayParams
+}
+
+structure FirstWeekDayParams {
+    /// Lowercase day name, sunday through saturday.
+    @required
+    first_week_day: String
+}
+
+structure UpdateFirstWeekDayOutput {
+    @required
+    preference: FirstWeekDayPreference
+}
+
+structure FirstWeekDayPreference {
+    /// 0 is Sunday through 6 Saturday, as GetIdentity serves it.
+    @required
+    first_week_day: Integer
+}
+
+/// Set whether HEY renders times on a 12-hour or a 24-hour clock. Answers the
+/// stored preference. The parameter is the web toggle's, said honestly: true
+/// for the 24-hour clock, false for the 12-hour one.
+@idempotent
+@http(method: "PUT", uri: "/identity/time_format")
+@tags(["Identity"])
+@heyRetry(maxAttempts: 3, baseDelayMs: 1000, backoff: "exponential", retryOn: [429, 503])
+operation UpdateTimeFormat {
+    input: UpdateTimeFormatInput
+    output: UpdateTimeFormatOutput
+    errors: [UnauthorizedError, InternalServerError, ServiceUnavailableError]
+}
+
+structure UpdateTimeFormatInput {
+    @httpPayload
+    @required
+    body: UpdateTimeFormatRequestContent
+}
+
+structure UpdateTimeFormatRequestContent {
+    @required
+    twenty_four_hour_time_format: Boolean
+}
+
+structure UpdateTimeFormatOutput {
+    @required
+    preference: TimeFormatPreference
+}
+
+structure TimeFormatPreference {
+    /// "twelve_hour" or "twenty_four_hour", as GetIdentity serves it.
+    @required
+    time_format: String
 }
 
 // =============================================================================

--- a/spec/route-coverage.json
+++ b/spec/route-coverage.json
@@ -575,6 +575,11 @@
     "path": "/contacts/{contactId}/note.json"
   },
   {
+    "method": "PUT",
+    "operationId": "UpdateFirstWeekDay",
+    "path": "/calendar/identity/first_week_day"
+  },
+  {
     "method": "PATCH",
     "operationId": "UpdateHabit",
     "path": "/calendar/habits/{habitId}"
@@ -598,6 +603,11 @@
     "method": "PATCH",
     "operationId": "UpdateSticky",
     "path": "/stickies/{stickyId}"
+  },
+  {
+    "method": "PUT",
+    "operationId": "UpdateTimeFormat",
+    "path": "/identity/time_format"
   },
   {
     "method": "PUT",

--- a/spec/shape-fingerprint.json
+++ b/spec/shape-fingerprint.json
@@ -70,9 +70,11 @@
   "UpdateClearance": "c1597f10d3d5f9fabcf67ee69776dfedfe3f67752799276cda904caa9440b502",
   "UpdateContact": "e02333bf4001ecc7ef74a7fef1df25e15d77cf692f31a4e61e314a0446240aaf",
   "UpdateContactNote": "8333012b045fd6fef793cc5e757cbca113eda36bc1d592a3e91a8b60abe6f2b6",
+  "UpdateFirstWeekDay": "3ba3da20ba0ffa86b09988615de3083d2132b0ad9ee1bc90d61aba3642f30d4a",
   "UpdateHabit": "abdae94f7cb43bfa8d8fc2db6ead534ae9911b6f73d71a5d9bb212d876802444",
   "UpdateJournalEntry": "c28bc6186595cfc9bb61c3e90f3735fb90e50c81a78a60e45c08189713db9004",
   "UpdateMyClearance": "8339f944b2987935481a7ed6d5ece614d3bda79633778c5d685906fda9bf842b",
   "UpdateSticky": "59bd8472ed21daeff7a1c0e91ba53dff8821810a7badd9d1d05cf0e3f8bac339",
+  "UpdateTimeFormat": "76467582a986cd0b4c3efe7f8ea96b210eaa7de1693d70d838b8ebc09f79c1b8",
   "UpdateTimeTrack": "eb9135887276c0f3262eb6b4c74c5f9a533499d66d9b10d5965f791850fc496b"
 }


### PR DESCRIPTION
HEY's calendar settings — the first day of the week and the 12/24-hour clock — could be read through `GetIdentity` but not written. HEY answers JSON on both writes now, so this models them in the Smithy spec instead of hand-writing them:

- `UpdateFirstWeekDay` — `PUT /calendar/identity/first_week_day` with `{"identity_preference":{"first_week_day":"monday"}}`, answering the stored day as its number (`{"first_week_day":1}`).
- `UpdateTimeFormat` — `PUT /identity/time_format` with `{"twenty_four_hour_time_format":true|false}`, answering the stored format as its name (`{"time_format":"twenty_four_hour"}`).

Both answer in the shapes `GetIdentity` already serves these fields, and the wrappers return what HEY stored rather than what was asked for. The PUT entries leave `excluded-routes.json`; the PATCH entries stay, renamed to say they are the same Rails routes under the modelled method.

Consumer: hey-cli's new calendar settings page.

`make check` passes — Smithy build, drift gates, Go tests (request bodies and decoded answers pinned for both operations), and conformance.

Bumps the version to 0.23.0 ahead of the release tag, per CONTRIBUTING.