### PR TITLE
Model scheduled bubble-up: SchedulePostingsBubbleUp

### DIFF
--- a/behavior-model.json
+++ b/behavior-model.json
@@ -1336,6 +1336,19 @@
         ]
       }
     },
+    "SchedulePostingsBubbleUp": {
+      "idempotent": false,
+      "readonly": false,
+      "retry": {
+        "backoff": "exponential",
+        "base_delay_ms": 1000,
+        "max": 2,
+        "retry_on": [
+          429,
+          503
+        ]
+      }
+    },
     "StartTimeTrack": {
       "idempotent": false,
       "readonly": false,

--- a/conformance/runner/go/main.go
+++ b/conformance/runner/go/main.go
@@ -1209,6 +1209,13 @@ func executeOperation(client *generated.Client, ctx context.Context, tc TestCase
 	case "CancelPostingsBubbleUp":
 		params := &generated.CancelPostingsBubbleUpParams{PostingIds: getStringParam(tc.QueryParams, "posting_ids")}
 		return client.CancelPostingsBubbleUp(ctx, params)
+	case "SchedulePostingsBubbleUp":
+		body := generated.SchedulePostingsBubbleUpJSONRequestBody{
+			PostingIds: getInt64SliceParam(tc.RequestBody, "posting_ids"),
+			Slot:       getStringParam(tc.RequestBody, "slot"),
+			Date:       getStringParam(tc.RequestBody, "date"),
+		}
+		return client.SchedulePostingsBubbleUp(ctx, body)
 	case "BubbleUpPostingsNow":
 		body := generated.BubbleUpPostingsNowJSONRequestBody{
 			PostingIds: getInt64SliceParam(tc.RequestBody, "posting_ids"),

--- a/conformance/tests/paths.json
+++ b/conformance/tests/paths.json
@@ -1722,6 +1722,53 @@
     ]
   },
   {
+    "name": "SchedulePostingsBubbleUp uses /postings/bubble_up.json path",
+    "description": "Verifies that SchedulePostingsBubbleUp constructs the URL path /postings/bubble_up.json",
+    "operation": "SchedulePostingsBubbleUp",
+    "method": "POST",
+    "path": "/postings/bubble_up.json",
+    "requestBody": {
+      "posting_ids": [
+        1,
+        2
+      ],
+      "slot": "custom",
+      "date": "2026-09-04"
+    },
+    "mockResponses": [
+      {
+        "status": 201,
+        "body": {}
+      }
+    ],
+    "assertions": [
+      {
+        "type": "requestPath",
+        "expected": "/postings/bubble_up.json"
+      },
+      {
+        "type": "noError"
+      },
+      {
+        "type": "requestMethod",
+        "expected": "POST"
+      },
+      {
+        "type": "requestBody",
+        "expected": {
+          "posting_ids.0": 1,
+          "posting_ids.1": 2,
+          "slot": "custom",
+          "date": "2026-09-04"
+        }
+      }
+    ],
+    "tags": [
+      "path",
+      "postings"
+    ]
+  },
+  {
     "name": "BubbleUpPostingsNow uses /postings/bulk_bubble_up_now.json path",
     "description": "Verifies that BubbleUpPostingsNow constructs the URL path /postings/bulk_bubble_up_now.json",
     "operation": "BubbleUpPostingsNow",

--- a/go/pkg/generated/client.gen.go
+++ b/go/pkg/generated/client.gen.go
@@ -1313,6 +1313,13 @@ type ReplyMessagePayload struct {
 // RevealContactResponseContent Contact — the identity of someone in HEY
 type RevealContactResponseContent = Contact
 
+// SchedulePostingsBubbleUpRequestContent defines model for SchedulePostingsBubbleUpRequestContent.
+type SchedulePostingsBubbleUpRequestContent struct {
+	Date       string  `json:"date,omitempty"`
+	PostingIds []int64 `json:"posting_ids"`
+	Slot       string  `json:"slot"`
+}
+
 // SearchFilterItem SearchFilterItem — one option offered by the advanced search refine form
 type SearchFilterItem struct {
 	Title string `json:"title,omitempty"`
@@ -1952,6 +1959,9 @@ type UpdateMyClearanceJSONRequestBody = UpdateMyClearanceRequestContent
 // AddPostingsToBoxGroupJSONRequestBody defines body for AddPostingsToBoxGroup for application/json ContentType.
 type AddPostingsToBoxGroupJSONRequestBody = AddPostingsToBoxGroupRequestContent
 
+// SchedulePostingsBubbleUpJSONRequestBody defines body for SchedulePostingsBubbleUp for application/json ContentType.
+type SchedulePostingsBubbleUpJSONRequestBody = SchedulePostingsBubbleUpRequestContent
+
 // BubbleUpPostingsNowJSONRequestBody defines body for BubbleUpPostingsNow for application/json ContentType.
 type BubbleUpPostingsNowJSONRequestBody = MarkPostingsRequestContent
 
@@ -2533,6 +2543,11 @@ type ClientInterface interface {
 
 	// CancelPostingsBubbleUp request
 	CancelPostingsBubbleUp(ctx context.Context, params *CancelPostingsBubbleUpParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// SchedulePostingsBubbleUpWithBody request with any body
+	SchedulePostingsBubbleUpWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	SchedulePostingsBubbleUp(ctx context.Context, body SchedulePostingsBubbleUpJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// BubbleUpPostingsNowWithBody request with any body
 	BubbleUpPostingsNowWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -4026,6 +4041,36 @@ func (c *Client) CancelPostingsBubbleUp(ctx context.Context, params *CancelPosti
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewCancelPostingsBubbleUpRequest(c.Server, params)
 	}, true, "CancelPostingsBubbleUp", reqEditors...)
+
+}
+
+// SchedulePostingsBubbleUpWithBody executes the SchedulePostingsBubbleUp operation.
+
+func (c *Client) SchedulePostingsBubbleUpWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+
+	req, err := NewSchedulePostingsBubbleUpRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+
+}
+
+func (c *Client) SchedulePostingsBubbleUp(ctx context.Context, body SchedulePostingsBubbleUpJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+
+	req, err := NewSchedulePostingsBubbleUpRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
 
 }
 
@@ -8538,6 +8583,46 @@ func NewCancelPostingsBubbleUpRequest(server string, params *CancelPostingsBubbl
 	return req, nil
 }
 
+// NewSchedulePostingsBubbleUpRequest calls the generic SchedulePostingsBubbleUp builder with application/json body
+func NewSchedulePostingsBubbleUpRequest(server string, body SchedulePostingsBubbleUpJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewSchedulePostingsBubbleUpRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewSchedulePostingsBubbleUpRequestWithBody generates requests for SchedulePostingsBubbleUp with any type of body
+func NewSchedulePostingsBubbleUpRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/postings/bubble_up.json")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
 // NewBubbleUpPostingsNowRequest calls the generic BubbleUpPostingsNow builder with application/json body
 func NewBubbleUpPostingsNowRequest(server string, body BubbleUpPostingsNowJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
@@ -10166,6 +10251,7 @@ var operationMetadata = map[string]OperationMetadata{
 	"RemovePostingsFromBoxGroup": {Idempotent: true, HasSensitiveParams: false},
 	"AddPostingsToBoxGroup":      {Idempotent: false, HasSensitiveParams: false},
 	"CancelPostingsBubbleUp":     {Idempotent: true, HasSensitiveParams: false},
+	"SchedulePostingsBubbleUp":   {Idempotent: false, HasSensitiveParams: false},
 	"BubbleUpPostingsNow":        {Idempotent: false, HasSensitiveParams: false},
 	"UnfilePostings":             {Idempotent: true, HasSensitiveParams: false},
 	"FilePostings":               {Idempotent: false, HasSensitiveParams: false},
@@ -11700,6 +11786,34 @@ type ClientWithResponsesInterface interface {
 	//
 	// Returns a wrapper object for the known response body format(s).
 	CancelPostingsBubbleUpWithResponse(ctx context.Context, params *CancelPostingsBubbleUpParams, reqEditors ...RequestEditorFn) (*CancelPostingsBubbleUpResponse, error)
+
+	// SchedulePostingsBubbleUpWithBodyWithResponse performs a POST /postings/bubble_up.json (the `SchedulePostingsBubbleUp` operationId) request,
+	// with any type of body and a specified content type.
+	//
+	// Schedule a selection of postings to bubble up.
+	//
+	// HEY's scheduler takes a `slot` — today, tomorrow, weekend, next_week, surprise_me
+	// or custom — and a custom slot also carries the `date` (YYYY-MM-DD) to bubble up on,
+	// at HEY's morning hour. The today slot lands at HEY's evening hour of the current
+	// day instead, and both hours are UTC over JSON. An unknown slot, or a custom slot
+	// without a date, is a server error rather than a validation response, so callers
+	// check both first. Responds 201 Created.
+	//
+	// Returns a wrapper object for the known response body format(s).
+	SchedulePostingsBubbleUpWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SchedulePostingsBubbleUpResponse, error)
+
+	// SchedulePostingsBubbleUpWithResponse performs a POST /postings/bubble_up.json (the `SchedulePostingsBubbleUp` operationId) request.
+	// Takes a body of the `application/json` content type, and returns a wrapper object for the known response body format(s).
+	//
+	// Schedule a selection of postings to bubble up.
+	//
+	// HEY's scheduler takes a `slot` — today, tomorrow, weekend, next_week, surprise_me
+	// or custom — and a custom slot also carries the `date` (YYYY-MM-DD) to bubble up on,
+	// at HEY's morning hour. The today slot lands at HEY's evening hour of the current
+	// day instead, and both hours are UTC over JSON. An unknown slot, or a custom slot
+	// without a date, is a server error rather than a validation response, so callers
+	// check both first. Responds 201 Created.
+	SchedulePostingsBubbleUpWithResponse(ctx context.Context, body SchedulePostingsBubbleUpJSONRequestBody, reqEditors ...RequestEditorFn) (*SchedulePostingsBubbleUpResponse, error)
 
 	// BubbleUpPostingsNowWithBodyWithResponse performs a POST /postings/bulk_bubble_up_now.json (the `BubbleUpPostingsNow` operationId) request,
 	// with any type of body and a specified content type.
@@ -17897,6 +18011,68 @@ func (r CancelPostingsBubbleUpResponse) ContentType() string {
 	return ""
 }
 
+type SchedulePostingsBubbleUpResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	// JSON401 the response for an HTTP 401 `application/json` response
+	JSON401 *UnauthorizedErrorResponseContent
+	// JSON404 the response for an HTTP 404 `application/json` response
+	JSON404 *NotFoundErrorResponseContent
+	// JSON500 the response for an HTTP 500 `application/json` response
+	JSON500 *InternalServerErrorResponseContent
+	// JSON503 the response for an HTTP 503 `application/json` response
+	JSON503 *ServiceUnavailableErrorResponseContent
+}
+
+// GetJSON401 returns the response for an HTTP 401 `application/json` response
+func (r SchedulePostingsBubbleUpResponse) GetJSON401() *UnauthorizedErrorResponseContent {
+	return r.JSON401
+}
+
+// GetJSON404 returns the response for an HTTP 404 `application/json` response
+func (r SchedulePostingsBubbleUpResponse) GetJSON404() *NotFoundErrorResponseContent {
+	return r.JSON404
+}
+
+// GetJSON500 returns the response for an HTTP 500 `application/json` response
+func (r SchedulePostingsBubbleUpResponse) GetJSON500() *InternalServerErrorResponseContent {
+	return r.JSON500
+}
+
+// GetJSON503 returns the response for an HTTP 503 `application/json` response
+func (r SchedulePostingsBubbleUpResponse) GetJSON503() *ServiceUnavailableErrorResponseContent {
+	return r.JSON503
+}
+
+// GetBody returns the raw response body bytes
+func (r SchedulePostingsBubbleUpResponse) GetBody() []byte {
+	return r.Body
+}
+
+// Status returns HTTPResponse.Status
+func (r SchedulePostingsBubbleUpResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r SchedulePostingsBubbleUpResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r SchedulePostingsBubbleUpResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
 type BubbleUpPostingsNowResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -21749,6 +21925,46 @@ func (c *ClientWithResponses) CancelPostingsBubbleUpWithResponse(ctx context.Con
 		return nil, err
 	}
 	return ParseCancelPostingsBubbleUpResponse(rsp)
+}
+
+// SchedulePostingsBubbleUpWithBodyWithResponse performs a POST /postings/bubble_up.json (the `SchedulePostingsBubbleUp` operationId) request,
+// with any type of body and a specified content type.
+//
+// Schedule a selection of postings to bubble up.
+//
+// HEY's scheduler takes a `slot` — today, tomorrow, weekend, next_week, surprise_me
+// or custom — and a custom slot also carries the `date` (YYYY-MM-DD) to bubble up on,
+// at HEY's morning hour. The today slot lands at HEY's evening hour of the current
+// day instead, and both hours are UTC over JSON. An unknown slot, or a custom slot
+// without a date, is a server error rather than a validation response, so callers
+// check both first. Responds 201 Created.
+//
+// Returns a wrapper object for the known response body format(s).
+func (c *ClientWithResponses) SchedulePostingsBubbleUpWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SchedulePostingsBubbleUpResponse, error) {
+	rsp, err := c.SchedulePostingsBubbleUpWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseSchedulePostingsBubbleUpResponse(rsp)
+}
+
+// SchedulePostingsBubbleUpWithResponse performs a POST /postings/bubble_up.json (the `SchedulePostingsBubbleUp` operationId) request.
+// Takes a body of the `application/json` content type, and returns a wrapper object for the known response body format(s).
+//
+// Schedule a selection of postings to bubble up.
+//
+// HEY's scheduler takes a `slot` — today, tomorrow, weekend, next_week, surprise_me
+// or custom — and a custom slot also carries the `date` (YYYY-MM-DD) to bubble up on,
+// at HEY's morning hour. The today slot lands at HEY's evening hour of the current
+// day instead, and both hours are UTC over JSON. An unknown slot, or a custom slot
+// without a date, is a server error rather than a validation response, so callers
+// check both first. Responds 201 Created.
+func (c *ClientWithResponses) SchedulePostingsBubbleUpWithResponse(ctx context.Context, body SchedulePostingsBubbleUpJSONRequestBody, reqEditors ...RequestEditorFn) (*SchedulePostingsBubbleUpResponse, error) {
+	rsp, err := c.SchedulePostingsBubbleUp(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseSchedulePostingsBubbleUpResponse(rsp)
 }
 
 // BubbleUpPostingsNowWithBodyWithResponse performs a POST /postings/bulk_bubble_up_now.json (the `BubbleUpPostingsNow` operationId) request,
@@ -26978,6 +27194,56 @@ func ParseCancelPostingsBubbleUpResponse(rsp *http.Response) (*CancelPostingsBub
 	}
 
 	response := &CancelPostingsBubbleUpResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case rsp.StatusCode == 200:
+		break // No content-type
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest UnauthorizedErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFoundErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalServerErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 503:
+		var dest ServiceUnavailableErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON503 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseSchedulePostingsBubbleUpResponse parses an HTTP response from a SchedulePostingsBubbleUpWithResponse call
+func ParseSchedulePostingsBubbleUpResponse(rsp *http.Response) (*SchedulePostingsBubbleUpResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &SchedulePostingsBubbleUpResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}

--- a/go/pkg/hey/postings.go
+++ b/go/pkg/hey/postings.go
@@ -263,6 +263,45 @@ func (s *PostingsService) BubbleUpNow(ctx context.Context, postingIDs ...int64) 
 	})
 }
 
+// BubbleUpSlot is one of HEY's named bubble-up schedule slots — the web app's
+// "Later today", "Tomorrow", "This weekend" and "Next week". Later today lands at
+// HEY's evening hour of the current day, the others at its morning hour of their day
+// (Saturday for the weekend, Monday for next week) — in UTC, like every hour HEY
+// reads out of a JSON request.
+type BubbleUpSlot string
+
+const (
+	BubbleUpLaterToday  BubbleUpSlot = "today"
+	BubbleUpTomorrow    BubbleUpSlot = "tomorrow"
+	BubbleUpThisWeekend BubbleUpSlot = "weekend"
+	BubbleUpNextWeek    BubbleUpSlot = "next_week"
+)
+
+// ScheduleBubbleUp schedules one or more postings to bubble up on a date, written
+// YYYY-MM-DD. HEY resurfaces them at its morning hour of that day — in UTC, like every
+// hour HEY reads out of a JSON request. HEY does not refuse a past timestamp — the
+// postings bubble up on the next scheduler run instead.
+func (s *PostingsService) ScheduleBubbleUp(ctx context.Context, date string, postingIDs ...int64) (err error) {
+	return s.scheduleBubbleUp(ctx, "custom", date, postingIDs)
+}
+
+// ScheduleBubbleUpFor schedules one or more postings to bubble up at one of HEY's
+// named slots.
+func (s *PostingsService) ScheduleBubbleUpFor(ctx context.Context, slot BubbleUpSlot, postingIDs ...int64) (err error) {
+	return s.scheduleBubbleUp(ctx, string(slot), "", postingIDs)
+}
+
+func (s *PostingsService) scheduleBubbleUp(ctx context.Context, slot, date string, postingIDs []int64) error {
+	return s.bulkAction(ctx, "SchedulePostingsBubbleUp", postingIDs, func(ctx context.Context, ids []int64) error {
+		body := generated.SchedulePostingsBubbleUpRequestContent{PostingIds: ids, Slot: slot, Date: date}
+		resp, err := s.client.genClient().SchedulePostingsBubbleUpWithResponse(ctx, body)
+		if err != nil {
+			return err
+		}
+		return CheckResponse(resp.HTTPResponse)
+	})
+}
+
 // PostingChangesCursor is where a read of a box's changes feed starts. Since is an ISO
 // 8601 timestamp with milliseconds and is exclusive; Version is the contract version the
 // caller speaks. A box's PostingChangesUrl carries the pair to begin with — read it with

--- a/go/pkg/hey/postings_test.go
+++ b/go/pkg/hey/postings_test.go
@@ -120,6 +120,58 @@ func TestPostingsService_BulkEndpoints(t *testing.T) {
 	}
 }
 
+func TestPostingsService_ScheduleBubbleUp(t *testing.T) {
+	c, reqs, _ := newPostingsTestClient(t, 201)
+	if err := c.Postings().ScheduleBubbleUp(context.Background(), "2026-09-04", 11, 12); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(*reqs) != 1 {
+		t.Fatalf("expected 1 request, got %d", len(*reqs))
+	}
+	r := (*reqs)[0]
+	if r.Method != "POST" || r.Path != "/postings/bubble_up.json" {
+		t.Errorf("got %s %s, want POST /postings/bubble_up.json", r.Method, r.Path)
+	}
+	if got := idsOf(r.Body); len(got) != 2 || got[0] != 11 || got[1] != 12 {
+		t.Errorf("posting_ids = %v, want [11 12]", got)
+	}
+	if r.Body["slot"] != "custom" {
+		t.Errorf("slot = %v, want custom", r.Body["slot"])
+	}
+	if r.Body["date"] != "2026-09-04" {
+		t.Errorf("date = %v, want 2026-09-04", r.Body["date"])
+	}
+}
+
+func TestPostingsService_ScheduleBubbleUpFor(t *testing.T) {
+	for slot, want := range map[BubbleUpSlot]string{
+		BubbleUpLaterToday:  "today",
+		BubbleUpTomorrow:    "tomorrow",
+		BubbleUpThisWeekend: "weekend",
+		BubbleUpNextWeek:    "next_week",
+	} {
+		t.Run(want, func(t *testing.T) {
+			c, reqs, _ := newPostingsTestClient(t, 201)
+			if err := c.Postings().ScheduleBubbleUpFor(context.Background(), slot, 11); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(*reqs) != 1 {
+				t.Fatalf("expected 1 request, got %d", len(*reqs))
+			}
+			r := (*reqs)[0]
+			if r.Method != "POST" || r.Path != "/postings/bubble_up.json" {
+				t.Errorf("got %s %s, want POST /postings/bubble_up.json", r.Method, r.Path)
+			}
+			if r.Body["slot"] != want {
+				t.Errorf("slot = %v, want %s", r.Body["slot"], want)
+			}
+			if _, present := r.Body["date"]; present {
+				t.Errorf("date = %v, want it absent", r.Body["date"])
+			}
+		})
+	}
+}
+
 func TestPostingsService_BoxKindResolvedOnce(t *testing.T) {
 	ctx := context.Background()
 	c, reqs, boxCalls := newPostingsTestClient(t, 204)

--- a/go/pkg/hey/url-routes.json
+++ b/go/pkg/hey/url-routes.json
@@ -749,7 +749,8 @@
       "pattern": "/postings/bubble_up",
       "resource": "Postings",
       "operations": {
-        "DELETE": "CancelPostingsBubbleUp"
+        "DELETE": "CancelPostingsBubbleUp",
+        "POST": "SchedulePostingsBubbleUp"
       },
       "params": {}
     },

--- a/go/pkg/hey/version.go
+++ b/go/pkg/hey/version.go
@@ -1,7 +1,7 @@
 package hey
 
 // Version is the current version of the HEY Go SDK.
-const Version = "0.23.0"
+const Version = "0.24.0"
 
 // APIVersion is the HEY API version this SDK targets.
 const APIVersion = "2026-08-21"

--- a/openapi.json
+++ b/openapi.json
@@ -7127,6 +7127,77 @@
             503
           ]
         }
+      },
+      "post": {
+        "description": "Schedule a selection of postings to bubble up.\n\nHEY's scheduler takes a `slot` — today, tomorrow, weekend, next_week, surprise_me\nor custom — and a custom slot also carries the `date` (YYYY-MM-DD) to bubble up on,\nat HEY's morning hour. The today slot lands at HEY's evening hour of the current\nday instead, and both hours are UTC over JSON. An unknown slot, or a custom slot\nwithout a date, is a server error rather than a validation response, so callers\ncheck both first. Responds 201 Created.",
+        "operationId": "SchedulePostingsBubbleUp",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SchedulePostingsBubbleUpRequestContent"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "SchedulePostingsBubbleUp 200 response"
+          },
+          "401": {
+            "description": "UnauthorizedError 401 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedErrorResponseContent"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFoundError 404 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundErrorResponseContent"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "InternalServerError 500 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerErrorResponseContent"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "ServiceUnavailableError 503 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceUnavailableErrorResponseContent"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Postings"
+        ],
+        "x-hey-retry": {
+          "maxAttempts": 2,
+          "baseDelayMs": 1000,
+          "backoff": "exponential",
+          "retryOn": [
+            429,
+            503
+          ]
+        }
       }
     },
     "/postings/bulk_bubble_up_now.json": {
@@ -12943,6 +13014,28 @@
       },
       "RevealContactResponseContent": {
         "$ref": "#/components/schemas/Contact"
+      },
+      "SchedulePostingsBubbleUpRequestContent": {
+        "type": "object",
+        "properties": {
+          "posting_ids": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          "slot": {
+            "type": "string"
+          },
+          "date": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "posting_ids",
+          "slot"
+        ]
       },
       "SearchFilterItem": {
         "type": "object",

--- a/spec/excluded-routes.json
+++ b/spec/excluded-routes.json
@@ -2635,11 +2635,6 @@
     "reason": "phase-2: personal settings and preferences"
   },
   {
-    "method": "POST",
-    "path": "/postings/bubble_up",
-    "reason": "phase-2: posting bubble up"
-  },
-  {
     "method": "GET",
     "path": "/postings/bubble_up/menu",
     "reason": "phase-2: posting bubble up"

--- a/spec/hey.smithy
+++ b/spec/hey.smithy
@@ -165,6 +165,7 @@ service HEY {
         CreateFolderForPostings
         CancelPostingsBubbleUp
         BubbleUpPostingsNow
+        SchedulePostingsBubbleUp
 
         // Topics — status and moves
         TrashTopic
@@ -3134,6 +3135,38 @@ operation CancelPostingsBubbleUp {
 operation BubbleUpPostingsNow {
     input: MarkPostingsInput
     errors: [UnauthorizedError, NotFoundError, InternalServerError, ServiceUnavailableError]
+}
+
+/// Schedule a selection of postings to bubble up.
+///
+/// HEY's scheduler takes a `slot` — today, tomorrow, weekend, next_week, surprise_me
+/// or custom — and a custom slot also carries the `date` (YYYY-MM-DD) to bubble up on,
+/// at HEY's morning hour. The today slot lands at HEY's evening hour of the current
+/// day instead, and both hours are UTC over JSON. An unknown slot, or a custom slot
+/// without a date, is a server error rather than a validation response, so callers
+/// check both first. Responds 201 Created.
+@http(method: "POST", uri: "/postings/bubble_up.json")
+@tags(["Postings"])
+@heyRetry(maxAttempts: 2, baseDelayMs: 1000, backoff: "exponential", retryOn: [429, 503])
+operation SchedulePostingsBubbleUp {
+    input: SchedulePostingsBubbleUpInput
+    errors: [UnauthorizedError, NotFoundError, InternalServerError, ServiceUnavailableError]
+}
+
+structure SchedulePostingsBubbleUpInput {
+    @httpPayload
+    @required
+    body: SchedulePostingsBubbleUpRequestContent
+}
+
+structure SchedulePostingsBubbleUpRequestContent {
+    @required
+    posting_ids: PostingIdList
+
+    @required
+    slot: String
+
+    date: String
 }
 
 // =============================================================================

--- a/spec/route-coverage.json
+++ b/spec/route-coverage.json
@@ -496,6 +496,11 @@
   },
   {
     "method": "POST",
+    "operationId": "SchedulePostingsBubbleUp",
+    "path": "/postings/bubble_up.json"
+  },
+  {
+    "method": "POST",
     "operationId": "StartTimeTrack",
     "path": "/calendar/ongoing_time_track.json"
   },


### PR DESCRIPTION
Models `POST /postings/bubble_up.json`, the endpoint behind HEY's "Bubble Up" scheduling menu, and wraps it as `Postings().ScheduleBubbleUp` / `Postings().ScheduleBubbleUpFor`.

## API behavior

The endpoint takes `posting_ids`, a `slot`, and — for the custom slot — a `date`:

- Named slots: `today` (later today), `tomorrow`, `weekend`, `next_week`. HEY schedules the bubble-up for the morning of the slot's day (Saturday for the weekend, Monday for next week); `today` lands at 18:00 of the current day instead. Hours are UTC, as with every hour HEY reads out of a JSON request.
- `custom` takes a `date` (`YYYY-MM-DD`) and schedules the morning of that day. A past date isn't refused — the postings bubble up on the next scheduler run.
- Responds `201 Created`. An unknown slot, or `custom` without a date, is a server error rather than a validation response, so callers should validate first.

## SDK surface

- `BubbleUpSlot` with `BubbleUpLaterToday`, `BubbleUpTomorrow`, `BubbleUpThisWeekend`, `BubbleUpNextWeek`
- `ScheduleBubbleUpFor(ctx, slot, ids...)` for the named slots
- `ScheduleBubbleUp(ctx, date, ids...)` for a custom date
- Both chunk ids through the same bulk-action path as the other posting bulk operations

Derived artifacts are regenerated (OpenAPI, generated client, url-routes, route coverage, shape fingerprint, behavior model), the now-modelled route is removed from `spec/excluded-routes.json`, and there are unit tests plus a conformance path case. `make check` is green.

Second commit bumps the SDK to 0.24.0 per the release process, so the tag can follow once this lands.

## Consumer

hey-cli's `hey bubble up` (basecamp/hey-cli#326) is waiting on this operation.
