### PR TITLE
Expose calendar recording pagination

### DIFF
--- a/conformance/runner/go/main.go
+++ b/conformance/runner/go/main.go
@@ -1038,7 +1038,12 @@ func executeOperation(client *generated.Client, ctx context.Context, tc TestCase
 		return client.ListCalendars(ctx)
 	case "GetCalendarRecordings":
 		calendarId := getInt64Param(tc.PathParams, "calendarId")
-		return client.GetCalendarRecordings(ctx, calendarId, nil)
+		params := &generated.GetCalendarRecordingsParams{
+			StartsOn: getStringPtrParam(tc.QueryParams, "starts_on"),
+			EndsOn:   getStringPtrParam(tc.QueryParams, "ends_on"),
+			Page:     getStringPtrParam(tc.QueryParams, "page"),
+		}
+		return client.GetCalendarRecordings(ctx, calendarId, params)
 
 	// Calendar Todos
 	case "CreateCalendarTodo":

--- a/conformance/tests/pagination.json
+++ b/conformance/tests/pagination.json
@@ -23,6 +23,36 @@
     "tags": ["pagination", "link-header"]
   },
   {
+    "name": "Calendar recordings carry the geared pagination cursor",
+    "description": "Verifies that calendar recording windows send their dates and the opaque cursor from the previous Link header",
+    "operation": "GetCalendarRecordings",
+    "method": "GET",
+    "path": "/calendars/{calendarId}/recordings",
+    "pathParams": {
+      "calendarId": 456
+    },
+    "queryParams": {
+      "starts_on": "2026-08-01",
+      "ends_on": "2026-08-31",
+      "page": "older-starts"
+    },
+    "mockResponses": [
+      {
+        "status": 200,
+        "body": {
+          "Calendar::Event": [{"id": 702, "title": "Weekly planning"}]
+        }
+      }
+    ],
+    "assertions": [
+      {"type": "requestCount", "expected": 1},
+      {"type": "statusCode", "expected": 200},
+      {"type": "requestQuery", "expected": {"starts_on": "2026-08-01", "ends_on": "2026-08-31", "page": "older-starts"}},
+      {"type": "noError"}
+    ],
+    "tags": ["pagination", "calendars"]
+  },
+  {
     "name": "Tracked time is read without empty pagination parameters",
     "description": "Verifies that an unfiltered first read of the tracked-time index sends neither page nor category_id, so geared_pagination is not handed a blank cursor",
     "operation": "ListTimeTracks",

--- a/go/pkg/generated/client.gen.go
+++ b/go/pkg/generated/client.gen.go
@@ -1762,6 +1762,7 @@ type ListCalendarWeeksParams struct {
 type GetCalendarRecordingsParams struct {
 	StartsOn *string `form:"starts_on,omitempty" json:"starts_on,omitempty"`
 	EndsOn   *string `form:"ends_on,omitempty" json:"ends_on,omitempty"`
+	Page     *string `form:"page,omitempty" json:"page,omitempty"`
 }
 
 // GetClearancesParams defines parameters for GetClearances.
@@ -6773,6 +6774,22 @@ func NewGetCalendarRecordingsRequest(server string, calendarId int64, params *Ge
 		if params.EndsOn != nil {
 
 			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "ends_on", runtime.ParamLocationQuery, *params.EndsOn); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Page != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "page", runtime.ParamLocationQuery, *params.Page); err != nil {
 				return nil, err
 			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
 				return nil, err

--- a/go/pkg/hey/calendars.go
+++ b/go/pkg/hey/calendars.go
@@ -116,8 +116,26 @@ func (s *CalendarsService) ListWithChanges(ctx context.Context) (result *Calenda
 	return result, err
 }
 
-// GetRecordings returns recordings for a specific calendar.
-func (s *CalendarsService) GetRecordings(ctx context.Context, calendarID int64, params *generated.GetCalendarRecordingsParams) (result *generated.CalendarRecordingsResponse, err error) {
+// CalendarRecordingsPage is one page of a calendar's recordings and the cursor for the
+// page after it. NextPage is empty on the last page.
+type CalendarRecordingsPage struct {
+	Recordings *generated.CalendarRecordingsResponse
+	NextPage   string
+}
+
+// GetRecordings returns one requested page of recordings for a specific calendar.
+// GetRecordingsPage also returns the cursor needed to continue through the window.
+func (s *CalendarsService) GetRecordings(ctx context.Context, calendarID int64, params *generated.GetCalendarRecordingsParams) (*generated.CalendarRecordingsResponse, error) {
+	page, err := s.GetRecordingsPage(ctx, calendarID, params)
+	if err != nil {
+		return nil, err
+	}
+	return page.Recordings, nil
+}
+
+// GetRecordingsPage returns recordings for a specific calendar along with the cursor for
+// the page after them. Leave Page empty for the first page, then set it to each NextPage.
+func (s *CalendarsService) GetRecordingsPage(ctx context.Context, calendarID int64, params *generated.GetCalendarRecordingsParams) (result *CalendarRecordingsPage, err error) {
 	op := OperationInfo{
 		Service: "Calendars", Operation: "GetCalendarRecordings",
 		ResourceType: "recording", IsMutation: false, ResourceID: calendarID,
@@ -139,5 +157,10 @@ func (s *CalendarsService) GetRecordings(ctx context.Context, calendarID int64, 
 	if err = CheckResponse(resp.HTTPResponse); err != nil {
 		return nil, err
 	}
-	return resp.JSON200, nil
+
+	result = &CalendarRecordingsPage{Recordings: resp.JSON200}
+	if resp.HTTPResponse != nil {
+		result.NextPage = gearedPageFromLink(resp.HTTPResponse.Header.Get("Link"))
+	}
+	return result, nil
 }

--- a/go/pkg/hey/services_test.go
+++ b/go/pkg/hey/services_test.go
@@ -694,6 +694,33 @@ func TestCalendarsService_GetRecordings(t *testing.T) {
 	}
 }
 
+func TestCalendarsService_GetRecordingsPage(t *testing.T) {
+	var gotPage string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPage = r.URL.Query().Get("page")
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Link", `<http://`+r.Host+`/calendars/1/recordings.json?page=next-cursor>; rel="next"`)
+		_, _ = io.WriteString(w, `{"Calendar::Event":[{"id":1}]}`)
+	}))
+	t.Cleanup(server.Close)
+	client := NewClient(&Config{BaseURL: server.URL}, &StaticTokenProvider{Token: "t"}, WithMaxRetries(0))
+
+	cursor := "current-cursor"
+	page, err := client.Calendars().GetRecordingsPage(context.Background(), 1, &generated.GetCalendarRecordingsParams{Page: &cursor})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotPage != cursor {
+		t.Errorf("page = %q, want %q", gotPage, cursor)
+	}
+	if page.Recordings == nil || len((*page.Recordings)["Calendar::Event"]) != 1 {
+		t.Errorf("recordings = %+v, want the event page", page.Recordings)
+	}
+	if page.NextPage != "next-cursor" {
+		t.Errorf("next page = %q, want the Link header's cursor", page.NextPage)
+	}
+}
+
 // --- CalendarTodos ---
 
 func TestCalendarTodosService_Create(t *testing.T) {

--- a/go/pkg/hey/version.go
+++ b/go/pkg/hey/version.go
@@ -1,7 +1,7 @@
 package hey
 
 // Version is the current version of the HEY Go SDK.
-const Version = "0.24.0"
+const Version = "0.25.0"
 
 // APIVersion is the HEY API version this SDK targets.
 const APIVersion = "2026-08-21"

--- a/openapi.json
+++ b/openapi.json
@@ -3640,6 +3640,14 @@
               "type": "string",
               "x-go-type-skip-optional-pointer": false
             }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "x-go-type-skip-optional-pointer": false
+            }
           }
         ],
         "responses": {

--- a/spec/hey.smithy
+++ b/spec/hey.smithy
@@ -2138,6 +2138,9 @@ structure GetCalendarRecordingsInput {
 
     @httpQuery("ends_on")
     ends_on: String
+
+    @httpQuery("page")
+    page: String
 }
 
 structure GetCalendarRecordingsOutput {


### PR DESCRIPTION
Calendar recording windows are geared-paginated, but the SDK discarded their `Link` cursor. This adds the cursor-bearing page API needed for callers to enumerate complete windows, including recurring series whose original start falls after the first page.

## API surface

- Adds the optional `page` query parameter to `GetCalendarRecordingsParams`.
- Adds `CalendarRecordingsPage` and `Calendars().GetRecordingsPage`.
- Keeps `Calendars().GetRecordings` source-compatible and returning the requested page as before.
- Bumps the Go SDK version to 0.25.0.

## Proof

- Unit coverage verifies the requested cursor is sent and the next cursor is extracted from the response `Link` header.
- Conformance coverage verifies the date window and opaque page cursor on the generated request.
- `make check` passes: Go tests and lint are green, generated artifacts are current, and all 165 conformance cases pass.

## Risk and reviewer focus

Risk is low: the generated parameter and wrapper are additive, and existing `GetRecordings` callers retain one-page behavior. Please focus on the page wrapper contract and preservation of the existing method.

## Consumer

basecamp/hey-cli#332 follows complete event, to-do, and journal windows with this page API. The original bug report was supplied out-of-band, so there is no durable issue link.
