### PR TITLE
Model a bundle's unseen postings: GetBundleUnseenPostings

### DIFF
--- a/behavior-model.json
+++ b/behavior-model.json
@@ -472,6 +472,23 @@
         ]
       }
     },
+    "GetBundleUnseenPostings": {
+      "idempotent": false,
+      "pagination": {
+        "style": "link",
+        "totalCountHeader": "X-Total-Count"
+      },
+      "readonly": true,
+      "retry": {
+        "backoff": "exponential",
+        "base_delay_ms": 1000,
+        "max": 3,
+        "retry_on": [
+          429,
+          503
+        ]
+      }
+    },
     "GetCalendarDay": {
       "idempotent": false,
       "readonly": true,

--- a/conformance/runner/go/main.go
+++ b/conformance/runner/go/main.go
@@ -1175,6 +1175,12 @@ func executeOperation(client *generated.Client, ctx context.Context, tc TestCase
 	case "UnmutePostings":
 		params := &generated.UnmutePostingsParams{PostingIds: getStringParam(tc.QueryParams, "posting_ids")}
 		return client.UnmutePostings(ctx, params)
+	case "GetBundleUnseenPostings":
+		postingId := getInt64Param(tc.PathParams, "postingId")
+		params := &generated.GetBundleUnseenPostingsParams{
+			Page: getStringPtrParam(tc.QueryParams, "page"),
+		}
+		return client.GetBundleUnseenPostings(ctx, postingId, params)
 	case "MarkPostingsSpam":
 		body := generated.MarkPostingsSpamJSONRequestBody{
 			PostingIds: getInt64SliceParam(tc.RequestBody, "posting_ids"),

--- a/conformance/tests/pagination.json
+++ b/conformance/tests/pagination.json
@@ -23,6 +23,35 @@
     "tags": ["pagination", "link-header"]
   },
   {
+    "name": "Bundle unseen postings carry the geared pagination cursor",
+    "description": "Verifies that reading a bundle's unseen postings sends the opaque cursor from the previous Link header",
+    "operation": "GetBundleUnseenPostings",
+    "method": "GET",
+    "path": "/postings/{postingId}/bundles/unseen.json",
+    "pathParams": {
+      "postingId": 311
+    },
+    "queryParams": {
+      "page": "older-postings"
+    },
+    "mockResponses": [
+      {
+        "status": 200,
+        "body": {
+          "contact": {"id": 88, "name": "GitHub"},
+          "postings": [{"id": 501, "kind": "topic", "name": "Deploy failed on main"}]
+        }
+      }
+    ],
+    "assertions": [
+      {"type": "requestCount", "expected": 1},
+      {"type": "statusCode", "expected": 200},
+      {"type": "requestQuery", "expected": {"page": "older-postings"}},
+      {"type": "noError"}
+    ],
+    "tags": ["pagination", "postings"]
+  },
+  {
     "name": "Calendar recordings carry the geared pagination cursor",
     "description": "Verifies that calendar recording windows send their dates and the opaque cursor from the previous Link header",
     "operation": "GetCalendarRecordings",

--- a/go/pkg/generated/client.gen.go
+++ b/go/pkg/generated/client.gen.go
@@ -743,6 +743,13 @@ type GetBoxResponseContent = BoxShowResponse
 // SDK response decoders normalize the nested variant to flat before decoding.
 type GetBubbleboxResponseContent = BoxShowResponse
 
+// GetBundleUnseenPostingsResponseContent defines model for GetBundleUnseenPostingsResponseContent.
+type GetBundleUnseenPostingsResponseContent struct {
+	// Contact Contact — the identity of someone in HEY
+	Contact  Contact   `json:"contact"`
+	Postings []Posting `json:"postings"`
+}
+
 // GetCalendarDayResponseContent CalendarPeriod — a day or a week: its bounds and everything in it, grouped by type.
 // Recurring events arrive expanded into the occurrences that fall inside the window,
 // which is what makes this a different answer than the recordings a calendar lists.
@@ -1842,6 +1849,11 @@ type UnmutePostingsParams struct {
 	PostingIds string `form:"posting_ids" json:"posting_ids"`
 }
 
+// GetBundleUnseenPostingsParams defines parameters for GetBundleUnseenPostings.
+type GetBundleUnseenPostingsParams struct {
+	Page *string `form:"page,omitempty" json:"page,omitempty"`
+}
+
 // GetLaterboxParams defines parameters for GetLaterbox.
 type GetLaterboxParams struct {
 	Page *string `form:"page,omitempty" json:"page,omitempty"`
@@ -2600,6 +2612,9 @@ type ClientInterface interface {
 	MarkPostingsUnseenWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	MarkPostingsUnseen(ctx context.Context, body MarkPostingsUnseenJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetBundleUnseenPostings request
+	GetBundleUnseenPostings(ctx context.Context, postingId int64, params *GetBundleUnseenPostingsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// CreateDirectUploadWithBody request with any body
 	CreateDirectUploadWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -4362,6 +4377,16 @@ func (c *Client) MarkPostingsUnseen(ctx context.Context, body MarkPostingsUnseen
 		return nil, err
 	}
 	return c.Client.Do(req)
+
+}
+
+// GetBundleUnseenPostings is marked as idempotent and will be retried on transient failures.
+
+func (c *Client) GetBundleUnseenPostings(ctx context.Context, postingId int64, params *GetBundleUnseenPostingsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		return NewGetBundleUnseenPostingsRequest(c.Server, postingId, params)
+	}, true, "GetBundleUnseenPostings", reqEditors...)
 
 }
 
@@ -9106,6 +9131,62 @@ func NewMarkPostingsUnseenRequestWithBody(server string, contentType string, bod
 	return req, nil
 }
 
+// NewGetBundleUnseenPostingsRequest generates requests for GetBundleUnseenPostings
+func NewGetBundleUnseenPostingsRequest(server string, postingId int64, params *GetBundleUnseenPostingsParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "postingId", runtime.ParamLocationPath, postingId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/postings/%s/bundles/unseen.json", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.Page != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "page", runtime.ParamLocationQuery, *params.Page); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewCreateDirectUploadRequest calls the generic CreateDirectUpload builder with application/json body
 func NewCreateDirectUploadRequest(server string, body CreateDirectUploadJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
@@ -10280,6 +10361,7 @@ var operationMetadata = map[string]OperationMetadata{
 	"MarkPostingsSpam":           {Idempotent: false, HasSensitiveParams: false},
 	"TrashPostings":              {Idempotent: false, HasSensitiveParams: false},
 	"MarkPostingsUnseen":         {Idempotent: false, HasSensitiveParams: false},
+	"GetBundleUnseenPostings":    {Idempotent: true, HasSensitiveParams: false},
 	"CreateDirectUpload":         {Idempotent: false, HasSensitiveParams: false},
 	"GetLaterbox":                {Idempotent: true, HasSensitiveParams: false},
 	"GetAsidebox":                {Idempotent: true, HasSensitiveParams: false},
@@ -11993,6 +12075,16 @@ type ClientWithResponsesInterface interface {
 	//
 	// Mark postings as unseen.
 	MarkPostingsUnseenWithResponse(ctx context.Context, body MarkPostingsUnseenJSONRequestBody, reqEditors ...RequestEditorFn) (*MarkPostingsUnseenResponse, error)
+
+	// GetBundleUnseenPostingsWithResponse performs a GET /postings/{postingId}/bundles/unseen.json (the `GetBundleUnseenPostings` operationId) request.
+	//
+	// List the unseen postings inside a bundle posting.
+	//
+	// A bundle posting groups one contact's unseen mail; this is its contents — the member
+	// postings, newest first, paged by cursor like a box. The posting must be a bundle.
+	//
+	// Returns a wrapper object for the known response body format(s).
+	GetBundleUnseenPostingsWithResponse(ctx context.Context, postingId int64, params *GetBundleUnseenPostingsParams, reqEditors ...RequestEditorFn) (*GetBundleUnseenPostingsResponse, error)
 
 	// CreateDirectUploadWithBodyWithResponse performs a POST /rails/active_storage/direct_uploads.json (the `CreateDirectUpload` operationId) request,
 	// with any type of body and a specified content type.
@@ -18765,6 +18857,75 @@ func (r MarkPostingsUnseenResponse) ContentType() string {
 	return ""
 }
 
+type GetBundleUnseenPostingsResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	// JSON200 the response for an HTTP 200 `application/json` response
+	JSON200 *GetBundleUnseenPostingsResponseContent
+	// JSON401 the response for an HTTP 401 `application/json` response
+	JSON401 *UnauthorizedErrorResponseContent
+	// JSON404 the response for an HTTP 404 `application/json` response
+	JSON404 *NotFoundErrorResponseContent
+	// JSON500 the response for an HTTP 500 `application/json` response
+	JSON500 *InternalServerErrorResponseContent
+	// JSON503 the response for an HTTP 503 `application/json` response
+	JSON503 *ServiceUnavailableErrorResponseContent
+}
+
+// GetJSON200 returns the response for an HTTP 200 `application/json` response
+func (r GetBundleUnseenPostingsResponse) GetJSON200() *GetBundleUnseenPostingsResponseContent {
+	return r.JSON200
+}
+
+// GetJSON401 returns the response for an HTTP 401 `application/json` response
+func (r GetBundleUnseenPostingsResponse) GetJSON401() *UnauthorizedErrorResponseContent {
+	return r.JSON401
+}
+
+// GetJSON404 returns the response for an HTTP 404 `application/json` response
+func (r GetBundleUnseenPostingsResponse) GetJSON404() *NotFoundErrorResponseContent {
+	return r.JSON404
+}
+
+// GetJSON500 returns the response for an HTTP 500 `application/json` response
+func (r GetBundleUnseenPostingsResponse) GetJSON500() *InternalServerErrorResponseContent {
+	return r.JSON500
+}
+
+// GetJSON503 returns the response for an HTTP 503 `application/json` response
+func (r GetBundleUnseenPostingsResponse) GetJSON503() *ServiceUnavailableErrorResponseContent {
+	return r.JSON503
+}
+
+// GetBody returns the raw response body bytes
+func (r GetBundleUnseenPostingsResponse) GetBody() []byte {
+	return r.Body
+}
+
+// Status returns HTTPResponse.Status
+func (r GetBundleUnseenPostingsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetBundleUnseenPostingsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r GetBundleUnseenPostingsResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
 type CreateDirectUploadResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -22264,6 +22425,22 @@ func (c *ClientWithResponses) MarkPostingsUnseenWithResponse(ctx context.Context
 		return nil, err
 	}
 	return ParseMarkPostingsUnseenResponse(rsp)
+}
+
+// GetBundleUnseenPostingsWithResponse performs a GET /postings/{postingId}/bundles/unseen.json (the `GetBundleUnseenPostings` operationId) request.
+//
+// List the unseen postings inside a bundle posting.
+//
+// A bundle posting groups one contact's unseen mail; this is its contents — the member
+// postings, newest first, paged by cursor like a box. The posting must be a bundle.
+//
+// Returns a wrapper object for the known response body format(s).
+func (c *ClientWithResponses) GetBundleUnseenPostingsWithResponse(ctx context.Context, postingId int64, params *GetBundleUnseenPostingsParams, reqEditors ...RequestEditorFn) (*GetBundleUnseenPostingsResponse, error) {
+	rsp, err := c.GetBundleUnseenPostings(ctx, postingId, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetBundleUnseenPostingsResponse(rsp)
 }
 
 // CreateDirectUploadWithBodyWithResponse performs a POST /rails/active_storage/direct_uploads.json (the `CreateDirectUpload` operationId) request,
@@ -27825,6 +28002,60 @@ func ParseMarkPostingsUnseenResponse(rsp *http.Response) (*MarkPostingsUnseenRes
 			return nil, err
 		}
 		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalServerErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 503:
+		var dest ServiceUnavailableErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON503 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetBundleUnseenPostingsResponse parses an HTTP response from a GetBundleUnseenPostingsWithResponse call
+func ParseGetBundleUnseenPostingsResponse(rsp *http.Response) (*GetBundleUnseenPostingsResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetBundleUnseenPostingsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest GetBundleUnseenPostingsResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest UnauthorizedErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFoundErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest InternalServerErrorResponseContent

--- a/go/pkg/hey/postings.go
+++ b/go/pkg/hey/postings.go
@@ -302,6 +302,49 @@ func (s *PostingsService) scheduleBubbleUp(ctx context.Context, slot, date strin
 	})
 }
 
+// BundlePage is one page of the unseen postings inside a bundle posting: the bundled
+// contact, the member postings newest first, and the cursor for the page below —
+// empty on the last page.
+type BundlePage struct {
+	Contact  generated.Contact
+	Postings []generated.Posting
+	NextPage string
+}
+
+// BundleUnseenPage reads one page of the unseen postings a bundle posting groups
+// (GET /postings/{id}/bundles/unseen). An empty cursor starts at the top; the next
+// page's cursor comes back on the page before it. The posting must be a bundle.
+func (s *PostingsService) BundleUnseenPage(ctx context.Context, postingID int64, cursor string) (result *BundlePage, err error) {
+	op := OperationInfo{
+		Service: "Postings", Operation: "GetBundleUnseenPostings",
+		ResourceType: "posting", IsMutation: false, ResourceID: postingID,
+	}
+
+	err = s.client.instrument(ctx, op, func(ctx context.Context) error {
+		params := &generated.GetBundleUnseenPostingsParams{}
+		if cursor != "" {
+			params.Page = &cursor
+		}
+		resp, rerr := s.client.genClient().GetBundleUnseenPostingsWithResponse(ctx, postingID, params)
+		if rerr != nil {
+			return rerr
+		}
+		if cerr := CheckResponse(resp.HTTPResponse); cerr != nil {
+			return cerr
+		}
+		result = &BundlePage{}
+		if resp.JSON200 != nil {
+			result.Contact = resp.JSON200.Contact
+			result.Postings = resp.JSON200.Postings
+		}
+		if resp.HTTPResponse != nil {
+			result.NextPage = gearedPageFromLink(resp.HTTPResponse.Header.Get("Link"))
+		}
+		return nil
+	})
+	return result, err
+}
+
 // PostingChangesCursor is where a read of a box's changes feed starts. Since is an ISO
 // 8601 timestamp with milliseconds and is exclusive; Version is the contract version the
 // caller speaks. A box's PostingChangesUrl carries the pair to begin with — read it with

--- a/go/pkg/hey/postings_test.go
+++ b/go/pkg/hey/postings_test.go
@@ -561,3 +561,47 @@ func TestPostingsService_ChangesRequiresACursor(t *testing.T) {
 		t.Fatal("expected error for a cursor with no since")
 	}
 }
+
+func TestPostingsService_BundleUnseenPage(t *testing.T) {
+	var queries []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/postings/311/bundles/unseen.json" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		queries = append(queries, r.URL.RawQuery)
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Query().Get("page") == "" {
+			w.Header().Set("Link", `<http://`+r.Host+`/postings/311/bundles/unseen.json?page=eyJwYWdlIjoyfQ>; rel="next"`)
+			_, _ = w.Write([]byte(`{"contact":{"id":88,"name":"GitHub","email_address":"notifications@example.com"},"postings":[{"id":501,"kind":"topic","name":"Deploy failed on main","app_url":"https://app.hey.com/topics/9001"}]}`))
+		} else {
+			_, _ = w.Write([]byte(`{"contact":{"id":88,"name":"GitHub","email_address":"notifications@example.com"},"postings":[{"id":502,"kind":"topic","name":"Nightly build is green again","app_url":"https://app.hey.com/topics/9002"}]}`))
+		}
+	}))
+	t.Cleanup(server.Close)
+	c := NewClient(&Config{BaseURL: server.URL}, &StaticTokenProvider{Token: "test-token"}, WithMaxRetries(0))
+
+	page, err := c.Postings().BundleUnseenPage(context.Background(), 311, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if page.Contact.Name != "GitHub" || len(page.Postings) != 1 || page.Postings[0].Id != 501 {
+		t.Errorf("page = %+v", page)
+	}
+	if page.NextPage != "eyJwYWdlIjoyfQ" {
+		t.Errorf("NextPage = %q, want the Link header's cursor", page.NextPage)
+	}
+
+	next, err := c.Postings().BundleUnseenPage(context.Background(), 311, page.NextPage)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if next.NextPage != "" {
+		t.Errorf("NextPage = %q, want none on the last page", next.NextPage)
+	}
+	if len(next.Postings) != 1 || next.Postings[0].Id != 502 {
+		t.Errorf("page = %+v", next)
+	}
+	if len(queries) != 2 || queries[0] != "" || queries[1] != "page=eyJwYWdlIjoyfQ" {
+		t.Errorf("queries = %q, want the cursor passed through", queries)
+	}
+}

--- a/go/pkg/hey/url-routes.json
+++ b/go/pkg/hey/url-routes.json
@@ -829,6 +829,19 @@
       "params": {}
     },
     {
+      "pattern": "/postings/{postingId}/bundles/unseen",
+      "resource": "Postings",
+      "operations": {
+        "GET": "GetBundleUnseenPostings"
+      },
+      "params": {
+        "postingId": {
+          "role": "parent",
+          "type": "int64"
+        }
+      }
+    },
+    {
       "pattern": "/rails/active_storage/direct_uploads",
       "resource": "Attachments",
       "operations": {

--- a/go/pkg/hey/version.go
+++ b/go/pkg/hey/version.go
@@ -1,7 +1,7 @@
 package hey
 
 // Version is the current version of the HEY Go SDK.
-const Version = "0.25.0"
+const Version = "0.26.0"
 
 // APIVersion is the HEY API version this SDK targets.
 const APIVersion = "2026-08-21"

--- a/openapi.json
+++ b/openapi.json
@@ -8010,6 +8010,99 @@
         }
       }
     },
+    "/postings/{postingId}/bundles/unseen.json": {
+      "get": {
+        "description": "List the unseen postings inside a bundle posting.\n\nA bundle posting groups one contact's unseen mail; this is its contents — the member\npostings, newest first, paged by cursor like a box. The posting must be a bundle.",
+        "operationId": "GetBundleUnseenPostings",
+        "parameters": [
+          {
+            "name": "postingId",
+            "in": "path",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "required": true
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "x-go-type-skip-optional-pointer": false
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "GetBundleUnseenPostings 200 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetBundleUnseenPostingsResponseContent"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "UnauthorizedError 401 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedErrorResponseContent"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFoundError 404 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundErrorResponseContent"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "InternalServerError 500 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerErrorResponseContent"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "ServiceUnavailableError 503 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceUnavailableErrorResponseContent"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Postings"
+        ],
+        "x-hey-pagination": {
+          "style": "link",
+          "totalCountHeader": "X-Total-Count"
+        },
+        "x-hey-retry": {
+          "maxAttempts": 3,
+          "baseDelayMs": 1000,
+          "backoff": "exponential",
+          "retryOn": [
+            429,
+            503
+          ]
+        }
+      }
+    },
     "/rails/active_storage/direct_uploads.json": {
       "post": {
         "description": "Create an Active Storage direct upload for an outgoing attachment.\nThe returned URL is self-authenticating and accepts the raw file bytes via PUT.",
@@ -11777,6 +11870,24 @@
       },
       "GetBubbleboxResponseContent": {
         "$ref": "#/components/schemas/BoxShowResponse"
+      },
+      "GetBundleUnseenPostingsResponseContent": {
+        "type": "object",
+        "properties": {
+          "contact": {
+            "$ref": "#/components/schemas/Contact"
+          },
+          "postings": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Posting"
+            }
+          }
+        },
+        "required": [
+          "contact",
+          "postings"
+        ]
       },
       "GetCalendarDayResponseContent": {
         "$ref": "#/components/schemas/CalendarPeriod"

--- a/spec/excluded-routes.json
+++ b/spec/excluded-routes.json
@@ -2670,11 +2670,6 @@
     "reason": "phase-2: posting bulk bubble up"
   },
   {
-    "method": "GET",
-    "path": "/postings/{posting_id}/bundles/unseen",
-    "reason": "phase-2: posting bundles unseen"
-  },
-  {
     "method": "POST",
     "path": "/postings/collections",
     "reason": "phase-2: posting collections"

--- a/spec/hey.smithy
+++ b/spec/hey.smithy
@@ -156,6 +156,9 @@ service HEY {
         MutePostings
         UnmutePostings
 
+        // Postings — bundles
+        GetBundleUnseenPostings
+
         // Postings — bulk
         MarkPostingsSpam
         AddPostingsToBoxGroup
@@ -2988,6 +2991,38 @@ structure MessageDraft {
 
 /// Posting ids as a comma-joined string, for verbs that carry no body
 string PostingIdsParam
+
+/// List the unseen postings inside a bundle posting.
+///
+/// A bundle posting groups one contact's unseen mail; this is its contents — the member
+/// postings, newest first, paged by cursor like a box. The posting must be a bundle.
+@readonly
+@http(method: "GET", uri: "/postings/{postingId}/bundles/unseen.json")
+@tags(["Postings"])
+@heyRetry(maxAttempts: 3, baseDelayMs: 1000, backoff: "exponential", retryOn: [429, 503])
+@heyPagination(style: "link", totalCountHeader: "X-Total-Count")
+operation GetBundleUnseenPostings {
+    input: GetBundleUnseenPostingsInput
+    output: GetBundleUnseenPostingsOutput
+    errors: [UnauthorizedError, NotFoundError, InternalServerError, ServiceUnavailableError]
+}
+
+structure GetBundleUnseenPostingsInput {
+    @httpLabel
+    @required
+    postingId: Long
+
+    @httpQuery("page")
+    page: String
+}
+
+structure GetBundleUnseenPostingsOutput {
+    @required
+    contact: Contact
+
+    @required
+    postings: PostingList
+}
 
 // =============================================================================
 // POSTINGS — bulk actions across a selection

--- a/spec/route-coverage.json
+++ b/spec/route-coverage.json
@@ -186,6 +186,11 @@
   },
   {
     "method": "GET",
+    "operationId": "GetBundleUnseenPostings",
+    "path": "/postings/{postingId}/bundles/unseen.json"
+  },
+  {
+    "method": "GET",
     "operationId": "GetCalendarDay",
     "path": "/calendar/days/{day}"
   },

--- a/spec/shape-fingerprint.json
+++ b/spec/shape-fingerprint.json
@@ -16,6 +16,7 @@
   "GetBox": "373b5de0c686345126ca4da129f6991776936ecc1fa1e00fae00cd45cb6436e9",
   "GetBoxPostingChanges": "003137f72b12fc7232fc2127316479999c0d0edcc0f89d53cb07eed1c3854ac1",
   "GetBubblebox": "b736b44d157cb75c0e50a75feb2be37c8f9988024aa8c6503ab7bde347560cce",
+  "GetBundleUnseenPostings": "1dc0e7a2eb92b998bfee38c6e93ad8c9f417fa805c88f7acd1ed9f0711a32ec3",
   "GetCalendarDay": "65bed3aa8452bd710921a9c836d1e6a59f374fe4113171f0cd2a8df53ea288f4",
   "GetCalendarRecordings": "4ff27c9fc232cbd2f3ac3e0f4a4f7ee60e40d5c99e8c8efceefa2ea723e4b5ab",
   "GetCalendarWeek": "b7e262f22ec44f52747aca2b5f9524070802b405fddc9e18d4a1c3c42c6be508",


### PR DESCRIPTION
A bundle posting groups one contact's unseen mail, but its contents were unreadable through the SDK — `GET /postings/{posting_id}/bundles/unseen` sat on the excluded-routes list as "phase-2". HEY now answers JSON on that route (the bundled contact plus a page of postings in the standard posting shape, geared-paginated via the `Link` header), so this models it.

## API surface

- Adds `GetBundleUnseenPostings` to the Smithy spec and removes the route's exclusion entry.
- Adds `BundlePage` and `Postings().BundleUnseenPage(ctx, postingID, cursor)`, a cursor-bearing page read: an empty cursor starts at the top, and the next page's cursor is extracted from the response `Link` header, following the `Clearances().PendingPage` pattern.
- Bumps the Go SDK version to 0.26.0.

## Proof

- Unit coverage verifies the cursor is passed through as the `page` query, the next cursor is read from the `Link` header, and the last page answers no cursor.
- Conformance coverage verifies the opaque page cursor on the generated request.
- `make check` passes: Go tests and lint are green, generated artifacts are current, and all 166 conformance cases pass.

## Risk and reviewer focus

Risk is low: the operation and wrapper are additive. The response requires the HEY-side change to be deployed; until then the route answers the HTML-era behavior. Please focus on the output shape (`contact` + `postings`) and the pagination contract.

## Consumer

hey-cli's TUI opens a bundle row as the list of threads inside it with this operation, instead of failing with "resource not found" (basecamp/hey-cli#156 is the standing issue for reading bundles).