### PR TITLE
Model the contact thread list: page cursor and postings on GetContact

### DIFF
--- a/behavior-model.json
+++ b/behavior-model.json
@@ -580,6 +580,10 @@
     },
     "GetContact": {
       "idempotent": false,
+      "pagination": {
+        "style": "link",
+        "totalCountHeader": "X-Total-Count"
+      },
       "readonly": true,
       "retry": {
         "backoff": "exponential",

--- a/conformance/runner/go/main.go
+++ b/conformance/runner/go/main.go
@@ -1031,7 +1031,9 @@ func executeOperation(client *generated.Client, ctx context.Context, tc TestCase
 		return client.ListContacts(ctx, nil)
 	case "GetContact":
 		contactId := getInt64Param(tc.PathParams, "contactId")
-		return client.GetContact(ctx, contactId)
+		return client.GetContact(ctx, contactId, &generated.GetContactParams{
+			Page: getStringPtrParam(tc.QueryParams, "page"),
+		})
 
 	// Calendars
 	case "ListCalendars":

--- a/conformance/tests/pagination.json
+++ b/conformance/tests/pagination.json
@@ -52,6 +52,37 @@
     "tags": ["pagination", "postings"]
   },
   {
+    "name": "A contact's threads carry the geared pagination cursor",
+    "description": "Verifies that reading a contact's thread list sends the opaque cursor from the previous Link header",
+    "operation": "GetContact",
+    "method": "GET",
+    "path": "/contacts/{contactId}.json",
+    "pathParams": {
+      "contactId": 88
+    },
+    "queryParams": {
+      "page": "older-threads"
+    },
+    "mockResponses": [
+      {
+        "status": 200,
+        "body": {
+          "id": 88,
+          "name": "GitHub",
+          "entries_title": "All threads with GitHub",
+          "postings": [{"id": 501, "kind": "topic", "name": "Deploy failed on main"}]
+        }
+      }
+    ],
+    "assertions": [
+      {"type": "requestCount", "expected": 1},
+      {"type": "statusCode", "expected": 200},
+      {"type": "requestQuery", "expected": {"page": "older-threads"}},
+      {"type": "noError"}
+    ],
+    "tags": ["pagination", "contacts"]
+  },
+  {
     "name": "Calendar recordings carry the geared pagination cursor",
     "description": "Verifies that calendar recording windows send their dates and the opaque cursor from the previous Link header",
     "operation": "GetCalendarRecordings",

--- a/go/pkg/generated/client.gen.go
+++ b/go/pkg/generated/client.gen.go
@@ -452,10 +452,16 @@ type ContactDetail struct {
 	Domain       Domain `json:"domain,omitempty"`
 	EditAppUrl   string `json:"edit_app_url,omitempty"`
 	EmailAddress string `json:"email_address,omitempty"`
+
+	// EntriesTitle The heading HEY gives the thread list, e.g. "All threads with GitHub"
+	EntriesTitle string `json:"entries_title,omitempty"`
 	Id           int64  `json:"id"`
 	Initials     string `json:"initials,omitempty"`
 	Name         string `json:"name,omitempty"`
 	NameTag      string `json:"name_tag,omitempty"`
+
+	// Postings One page of the threads this contact is on, newest first
+	Postings []Posting `json:"postings,omitempty"`
 
 	// UpdatedAt ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
 	UpdatedAt time.Time `json:"updated_at,omitempty,omitzero"`
@@ -1794,6 +1800,11 @@ type ListContactsParams struct {
 	Q    *string `form:"q,omitempty" json:"q,omitempty"`
 }
 
+// GetContactParams defines parameters for GetContact.
+type GetContactParams struct {
+	Page *string `form:"page,omitempty" json:"page,omitempty"`
+}
+
 // ListDraftsParams defines parameters for ListDrafts.
 type ListDraftsParams struct {
 	Page *string `form:"page,omitempty" json:"page,omitempty"`
@@ -2447,7 +2458,7 @@ type ClientInterface interface {
 	HideContact(ctx context.Context, contactId int64, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetContact request
-	GetContact(ctx context.Context, contactId int64, reqEditors ...RequestEditorFn) (*http.Response, error)
+	GetContact(ctx context.Context, contactId int64, params *GetContactParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// UpdateContactWithBody request with any body
 	UpdateContactWithBody(ctx context.Context, contactId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -3572,10 +3583,10 @@ func (c *Client) HideContact(ctx context.Context, contactId int64, reqEditors ..
 
 // GetContact is marked as idempotent and will be retried on transient failures.
 
-func (c *Client) GetContact(ctx context.Context, contactId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
+func (c *Client) GetContact(ctx context.Context, contactId int64, params *GetContactParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
-		return NewGetContactRequest(c.Server, contactId)
+		return NewGetContactRequest(c.Server, contactId, params)
 	}, true, "GetContact", reqEditors...)
 
 }
@@ -7371,7 +7382,7 @@ func NewHideContactRequest(server string, contactId int64) (*http.Request, error
 }
 
 // NewGetContactRequest generates requests for GetContact
-func NewGetContactRequest(server string, contactId int64) (*http.Request, error) {
+func NewGetContactRequest(server string, contactId int64, params *GetContactParams) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -7394,6 +7405,28 @@ func NewGetContactRequest(server string, contactId int64) (*http.Request, error)
 	queryURL, err := serverURL.Parse(operationPath)
 	if err != nil {
 		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.Page != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "page", runtime.ParamLocationQuery, *params.Page); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
 	}
 
 	req, err := http.NewRequest("GET", queryURL.String(), nil)
@@ -11569,10 +11602,10 @@ type ClientWithResponsesInterface interface {
 
 	// GetContactWithResponse performs a GET /contacts/{contactId} (the `GetContact` operationId) request.
 	//
-	// Get a contact.
+	// Get a contact, with a page of the threads they are on
 	//
 	// Returns a wrapper object for the known response body format(s).
-	GetContactWithResponse(ctx context.Context, contactId int64, reqEditors ...RequestEditorFn) (*GetContactResponse, error)
+	GetContactWithResponse(ctx context.Context, contactId int64, params *GetContactParams, reqEditors ...RequestEditorFn) (*GetContactResponse, error)
 
 	// UpdateContactWithBodyWithResponse performs a PATCH /contacts/{contactId} (the `UpdateContact` operationId) request,
 	// with any type of body and a specified content type.
@@ -21548,11 +21581,11 @@ func (c *ClientWithResponses) HideContactWithResponse(ctx context.Context, conta
 
 // GetContactWithResponse performs a GET /contacts/{contactId} (the `GetContact` operationId) request.
 //
-// Get a contact.
+// # Get a contact, with a page of the threads they are on
 //
 // Returns a wrapper object for the known response body format(s).
-func (c *ClientWithResponses) GetContactWithResponse(ctx context.Context, contactId int64, reqEditors ...RequestEditorFn) (*GetContactResponse, error) {
-	rsp, err := c.GetContact(ctx, contactId, reqEditors...)
+func (c *ClientWithResponses) GetContactWithResponse(ctx context.Context, contactId int64, params *GetContactParams, reqEditors ...RequestEditorFn) (*GetContactResponse, error) {
+	rsp, err := c.GetContact(ctx, contactId, params, reqEditors...)
 	if err != nil {
 		return nil, err
 	}

--- a/go/pkg/hey/contacts.go
+++ b/go/pkg/hey/contacts.go
@@ -61,7 +61,7 @@ func (s *ContactsService) Get(ctx context.Context, contactID int64) (result *gen
 
 // get is the un-instrumented read shared by Get and Update.
 func (s *ContactsService) get(ctx context.Context, contactID int64) (*generated.ContactDetail, error) {
-	resp, err := s.client.genClient().GetContactWithResponse(ctx, contactID)
+	resp, err := s.client.genClient().GetContactWithResponse(ctx, contactID, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -69,6 +69,43 @@ func (s *ContactsService) get(ctx context.Context, contactID int64) (*generated.
 		return nil, err
 	}
 	return resp.JSON200, nil
+}
+
+// ContactPage is one page of a contact and the threads they are on: the cursor for the
+// page below is empty on the last page.
+type ContactPage struct {
+	Contact  *generated.ContactDetail
+	NextPage string
+}
+
+// ThreadsPage reads a contact with one page of the threads they are on — what HEY heads
+// "All threads with …" (the contact's entries_title). An empty cursor starts at the top;
+// the next page's cursor comes back on the page before it.
+func (s *ContactsService) ThreadsPage(ctx context.Context, contactID int64, cursor string) (result *ContactPage, err error) {
+	op := OperationInfo{
+		Service: "Contacts", Operation: "GetContact",
+		ResourceType: "contact", IsMutation: false, ResourceID: contactID,
+	}
+
+	err = s.client.instrument(ctx, op, func(ctx context.Context) error {
+		params := &generated.GetContactParams{}
+		if cursor != "" {
+			params.Page = &cursor
+		}
+		resp, rerr := s.client.genClient().GetContactWithResponse(ctx, contactID, params)
+		if rerr != nil {
+			return rerr
+		}
+		if cerr := CheckResponse(resp.HTTPResponse); cerr != nil {
+			return cerr
+		}
+		result = &ContactPage{Contact: resp.JSON200}
+		if resp.HTTPResponse != nil {
+			result.NextPage = gearedPageFromLink(resp.HTTPResponse.Header.Get("Link"))
+		}
+		return nil
+	})
+	return result, err
 }
 
 // --- Bundling and screening ---

--- a/go/pkg/hey/services_test.go
+++ b/go/pkg/hey/services_test.go
@@ -664,6 +664,42 @@ func TestContactsService_Get(t *testing.T) {
 	}
 }
 
+func TestContactsService_ThreadsPage(t *testing.T) {
+	var queries []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		queries = append(queries, r.URL.RawQuery)
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Query().Get("page") == "" {
+			w.Header().Set("Link", `<http://`+r.Host+`/contacts/88.json?page=b2xkZXI>; rel="next"`)
+		}
+		_, _ = w.Write([]byte(`{"id":88,"name":"GitHub","entries_title":"All threads with GitHub","postings":[{"id":501,"kind":"topic","name":"Deploy failed on main","app_url":"https://app.hey.com/topics/9001"}]}`))
+	}))
+	t.Cleanup(server.Close)
+	client := NewClient(&Config{BaseURL: server.URL}, &StaticTokenProvider{Token: "test-token"}, WithMaxRetries(0))
+
+	page, err := client.Contacts().ThreadsPage(context.Background(), 88, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if page.Contact.EntriesTitle != "All threads with GitHub" || len(page.Contact.Postings) != 1 {
+		t.Errorf("page = %+v", page.Contact)
+	}
+	if page.NextPage != "b2xkZXI" {
+		t.Errorf("NextPage = %q, want the Link header's cursor", page.NextPage)
+	}
+
+	next, err := client.Contacts().ThreadsPage(context.Background(), 88, page.NextPage)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if next.NextPage != "" {
+		t.Errorf("NextPage = %q, want none on the last page", next.NextPage)
+	}
+	if len(queries) != 2 || queries[0] != "" || queries[1] != "page=b2xkZXI" {
+		t.Errorf("queries = %q, want the cursor passed through", queries)
+	}
+}
+
 // --- Calendars ---
 
 func TestCalendarsService_List(t *testing.T) {

--- a/go/pkg/hey/version.go
+++ b/go/pkg/hey/version.go
@@ -1,7 +1,7 @@
 package hey
 
 // Version is the current version of the HEY Go SDK.
-const Version = "0.26.0"
+const Version = "0.27.0"
 
 // APIVersion is the HEY API version this SDK targets.
 const APIVersion = "2026-08-21"

--- a/openapi.json
+++ b/openapi.json
@@ -4679,7 +4679,7 @@
         }
       },
       "get": {
-        "description": "Get a contact",
+        "description": "Get a contact, with a page of the threads they are on",
         "operationId": "GetContact",
         "parameters": [
           {
@@ -4690,6 +4690,14 @@
               "format": "int64"
             },
             "required": true
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "x-go-type-skip-optional-pointer": false
+            }
           }
         ],
         "responses": {
@@ -4747,6 +4755,10 @@
         "tags": [
           "Contacts"
         ],
+        "x-hey-pagination": {
+          "style": "link",
+          "totalCountHeader": "X-Total-Count"
+        },
         "x-hey-retry": {
           "maxAttempts": 3,
           "baseDelayMs": 1000,
@@ -11180,6 +11192,17 @@
           },
           "domain": {
             "$ref": "#/components/schemas/Domain"
+          },
+          "entries_title": {
+            "type": "string",
+            "description": "The heading HEY gives the thread list, e.g. \"All threads with GitHub\""
+          },
+          "postings": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Posting"
+            },
+            "description": "One page of the threads this contact is on, newest first"
           }
         },
         "required": [

--- a/spec/hey.smithy
+++ b/spec/hey.smithy
@@ -1894,11 +1894,12 @@ structure ListContactsOutput {
     contacts: ContactList
 }
 
-/// Get a contact
+/// Get a contact, with a page of the threads they are on
 @readonly
 @http(method: "GET", uri: "/contacts/{contactId}")
 @tags(["Contacts"])
 @heyRetry(maxAttempts: 3, baseDelayMs: 1000, backoff: "exponential", retryOn: [429, 503])
+@heyPagination(style: "link", totalCountHeader: "X-Total-Count")
 operation GetContact {
     input: GetContactInput
     output: GetContactOutput
@@ -1909,6 +1910,9 @@ structure GetContactInput {
     @httpLabel
     @required
     contactId: Long
+
+    @httpQuery("page")
+    page: String
 }
 
 /// ContactDetail — extended contact with additional show fields
@@ -1929,6 +1933,12 @@ structure ContactDetail {
     clearance: Clearance
     aliases: ContactList
     domain: Domain
+
+    /// The heading HEY gives the thread list, e.g. "All threads with GitHub"
+    entries_title: String
+
+    /// One page of the threads this contact is on, newest first
+    postings: PostingList
 }
 
 structure GetContactOutput {


### PR DESCRIPTION
A contact's JSON has always carried one page of the threads they are on — the list HEY heads "All threads with GitHub" — but the SDK dropped the `postings`, the `entries_title` heading, and the `Link` cursor. No server change involved; this models what the endpoint already serves.

## API surface

- Adds the optional `page` query parameter to `GetContact` and `entries_title` + `postings` to `ContactDetail`.
- Adds `ContactPage` and `Contacts().ThreadsPage(ctx, contactID, cursor)`: an empty cursor starts at the top, the next page's cursor is read from the response `Link` header, following the page-read pattern.
- `Contacts().Get` keeps its signature and one-page behavior.
- Bumps the Go SDK version to 0.27.0.

## Proof

- Unit coverage verifies the heading and postings parse, the cursor is passed through as the `page` query, and the last page answers no cursor.
- Conformance coverage verifies the opaque page cursor on the generated request.
- `make check` passes: Go tests and lint green, generated artifacts current, all 167 conformance cases pass.

## Risk and reviewer focus

Low: the parameter and fields are additive and the existing `Get` is unchanged. Please focus on the `ContactDetail` additions matching the served JSON.

## Consumer

hey-cli's TUI: opening a fully read bundle shows the contact's thread list (the web app's behavior), where today it dead-ends on an empty screen. Follows up basecamp/hey-cli#337.