### PR TITLE
Preserve configured senders across draft writes

### DIFF
--- a/go/pkg/hey/drafts_test.go
+++ b/go/pkg/hey/drafts_test.go
@@ -183,6 +183,30 @@ func TestMessagesService_UpdateDraft_ReplacesRecipientsWithWhatIsSent(t *testing
 	}
 }
 
+func TestMessagesService_UpdateDraft_PreservesExplicitSender(t *testing.T) {
+	client := newDraftTestClient(t, map[string]draftTestRoute{
+		"/messages/12345.json": {
+			method: "PUT",
+			status: http.StatusNoContent,
+			validate: func(t *testing.T, body map[string]any) {
+				t.Helper()
+				if body["acting_sender_id"] != float64(77) {
+					t.Errorf("acting_sender_id = %v, want 77", body["acting_sender_id"])
+				}
+			},
+		},
+	})
+
+	err := client.Messages().UpdateDraft(context.Background(), 12345, DraftContent{
+		ActingSenderID: 77,
+		Subject:        "Quarterly planning",
+		Content:        "<div>Agenda.</div>",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestMessagesService_SendDraft(t *testing.T) {
 	client := newDraftTestClient(t, map[string]draftTestRoute{
 		"/messages/12345.json": {
@@ -321,6 +345,40 @@ func TestEntriesService_CreateReplyDraft(t *testing.T) {
 	}
 	if id != 777 {
 		t.Errorf("draft entry id = %d, want 777 (from Location)", id)
+	}
+}
+
+func TestEntriesService_CreateReplyDraftWithSender(t *testing.T) {
+	client := newDraftTestClient(t, map[string]draftTestRoute{
+		"/entries/10/replies.json": {
+			method:   "POST",
+			status:   http.StatusNoContent,
+			location: "https://app.hey.com/messages/778",
+			validate: func(t *testing.T, body map[string]any) {
+				t.Helper()
+				if body["acting_sender_id"] != float64(77) {
+					t.Errorf("acting_sender_id = %v, want 77", body["acting_sender_id"])
+				}
+			},
+		},
+	})
+
+	id, err := client.Entries().CreateReplyDraftWithSender(context.Background(), 10, 77,
+		"<div>Drafting a reply.</div>", []string{"maria@example.com"}, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id != 778 {
+		t.Errorf("draft entry id = %d, want 778", id)
+	}
+}
+
+func TestEntriesService_CreateReplyDraftWithSenderRequiresPositiveID(t *testing.T) {
+	client := newDraftTestClient(t, nil)
+	_, err := client.Entries().CreateReplyDraftWithSender(context.Background(), 10, 0,
+		"<div>Drafting a reply.</div>", nil, nil, nil)
+	if e := AsError(err); e == nil || e.Code != CodeUsage {
+		t.Fatalf("expected a usage error, got %#v", err)
 	}
 }
 

--- a/go/pkg/hey/drafts_test.go
+++ b/go/pkg/hey/drafts_test.go
@@ -207,6 +207,45 @@ func TestMessagesService_UpdateDraft_PreservesExplicitSender(t *testing.T) {
 	}
 }
 
+func TestMessagesService_DraftWritesRejectNegativeSenderID(t *testing.T) {
+	client := newDraftTestClient(t, nil)
+	draft := DraftContent{
+		ActingSenderID: -1,
+		Subject:        "Quarterly planning",
+		Content:        "<div>Agenda.</div>",
+		To:             []string{"maria@example.com"},
+	}
+
+	tests := []struct {
+		name  string
+		write func() error
+	}{
+		{
+			name: "create",
+			write: func() error {
+				_, err := client.Messages().CreateDraft(context.Background(), draft)
+				return err
+			},
+		},
+		{
+			name:  "update",
+			write: func() error { return client.Messages().UpdateDraft(context.Background(), 12345, draft) },
+		},
+		{
+			name:  "send",
+			write: func() error { return client.Messages().SendDraft(context.Background(), 12345, draft) },
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if e := AsError(tt.write()); e == nil || e.Code != CodeUsage {
+				t.Fatalf("expected a usage error, got %#v", e)
+			}
+		})
+	}
+}
+
 func TestMessagesService_SendDraft(t *testing.T) {
 	client := newDraftTestClient(t, map[string]draftTestRoute{
 		"/messages/12345.json": {

--- a/go/pkg/hey/entries.go
+++ b/go/pkg/hey/entries.go
@@ -165,15 +165,33 @@ func (s *EntriesService) DeleteDraft(ctx context.Context, entryID int64) error {
 // whatever the draft carries — and unlike a message draft it carries no subject, since
 // a reply stays under its thread's.
 func (s *EntriesService) CreateReplyDraft(ctx context.Context, entryID int64, content string, to, cc, bcc []string) (draftEntryID int64, err error) {
+	return s.createReplyDraft(ctx, entryID, 0, content, to, cc, bcc)
+}
+
+// CreateReplyDraftWithSender saves a reply draft with one exact configured sender.
+// The caller obtains the sender id from Identity and must keep it scoped to the same
+// mail account as the entry. This is intentionally separate from CreateReplyDraft so
+// existing callers retain the identity's default-sender behavior.
+func (s *EntriesService) CreateReplyDraftWithSender(ctx context.Context, entryID, actingSenderID int64, content string, to, cc, bcc []string) (draftEntryID int64, err error) {
+	if actingSenderID <= 0 {
+		return 0, ErrUsage("acting sender ID must be a positive integer")
+	}
+	return s.createReplyDraft(ctx, entryID, actingSenderID, content, to, cc, bcc)
+}
+
+func (s *EntriesService) createReplyDraft(ctx context.Context, entryID, actingSenderID int64, content string, to, cc, bcc []string) (draftEntryID int64, err error) {
 	op := OperationInfo{
 		Service: "Entries", Operation: "CreateReply",
 		ResourceType: "draft", IsMutation: true, ResourceID: entryID,
 	}
 
 	err = s.client.instrument(ctx, op, func(ctx context.Context) error {
-		senderID, serr := s.client.DefaultSenderID(ctx)
-		if serr != nil {
-			return serr
+		if actingSenderID == 0 {
+			var serr error
+			actingSenderID, serr = s.client.DefaultSenderID(ctx)
+			if serr != nil {
+				return serr
+			}
 		}
 
 		entry := &generated.MessageEntryPayload{
@@ -181,7 +199,7 @@ func (s *EntriesService) CreateReplyDraft(ctx context.Context, entryID int64, co
 			Addressed: &generated.MessageAddressed{Directly: to, Copied: cc, Blindcopied: bcc},
 		}
 		body := generated.CreateReplyRequestContent{
-			ActingSenderId: senderID,
+			ActingSenderId: actingSenderID,
 			Message:        generated.ReplyMessagePayload{Content: content},
 			Entry:          entry,
 		}

--- a/go/pkg/hey/messages.go
+++ b/go/pkg/hey/messages.go
@@ -121,6 +121,9 @@ type DraftContent struct {
 }
 
 func (s *MessagesService) draftSenderID(ctx context.Context, draft DraftContent) (int64, error) {
+	if draft.ActingSenderID < 0 {
+		return 0, ErrUsage("acting sender ID must be zero or a positive integer")
+	}
 	if draft.ActingSenderID > 0 {
 		return draft.ActingSenderID, nil
 	}

--- a/go/pkg/hey/messages.go
+++ b/go/pkg/hey/messages.go
@@ -106,15 +106,25 @@ func entryPayload(to, cc, bcc []string) *generated.MessageEntryPayload {
 // whole of it — see UpdateDraft — so a caller edits by reading the draft (GetEdit),
 // changing fields and sending everything back.
 type DraftContent struct {
-	Subject string
-	Content string
-	To      []string
-	CC      []string
-	BCC     []string
+	// ActingSenderID preserves the sender already selected on an existing draft.
+	// Zero selects the identity's default sender for a new draft.
+	ActingSenderID int64
+	Subject        string
+	Content        string
+	To             []string
+	CC             []string
+	BCC            []string
 
 	// Schedule delivers the draft at an hour of a day. Nil means no scheduled
 	// delivery — and on an update, clears one already set.
 	Schedule *DraftSchedule
+}
+
+func (s *MessagesService) draftSenderID(ctx context.Context, draft DraftContent) (int64, error) {
+	if draft.ActingSenderID > 0 {
+		return draft.ActingSenderID, nil
+	}
+	return s.client.DefaultSenderID(ctx)
 }
 
 // DraftSchedule names a delivery time to the hour, read in the identity's time zone.
@@ -177,7 +187,7 @@ func (s *MessagesService) CreateDraft(ctx context.Context, draft DraftContent) (
 	}
 
 	err = s.client.instrument(ctx, op, func(ctx context.Context) error {
-		senderID, serr := s.client.DefaultSenderID(ctx)
+		senderID, serr := s.draftSenderID(ctx, draft)
 		if serr != nil {
 			return serr
 		}
@@ -212,7 +222,7 @@ func (s *MessagesService) UpdateDraft(ctx context.Context, entryID int64, draft 
 	}
 
 	return s.client.instrument(ctx, op, func(ctx context.Context) error {
-		senderID, serr := s.client.DefaultSenderID(ctx)
+		senderID, serr := s.draftSenderID(ctx, draft)
 		if serr != nil {
 			return serr
 		}
@@ -249,7 +259,7 @@ func (s *MessagesService) SendDraft(ctx context.Context, entryID int64, draft Dr
 	}
 
 	return s.client.instrument(ctx, op, func(ctx context.Context) error {
-		senderID, serr := s.client.DefaultSenderID(ctx)
+		senderID, serr := s.draftSenderID(ctx, draft)
 		if serr != nil {
 			return serr
 		}


### PR DESCRIPTION
## Summary

- expose the optional acting sender ID on draft content
- preserve an explicitly selected sender when creating, updating, and sending drafts
- add `CreateReplyDraftWithSender` while retaining the existing default-sender behavior for current callers
- cover create, update, send, and reply-draft sender propagation with focused tests

## Testing

- `mise exec -- make check`
- `go test -race -count=1 ./...`
- `GOTOOLCHAIN=go1.26.6 govulncheck ./...`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves an explicitly selected sender across draft create, update, send, and reply-draft flows, instead of always falling back to the identity's default sender.

- Adds `ActingSenderID` to `DraftContent` for message drafts; zero keeps the default-sender behavior.
- Adds `CreateReplyDraftWithSender` for reply drafts while existing callers keep using the default sender.
- Rejects negative acting sender IDs with a usage error on draft writes.

Looks good!

<sup>Written for commit baa9c85cd3d60bf74e24f089f377f3719f915fc9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-sdk/pull/128?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

