### PR TITLE
Fix all-day calendar event updates sending invalid clock times

### DIFF
--- a/conformance/runner/go/main.go
+++ b/conformance/runner/go/main.go
@@ -235,13 +235,19 @@ func runTest(tc TestCase) TestResult {
 		}
 	}
 
-	// Execute the operation. Account-scoped cases exercise the hand-written
-	// client layer because account scope is an SDK behavior rather than a
-	// generated Smithy operation.
+	// Execute the operation. Cases for SDK-layer behavior exercise the hand-written client;
+	// the remaining cases exercise generated Smithy operations.
 	ctx := context.Background()
 	var sdkResp *http.Response
 	var sdkErr error
-	if _, scoped := tc.ConfigOverrides["accountId"]; scoped {
+	if layer, _ := tc.ConfigOverrides["clientLayer"].(string); layer == "hey" {
+		rootClient := hey.NewClient(
+			&hey.Config{BaseURL: server.URL},
+			&hey.StaticTokenProvider{Token: "conformance-test-token"},
+			hey.WithMaxRetries(0),
+		)
+		sdkErr = executeHEYOperation(rootClient, ctx, tc)
+	} else if _, scoped := tc.ConfigOverrides["accountId"]; scoped {
 		accountID := getInt64Param(tc.ConfigOverrides, "accountId")
 		rootClient := hey.NewClient(
 			&hey.Config{BaseURL: server.URL},
@@ -620,6 +626,34 @@ func checkAssertion(testName string, a Assertion, s checkState) TestResult {
 			}
 			if fmt.Sprint(got) != fmt.Sprint(want) {
 				return fail(testName, "Expected body key %q = %v, got %v", path, want, got)
+			}
+		}
+
+	case "requestForm":
+		// expected: {"field": value, ...}; a null value asserts the field is absent.
+		expected, ok := a.Expected.(map[string]interface{})
+		if !ok {
+			return fail(testName, "requestForm: expected an object, got %T", a.Expected)
+		}
+		if len(s.requestBodies) == 0 {
+			return fail(testName, "Expected a request, but none were recorded")
+		}
+		values, err := url.ParseQuery(string(s.requestBodies[0]))
+		if err != nil {
+			return fail(testName, "requestForm: request body is not form encoded: %v", err)
+		}
+		for field, want := range expected {
+			if want == nil {
+				if values.Has(field) {
+					return fail(testName, "Expected form field %q to be absent, got %q", field, values.Get(field))
+				}
+				continue
+			}
+			if !values.Has(field) {
+				return fail(testName, "Expected form field %q = %v, but it is absent", field, want)
+			}
+			if got := values.Get(field); got != fmt.Sprint(want) {
+				return fail(testName, "Expected form field %q = %v, got %q", field, want, got)
 			}
 		}
 
@@ -1448,6 +1482,24 @@ func executeOperation(client *generated.Client, ctx context.Context, tc TestCase
 	}
 }
 
+func executeHEYOperation(client *hey.Client, ctx context.Context, tc TestCase) error {
+	switch tc.Operation {
+	case "UpdateCalendarEvent":
+		eventID := getInt64Param(tc.PathParams, "eventId")
+		_, err := client.CalendarEvents().Update(ctx, eventID, hey.UpdateCalendarEventParams{
+			Title:     getStringPtrParam(tc.RequestBody, "title"),
+			StartsAt:  getStringPtrParam(tc.RequestBody, "starts_at"),
+			EndsAt:    getStringPtrParam(tc.RequestBody, "ends_at"),
+			AllDay:    getBoolPtrParam(tc.RequestBody, "all_day"),
+			StartTime: getStringPtrParam(tc.RequestBody, "start_time"),
+			EndTime:   getStringPtrParam(tc.RequestBody, "end_time"),
+		})
+		return err
+	default:
+		return fmt.Errorf("HEY client conformance does not support operation: %s", tc.Operation)
+	}
+}
+
 func executeAccountScopedOperation(client *hey.Client, ctx context.Context, tc TestCase) error {
 	switch tc.Operation {
 	case "ListBoxes":
@@ -1599,6 +1651,16 @@ func getStringPtrParam(params map[string]interface{}, key string) *string {
 	if val, ok := params[key]; ok {
 		if s, ok := val.(string); ok {
 			return &s
+		}
+	}
+	return nil
+}
+
+// getBoolPtrParam extracts a *bool parameter from a map.
+func getBoolPtrParam(params map[string]interface{}, key string) *bool {
+	if val, ok := params[key]; ok {
+		if b, ok := val.(bool); ok {
+			return &b
 		}
 	}
 	return nil

--- a/conformance/tests/calendar-events.json
+++ b/conformance/tests/calendar-events.json
@@ -1,0 +1,61 @@
+[
+  {
+    "name": "All-day calendar event updates omit clock times",
+    "description": "Verifies that an all-day update carries its dates without clock-time fields",
+    "operation": "UpdateCalendarEvent",
+    "method": "PATCH",
+    "path": "/calendar/events/{eventId}.json",
+    "pathParams": {
+      "eventId": 99
+    },
+    "requestBody": {
+      "title": "Sarah's birthday",
+      "starts_at": "2026-09-02",
+      "ends_at": "2026-09-02",
+      "all_day": true,
+      "start_time": "",
+      "end_time": ""
+    },
+    "mockResponses": [
+      {
+        "status": 200,
+        "body": {
+          "id": 99,
+          "title": "Sarah's birthday",
+          "type": "Calendar::Event",
+          "all_day": true
+        }
+      }
+    ],
+    "assertions": [
+      {
+        "type": "requestPath",
+        "expected": "/calendar/events/99.json"
+      },
+      {
+        "type": "requestMethod",
+        "expected": "PATCH"
+      },
+      {
+        "type": "requestForm",
+        "expected": {
+          "calendar_event[all_day]": "1",
+          "calendar_event[starts_at]": "2026-09-02",
+          "calendar_event[ends_at]": "2026-09-02",
+          "calendar_event[starts_at_time]": null,
+          "calendar_event[ends_at_time]": null
+        }
+      },
+      {
+        "type": "noError"
+      }
+    ],
+    "configOverrides": {
+      "clientLayer": "hey"
+    },
+    "tags": [
+      "calendar-events",
+      "form"
+    ]
+  }
+]

--- a/go/pkg/hey/calendar_events.go
+++ b/go/pkg/hey/calendar_events.go
@@ -464,11 +464,16 @@ func updateEventValues(params UpdateCalendarEventParams) url.Values {
 			values.Set("calendar_event[all_day]", "0")
 		}
 	}
-	if params.StartTime != nil {
-		values.Set("calendar_event[starts_at_time]", *params.StartTime+":00")
-	}
-	if params.EndTime != nil {
-		values.Set("calendar_event[ends_at_time]", *params.EndTime+":00")
+	// Clock times belong on timed events only. Create already omits them for all-day
+	// events; sending "" here would become ":00" and HEY answers 400.
+	allDay := params.AllDay != nil && *params.AllDay
+	if !allDay {
+		if params.StartTime != nil && *params.StartTime != "" {
+			values.Set("calendar_event[starts_at_time]", *params.StartTime+":00")
+		}
+		if params.EndTime != nil && *params.EndTime != "" {
+			values.Set("calendar_event[ends_at_time]", *params.EndTime+":00")
+		}
 	}
 	if params.CalendarID != nil {
 		values.Set("calendar_event[calendar_id]", fmt.Sprintf("%d", *params.CalendarID))

--- a/go/pkg/hey/calendar_events.go
+++ b/go/pkg/hey/calendar_events.go
@@ -464,14 +464,14 @@ func updateEventValues(params UpdateCalendarEventParams) url.Values {
 			values.Set("calendar_event[all_day]", "0")
 		}
 	}
-	// Clock times belong on timed events only. Create already omits them for all-day
-	// events; sending "" here would become ":00" and HEY answers 400.
+	// Clock times belong to timed events. All-day updates carry dates without clock times,
+	// matching all-day creates.
 	allDay := params.AllDay != nil && *params.AllDay
 	if !allDay {
-		if params.StartTime != nil && *params.StartTime != "" {
+		if params.StartTime != nil {
 			values.Set("calendar_event[starts_at_time]", *params.StartTime+":00")
 		}
-		if params.EndTime != nil && *params.EndTime != "" {
+		if params.EndTime != nil {
 			values.Set("calendar_event[ends_at_time]", *params.EndTime+":00")
 		}
 	}

--- a/go/pkg/hey/services_test.go
+++ b/go/pkg/hey/services_test.go
@@ -1626,22 +1626,16 @@ func TestCalendarEventsService_Update(t *testing.T) {
 	}
 }
 
-// An all-day update must not send clock times. Empty strings would become ":00", which HEY
-// rejects with 400 — the failure the CLI and TUI hit when saving a birthday or any other
-// all-day event.
+// An all-day update carries dates without clock times.
 func TestCalendarEventsService_Update_AllDayOmitsClockTimes(t *testing.T) {
 	client := newFormJSONTestClient(t, "PATCH", "/calendar/events/%s",
 		func(t *testing.T, values url.Values) {
-			t.Helper()
-			if got := values.Get("calendar_event[all_day]"); got != "1" {
-				t.Errorf("all_day = %q, want 1", got)
-			}
-			if got := values.Get("calendar_event[starts_at_time]"); got != "" {
-				t.Errorf("starts_at_time = %q, want none on an all-day update", got)
-			}
-			if got := values.Get("calendar_event[ends_at_time]"); got != "" {
-				t.Errorf("ends_at_time = %q, want none on an all-day update", got)
-			}
+			assertFormFields(t, values, map[string]string{
+				"calendar_event[all_day]": "1",
+			},
+				"calendar_event[starts_at_time]",
+				"calendar_event[ends_at_time]",
+			)
 		},
 		200, `{"id": 99, "title": "Sarah's birthday", "type": "Calendar::Event", "all_day": true}`,
 	)

--- a/go/pkg/hey/services_test.go
+++ b/go/pkg/hey/services_test.go
@@ -1626,6 +1626,44 @@ func TestCalendarEventsService_Update(t *testing.T) {
 	}
 }
 
+// An all-day update must not send clock times. Empty strings would become ":00", which HEY
+// rejects with 400 — the failure the CLI and TUI hit when saving a birthday or any other
+// all-day event.
+func TestCalendarEventsService_Update_AllDayOmitsClockTimes(t *testing.T) {
+	client := newFormJSONTestClient(t, "PATCH", "/calendar/events/%s",
+		func(t *testing.T, values url.Values) {
+			t.Helper()
+			if got := values.Get("calendar_event[all_day]"); got != "1" {
+				t.Errorf("all_day = %q, want 1", got)
+			}
+			if got := values.Get("calendar_event[starts_at_time]"); got != "" {
+				t.Errorf("starts_at_time = %q, want none on an all-day update", got)
+			}
+			if got := values.Get("calendar_event[ends_at_time]"); got != "" {
+				t.Errorf("ends_at_time = %q, want none on an all-day update", got)
+			}
+		},
+		200, `{"id": 99, "title": "Sarah's birthday", "type": "Calendar::Event", "all_day": true}`,
+	)
+
+	title := "Sarah's birthday"
+	startsAt := "2026-09-02"
+	endsAt := "2026-09-02"
+	allDay := true
+	empty := ""
+	_, err := client.CalendarEvents().Update(context.Background(), 99, UpdateCalendarEventParams{
+		Title:     &title,
+		StartsAt:  &startsAt,
+		EndsAt:    &endsAt,
+		AllDay:    &allDay,
+		StartTime: &empty,
+		EndTime:   &empty,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 // An event can start in one zone and finish in another, which is what a flight is.
 func TestCalendarEventsService_Update_WithAZonePerEnd(t *testing.T) {
 	departs, arrives := "Europe/Zagreb", "America/New_York"


### PR DESCRIPTION
## Summary

Fixes HTTP 400 when updating all-day calendar events via `hey-cli` and the HEY TUI.

When `UpdateCalendarEventParams` carries empty `StartTime` and `EndTime` pointers alongside `AllDay=true`, `updateEventValues` was encoding `starts_at_time` and `ends_at_time` as `:00`. HEY's API rejects that malformed payload with HTTP 400.

Creating all-day events already omitted clock times; updates now match.

## Reproduce (before fix)

```bash
hey event add "All day test" --starts-on 2026-08-31 --json
hey event edit <id> --title "edited" --json   # Form request failed (HTTP 400)
```

Same failure when saving all-day events in `hey tui`.

## Test plan

- [x] `go test ./pkg/hey/ -run TestCalendarEventsService_Update_AllDayOmitsClockTimes`
- [x] Existing update tests still pass
- [ ] `hey event edit` on an all-day event after bumping hey-cli to this SDK version

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes HTTP 400 errors when updating all-day calendar events in `hey-cli` and the HEY TUI. `updateEventValues` encoded empty `StartTime` and `EndTime` pointers as `:00` when `AllDay=true`; all-day updates now omit clock times, matching all-day creates, while timed updates keep their clock-time encoding. Adds a regression test and request-form conformance coverage for the all-day update payload.

<sup>Written for commit 5cccdc55e45f420717191503b6dae6908209a7fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-sdk/pull/131?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

