### PR TITLE
Bump version to 0.28.1

### DIFF
--- a/go/pkg/hey/version.go
+++ b/go/pkg/hey/version.go
@@ -1,7 +1,7 @@
 package hey
 
 // Version is the current version of the HEY Go SDK.
-const Version = "0.28.0"
+const Version = "0.28.1"
 
 // APIVersion is the HEY API version this SDK targets.
 const APIVersion = "2026-08-21"


### PR DESCRIPTION
## Summary

Bump the Go SDK version to 0.28.1 for the all-day calendar event update fix in #131.

## Test plan

- [x] `GOWORK=off make check`
- [x] 168 conformance cases pass


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps the Go SDK version to 0.28.1 to release the all-day calendar event update fix from #131.

<sup>Written for commit 39f5b557cbae847c504b6f84e8a265a0991e3399. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-sdk/pull/132?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

