### PR TITLE
fix: surface 422 validation error messages in SendDraft and UpdateDraft

### DIFF
--- a/conformance/tests/draft-lifecycle.json
+++ b/conformance/tests/draft-lifecycle.json
@@ -106,7 +106,9 @@
       "acting_sender_id": 314,
       "subject": "From the support address",
       "content": "Final body",
-      "to": ["someone@example.com"]
+      "to": [
+        "someone@example.com"
+      ]
     },
     "mockResponses": [
       {
@@ -143,6 +145,125 @@
     "tags": [
       "drafts",
       "acting-sender"
+    ]
+  },
+  {
+    "name": "UpdateDraft's 422 keeps the status and request id behind HEY's reasons",
+    "description": "Verifies MessagesService.UpdateDraft maps a 422 HEY answered with a reasons list to a validation error that still carries the HTTP status and X-Request-Id CheckResponse puts on every other status",
+    "operation": "UpdateDraft",
+    "method": "PUT",
+    "path": "/messages/{entryId}.json",
+    "pathParams": {
+      "entryId": 777
+    },
+    "requestBody": {
+      "acting_sender_id": 314,
+      "subject": "",
+      "content": "Final body"
+    },
+    "mockResponses": [
+      {
+        "status": 422,
+        "headers": {
+          "X-Request-Id": "req-draft-422"
+        },
+        "body": {
+          "errors": [
+            "Subject can't be blank"
+          ]
+        }
+      }
+    ],
+    "assertions": [
+      {
+        "type": "errorCode",
+        "expected": "validation"
+      },
+      {
+        "type": "errorField",
+        "path": "httpStatus",
+        "expected": 422
+      },
+      {
+        "type": "errorField",
+        "path": "retryable",
+        "expected": false
+      },
+      {
+        "type": "errorField",
+        "path": "requestId",
+        "expected": "req-draft-422"
+      }
+    ],
+    "configOverrides": {
+      "clientLayer": "hey"
+    },
+    "tags": [
+      "drafts",
+      "error-mapping",
+      "validation",
+      "structured-error"
+    ]
+  },
+  {
+    "name": "SendDraft's 422 keeps the status and request id behind HEY's reasons",
+    "description": "Verifies MessagesService.SendDraft maps a 422 HEY answered with a reasons list to a validation error that still carries the HTTP status and X-Request-Id CheckResponse puts on every other status",
+    "operation": "SendDraft",
+    "method": "PUT",
+    "path": "/messages/{entryId}.json",
+    "pathParams": {
+      "entryId": 777
+    },
+    "requestBody": {
+      "acting_sender_id": 314,
+      "subject": "",
+      "content": "Final body",
+      "to": [
+        "someone@example.com"
+      ]
+    },
+    "mockResponses": [
+      {
+        "status": 422,
+        "headers": {
+          "X-Request-Id": "req-draft-422"
+        },
+        "body": {
+          "errors": [
+            "Subject can't be blank"
+          ]
+        }
+      }
+    ],
+    "assertions": [
+      {
+        "type": "errorCode",
+        "expected": "validation"
+      },
+      {
+        "type": "errorField",
+        "path": "httpStatus",
+        "expected": 422
+      },
+      {
+        "type": "errorField",
+        "path": "retryable",
+        "expected": false
+      },
+      {
+        "type": "errorField",
+        "path": "requestId",
+        "expected": "req-draft-422"
+      }
+    ],
+    "configOverrides": {
+      "clientLayer": "hey"
+    },
+    "tags": [
+      "drafts",
+      "error-mapping",
+      "validation",
+      "structured-error"
     ]
   }
 ]

--- a/go/pkg/hey/drafts_test.go
+++ b/go/pkg/hey/drafts_test.go
@@ -13,12 +13,13 @@ import (
 // draftTestRoute is one route a draft test serves: the validation to run on the
 // request and the response to answer with. A zero status means 200.
 type draftTestRoute struct {
-	method   string
-	status   int
-	location string
-	body     string
-	link     string
-	validate func(t *testing.T, body map[string]any)
+	method    string
+	status    int
+	location  string
+	body      string
+	link      string
+	requestID string
+	validate  func(t *testing.T, body map[string]any)
 }
 
 // newDraftTestClient serves /identity.json for the sender lookup and the given routes,
@@ -49,6 +50,9 @@ func newDraftTestClient(t *testing.T, routes map[string]draftTestRoute) *Client 
 			}
 			if route.link != "" {
 				w.Header().Set("Link", route.link)
+			}
+			if route.requestID != "" {
+				w.Header().Set("X-Request-Id", route.requestID)
 			}
 			status := route.status
 			if status == 0 {
@@ -259,6 +263,76 @@ func TestDraftLifecycleCarriesTheChosenActingSender(t *testing.T) {
 	unchosen := DraftContent{Subject: "As myself", Content: "<div>…</div>", To: []string{"maria@example.com"}}
 	if err := client.Messages().SendDraft(context.Background(), 67890, unchosen); err != nil {
 		t.Fatalf("SendDraft (default sender): %v", err)
+	}
+}
+
+func TestMessagesService_UpdateDraft_SurfacesTheReasonsFor422(t *testing.T) {
+	client := newDraftTestClient(t, map[string]draftTestRoute{
+		"/messages/12345.json": {
+			method:    "PUT",
+			status:    422,
+			body:      `{"errors":["Subject is too long (maximum is 255 characters)","Content can't be blank"]}`,
+			requestID: "req-draft-422",
+		},
+	})
+
+	err := client.Messages().UpdateDraft(context.Background(), 12345, DraftContent{
+		Subject: "Quarterly planning",
+	})
+	assertDraftValidationError(t, err, "Subject is too long (maximum is 255 characters); Content can't be blank", "req-draft-422")
+}
+
+func TestMessagesService_SendDraft_SurfacesTheReasonsFor422(t *testing.T) {
+	client := newDraftTestClient(t, map[string]draftTestRoute{
+		"/messages/12345.json": {
+			method:    "PUT",
+			status:    422,
+			body:      `{"errors":["Recipient maria@example is not a valid email address"]}`,
+			requestID: "req-draft-422",
+		},
+	})
+
+	err := client.Messages().SendDraft(context.Background(), 12345, DraftContent{
+		Subject: "Quarterly planning",
+		Content: "<div>Agenda.</div>",
+		To:      []string{"maria@example"},
+	})
+	assertDraftValidationError(t, err, "Recipient maria@example is not a valid email address", "req-draft-422")
+}
+
+func TestMessagesService_SendDraft_KeepsTheGenericMessageForABodyless422(t *testing.T) {
+	client := newDraftTestClient(t, map[string]draftTestRoute{
+		"/messages/12345.json": {method: "PUT", status: 422, requestID: "req-draft-bare"},
+	})
+
+	err := client.Messages().SendDraft(context.Background(), 12345, DraftContent{
+		Subject: "Quarterly planning",
+		Content: "<div>Agenda.</div>",
+		To:      []string{"maria@example.com"},
+	})
+	assertDraftValidationError(t, err, "validation error", "req-draft-bare")
+}
+
+// assertDraftValidationError checks a draft write's 422 keeps the structured contract
+// CheckResponse gives every other status — code, status and request id — with HEY's
+// reasons as the message.
+func assertDraftValidationError(t *testing.T, err error, message, requestID string) {
+	t.Helper()
+	e := AsError(err)
+	if e == nil || e.Code != CodeValidation {
+		t.Fatalf("expected a validation error, got %#v", err)
+	}
+	if e.Message != message {
+		t.Errorf("Message = %q, want %q", e.Message, message)
+	}
+	if e.HTTPStatus != 422 {
+		t.Errorf("HTTPStatus = %d, want 422", e.HTTPStatus)
+	}
+	if e.RequestID != requestID {
+		t.Errorf("RequestID = %q, want %q", e.RequestID, requestID)
+	}
+	if e.Retryable {
+		t.Error("a validation error is not retryable")
 	}
 }
 

--- a/go/pkg/hey/messages.go
+++ b/go/pkg/hey/messages.go
@@ -208,6 +208,23 @@ func (s *MessagesService) CreateDraft(ctx context.Context, draft DraftContent) (
 	return entryID, err
 }
 
+// draftWriteError maps a draft write's failure. A 422 the generated client parsed
+// carries HEY's own reasons, and those are the error a caller can act on; the status
+// and request id stay on it as CheckResponse would have left them. Anything else maps
+// by status.
+func draftWriteError(invalid *generated.UnprocessableEntityErrorResponseContent, resp *http.Response) error {
+	if invalid == nil {
+		return CheckResponse(resp)
+	}
+	reasons := invalid.Errors
+	if len(reasons) == 0 && invalid.Message != "" {
+		reasons = []string{invalid.Message}
+	}
+	err := ErrValidation(reasons...)
+	err.RequestID = resp.Header.Get("X-Request-Id")
+	return err
+}
+
 // UpdateDraft revises a draft in place from the whole of draft: the subject, the body
 // and the recipients are replaced with what is sent (empty recipients remove them),
 // and the scheduled delivery is rewritten too — a nil Schedule clears one already set.
@@ -234,13 +251,7 @@ func (s *MessagesService) UpdateDraft(ctx context.Context, entryID int64, draft 
 		if rerr != nil {
 			return rerr
 		}
-		if resp.JSON422 != nil {
-			return &Error{
-				Code:       CodeValidation,
-				Message:    strings.Join(resp.JSON422.Errors, ", "),
-			}
-		}
-		return CheckResponse(resp.HTTPResponse)
+		return draftWriteError(resp.JSON422, resp.HTTPResponse)
 	})
 }
 
@@ -277,13 +288,7 @@ func (s *MessagesService) SendDraft(ctx context.Context, entryID int64, draft Dr
 		if rerr != nil {
 			return rerr
 		}
-		if resp.JSON422 != nil {
-			return &Error{
-				Code:       CodeValidation,
-				Message:    strings.Join(resp.JSON422.Errors, ", "),
-			}
-		}
-		return CheckResponse(resp.HTTPResponse)
+		return draftWriteError(resp.JSON422, resp.HTTPResponse)
 	})
 }
 

--- a/go/pkg/hey/messages.go
+++ b/go/pkg/hey/messages.go
@@ -234,6 +234,12 @@ func (s *MessagesService) UpdateDraft(ctx context.Context, entryID int64, draft 
 		if rerr != nil {
 			return rerr
 		}
+		if resp.JSON422 != nil {
+			return &Error{
+				Code:       CodeValidation,
+				Message:    strings.Join(resp.JSON422.Errors, ", "),
+			}
+		}
 		return CheckResponse(resp.HTTPResponse)
 	})
 }

--- a/go/pkg/hey/messages.go
+++ b/go/pkg/hey/messages.go
@@ -277,6 +277,12 @@ func (s *MessagesService) SendDraft(ctx context.Context, entryID int64, draft Dr
 		if rerr != nil {
 			return rerr
 		}
+		if resp.JSON422 != nil {
+			return &Error{
+				Code:       CodeValidation,
+				Message:    strings.Join(resp.JSON422.Errors, ", "),
+			}
+		}
 		return CheckResponse(resp.HTTPResponse)
 	})
 }


### PR DESCRIPTION
The generated client parses 422 responses into JSON422, but the service wrappers (UpdateDraft and SendDraft) discarded this and fell back to CheckResponse which returns a generic validation error string. Parse JSON422 and return specific messages from the response body instead.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`UpdateDraft` and `SendDraft` now return the specific validation error messages from HEY API 422 responses instead of a generic "validation error" string. The error keeps the HTTP status and X-Request-Id, and falls back to the generic message when the response body carries no reasons.

- Adds conformance tests for both operations answering 422 with a reasons list.

<sup>Written for commit cdae58eb853bda36eb5cf7b5a9b8e0e007872ad8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-sdk/pull/133?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

