### PR TITLE
Let a reply carry its subject

### DIFF
--- a/.github/apidiff-accepted
+++ b/.github/apidiff-accepted
@@ -1,0 +1,6 @@
+# Deliberate API breaks, as exact apidiff -incompatible lines (grep -Fx).
+# Comment lines never match apidiff output. Entries are self-expiring once the
+# baseline moves past them; prune at leisure.
+# v0.x: replies carry their subject (#134).
+- (*EntriesService).CreateReply: changed from func(context.Context, int64, string, []string, []string, []string) error to func(context.Context, int64, string, string, []string, []string, []string) error
+- (*EntriesService).CreateReplyDraft: changed from func(context.Context, int64, string, []string, []string, []string) (int64, error) to func(context.Context, int64, string, string, []string, []string, []string) (int64, error)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -177,6 +177,14 @@ jobs:
           # point of the release rather than a break -- and it is why version.go went
           # unbumped from v0.1.1 through v0.3.0.
           CHANGES=$(printf '%s\n' "$CHANGES" | grep -Ev '^- (Version|APIVersion|DefaultUserAgent): value changed' || true)
+
+          # Deliberate breaks ride in .github/apidiff-accepted as the exact lines
+          # apidiff prints, matched whole (-Fx). Each entry is self-expiring: it
+          # names the old signature, so once merged it can never mask a later
+          # accidental change, which apidiff reports from the new baseline.
+          if [ -f .github/apidiff-accepted ]; then
+            CHANGES=$(printf '%s\n' "$CHANGES" | grep -Fxvf .github/apidiff-accepted || true)
+          fi
           CHANGES=$(printf '%s' "$CHANGES" | sed '/^$/d')
 
           if [ -n "$CHANGES" ]; then

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ imbox, _ := client.Boxes().GetImbox(ctx, nil)   // postings in the Imbox
 
 // Sending: recipients are required — HEY saves an unaddressed reply as a draft.
 _ = client.Messages().Create(ctx, "Subject", "Body", []string{"someone@example.com"}, nil, nil)
-_ = client.Entries().CreateReply(ctx, entryID, "Reply body", []string{"someone@example.com"}, nil, nil)
+_ = client.Entries().CreateReply(ctx, entryID, "Re: Subject", "Reply body", []string{"someone@example.com"}, nil, nil)
 
 // Postings are bulk operations, as they are in HEY.
 _ = client.Postings().MoveToSetAside(ctx, postingID)

--- a/conformance/runner/go/main.go
+++ b/conformance/runner/go/main.go
@@ -1055,6 +1055,7 @@ func executeOperation(client *generated.Client, ctx context.Context, tc TestCase
 		entryId := getInt64Param(tc.PathParams, "entryId")
 		body := generated.CreateReplyJSONRequestBody{
 			Message: generated.ReplyMessagePayload{
+				Subject: getStringParam(tc.RequestBody, "subject"),
 				Content: getStringParam(tc.RequestBody, "content"),
 			},
 		}

--- a/conformance/tests/paths.json
+++ b/conformance/tests/paths.json
@@ -198,7 +198,8 @@
       "entryId": 456
     },
     "requestBody": {
-      "content": "Reply text"
+      "content": "Reply text",
+      "subject": "Re: Reply subject"
     },
     "mockResponses": [
       {
@@ -225,7 +226,8 @@
         "type": "requestBody",
         "expected": {
           "message.content": "Reply text",
-          "entry": null
+          "entry": null,
+          "message.subject": "Re: Reply subject"
         }
       }
     ],

--- a/go/pkg/generated/client.gen.go
+++ b/go/pkg/generated/client.gen.go
@@ -556,14 +556,20 @@ type CreateMessageRequestContent struct {
 	Message        MessagePayload       `json:"message"`
 }
 
-// CreateReplyRequestContent Wire format: {acting_sender_id, message: {content}, entry: {addressed: {directly: [...]}}}
+// CreateReplyRequestContent Wire format: {acting_sender_id, message: {subject, content}, entry: {addressed: {directly: [...]}}}
 // entry.addressed is optional on the wire but a reply posted without it is saved as a
 // draft rather than delivered — HEY does not reply-all for the caller. Resolve the
 // thread's recipients first and always send them.
 type CreateReplyRequestContent struct {
 	ActingSenderId int64                `json:"acting_sender_id"`
 	Entry          *MessageEntryPayload `json:"entry,omitempty"`
-	Message        ReplyMessagePayload  `json:"message"`
+
+	// Message HEY does not derive a subject for a reply: a reply draft saved without message.subject
+	// reads "No subject" in Drafts. NewEntryReply hands back the prefilled subject ("Re: …") —
+	// send it here. Content is the caller's reply body alone: the server appends the quoted
+	// original at delivery (auto_quoting defaults on), so the prefill's quoted content must
+	// not be echoed back.
+	Message ReplyMessagePayload `json:"message"`
 }
 
 // CreateStickyResponseContent Sticky — a note on the stickies board
@@ -1323,9 +1329,14 @@ type Reminder struct {
 	UpdatedAt time.Time `json:"updated_at,omitempty,omitzero"`
 }
 
-// ReplyMessagePayload defines model for ReplyMessagePayload.
+// ReplyMessagePayload HEY does not derive a subject for a reply: a reply draft saved without message.subject
+// reads "No subject" in Drafts. NewEntryReply hands back the prefilled subject ("Re: …") —
+// send it here. Content is the caller's reply body alone: the server appends the quoted
+// original at delivery (auto_quoting defaults on), so the prefill's quoted content must
+// not be echoed back.
 type ReplyMessagePayload struct {
 	Content string `json:"content"`
+	Subject string `json:"subject,omitempty"`
 }
 
 // RevealContactResponseContent Contact — the identity of someone in HEY

--- a/go/pkg/hey/account_scope_test.go
+++ b/go/pkg/hey/account_scope_test.go
@@ -702,7 +702,7 @@ func TestScopedMessageAndReplyUseAccountSender(t *testing.T) {
 	if err := client.Messages().Create(context.Background(), "Subject", "Body", []string{"jane@example.com"}, nil, nil); err != nil {
 		t.Fatal(err)
 	}
-	if err := client.Entries().CreateReply(context.Background(), 99, "Reply", []string{"jane@example.com"}, nil, nil); err != nil {
+	if err := client.Entries().CreateReply(context.Background(), 99, "Re: Subject", "Reply", []string{"jane@example.com"}, nil, nil); err != nil {
 		t.Fatal(err)
 	}
 	mu.Lock()

--- a/go/pkg/hey/drafts_test.go
+++ b/go/pkg/hey/drafts_test.go
@@ -307,15 +307,17 @@ func TestEntriesService_CreateReplyDraft(t *testing.T) {
 				if msg["content"] != "<div>Drafting a reply.</div>" {
 					t.Errorf("content = %v", msg["content"])
 				}
-				if _, subject := msg["subject"]; subject {
-					t.Error("a reply carries no subject; it stays under its thread's")
+				// HEY does not derive a subject for a reply: a draft saved without
+				// one shows as "No subject" in Drafts.
+				if msg["subject"] != "Re: Original subject" {
+					t.Errorf("subject = %v, want the prefilled Re: subject", msg["subject"])
 				}
 			},
 		},
 	})
 
 	// No recipients: unlike CreateReply, a reply draft is allowed to have nobody on it.
-	id, err := client.Entries().CreateReplyDraft(context.Background(), 10, "<div>Drafting a reply.</div>", nil, nil, nil)
+	id, err := client.Entries().CreateReplyDraft(context.Background(), 10, "Re: Original subject", "<div>Drafting a reply.</div>", nil, nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/go/pkg/hey/entries.go
+++ b/go/pkg/hey/entries.go
@@ -46,11 +46,14 @@ func (s *EntriesService) ListDrafts(ctx context.Context, params *generated.ListD
 // CreateReply replies to an entry (POST /entries/{entryId}/replies.json) and delivers it.
 // The acting sender ID is automatically resolved.
 //
+// Subject is the reply's own subject line — HEY does not derive one, so pass the
+// prefilled "Re: …" that NewReply hands back. Empty leaves it off the wire.
+//
 // Recipients are required. HEY does not reply-all on the caller's behalf: a reply
 // posted without entry.addressed is saved as a draft (the server answers with a
 // redirect to the thread with the draft expanded) rather than delivered. Callers
 // resolve the thread's recipients first — hey-cli reads them from the topic page.
-func (s *EntriesService) CreateReply(ctx context.Context, entryID int64, content string, to, cc, bcc []string) (err error) {
+func (s *EntriesService) CreateReply(ctx context.Context, entryID int64, subject, content string, to, cc, bcc []string) (err error) {
 	if len(to)+len(cc)+len(bcc) == 0 {
 		return ErrUsage("a reply needs at least one recipient (to, cc or bcc); HEY saves an unaddressed reply as a draft")
 	}
@@ -74,7 +77,7 @@ func (s *EntriesService) CreateReply(ctx context.Context, entryID int64, content
 
 	body := generated.CreateReplyRequestContent{
 		ActingSenderId: senderID,
-		Message:        generated.ReplyMessagePayload{Content: content},
+		Message:        generated.ReplyMessagePayload{Subject: subject, Content: content},
 		Entry:          entryPayload(to, cc, bcc),
 	}
 
@@ -162,9 +165,12 @@ func (s *EntriesService) DeleteDraft(ctx context.Context, entryID int64) error {
 
 // CreateReplyDraft saves a reply to an entry as a draft instead of delivering it, and
 // answers the draft's entry id. Unlike CreateReply it needs no recipients — HEY keeps
-// whatever the draft carries — and unlike a message draft it carries no subject, since
-// a reply stays under its thread's.
-func (s *EntriesService) CreateReplyDraft(ctx context.Context, entryID int64, content string, to, cc, bcc []string) (draftEntryID int64, err error) {
+// whatever the draft carries.
+//
+// Subject matters here: HEY does not derive one, and a reply draft saved without it
+// shows as "No subject" in Drafts. Pass the prefilled "Re: …" from NewReply. Empty
+// leaves it off the wire.
+func (s *EntriesService) CreateReplyDraft(ctx context.Context, entryID int64, subject, content string, to, cc, bcc []string) (draftEntryID int64, err error) {
 	op := OperationInfo{
 		Service: "Entries", Operation: "CreateReply",
 		ResourceType: "draft", IsMutation: true, ResourceID: entryID,
@@ -182,7 +188,7 @@ func (s *EntriesService) CreateReplyDraft(ctx context.Context, entryID int64, co
 		}
 		body := generated.CreateReplyRequestContent{
 			ActingSenderId: senderID,
-			Message:        generated.ReplyMessagePayload{Content: content},
+			Message:        generated.ReplyMessagePayload{Subject: subject, Content: content},
 			Entry:          entry,
 		}
 

--- a/go/pkg/hey/services_test.go
+++ b/go/pkg/hey/services_test.go
@@ -582,11 +582,32 @@ func TestEntriesService_CreateReply(t *testing.T) {
 			if msg["content"] != "My reply" {
 				t.Errorf("expected content 'My reply', got %v", msg["content"])
 			}
+			if msg["subject"] != "Re: A thread" {
+				t.Errorf("expected subject 'Re: A thread', got %v", msg["subject"])
+			}
 		},
 		`{"notice":"sent"}`,
 	)
 
-	err := client.Entries().CreateReply(context.Background(), 10, "My reply", []string{"test@example.com"}, nil, nil)
+	err := client.Entries().CreateReply(context.Background(), 10, "Re: A thread", "My reply", []string{"test@example.com"}, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestEntriesService_CreateReply_EmptySubjectStaysOffTheWire(t *testing.T) {
+	client := newMutationTestClientWithValidation(t, "POST", "/entries/%s/replies.json",
+		func(t *testing.T, body map[string]any) {
+			t.Helper()
+			msg, _ := body["message"].(map[string]any)
+			if _, present := msg["subject"]; present {
+				t.Errorf("an empty subject must be omitted, got %v", msg["subject"])
+			}
+		},
+		`{"notice":"sent"}`,
+	)
+
+	err := client.Entries().CreateReply(context.Background(), 10, "", "My reply", []string{"test@example.com"}, nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -599,7 +620,7 @@ func TestEntriesService_CreateReply_RequiresRecipients(t *testing.T) {
 		func(t *testing.T, _ map[string]any) { t.Helper(); t.Error("no request should be sent") },
 		`{"notice":"sent"}`,
 	)
-	err := client.Entries().CreateReply(context.Background(), 10, "hello", nil, nil, nil)
+	err := client.Entries().CreateReply(context.Background(), 10, "Re: hello", "hello", nil, nil, nil)
 	if e := AsError(err); e == nil || e.Code != CodeUsage {
 		t.Fatalf("expected a usage error, got %#v", err)
 	}
@@ -628,7 +649,7 @@ func TestEntriesService_CreateReply_RecipientsAreArrays(t *testing.T) {
 		`{"notice":"sent"}`,
 	)
 
-	err := client.Entries().CreateReply(context.Background(), 10, "hi", []string{"a@x.com"}, nil, []string{"b@x.com"})
+	err := client.Entries().CreateReply(context.Background(), 10, "Re: hi", "hi", []string{"a@x.com"}, nil, []string{"b@x.com"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/openapi.json
+++ b/openapi.json
@@ -11485,7 +11485,7 @@
       },
       "CreateReplyRequestContent": {
         "type": "object",
-        "description": "Wire format: {acting_sender_id, message: {content}, entry: {addressed: {directly: [...]}}}\nentry.addressed is optional on the wire but a reply posted without it is saved as a\ndraft rather than delivered — HEY does not reply-all for the caller. Resolve the\nthread's recipients first and always send them.",
+        "description": "Wire format: {acting_sender_id, message: {subject, content}, entry: {addressed: {directly: [...]}}}\nentry.addressed is optional on the wire but a reply posted without it is saved as a\ndraft rather than delivered — HEY does not reply-all for the caller. Resolve the\nthread's recipients first and always send them.",
         "properties": {
           "acting_sender_id": {
             "type": "integer",
@@ -13218,7 +13218,11 @@
       },
       "ReplyMessagePayload": {
         "type": "object",
+        "description": "HEY does not derive a subject for a reply: a reply draft saved without message.subject\nreads \"No subject\" in Drafts. NewEntryReply hands back the prefilled subject (\"Re: …\") —\nsend it here. Content is the caller's reply body alone: the server appends the quoted\noriginal at delivery (auto_quoting defaults on), so the prefill's quoted content must\nnot be echoed back.",
         "properties": {
+          "subject": {
+            "type": "string"
+          },
           "content": {
             "type": "string"
           }

--- a/spec/hey.smithy
+++ b/spec/hey.smithy
@@ -1863,7 +1863,7 @@ structure CreateReplyInput {
     body: CreateReplyRequestContent
 }
 
-/// Wire format: {acting_sender_id, message: {content}, entry: {addressed: {directly: [...]}}}
+/// Wire format: {acting_sender_id, message: {subject, content}, entry: {addressed: {directly: [...]}}}
 /// entry.addressed is optional on the wire but a reply posted without it is saved as a
 /// draft rather than delivered — HEY does not reply-all for the caller. Resolve the
 /// thread's recipients first and always send them.
@@ -1877,7 +1877,14 @@ structure CreateReplyRequestContent {
     entry: MessageEntryPayload
 }
 
+/// HEY does not derive a subject for a reply: a reply draft saved without message.subject
+/// reads "No subject" in Drafts. NewEntryReply hands back the prefilled subject ("Re: …") —
+/// send it here. Content is the caller's reply body alone: the server appends the quoted
+/// original at delivery (auto_quoting defaults on), so the prefill's quoted content must
+/// not be echoed back.
 structure ReplyMessagePayload {
+    subject: String
+
     @required
     content: String
 }


### PR DESCRIPTION
`ReplyMessagePayload` modeled only `content`, so a reply had no way to carry a subject. HEY never derives one: the server permits `message[subject]` on `POST /entries/{id}/replies.json`, and `NewEntryReply` hands back the prefilled `"Re: …"` subject — but the model provided nowhere to send it back, so every reply draft the SDK saved showed as **"No subject"** in HEY's Drafts.

## Change

- `spec/hey.smithy`: optional `subject` on `ReplyMessagePayload`, with wire-format docs; `openapi.json` and `client.gen.go` regenerated.
- `EntriesService.CreateReply` and `CreateReplyDraft` take `subject` ahead of `content`, mirroring `MessagesService.Create`. An empty subject stays off the wire (`omitempty`), leaving today's requests byte-identical.
- Content stays the caller's reply body alone: the server appends the quoted original at delivery (`auto_quoting` defaults on), so the prefill's quoted content must not be echoed back — now documented on the payload.

## Tests

- Unit: subject asserted on the wire for both reply and reply-draft paths; empty subject asserted absent; the old draft test asserting subject must *not* be sent (built on the "a reply stays under its thread's subject" misconception) flipped.
- Conformance: `CreateReply` case now round-trips `message.subject`.
- `make check` green (MVP gate, 168/168 conformance).

Breaking signature change to the two wrappers; hey-cli follow-up passes the prefill subject through: basecamp/hey-cli#370 (pins this branch's commit; bumps to the tagged release once this merges).

Basecamp: [A reply can't carry a subject — every reply draft saves as "No subject"](https://app.basecamp.com/2914079/buckets/48521764/card_tables/cards/10241628617)
Fixes the subject leg of basecamp/hey-cli#341.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lets a reply carry its subject, so reply drafts no longer save as "No subject" in HEY's Drafts. `ReplyMessagePayload` gains an optional `subject` that stays off the wire when empty; content remains the caller's reply body alone.

**Breaking change**
- `CreateReply` and `CreateReplyDraft` now take `subject` before `content`; hey-cli passes the prefilled "Re: …" subject (basecamp/hey-cli#370).
- The apidiff gate accepts the deliberate break via `.github/apidiff-accepted`, and the README example is updated.

<sup>Written for commit 44894c6c46d0451351ed10d12633c1b643e71885. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-sdk/pull/134?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

