### PR TITLE
Send a reply as the sender the prefill resolved

### DIFF
--- a/.github/apidiff-accepted
+++ b/.github/apidiff-accepted
@@ -4,3 +4,6 @@
 # v0.x: replies carry their subject (#134).
 - (*EntriesService).CreateReply: changed from func(context.Context, int64, string, []string, []string, []string) error to func(context.Context, int64, string, string, []string, []string, []string) error
 - (*EntriesService).CreateReplyDraft: changed from func(context.Context, int64, string, []string, []string, []string) (int64, error) to func(context.Context, int64, string, string, []string, []string, []string) (int64, error)
+# v0.x: replies go out as the sender the prefill resolved, not the account default (#341 part 2).
+- (*EntriesService).CreateReply: changed from func(context.Context, int64, string, string, []string, []string, []string) error to func(context.Context, int64, int64, string, string, []string, []string, []string) error
+- (*EntriesService).CreateReplyDraft: changed from func(context.Context, int64, string, string, []string, []string, []string) (int64, error) to func(context.Context, int64, int64, string, string, []string, []string, []string) (int64, error)

--- a/README.md
+++ b/README.md
@@ -43,11 +43,19 @@ boxes, _ := client.Boxes().List(ctx)          // Imbox, The Feed, Paper Trail, .
 imbox, _ := client.Boxes().GetImbox(ctx, nil)   // postings in the Imbox
 
 // Sending: recipients are required — HEY saves an unaddressed reply as a draft.
-// A reply's acting sender comes from the NewReply prefill (0 = the account default).
 _ = client.Messages().Create(ctx, "Subject", "Body", []string{"someone@example.com"}, nil, nil)
-if prefill, err := client.Entries().NewReply(ctx, entryID); err == nil {
-	_ = client.Entries().CreateReply(ctx, entryID, prefill.Sender.Id, prefill.Subject, "Reply body", []string{"someone@example.com"}, nil, nil)
+
+// Replying: start from the NewReply prefill — it carries the reply's subject, its
+// acting sender (0 = the account default) and the recipients HEY resolved.
+prefill, err := client.Entries().NewReply(ctx, entryID)
+if err != nil {
+	return err // nothing to reply with
 }
+var to []string
+for _, contact := range prefill.Addressed.Directly {
+	to = append(to, contact.EmailAddress)
+}
+_ = client.Entries().CreateReply(ctx, entryID, prefill.Sender.Id, prefill.Subject, "Reply body", to, nil, nil)
 
 // Postings are bulk operations, as they are in HEY.
 _ = client.Postings().MoveToSetAside(ctx, postingID)

--- a/README.md
+++ b/README.md
@@ -45,8 +45,9 @@ imbox, _ := client.Boxes().GetImbox(ctx, nil)   // postings in the Imbox
 // Sending: recipients are required — HEY saves an unaddressed reply as a draft.
 // A reply's acting sender comes from the NewReply prefill (0 = the account default).
 _ = client.Messages().Create(ctx, "Subject", "Body", []string{"someone@example.com"}, nil, nil)
-prefill, _ := client.Entries().NewReply(ctx, entryID)
-_ = client.Entries().CreateReply(ctx, entryID, prefill.Sender.Id, prefill.Subject, "Reply body", []string{"someone@example.com"}, nil, nil)
+if prefill, err := client.Entries().NewReply(ctx, entryID); err == nil {
+	_ = client.Entries().CreateReply(ctx, entryID, prefill.Sender.Id, prefill.Subject, "Reply body", []string{"someone@example.com"}, nil, nil)
+}
 
 // Postings are bulk operations, as they are in HEY.
 _ = client.Postings().MoveToSetAside(ctx, postingID)

--- a/README.md
+++ b/README.md
@@ -43,8 +43,10 @@ boxes, _ := client.Boxes().List(ctx)          // Imbox, The Feed, Paper Trail, .
 imbox, _ := client.Boxes().GetImbox(ctx, nil)   // postings in the Imbox
 
 // Sending: recipients are required — HEY saves an unaddressed reply as a draft.
+// A reply's acting sender comes from the NewReply prefill (0 = the account default).
 _ = client.Messages().Create(ctx, "Subject", "Body", []string{"someone@example.com"}, nil, nil)
-_ = client.Entries().CreateReply(ctx, entryID, "Re: Subject", "Reply body", []string{"someone@example.com"}, nil, nil)
+prefill, _ := client.Entries().NewReply(ctx, entryID)
+_ = client.Entries().CreateReply(ctx, entryID, prefill.Sender.Id, prefill.Subject, "Reply body", []string{"someone@example.com"}, nil, nil)
 
 // Postings are bulk operations, as they are in HEY.
 _ = client.Postings().MoveToSetAside(ctx, postingID)

--- a/conformance/runner/go/main.go
+++ b/conformance/runner/go/main.go
@@ -1497,6 +1497,21 @@ func executeHEYOperation(client *hey.Client, ctx context.Context, tc TestCase) e
 			EndTime:   getStringPtrParam(tc.RequestBody, "end_time"),
 		})
 		return err
+	case "CreateReply":
+		entryID := getInt64Param(tc.PathParams, "entryId")
+		return client.Entries().CreateReply(ctx, entryID,
+			getInt64Param(tc.RequestBody, "acting_sender_id"),
+			getStringParam(tc.RequestBody, "subject"),
+			getStringParam(tc.RequestBody, "content"),
+			getStringSliceParam(tc.RequestBody, "to"), nil, nil)
+	case "CreateReplyDraft":
+		entryID := getInt64Param(tc.PathParams, "entryId")
+		_, err := client.Entries().CreateReplyDraft(ctx, entryID,
+			getInt64Param(tc.RequestBody, "acting_sender_id"),
+			getStringParam(tc.RequestBody, "subject"),
+			getStringParam(tc.RequestBody, "content"),
+			getStringSliceParam(tc.RequestBody, "to"), nil, nil)
+		return err
 	default:
 		return fmt.Errorf("HEY client conformance does not support operation: %s", tc.Operation)
 	}

--- a/conformance/runner/go/main.go
+++ b/conformance/runner/go/main.go
@@ -1503,14 +1503,18 @@ func executeHEYOperation(client *hey.Client, ctx context.Context, tc TestCase) e
 			getInt64Param(tc.RequestBody, "acting_sender_id"),
 			getStringParam(tc.RequestBody, "subject"),
 			getStringParam(tc.RequestBody, "content"),
-			getStringSliceParam(tc.RequestBody, "to"), nil, nil)
+			getStringSliceParam(tc.RequestBody, "to"),
+			getStringSliceParam(tc.RequestBody, "cc"),
+			getStringSliceParam(tc.RequestBody, "bcc"))
 	case "CreateReplyDraft":
 		entryID := getInt64Param(tc.PathParams, "entryId")
 		_, err := client.Entries().CreateReplyDraft(ctx, entryID,
 			getInt64Param(tc.RequestBody, "acting_sender_id"),
 			getStringParam(tc.RequestBody, "subject"),
 			getStringParam(tc.RequestBody, "content"),
-			getStringSliceParam(tc.RequestBody, "to"), nil, nil)
+			getStringSliceParam(tc.RequestBody, "to"),
+			getStringSliceParam(tc.RequestBody, "cc"),
+			getStringSliceParam(tc.RequestBody, "bcc"))
 		return err
 	case "CreateDraft":
 		_, err := client.Messages().CreateDraft(ctx, draftContentParam(tc.RequestBody))

--- a/conformance/runner/go/main.go
+++ b/conformance/runner/go/main.go
@@ -1054,6 +1054,7 @@ func executeOperation(client *generated.Client, ctx context.Context, tc TestCase
 	case "CreateReply":
 		entryId := getInt64Param(tc.PathParams, "entryId")
 		body := generated.CreateReplyJSONRequestBody{
+			ActingSenderId: getInt64Param(tc.RequestBody, "acting_sender_id"),
 			Message: generated.ReplyMessagePayload{
 				Subject: getStringParam(tc.RequestBody, "subject"),
 				Content: getStringParam(tc.RequestBody, "content"),

--- a/conformance/runner/go/main.go
+++ b/conformance/runner/go/main.go
@@ -1512,8 +1512,30 @@ func executeHEYOperation(client *hey.Client, ctx context.Context, tc TestCase) e
 			getStringParam(tc.RequestBody, "content"),
 			getStringSliceParam(tc.RequestBody, "to"), nil, nil)
 		return err
+	case "CreateDraft":
+		_, err := client.Messages().CreateDraft(ctx, draftContentParam(tc.RequestBody))
+		return err
+	case "UpdateDraft":
+		entryID := getInt64Param(tc.PathParams, "entryId")
+		return client.Messages().UpdateDraft(ctx, entryID, draftContentParam(tc.RequestBody))
+	case "SendDraft":
+		entryID := getInt64Param(tc.PathParams, "entryId")
+		return client.Messages().SendDraft(ctx, entryID, draftContentParam(tc.RequestBody))
 	default:
 		return fmt.Errorf("HEY client conformance does not support operation: %s", tc.Operation)
+	}
+}
+
+// draftContentParam builds the DraftContent a lifecycle case sends, acting sender
+// included — the wire behavior the HEY-layer draft cases exist to pin down.
+func draftContentParam(requestBody map[string]interface{}) hey.DraftContent {
+	return hey.DraftContent{
+		ActingSenderID: getInt64Param(requestBody, "acting_sender_id"),
+		Subject:        getStringParam(requestBody, "subject"),
+		Content:        getStringParam(requestBody, "content"),
+		To:             getStringSliceParam(requestBody, "to"),
+		CC:             getStringSliceParam(requestBody, "cc"),
+		BCC:            getStringSliceParam(requestBody, "bcc"),
 	}
 }
 

--- a/conformance/tests/draft-lifecycle.json
+++ b/conformance/tests/draft-lifecycle.json
@@ -1,0 +1,148 @@
+[
+  {
+    "name": "CreateDraft saves as the chosen acting sender",
+    "description": "Verifies MessagesService.CreateDraft carries DraftContent.ActingSenderID to the wire instead of resolving the account default",
+    "operation": "CreateDraft",
+    "method": "POST",
+    "path": "/messages.json",
+    "requestBody": {
+      "acting_sender_id": 314,
+      "subject": "From the support address",
+      "content": "Draft body"
+    },
+    "mockResponses": [
+      {
+        "status": 204,
+        "headers": {
+          "Location": "https://app.hey.com/messages/777"
+        }
+      }
+    ],
+    "assertions": [
+      {
+        "type": "requestCount",
+        "expected": 1
+      },
+      {
+        "type": "requestPath",
+        "expected": "/messages.json"
+      },
+      {
+        "type": "requestBody",
+        "expected": {
+          "acting_sender_id": 314,
+          "entry.status": "drafted"
+        }
+      },
+      {
+        "type": "noError"
+      }
+    ],
+    "configOverrides": {
+      "clientLayer": "hey"
+    },
+    "tags": [
+      "drafts",
+      "acting-sender"
+    ]
+  },
+  {
+    "name": "UpdateDraft keeps the chosen acting sender through a revision",
+    "description": "Verifies MessagesService.UpdateDraft says the chosen acting_sender_id back on a rewrite, since HEY revises a draft from the whole request",
+    "operation": "UpdateDraft",
+    "method": "PUT",
+    "path": "/messages/{entryId}.json",
+    "pathParams": {
+      "entryId": 777
+    },
+    "requestBody": {
+      "acting_sender_id": 314,
+      "subject": "From the support address (v2)",
+      "content": "Rewritten body"
+    },
+    "mockResponses": [
+      {
+        "status": 204
+      }
+    ],
+    "assertions": [
+      {
+        "type": "requestCount",
+        "expected": 1
+      },
+      {
+        "type": "requestPath",
+        "expected": "/messages/777.json"
+      },
+      {
+        "type": "requestBody",
+        "expected": {
+          "acting_sender_id": 314,
+          "entry.status": "drafted"
+        }
+      },
+      {
+        "type": "noError"
+      }
+    ],
+    "configOverrides": {
+      "clientLayer": "hey"
+    },
+    "tags": [
+      "drafts",
+      "acting-sender"
+    ]
+  },
+  {
+    "name": "SendDraft delivers as the chosen acting sender",
+    "description": "Verifies MessagesService.SendDraft carries the chosen acting_sender_id on the final delivery instead of handing the draft back to the account default",
+    "operation": "SendDraft",
+    "method": "PUT",
+    "path": "/messages/{entryId}.json",
+    "pathParams": {
+      "entryId": 777
+    },
+    "requestBody": {
+      "acting_sender_id": 314,
+      "subject": "From the support address",
+      "content": "Final body",
+      "to": ["someone@example.com"]
+    },
+    "mockResponses": [
+      {
+        "status": 200,
+        "body": {
+          "id": 777
+        }
+      }
+    ],
+    "assertions": [
+      {
+        "type": "requestCount",
+        "expected": 1
+      },
+      {
+        "type": "requestPath",
+        "expected": "/messages/777.json"
+      },
+      {
+        "type": "requestBody",
+        "expected": {
+          "acting_sender_id": 314,
+          "entry.status": null,
+          "entry.addressed.directly.0": "someone@example.com"
+        }
+      },
+      {
+        "type": "noError"
+      }
+    ],
+    "configOverrides": {
+      "clientLayer": "hey"
+    },
+    "tags": [
+      "drafts",
+      "acting-sender"
+    ]
+  }
+]

--- a/conformance/tests/paths.json
+++ b/conformance/tests/paths.json
@@ -199,7 +199,8 @@
     },
     "requestBody": {
       "content": "Reply text",
-      "subject": "Re: Reply subject"
+      "subject": "Re: Reply subject",
+      "acting_sender_id": 314
     },
     "mockResponses": [
       {
@@ -227,7 +228,8 @@
         "expected": {
           "message.content": "Reply text",
           "entry": null,
-          "message.subject": "Re: Reply subject"
+          "message.subject": "Re: Reply subject",
+          "acting_sender_id": 314
         }
       }
     ],

--- a/conformance/tests/replies.json
+++ b/conformance/tests/replies.json
@@ -1,0 +1,101 @@
+[
+  {
+    "name": "CreateReply wrapper sends the chosen acting sender untouched",
+    "description": "Verifies the hand-written EntriesService.CreateReply carries a caller-chosen acting_sender_id to the wire instead of resolving the account default",
+    "operation": "CreateReply",
+    "method": "POST",
+    "path": "/entries/{entryId}/replies.json",
+    "pathParams": {
+      "entryId": 456
+    },
+    "requestBody": {
+      "acting_sender_id": 314,
+      "subject": "Re: From the support address",
+      "content": "Reply text",
+      "to": ["someone@example.com"]
+    },
+    "mockResponses": [
+      {
+        "status": 200,
+        "body": {
+          "notice": "sent"
+        }
+      }
+    ],
+    "assertions": [
+      {
+        "type": "requestCount",
+        "expected": 1
+      },
+      {
+        "type": "requestPath",
+        "expected": "/entries/456/replies.json"
+      },
+      {
+        "type": "requestBody",
+        "expected": {
+          "acting_sender_id": 314,
+          "message.subject": "Re: From the support address",
+          "message.content": "Reply text",
+          "entry.addressed.directly.0": "someone@example.com"
+        }
+      },
+      {
+        "type": "noError"
+      }
+    ],
+    "configOverrides": {
+      "clientLayer": "hey"
+    },
+    "tags": [
+      "replies",
+      "acting-sender"
+    ]
+  },
+  {
+    "name": "CreateReplyDraft wrapper sends the chosen acting sender untouched",
+    "description": "Verifies the hand-written EntriesService.CreateReplyDraft saves the draft as the caller-chosen acting_sender_id instead of resolving the account default",
+    "operation": "CreateReplyDraft",
+    "method": "POST",
+    "path": "/entries/{entryId}/replies.json",
+    "pathParams": {
+      "entryId": 456
+    },
+    "requestBody": {
+      "acting_sender_id": 314,
+      "subject": "Re: From the support address",
+      "content": "Draft text"
+    },
+    "mockResponses": [
+      {
+        "status": 204,
+        "headers": {
+          "Location": "https://app.hey.com/messages/777"
+        }
+      }
+    ],
+    "assertions": [
+      {
+        "type": "requestCount",
+        "expected": 1
+      },
+      {
+        "type": "requestBody",
+        "expected": {
+          "acting_sender_id": 314,
+          "entry.status": "drafted"
+        }
+      },
+      {
+        "type": "noError"
+      }
+    ],
+    "configOverrides": {
+      "clientLayer": "hey"
+    },
+    "tags": [
+      "replies",
+      "acting-sender"
+    ]
+  }
+]

--- a/go/pkg/hey/account_scope_test.go
+++ b/go/pkg/hey/account_scope_test.go
@@ -702,7 +702,7 @@ func TestScopedMessageAndReplyUseAccountSender(t *testing.T) {
 	if err := client.Messages().Create(context.Background(), "Subject", "Body", []string{"jane@example.com"}, nil, nil); err != nil {
 		t.Fatal(err)
 	}
-	if err := client.Entries().CreateReply(context.Background(), 99, "Re: Subject", "Reply", []string{"jane@example.com"}, nil, nil); err != nil {
+	if err := client.Entries().CreateReply(context.Background(), 99, 0, "Re: Subject", "Reply", []string{"jane@example.com"}, nil, nil); err != nil {
 		t.Fatal(err)
 	}
 	mu.Lock()

--- a/go/pkg/hey/client.go
+++ b/go/pkg/hey/client.go
@@ -1185,6 +1185,17 @@ func (c *Client) World() *WorldService {
 	return c.world
 }
 
+// resolveActingSenderID answers the acting sender an operation goes out as: the
+// caller's choice passed through untouched when one was made — an id the server
+// does not recognize is the server's to reject — and the account's default sender
+// for the zero value.
+func (c *Client) resolveActingSenderID(ctx context.Context, actingSenderID int64) (int64, error) {
+	if actingSenderID != 0 {
+		return actingSenderID, nil
+	}
+	return c.DefaultSenderID(ctx)
+}
+
 // DefaultSenderID returns the default sender contact ID for this client. An
 // account-scoped client selects only senders belonging to its account. An All
 // Accounts client preserves the identity-wide default sender behavior.

--- a/go/pkg/hey/drafts_test.go
+++ b/go/pkg/hey/drafts_test.go
@@ -317,12 +317,32 @@ func TestEntriesService_CreateReplyDraft(t *testing.T) {
 	})
 
 	// No recipients: unlike CreateReply, a reply draft is allowed to have nobody on it.
-	id, err := client.Entries().CreateReplyDraft(context.Background(), 10, "Re: Original subject", "<div>Drafting a reply.</div>", nil, nil, nil)
+	id, err := client.Entries().CreateReplyDraft(context.Background(), 10, 0, "Re: Original subject", "<div>Drafting a reply.</div>", nil, nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if id != 777 {
 		t.Errorf("draft entry id = %d, want 777 (from Location)", id)
+	}
+}
+
+func TestEntriesService_CreateReplyDraft_SendsTheChosenActingSender(t *testing.T) {
+	client := newDraftTestClient(t, map[string]draftTestRoute{
+		"/entries/10/replies.json": {
+			method:   "POST",
+			status:   204,
+			location: "https://app.hey.com/messages/777",
+			validate: func(t *testing.T, body map[string]any) {
+				t.Helper()
+				if got, _ := body["acting_sender_id"].(float64); got != 4242 {
+					t.Errorf("acting_sender_id = %v, want the chosen sender 4242", body["acting_sender_id"])
+				}
+			},
+		},
+	})
+
+	if _, err := client.Entries().CreateReplyDraft(context.Background(), 10, 4242, "Re: Original subject", "<div>Drafting a reply.</div>", nil, nil, nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/go/pkg/hey/drafts_test.go
+++ b/go/pkg/hey/drafts_test.go
@@ -213,6 +213,55 @@ func TestMessagesService_SendDraft(t *testing.T) {
 	}
 }
 
+func TestDraftLifecycleCarriesTheChosenActingSender(t *testing.T) {
+	// A draft saved as an alternate identity (the reply prefill's sender) must stay
+	// that identity through every revision and the final send: HEY revises a draft
+	// from the whole of what is sent, acting_sender_id included, so a lifecycle call
+	// that fell back to the account default would hand the draft back to it.
+	senderOn := func(want float64) func(*testing.T, map[string]any) {
+		return func(t *testing.T, body map[string]any) {
+			t.Helper()
+			if got, _ := body["acting_sender_id"].(float64); got != want {
+				t.Errorf("acting_sender_id = %v, want %v", body["acting_sender_id"], want)
+			}
+		}
+	}
+	client := newDraftTestClient(t, map[string]draftTestRoute{
+		"/messages.json": {
+			method: "POST", status: 204,
+			location: "https://app.hey.com/messages/12345",
+			validate: senderOn(4242),
+		},
+		"/messages/12345.json": {
+			method: "PUT", status: 204,
+			location: "https://app.hey.com/messages/12345",
+			validate: senderOn(4242),
+		},
+		"/messages/67890.json": {
+			method: "PUT", body: `{"id":99}`,
+			validate: senderOn(42), // zero falls back to the account default
+		},
+	})
+
+	chosen := DraftContent{Subject: "From the support address", Content: "<div>…</div>", ActingSenderID: 4242}
+	if _, err := client.Messages().CreateDraft(context.Background(), chosen); err != nil {
+		t.Fatalf("CreateDraft: %v", err)
+	}
+	if err := client.Messages().UpdateDraft(context.Background(), 12345, chosen); err != nil {
+		t.Fatalf("UpdateDraft: %v", err)
+	}
+	chosen.ActingSenderID = 4242
+	chosen.To = []string{"maria@example.com"}
+	if err := client.Messages().SendDraft(context.Background(), 12345, chosen); err != nil {
+		t.Fatalf("SendDraft: %v", err)
+	}
+
+	unchosen := DraftContent{Subject: "As myself", Content: "<div>…</div>", To: []string{"maria@example.com"}}
+	if err := client.Messages().SendDraft(context.Background(), 67890, unchosen); err != nil {
+		t.Fatalf("SendDraft (default sender): %v", err)
+	}
+}
+
 func TestMessagesService_SendDraft_RequiresRecipients(t *testing.T) {
 	client := newDraftTestClient(t, nil)
 

--- a/go/pkg/hey/entries.go
+++ b/go/pkg/hey/entries.go
@@ -75,7 +75,7 @@ func (s *EntriesService) CreateReply(ctx context.Context, entryID, actingSenderI
 	ctx = s.client.hooks.OnOperationStart(ctx, op)
 	defer func() { s.client.hooks.OnOperationEnd(ctx, op, err, time.Since(start)) }()
 
-	senderID, err := s.resolveActingSenderID(ctx, actingSenderID)
+	senderID, err := s.client.resolveActingSenderID(ctx, actingSenderID)
 	if err != nil {
 		return err
 	}
@@ -91,15 +91,6 @@ func (s *EntriesService) CreateReply(ctx context.Context, entryID, actingSenderI
 		return err
 	}
 	return CheckResponse(resp.HTTPResponse)
-}
-
-// resolveActingSenderID answers the acting sender a reply is sent as: the caller's
-// choice when one was made, the account's default sender otherwise.
-func (s *EntriesService) resolveActingSenderID(ctx context.Context, actingSenderID int64) (int64, error) {
-	if actingSenderID > 0 {
-		return actingSenderID, nil
-	}
-	return s.client.DefaultSenderID(ctx)
 }
 
 // MarkSpam marks an entry as spam. The server denies the sender outright when every thread
@@ -195,7 +186,7 @@ func (s *EntriesService) CreateReplyDraft(ctx context.Context, entryID, actingSe
 	}
 
 	err = s.client.instrument(ctx, op, func(ctx context.Context) error {
-		senderID, serr := s.resolveActingSenderID(ctx, actingSenderID)
+		senderID, serr := s.client.resolveActingSenderID(ctx, actingSenderID)
 		if serr != nil {
 			return serr
 		}

--- a/go/pkg/hey/entries.go
+++ b/go/pkg/hey/entries.go
@@ -44,7 +44,12 @@ func (s *EntriesService) ListDrafts(ctx context.Context, params *generated.ListD
 }
 
 // CreateReply replies to an entry (POST /entries/{entryId}/replies.json) and delivers it.
-// The acting sender ID is automatically resolved.
+//
+// ActingSenderID is the identity the reply goes out as. HEY resolves a reply's sender
+// from the thread — on a shared or alternate address (a HEY for Work support address,
+// an extension, a forwarded external account) that is not the account default — and
+// hands it back as NewReply's Sender. Pass that prefill's Sender.Id; zero falls back
+// to the account's default sender, which on such a thread is the wrong identity.
 //
 // Subject is the reply's own subject line — HEY does not derive one, so pass the
 // prefilled "Re: …" that NewReply hands back. Empty leaves it off the wire.
@@ -53,7 +58,7 @@ func (s *EntriesService) ListDrafts(ctx context.Context, params *generated.ListD
 // posted without entry.addressed is saved as a draft (the server answers with a
 // redirect to the thread with the draft expanded) rather than delivered. Callers
 // resolve the thread's recipients first — hey-cli reads them from the topic page.
-func (s *EntriesService) CreateReply(ctx context.Context, entryID int64, subject, content string, to, cc, bcc []string) (err error) {
+func (s *EntriesService) CreateReply(ctx context.Context, entryID, actingSenderID int64, subject, content string, to, cc, bcc []string) (err error) {
 	if len(to)+len(cc)+len(bcc) == 0 {
 		return ErrUsage("a reply needs at least one recipient (to, cc or bcc); HEY saves an unaddressed reply as a draft")
 	}
@@ -70,7 +75,7 @@ func (s *EntriesService) CreateReply(ctx context.Context, entryID int64, subject
 	ctx = s.client.hooks.OnOperationStart(ctx, op)
 	defer func() { s.client.hooks.OnOperationEnd(ctx, op, err, time.Since(start)) }()
 
-	senderID, err := s.client.DefaultSenderID(ctx)
+	senderID, err := s.resolveActingSenderID(ctx, actingSenderID)
 	if err != nil {
 		return err
 	}
@@ -86,6 +91,15 @@ func (s *EntriesService) CreateReply(ctx context.Context, entryID int64, subject
 		return err
 	}
 	return CheckResponse(resp.HTTPResponse)
+}
+
+// resolveActingSenderID answers the acting sender a reply is sent as: the caller's
+// choice when one was made, the account's default sender otherwise.
+func (s *EntriesService) resolveActingSenderID(ctx context.Context, actingSenderID int64) (int64, error) {
+	if actingSenderID > 0 {
+		return actingSenderID, nil
+	}
+	return s.client.DefaultSenderID(ctx)
 }
 
 // MarkSpam marks an entry as spam. The server denies the sender outright when every thread
@@ -167,17 +181,21 @@ func (s *EntriesService) DeleteDraft(ctx context.Context, entryID int64) error {
 // answers the draft's entry id. Unlike CreateReply it needs no recipients — HEY keeps
 // whatever the draft carries.
 //
+// ActingSenderID works as it does on CreateReply: pass the prefill's Sender.Id from
+// NewReply so the draft is saved under the identity HEY resolved for the thread; zero
+// falls back to the account's default sender.
+//
 // Subject matters here: HEY does not derive one, and a reply draft saved without it
 // shows as "No subject" in Drafts. Pass the prefilled "Re: …" from NewReply. Empty
 // leaves it off the wire.
-func (s *EntriesService) CreateReplyDraft(ctx context.Context, entryID int64, subject, content string, to, cc, bcc []string) (draftEntryID int64, err error) {
+func (s *EntriesService) CreateReplyDraft(ctx context.Context, entryID, actingSenderID int64, subject, content string, to, cc, bcc []string) (draftEntryID int64, err error) {
 	op := OperationInfo{
 		Service: "Entries", Operation: "CreateReply",
 		ResourceType: "draft", IsMutation: true, ResourceID: entryID,
 	}
 
 	err = s.client.instrument(ctx, op, func(ctx context.Context) error {
-		senderID, serr := s.client.DefaultSenderID(ctx)
+		senderID, serr := s.resolveActingSenderID(ctx, actingSenderID)
 		if serr != nil {
 			return serr
 		}
@@ -205,10 +223,12 @@ func (s *EntriesService) CreateReplyDraft(ctx context.Context, entryID int64, su
 	return draftEntryID, err
 }
 
-// NewReply returns a prefilled reply to an entry: the quoted body and, in Addressed,
-// the recipients a reply goes to as HEY computes them — the entry's sender moved onto
-// the To line and the acting user's own addresses, aliases and catch-alls excluded.
-// This is the recipient list CreateReply should be handed.
+// NewReply returns a prefilled reply to an entry: the quoted body; in Addressed, the
+// recipients a reply goes to as HEY computes them — the entry's sender moved onto the
+// To line and the acting user's own addresses, aliases and catch-alls excluded; and in
+// Sender, the identity HEY resolved for the reply from the thread's own to and from
+// addresses, present only when it differs from the acting user. This is the recipient
+// list and acting sender CreateReply should be handed.
 func (s *EntriesService) NewReply(ctx context.Context, entryID int64) (result *generated.MessageDraft, err error) {
 	op := OperationInfo{
 		Service: "Entries", Operation: "NewEntryReply",

--- a/go/pkg/hey/messages.go
+++ b/go/pkg/hey/messages.go
@@ -112,6 +112,13 @@ type DraftContent struct {
 	CC      []string
 	BCC     []string
 
+	// ActingSenderID is the sender the draft is saved — and ultimately delivered —
+	// as. Zero means the account's default sender. A caller who chose an alternate
+	// identity (the reply prefill's Sender.Id) carries it on every revision: HEY
+	// revises a draft from the whole of what is sent, so leaving it zero on an
+	// update or send hands the draft back to the default identity.
+	ActingSenderID int64
+
 	// Schedule delivers the draft at an hour of a day. Nil means no scheduled
 	// delivery — and on an update, clears one already set.
 	Schedule *DraftSchedule
@@ -177,7 +184,7 @@ func (s *MessagesService) CreateDraft(ctx context.Context, draft DraftContent) (
 	}
 
 	err = s.client.instrument(ctx, op, func(ctx context.Context) error {
-		senderID, serr := s.client.DefaultSenderID(ctx)
+		senderID, serr := s.client.resolveActingSenderID(ctx, draft.ActingSenderID)
 		if serr != nil {
 			return serr
 		}
@@ -212,7 +219,7 @@ func (s *MessagesService) UpdateDraft(ctx context.Context, entryID int64, draft 
 	}
 
 	return s.client.instrument(ctx, op, func(ctx context.Context) error {
-		senderID, serr := s.client.DefaultSenderID(ctx)
+		senderID, serr := s.client.resolveActingSenderID(ctx, draft.ActingSenderID)
 		if serr != nil {
 			return serr
 		}
@@ -249,7 +256,7 @@ func (s *MessagesService) SendDraft(ctx context.Context, entryID int64, draft Dr
 	}
 
 	return s.client.instrument(ctx, op, func(ctx context.Context) error {
-		senderID, serr := s.client.DefaultSenderID(ctx)
+		senderID, serr := s.client.resolveActingSenderID(ctx, draft.ActingSenderID)
 		if serr != nil {
 			return serr
 		}

--- a/go/pkg/hey/services_test.go
+++ b/go/pkg/hey/services_test.go
@@ -589,7 +589,44 @@ func TestEntriesService_CreateReply(t *testing.T) {
 		`{"notice":"sent"}`,
 	)
 
-	err := client.Entries().CreateReply(context.Background(), 10, "Re: A thread", "My reply", []string{"test@example.com"}, nil, nil)
+	err := client.Entries().CreateReply(context.Background(), 10, 0, "Re: A thread", "My reply", []string{"test@example.com"}, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestEntriesService_CreateReply_SendsTheChosenActingSender(t *testing.T) {
+	// The identity a reply goes out as: HEY resolves it from the thread (a shared
+	// support address, an extension) and hands it back as NewReply's sender. The
+	// caller's choice must reach the wire untouched — not the account default.
+	client := newMutationTestClientWithValidation(t, "POST", "/entries/%s/replies.json",
+		func(t *testing.T, body map[string]any) {
+			t.Helper()
+			if got, _ := body["acting_sender_id"].(float64); got != 4242 {
+				t.Errorf("acting_sender_id = %v, want the chosen sender 4242", body["acting_sender_id"])
+			}
+		},
+		`{"notice":"sent"}`,
+	)
+
+	err := client.Entries().CreateReply(context.Background(), 10, 4242, "Re: A thread", "My reply", []string{"test@example.com"}, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestEntriesService_CreateReply_ZeroActingSenderFallsBackToDefault(t *testing.T) {
+	client := newMutationTestClientWithValidation(t, "POST", "/entries/%s/replies.json",
+		func(t *testing.T, body map[string]any) {
+			t.Helper()
+			if got, _ := body["acting_sender_id"].(float64); got != 42 {
+				t.Errorf("acting_sender_id = %v, want the account default 42", body["acting_sender_id"])
+			}
+		},
+		`{"notice":"sent"}`,
+	)
+
+	err := client.Entries().CreateReply(context.Background(), 10, 0, "Re: A thread", "My reply", []string{"test@example.com"}, nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -607,7 +644,7 @@ func TestEntriesService_CreateReply_EmptySubjectStaysOffTheWire(t *testing.T) {
 		`{"notice":"sent"}`,
 	)
 
-	err := client.Entries().CreateReply(context.Background(), 10, "", "My reply", []string{"test@example.com"}, nil, nil)
+	err := client.Entries().CreateReply(context.Background(), 10, 0, "", "My reply", []string{"test@example.com"}, nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -620,7 +657,7 @@ func TestEntriesService_CreateReply_RequiresRecipients(t *testing.T) {
 		func(t *testing.T, _ map[string]any) { t.Helper(); t.Error("no request should be sent") },
 		`{"notice":"sent"}`,
 	)
-	err := client.Entries().CreateReply(context.Background(), 10, "Re: hello", "hello", nil, nil, nil)
+	err := client.Entries().CreateReply(context.Background(), 10, 0, "Re: hello", "hello", nil, nil, nil)
 	if e := AsError(err); e == nil || e.Code != CodeUsage {
 		t.Fatalf("expected a usage error, got %#v", err)
 	}
@@ -649,7 +686,7 @@ func TestEntriesService_CreateReply_RecipientsAreArrays(t *testing.T) {
 		`{"notice":"sent"}`,
 	)
 
-	err := client.Entries().CreateReply(context.Background(), 10, "Re: hi", "hi", []string{"a@x.com"}, nil, []string{"b@x.com"})
+	err := client.Entries().CreateReply(context.Background(), 10, 0, "Re: hi", "hi", []string{"a@x.com"}, nil, []string{"b@x.com"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/go/pkg/hey/services_test.go
+++ b/go/pkg/hey/services_test.go
@@ -615,6 +615,26 @@ func TestEntriesService_CreateReply_SendsTheChosenActingSender(t *testing.T) {
 	}
 }
 
+func TestEntriesService_CreateReply_PassesNonZeroSendersThroughUntouched(t *testing.T) {
+	// Only zero means "the account default". Anything else — a stale or even
+	// negative id — goes to the server as given; an invalid sender is the
+	// server's to reject, not this SDK's to silently rewrite.
+	client := newMutationTestClientWithValidation(t, "POST", "/entries/%s/replies.json",
+		func(t *testing.T, body map[string]any) {
+			t.Helper()
+			if got, _ := body["acting_sender_id"].(float64); got != -7 {
+				t.Errorf("acting_sender_id = %v, want -7 passed through", body["acting_sender_id"])
+			}
+		},
+		`{"notice":"sent"}`,
+	)
+
+	err := client.Entries().CreateReply(context.Background(), 10, -7, "Re: A thread", "My reply", []string{"test@example.com"}, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestEntriesService_CreateReply_ZeroActingSenderFallsBackToDefault(t *testing.T) {
 	client := newMutationTestClientWithValidation(t, "POST", "/entries/%s/replies.json",
 		func(t *testing.T, body map[string]any) {


### PR DESCRIPTION
`CreateReply` and `CreateReplyDraft` always filled `acting_sender_id` from `DefaultSenderID` — the account's default sender — ignoring the sender HEY resolved for the thread. The reply prefill (`NewEntryReply`) picks its sender by inspecting the entry's own to and from addresses; the create path then trusts whatever `acting_sender_id` it is handed. So on a shared or alternate address (a HEY for Work support address, an extension, a forwarded external account) the SDK delivered every reply as the account owner: the wrong identity, every time. This is the acting-sender leg (part 2 of 3) of basecamp/hey-cli#341.

## Change

- `CreateReply` and `CreateReplyDraft` take an `actingSenderID`, sent as `acting_sender_id` untouched; zero keeps today's `DefaultSenderID` fallback, so a caller with no thread context loses nothing.
- Pass the prefill's `Sender.Id`: `NewReply` already hands it back, present exactly when HEY resolved a sender that differs from the acting user (`sender.id` shares the id-space `acting_sender_id` reads — both are the identity's sender contacts).
- No wire or spec change: `acting_sender_id` was always sent, it just carried the wrong value. `openapi.json` and the generated client are untouched.
- A deliberate v0.x signature break, acknowledged in `.github/apidiff-accepted` alongside the reply-subject one (#134); the local apidiff run against main matches the accepted lines exactly.

## Tests

- The chosen acting sender reaches the wire untouched, on both the delivery and the draft path.
- Zero falls back to the account default (asserting the exact default id, not just presence).
- Existing reply/draft/account-scope tests updated to the new signature; `make check` green.

The hey-cli companion (prefill sender onto `hey reply`, `hey compose --thread-id`, and the TUI reply) follows, stacked on basecamp/hey-cli#370.

Basecamp: [\[SDK\] Replies go out as the account owner, not the address the thread was sent to](https://app.basecamp.com/2914079/buckets/48521764/card_tables/cards/10241629296)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replies and drafts now go out as the sender HEY resolved for the thread instead of the account's default sender. `CreateReply`, `CreateReplyDraft`, and `DraftContent` carry an acting sender id sent untouched as `acting_sender_id`; zero keeps the `DefaultSenderID` fallback, so callers with no thread context lose nothing. Conformance exercises both reply wrappers at the HEY layer with `to`, `cc`, and `bcc`, plus the full draft lifecycle (`CreateDraft`, `UpdateDraft`, `SendDraft`), asserting the chosen sender reaches the wire through every revision and the final send. The README reply example now addresses the reply with the recipients the prefill resolved instead of a hardcoded one.

**Migration**
- Pass the prefill's `Sender.Id` from `NewReply`; no wire or spec change — `acting_sender_id` was always sent, it just carried the wrong value.
- A draft saved as an alternate identity now keeps it through `UpdateDraft` and `SendDraft`; only zero means the default — any other id reaches the server as given.
- The new `CreateReply`/`CreateReplyDraft` argument is a v0.x signature break, acknowledged in `apidiff-accepted`; the `DraftContent` field is additive.

<sup>Written for commit 51b9228e184444d714d3a140d3d1c661217e227c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-sdk/pull/135?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

