### PR TITLE
Ask for JSON on the deletes HEY already answers in JSON

### DIFF
--- a/behavior-model.json
+++ b/behavior-model.json
@@ -286,6 +286,32 @@
         ]
       }
     },
+    "DeleteCalendarEvent": {
+      "idempotent": true,
+      "readonly": false,
+      "retry": {
+        "backoff": "exponential",
+        "base_delay_ms": 1000,
+        "max": 3,
+        "retry_on": [
+          429,
+          503
+        ]
+      }
+    },
+    "DeleteCalendarEventOccurrence": {
+      "idempotent": true,
+      "readonly": false,
+      "retry": {
+        "backoff": "exponential",
+        "base_delay_ms": 1000,
+        "max": 3,
+        "retry_on": [
+          429,
+          503
+        ]
+      }
+    },
     "DeleteCalendarTodo": {
       "idempotent": true,
       "readonly": false,
@@ -313,6 +339,19 @@
       }
     },
     "DeleteDraft": {
+      "idempotent": true,
+      "readonly": false,
+      "retry": {
+        "backoff": "exponential",
+        "base_delay_ms": 1000,
+        "max": 2,
+        "retry_on": [
+          429,
+          503
+        ]
+      }
+    },
+    "DeleteExtenzion": {
       "idempotent": true,
       "readonly": false,
       "retry": {

--- a/conformance/runner/go/main.go
+++ b/conformance/runner/go/main.go
@@ -1497,6 +1497,16 @@ func executeHEYOperation(client *hey.Client, ctx context.Context, tc TestCase) e
 			EndTime:   getStringPtrParam(tc.RequestBody, "end_time"),
 		})
 		return err
+	case "DeleteCalendarEvent":
+		return client.CalendarEvents().Delete(ctx, getInt64Param(tc.PathParams, "eventId"))
+	case "DeleteCalendarEventOccurrence":
+		occurrence, err := hey.ParseOccurrenceID(getStringParam(tc.PathParams, "occurrenceId"))
+		if err != nil {
+			return err
+		}
+		return client.CalendarEvents().DeleteOccurrence(ctx, occurrence, hey.OccurrenceScope(getStringParam(tc.RequestBody, "scope")))
+	case "DeleteExtenzion":
+		return client.Extenzions().Delete(ctx, getInt64Param(tc.PathParams, "accountId"), getInt64Param(tc.PathParams, "extenzionId"))
 	case "CreateReply":
 		entryID := getInt64Param(tc.PathParams, "entryId")
 		return client.Entries().CreateReply(ctx, entryID,

--- a/conformance/tests/calendar-events.json
+++ b/conformance/tests/calendar-events.json
@@ -57,5 +57,84 @@
       "calendar-events",
       "form"
     ]
+  },
+  {
+    "name": "Calendar event deletes ask for JSON",
+    "description": "Verifies that DeleteCalendarEvent asks for the .json representation HEY answers 204 on, not the redirect its web form gets",
+    "operation": "DeleteCalendarEvent",
+    "method": "DELETE",
+    "path": "/calendar/events/{eventId}.json",
+    "pathParams": {
+      "eventId": 99
+    },
+    "mockResponses": [
+      {
+        "status": 204
+      }
+    ],
+    "assertions": [
+      {
+        "type": "requestPath",
+        "expected": "/calendar/events/99.json"
+      },
+      {
+        "type": "requestMethod",
+        "expected": "DELETE"
+      },
+      {
+        "type": "noError"
+      }
+    ],
+    "configOverrides": {
+      "clientLayer": "hey"
+    },
+    "tags": [
+      "calendar-events",
+      "json"
+    ]
+  },
+  {
+    "name": "Calendar event occurrence deletes ask for JSON with the scope in the query",
+    "description": "Verifies that DeleteCalendarEventOccurrence asks for the .json representation and carries apply_to_future explicitly",
+    "operation": "DeleteCalendarEventOccurrence",
+    "method": "DELETE",
+    "path": "/calendar/events/{eventId}/occurrences/{occurrence}.json",
+    "pathParams": {
+      "occurrenceId": "153688907_2026-08-21"
+    },
+    "requestBody": {
+      "scope": "this_and_following"
+    },
+    "mockResponses": [
+      {
+        "status": 204
+      }
+    ],
+    "assertions": [
+      {
+        "type": "requestPath",
+        "expected": "/calendar/events/153688907/occurrences/2026-08-21.json"
+      },
+      {
+        "type": "requestMethod",
+        "expected": "DELETE"
+      },
+      {
+        "type": "requestQuery",
+        "expected": {
+          "apply_to_future": "true"
+        }
+      },
+      {
+        "type": "noError"
+      }
+    ],
+    "configOverrides": {
+      "clientLayer": "hey"
+    },
+    "tags": [
+      "calendar-events",
+      "json"
+    ]
   }
 ]

--- a/conformance/tests/extenzions.json
+++ b/conformance/tests/extenzions.json
@@ -1,0 +1,38 @@
+[
+  {
+    "name": "Extenzion deletes ask for JSON",
+    "description": "Verifies that DeleteExtenzion asks for the .json representation HEY answers 204 on, not the redirect its web form gets",
+    "operation": "DeleteExtenzion",
+    "method": "DELETE",
+    "path": "/accounts/{accountId}/domains/extenzions/{extenzionId}.json",
+    "pathParams": {
+      "accountId": 1,
+      "extenzionId": 10
+    },
+    "mockResponses": [
+      {
+        "status": 204
+      }
+    ],
+    "assertions": [
+      {
+        "type": "requestPath",
+        "expected": "/accounts/1/domains/extenzions/10.json"
+      },
+      {
+        "type": "requestMethod",
+        "expected": "DELETE"
+      },
+      {
+        "type": "noError"
+      }
+    ],
+    "configOverrides": {
+      "clientLayer": "hey"
+    },
+    "tags": [
+      "extenzions",
+      "json"
+    ]
+  }
+]

--- a/go/pkg/generated/client.gen.go
+++ b/go/pkg/generated/client.gen.go
@@ -1766,6 +1766,12 @@ type ListCalendarDaysParams struct {
 	StartsAt *string `form:"starts_at,omitempty" json:"starts_at,omitempty"`
 }
 
+// DeleteCalendarEventOccurrenceParams defines parameters for DeleteCalendarEventOccurrence.
+type DeleteCalendarEventOccurrenceParams struct {
+	// ApplyToFuture Remove this day and every one after it. Off, only this day is removed.
+	ApplyToFuture *bool `form:"apply_to_future,omitempty" json:"apply_to_future,omitempty"`
+}
+
 // ListJournalEntriesParams defines parameters for ListJournalEntries.
 type ListJournalEntriesParams struct {
 	Page *string `form:"page,omitempty" json:"page,omitempty"`
@@ -2280,6 +2286,9 @@ func (c *Client) doWithRetry(ctx context.Context, buildRequest func() (*http.Req
 
 // The interface specification for the client above.
 type ClientInterface interface {
+	// DeleteExtenzion request
+	DeleteExtenzion(ctx context.Context, accountId int64, extenzionId int64, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// AdvancedSearch request
 	AdvancedSearch(ctx context.Context, params *AdvancedSearchParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -2347,6 +2356,12 @@ type ClientInterface interface {
 	UpdateJournalEntryWithBody(ctx context.Context, day string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	UpdateJournalEntry(ctx context.Context, day string, body UpdateJournalEntryJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// DeleteCalendarEvent request
+	DeleteCalendarEvent(ctx context.Context, eventId int64, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// DeleteCalendarEventOccurrence request
+	DeleteCalendarEventOccurrence(ctx context.Context, eventId int64, occurrence string, params *DeleteCalendarEventOccurrenceParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// CreateHabitWithBody request with any body
 	CreateHabitWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -2739,6 +2754,16 @@ type ClientInterface interface {
 	GetWorkflow(ctx context.Context, workflowId int64, reqEditors ...RequestEditorFn) (*http.Response, error)
 }
 
+// DeleteExtenzion is marked as idempotent and will be retried on transient failures.
+
+func (c *Client) DeleteExtenzion(ctx context.Context, accountId int64, extenzionId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
+
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		return NewDeleteExtenzionRequest(c.Server, accountId, extenzionId)
+	}, true, "DeleteExtenzion", reqEditors...)
+
+}
+
 // AdvancedSearch is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) AdvancedSearch(ctx context.Context, params *AdvancedSearchParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
@@ -3022,6 +3047,26 @@ func (c *Client) UpdateJournalEntry(ctx context.Context, day string, body Update
 		return nil, err
 	}
 	return c.Client.Do(req)
+
+}
+
+// DeleteCalendarEvent is marked as idempotent and will be retried on transient failures.
+
+func (c *Client) DeleteCalendarEvent(ctx context.Context, eventId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
+
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		return NewDeleteCalendarEventRequest(c.Server, eventId)
+	}, true, "DeleteCalendarEvent", reqEditors...)
+
+}
+
+// DeleteCalendarEventOccurrence is marked as idempotent and will be retried on transient failures.
+
+func (c *Client) DeleteCalendarEventOccurrence(ctx context.Context, eventId int64, occurrence string, params *DeleteCalendarEventOccurrenceParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		return NewDeleteCalendarEventOccurrenceRequest(c.Server, eventId, occurrence, params)
+	}, true, "DeleteCalendarEventOccurrence", reqEditors...)
 
 }
 
@@ -4811,6 +4856,47 @@ func (c *Client) GetWorkflow(ctx context.Context, workflowId int64, reqEditors .
 
 }
 
+// NewDeleteExtenzionRequest generates requests for DeleteExtenzion
+func NewDeleteExtenzionRequest(server string, accountId int64, extenzionId int64) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "accountId", runtime.ParamLocationPath, accountId)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "extenzionId", runtime.ParamLocationPath, extenzionId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/accounts/%s/domains/extenzions/%s", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("DELETE", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewAdvancedSearchRequest generates requests for AdvancedSearch
 func NewAdvancedSearchRequest(server string, params *AdvancedSearchParams) (*http.Request, error) {
 	var err error
@@ -5882,6 +5968,103 @@ func NewUpdateJournalEntryRequestWithBody(server string, day string, contentType
 	}
 
 	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewDeleteCalendarEventRequest generates requests for DeleteCalendarEvent
+func NewDeleteCalendarEventRequest(server string, eventId int64) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "eventId", runtime.ParamLocationPath, eventId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/calendar/events/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("DELETE", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewDeleteCalendarEventOccurrenceRequest generates requests for DeleteCalendarEventOccurrence
+func NewDeleteCalendarEventOccurrenceRequest(server string, eventId int64, occurrence string, params *DeleteCalendarEventOccurrenceParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "eventId", runtime.ParamLocationPath, eventId)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "occurrence", runtime.ParamLocationPath, occurrence)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/calendar/events/%s/occurrences/%s", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.ApplyToFuture != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "apply_to_future", runtime.ParamLocationQuery, *params.ApplyToFuture); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("DELETE", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
 
 	return req, nil
 }
@@ -10378,132 +10561,135 @@ type OperationMetadata struct {
 // This is generated from x-hey-* extensions in the OpenAPI spec.
 // GET/HEAD/PUT/DELETE operations are always considered idempotent for retry purposes.
 var operationMetadata = map[string]OperationMetadata{
-	"AdvancedSearch":             {Idempotent: true, HasSensitiveParams: false},
-	"GetAdvancedSearchFilters":   {Idempotent: true, HasSensitiveParams: false},
-	"ListBoxes":                  {Idempotent: true, HasSensitiveParams: false},
-	"GetBox":                     {Idempotent: true, HasSensitiveParams: false},
-	"CreateBoxDesignation":       {Idempotent: false, HasSensitiveParams: false},
-	"DeleteBoxDesignation":       {Idempotent: true, HasSensitiveParams: false},
-	"ListBoxGroups":              {Idempotent: true, HasSensitiveParams: false},
-	"CreateBoxGroup":             {Idempotent: false, HasSensitiveParams: false},
-	"DeleteBoxGroup":             {Idempotent: true, HasSensitiveParams: false},
-	"MarkBoxSeen":                {Idempotent: false, HasSensitiveParams: false},
-	"GetBoxPostingChanges":       {Idempotent: true, HasSensitiveParams: false},
-	"GetBubblebox":               {Idempotent: true, HasSensitiveParams: false},
-	"CreateBulkReply":            {Idempotent: false, HasSensitiveParams: false},
-	"NewBulkReply":               {Idempotent: true, HasSensitiveParams: false},
-	"ListCalendarDays":           {Idempotent: true, HasSensitiveParams: false},
-	"GetCalendarDay":             {Idempotent: true, HasSensitiveParams: false},
-	"UncompleteHabit":            {Idempotent: true, HasSensitiveParams: false},
-	"CompleteHabit":              {Idempotent: true, HasSensitiveParams: false},
-	"GetJournalEntry":            {Idempotent: true, HasSensitiveParams: false},
-	"UpdateJournalEntry":         {Idempotent: false, HasSensitiveParams: false},
-	"CreateHabit":                {Idempotent: false, HasSensitiveParams: false},
-	"DeleteHabit":                {Idempotent: true, HasSensitiveParams: false},
-	"UpdateHabit":                {Idempotent: false, HasSensitiveParams: false},
-	"ResumeHabit":                {Idempotent: true, HasSensitiveParams: false},
-	"StopHabit":                  {Idempotent: false, HasSensitiveParams: false},
-	"UpdateFirstWeekDay":         {Idempotent: true, HasSensitiveParams: false},
-	"ListJournalEntries":         {Idempotent: true, HasSensitiveParams: false},
-	"GetOngoingTimeTrack":        {Idempotent: true, HasSensitiveParams: false},
-	"StartTimeTrack":             {Idempotent: false, HasSensitiveParams: false},
-	"ListTimeTracks":             {Idempotent: true, HasSensitiveParams: false},
-	"CreateTimeTrack":            {Idempotent: false, HasSensitiveParams: false},
-	"ListTimeTrackCategories":    {Idempotent: true, HasSensitiveParams: false},
-	"DeleteTimeTrack":            {Idempotent: true, HasSensitiveParams: false},
-	"UpdateTimeTrack":            {Idempotent: true, HasSensitiveParams: false},
-	"CreateCalendarTodo":         {Idempotent: false, HasSensitiveParams: false},
-	"DeleteCalendarTodo":         {Idempotent: true, HasSensitiveParams: false},
-	"UpdateCalendarTodo":         {Idempotent: false, HasSensitiveParams: false},
-	"UncompleteCalendarTodo":     {Idempotent: true, HasSensitiveParams: false},
-	"CompleteCalendarTodo":       {Idempotent: true, HasSensitiveParams: false},
-	"ListCalendarWeeks":          {Idempotent: true, HasSensitiveParams: false},
-	"GetCalendarWeek":            {Idempotent: true, HasSensitiveParams: false},
-	"GetCalendarYear":            {Idempotent: true, HasSensitiveParams: false},
-	"ListCalendars":              {Idempotent: true, HasSensitiveParams: false},
-	"GetCalendarRecordings":      {Idempotent: true, HasSensitiveParams: false},
-	"ToggleCalendar":             {Idempotent: false, HasSensitiveParams: false},
-	"GetClearances":              {Idempotent: true, HasSensitiveParams: false},
-	"BulkUpdateClearances":       {Idempotent: false, HasSensitiveParams: false},
-	"PuntClearances":             {Idempotent: false, HasSensitiveParams: false},
-	"UpdateClearance":            {Idempotent: false, HasSensitiveParams: false},
-	"ListClips":                  {Idempotent: true, HasSensitiveParams: false},
-	"ListCollections":            {Idempotent: true, HasSensitiveParams: false},
-	"GetCollection":              {Idempotent: true, HasSensitiveParams: false},
-	"UpdateCollection":           {Idempotent: false, HasSensitiveParams: false},
-	"ListContacts":               {Idempotent: true, HasSensitiveParams: false},
-	"CreateContact":              {Idempotent: false, HasSensitiveParams: false},
-	"HideContact":                {Idempotent: true, HasSensitiveParams: false},
-	"GetContact":                 {Idempotent: true, HasSensitiveParams: false},
-	"UpdateContact":              {Idempotent: false, HasSensitiveParams: false},
-	"UnbundleContact":            {Idempotent: true, HasSensitiveParams: false},
-	"BundleContact":              {Idempotent: false, HasSensitiveParams: false},
-	"UpdateContactClearance":     {Idempotent: false, HasSensitiveParams: false},
-	"DeleteContactNote":          {Idempotent: true, HasSensitiveParams: false},
-	"GetContactNote":             {Idempotent: true, HasSensitiveParams: false},
-	"UpdateContactNote":          {Idempotent: false, HasSensitiveParams: false},
-	"RevealContact":              {Idempotent: false, HasSensitiveParams: false},
-	"ListDrafts":                 {Idempotent: true, HasSensitiveParams: false},
-	"DeleteDraft":                {Idempotent: true, HasSensitiveParams: false},
-	"NewEntryForward":            {Idempotent: true, HasSensitiveParams: false},
-	"CreateReply":                {Idempotent: false, HasSensitiveParams: false},
-	"NewEntryReply":              {Idempotent: true, HasSensitiveParams: false},
-	"MarkEntrySpam":              {Idempotent: true, HasSensitiveParams: false},
-	"GetFeedbox":                 {Idempotent: true, HasSensitiveParams: false},
-	"GetFolder":                  {Idempotent: true, HasSensitiveParams: false},
-	"GetIdentity":                {Idempotent: true, HasSensitiveParams: false},
-	"UpdateTimeFormat":           {Idempotent: true, HasSensitiveParams: false},
-	"GetImbox":                   {Idempotent: true, HasSensitiveParams: false},
-	"GetImboxSeen":               {Idempotent: true, HasSensitiveParams: false},
-	"CreateMessage":              {Idempotent: false, HasSensitiveParams: false},
-	"GetMessage":                 {Idempotent: true, HasSensitiveParams: false},
-	"UpdateMessage":              {Idempotent: true, HasSensitiveParams: false},
-	"GetMessageEdit":             {Idempotent: true, HasSensitiveParams: false},
-	"GetMyClearances":            {Idempotent: true, HasSensitiveParams: false},
-	"UpdateMyClearance":          {Idempotent: false, HasSensitiveParams: false},
-	"GetNavigation":              {Idempotent: true, HasSensitiveParams: false},
-	"GetTrailbox":                {Idempotent: true, HasSensitiveParams: false},
-	"RemovePostingsFromBoxGroup": {Idempotent: true, HasSensitiveParams: false},
-	"AddPostingsToBoxGroup":      {Idempotent: false, HasSensitiveParams: false},
-	"CancelPostingsBubbleUp":     {Idempotent: true, HasSensitiveParams: false},
-	"SchedulePostingsBubbleUp":   {Idempotent: false, HasSensitiveParams: false},
-	"BubbleUpPostingsNow":        {Idempotent: false, HasSensitiveParams: false},
-	"UnfilePostings":             {Idempotent: true, HasSensitiveParams: false},
-	"FilePostings":               {Idempotent: false, HasSensitiveParams: false},
-	"CreateFolderForPostings":    {Idempotent: false, HasSensitiveParams: false},
-	"MovePostings":               {Idempotent: false, HasSensitiveParams: false},
-	"UnmutePostings":             {Idempotent: true, HasSensitiveParams: false},
-	"MutePostings":               {Idempotent: false, HasSensitiveParams: false},
-	"MarkPostingsSeen":           {Idempotent: false, HasSensitiveParams: false},
-	"MarkPostingsSpam":           {Idempotent: false, HasSensitiveParams: false},
-	"TrashPostings":              {Idempotent: false, HasSensitiveParams: false},
-	"MarkPostingsUnseen":         {Idempotent: false, HasSensitiveParams: false},
-	"GetBundleUnseenPostings":    {Idempotent: true, HasSensitiveParams: false},
-	"CreateDirectUpload":         {Idempotent: false, HasSensitiveParams: false},
-	"GetLaterbox":                {Idempotent: true, HasSensitiveParams: false},
-	"GetAsidebox":                {Idempotent: true, HasSensitiveParams: false},
-	"ListSnippets":               {Idempotent: true, HasSensitiveParams: false},
-	"ListStickies":               {Idempotent: true, HasSensitiveParams: false},
-	"CreateSticky":               {Idempotent: false, HasSensitiveParams: false},
-	"MoveSticky":                 {Idempotent: false, HasSensitiveParams: false},
-	"DeleteSticky":               {Idempotent: true, HasSensitiveParams: false},
-	"UpdateSticky":               {Idempotent: false, HasSensitiveParams: false},
-	"GetEverythingTopics":        {Idempotent: true, HasSensitiveParams: false},
-	"GetSentTopics":              {Idempotent: true, HasSensitiveParams: false},
-	"GetSpamTopics":              {Idempotent: true, HasSensitiveParams: false},
-	"EmptySpam":                  {Idempotent: true, HasSensitiveParams: false},
-	"GetTrashTopics":             {Idempotent: true, HasSensitiveParams: false},
-	"EmptyTrash":                 {Idempotent: true, HasSensitiveParams: false},
-	"GetTopic":                   {Idempotent: true, HasSensitiveParams: false},
-	"GetTopicEntries":            {Idempotent: true, HasSensitiveParams: false},
-	"MoveTopic":                  {Idempotent: false, HasSensitiveParams: false},
-	"GetTopicPublication":        {Idempotent: true, HasSensitiveParams: false},
-	"RestoreTopic":               {Idempotent: true, HasSensitiveParams: false},
-	"MarkTopicHam":               {Idempotent: true, HasSensitiveParams: false},
-	"TrashTopic":                 {Idempotent: true, HasSensitiveParams: false},
-	"MoveWorkflowStaging":        {Idempotent: false, HasSensitiveParams: false},
-	"CreateWorkflowStaging":      {Idempotent: false, HasSensitiveParams: false},
-	"GetWorkflow":                {Idempotent: true, HasSensitiveParams: false},
+	"DeleteExtenzion":               {Idempotent: true, HasSensitiveParams: false},
+	"AdvancedSearch":                {Idempotent: true, HasSensitiveParams: false},
+	"GetAdvancedSearchFilters":      {Idempotent: true, HasSensitiveParams: false},
+	"ListBoxes":                     {Idempotent: true, HasSensitiveParams: false},
+	"GetBox":                        {Idempotent: true, HasSensitiveParams: false},
+	"CreateBoxDesignation":          {Idempotent: false, HasSensitiveParams: false},
+	"DeleteBoxDesignation":          {Idempotent: true, HasSensitiveParams: false},
+	"ListBoxGroups":                 {Idempotent: true, HasSensitiveParams: false},
+	"CreateBoxGroup":                {Idempotent: false, HasSensitiveParams: false},
+	"DeleteBoxGroup":                {Idempotent: true, HasSensitiveParams: false},
+	"MarkBoxSeen":                   {Idempotent: false, HasSensitiveParams: false},
+	"GetBoxPostingChanges":          {Idempotent: true, HasSensitiveParams: false},
+	"GetBubblebox":                  {Idempotent: true, HasSensitiveParams: false},
+	"CreateBulkReply":               {Idempotent: false, HasSensitiveParams: false},
+	"NewBulkReply":                  {Idempotent: true, HasSensitiveParams: false},
+	"ListCalendarDays":              {Idempotent: true, HasSensitiveParams: false},
+	"GetCalendarDay":                {Idempotent: true, HasSensitiveParams: false},
+	"UncompleteHabit":               {Idempotent: true, HasSensitiveParams: false},
+	"CompleteHabit":                 {Idempotent: true, HasSensitiveParams: false},
+	"GetJournalEntry":               {Idempotent: true, HasSensitiveParams: false},
+	"UpdateJournalEntry":            {Idempotent: false, HasSensitiveParams: false},
+	"DeleteCalendarEvent":           {Idempotent: true, HasSensitiveParams: false},
+	"DeleteCalendarEventOccurrence": {Idempotent: true, HasSensitiveParams: false},
+	"CreateHabit":                   {Idempotent: false, HasSensitiveParams: false},
+	"DeleteHabit":                   {Idempotent: true, HasSensitiveParams: false},
+	"UpdateHabit":                   {Idempotent: false, HasSensitiveParams: false},
+	"ResumeHabit":                   {Idempotent: true, HasSensitiveParams: false},
+	"StopHabit":                     {Idempotent: false, HasSensitiveParams: false},
+	"UpdateFirstWeekDay":            {Idempotent: true, HasSensitiveParams: false},
+	"ListJournalEntries":            {Idempotent: true, HasSensitiveParams: false},
+	"GetOngoingTimeTrack":           {Idempotent: true, HasSensitiveParams: false},
+	"StartTimeTrack":                {Idempotent: false, HasSensitiveParams: false},
+	"ListTimeTracks":                {Idempotent: true, HasSensitiveParams: false},
+	"CreateTimeTrack":               {Idempotent: false, HasSensitiveParams: false},
+	"ListTimeTrackCategories":       {Idempotent: true, HasSensitiveParams: false},
+	"DeleteTimeTrack":               {Idempotent: true, HasSensitiveParams: false},
+	"UpdateTimeTrack":               {Idempotent: true, HasSensitiveParams: false},
+	"CreateCalendarTodo":            {Idempotent: false, HasSensitiveParams: false},
+	"DeleteCalendarTodo":            {Idempotent: true, HasSensitiveParams: false},
+	"UpdateCalendarTodo":            {Idempotent: false, HasSensitiveParams: false},
+	"UncompleteCalendarTodo":        {Idempotent: true, HasSensitiveParams: false},
+	"CompleteCalendarTodo":          {Idempotent: true, HasSensitiveParams: false},
+	"ListCalendarWeeks":             {Idempotent: true, HasSensitiveParams: false},
+	"GetCalendarWeek":               {Idempotent: true, HasSensitiveParams: false},
+	"GetCalendarYear":               {Idempotent: true, HasSensitiveParams: false},
+	"ListCalendars":                 {Idempotent: true, HasSensitiveParams: false},
+	"GetCalendarRecordings":         {Idempotent: true, HasSensitiveParams: false},
+	"ToggleCalendar":                {Idempotent: false, HasSensitiveParams: false},
+	"GetClearances":                 {Idempotent: true, HasSensitiveParams: false},
+	"BulkUpdateClearances":          {Idempotent: false, HasSensitiveParams: false},
+	"PuntClearances":                {Idempotent: false, HasSensitiveParams: false},
+	"UpdateClearance":               {Idempotent: false, HasSensitiveParams: false},
+	"ListClips":                     {Idempotent: true, HasSensitiveParams: false},
+	"ListCollections":               {Idempotent: true, HasSensitiveParams: false},
+	"GetCollection":                 {Idempotent: true, HasSensitiveParams: false},
+	"UpdateCollection":              {Idempotent: false, HasSensitiveParams: false},
+	"ListContacts":                  {Idempotent: true, HasSensitiveParams: false},
+	"CreateContact":                 {Idempotent: false, HasSensitiveParams: false},
+	"HideContact":                   {Idempotent: true, HasSensitiveParams: false},
+	"GetContact":                    {Idempotent: true, HasSensitiveParams: false},
+	"UpdateContact":                 {Idempotent: false, HasSensitiveParams: false},
+	"UnbundleContact":               {Idempotent: true, HasSensitiveParams: false},
+	"BundleContact":                 {Idempotent: false, HasSensitiveParams: false},
+	"UpdateContactClearance":        {Idempotent: false, HasSensitiveParams: false},
+	"DeleteContactNote":             {Idempotent: true, HasSensitiveParams: false},
+	"GetContactNote":                {Idempotent: true, HasSensitiveParams: false},
+	"UpdateContactNote":             {Idempotent: false, HasSensitiveParams: false},
+	"RevealContact":                 {Idempotent: false, HasSensitiveParams: false},
+	"ListDrafts":                    {Idempotent: true, HasSensitiveParams: false},
+	"DeleteDraft":                   {Idempotent: true, HasSensitiveParams: false},
+	"NewEntryForward":               {Idempotent: true, HasSensitiveParams: false},
+	"CreateReply":                   {Idempotent: false, HasSensitiveParams: false},
+	"NewEntryReply":                 {Idempotent: true, HasSensitiveParams: false},
+	"MarkEntrySpam":                 {Idempotent: true, HasSensitiveParams: false},
+	"GetFeedbox":                    {Idempotent: true, HasSensitiveParams: false},
+	"GetFolder":                     {Idempotent: true, HasSensitiveParams: false},
+	"GetIdentity":                   {Idempotent: true, HasSensitiveParams: false},
+	"UpdateTimeFormat":              {Idempotent: true, HasSensitiveParams: false},
+	"GetImbox":                      {Idempotent: true, HasSensitiveParams: false},
+	"GetImboxSeen":                  {Idempotent: true, HasSensitiveParams: false},
+	"CreateMessage":                 {Idempotent: false, HasSensitiveParams: false},
+	"GetMessage":                    {Idempotent: true, HasSensitiveParams: false},
+	"UpdateMessage":                 {Idempotent: true, HasSensitiveParams: false},
+	"GetMessageEdit":                {Idempotent: true, HasSensitiveParams: false},
+	"GetMyClearances":               {Idempotent: true, HasSensitiveParams: false},
+	"UpdateMyClearance":             {Idempotent: false, HasSensitiveParams: false},
+	"GetNavigation":                 {Idempotent: true, HasSensitiveParams: false},
+	"GetTrailbox":                   {Idempotent: true, HasSensitiveParams: false},
+	"RemovePostingsFromBoxGroup":    {Idempotent: true, HasSensitiveParams: false},
+	"AddPostingsToBoxGroup":         {Idempotent: false, HasSensitiveParams: false},
+	"CancelPostingsBubbleUp":        {Idempotent: true, HasSensitiveParams: false},
+	"SchedulePostingsBubbleUp":      {Idempotent: false, HasSensitiveParams: false},
+	"BubbleUpPostingsNow":           {Idempotent: false, HasSensitiveParams: false},
+	"UnfilePostings":                {Idempotent: true, HasSensitiveParams: false},
+	"FilePostings":                  {Idempotent: false, HasSensitiveParams: false},
+	"CreateFolderForPostings":       {Idempotent: false, HasSensitiveParams: false},
+	"MovePostings":                  {Idempotent: false, HasSensitiveParams: false},
+	"UnmutePostings":                {Idempotent: true, HasSensitiveParams: false},
+	"MutePostings":                  {Idempotent: false, HasSensitiveParams: false},
+	"MarkPostingsSeen":              {Idempotent: false, HasSensitiveParams: false},
+	"MarkPostingsSpam":              {Idempotent: false, HasSensitiveParams: false},
+	"TrashPostings":                 {Idempotent: false, HasSensitiveParams: false},
+	"MarkPostingsUnseen":            {Idempotent: false, HasSensitiveParams: false},
+	"GetBundleUnseenPostings":       {Idempotent: true, HasSensitiveParams: false},
+	"CreateDirectUpload":            {Idempotent: false, HasSensitiveParams: false},
+	"GetLaterbox":                   {Idempotent: true, HasSensitiveParams: false},
+	"GetAsidebox":                   {Idempotent: true, HasSensitiveParams: false},
+	"ListSnippets":                  {Idempotent: true, HasSensitiveParams: false},
+	"ListStickies":                  {Idempotent: true, HasSensitiveParams: false},
+	"CreateSticky":                  {Idempotent: false, HasSensitiveParams: false},
+	"MoveSticky":                    {Idempotent: false, HasSensitiveParams: false},
+	"DeleteSticky":                  {Idempotent: true, HasSensitiveParams: false},
+	"UpdateSticky":                  {Idempotent: false, HasSensitiveParams: false},
+	"GetEverythingTopics":           {Idempotent: true, HasSensitiveParams: false},
+	"GetSentTopics":                 {Idempotent: true, HasSensitiveParams: false},
+	"GetSpamTopics":                 {Idempotent: true, HasSensitiveParams: false},
+	"EmptySpam":                     {Idempotent: true, HasSensitiveParams: false},
+	"GetTrashTopics":                {Idempotent: true, HasSensitiveParams: false},
+	"EmptyTrash":                    {Idempotent: true, HasSensitiveParams: false},
+	"GetTopic":                      {Idempotent: true, HasSensitiveParams: false},
+	"GetTopicEntries":               {Idempotent: true, HasSensitiveParams: false},
+	"MoveTopic":                     {Idempotent: false, HasSensitiveParams: false},
+	"GetTopicPublication":           {Idempotent: true, HasSensitiveParams: false},
+	"RestoreTopic":                  {Idempotent: true, HasSensitiveParams: false},
+	"MarkTopicHam":                  {Idempotent: true, HasSensitiveParams: false},
+	"TrashTopic":                    {Idempotent: true, HasSensitiveParams: false},
+	"MoveWorkflowStaging":           {Idempotent: false, HasSensitiveParams: false},
+	"CreateWorkflowStaging":         {Idempotent: false, HasSensitiveParams: false},
+	"GetWorkflow":                   {Idempotent: true, HasSensitiveParams: false},
 }
 
 // GetOperationMetadata returns metadata for the given operation ID.
@@ -11117,6 +11303,14 @@ func WithBaseURL(baseURL string) ClientOption {
 // ClientWithResponsesInterface is the interface specification for the client with responses above.
 type ClientWithResponsesInterface interface {
 
+	// DeleteExtenzionWithResponse performs a DELETE /accounts/{accountId}/domains/extenzions/{extenzionId} (the `DeleteExtenzion` operationId) request.
+	//
+	// Delete an extenzion. The id is the extenzion's contact id, the one its app_url
+	// carries. Answers 204; forbidden when the caller cannot edit the extenzion.
+	//
+	// Returns a wrapper object for the known response body format(s).
+	DeleteExtenzionWithResponse(ctx context.Context, accountId int64, extenzionId int64, reqEditors ...RequestEditorFn) (*DeleteExtenzionResponse, error)
+
 	// AdvancedSearchWithResponse performs a GET /advanced_search.json (the `AdvancedSearch` operationId) request.
 	//
 	// Get the options the advanced search refine form offers.
@@ -11308,6 +11502,23 @@ type ClientWithResponsesInterface interface {
 	// Update the journal entry for a day: writes (or creates) it and answers the entry as a
 	// recording, or 204 when empty content removes it.
 	UpdateJournalEntryWithResponse(ctx context.Context, day string, body UpdateJournalEntryJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateJournalEntryResponse, error)
+
+	// DeleteCalendarEventWithResponse performs a DELETE /calendar/events/{eventId} (the `DeleteCalendarEvent` operationId) request.
+	//
+	// Delete a calendar event, cancelling it for every attendee. Answers 204.
+	//
+	// Returns a wrapper object for the known response body format(s).
+	DeleteCalendarEventWithResponse(ctx context.Context, eventId int64, reqEditors ...RequestEditorFn) (*DeleteCalendarEventResponse, error)
+
+	// DeleteCalendarEventOccurrenceWithResponse performs a DELETE /calendar/events/{eventId}/occurrences/{occurrence} (the `DeleteCalendarEventOccurrence` operationId) request.
+	//
+	// Delete one day of a repeating event, or that day and every one after it.
+	// Answers 204. A single day becomes an exception in the series' schedule; with
+	// apply_to_future the series is truncated at the day before, or destroyed if this
+	// was its first day.
+	//
+	// Returns a wrapper object for the known response body format(s).
+	DeleteCalendarEventOccurrenceWithResponse(ctx context.Context, eventId int64, occurrence string, params *DeleteCalendarEventOccurrenceParams, reqEditors ...RequestEditorFn) (*DeleteCalendarEventOccurrenceResponse, error)
 
 	// CreateHabitWithBodyWithResponse performs a POST /calendar/habits.json (the `CreateHabit` operationId) request,
 	// with any type of body and a specified content type.
@@ -12435,6 +12646,75 @@ type ClientWithResponsesInterface interface {
 	//
 	// Returns a wrapper object for the known response body format(s).
 	GetWorkflowWithResponse(ctx context.Context, workflowId int64, reqEditors ...RequestEditorFn) (*GetWorkflowResponse, error)
+}
+
+type DeleteExtenzionResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	// JSON401 the response for an HTTP 401 `application/json` response
+	JSON401 *UnauthorizedErrorResponseContent
+	// JSON403 the response for an HTTP 403 `application/json` response
+	JSON403 *ForbiddenErrorResponseContent
+	// JSON404 the response for an HTTP 404 `application/json` response
+	JSON404 *NotFoundErrorResponseContent
+	// JSON500 the response for an HTTP 500 `application/json` response
+	JSON500 *InternalServerErrorResponseContent
+	// JSON503 the response for an HTTP 503 `application/json` response
+	JSON503 *ServiceUnavailableErrorResponseContent
+}
+
+// GetJSON401 returns the response for an HTTP 401 `application/json` response
+func (r DeleteExtenzionResponse) GetJSON401() *UnauthorizedErrorResponseContent {
+	return r.JSON401
+}
+
+// GetJSON403 returns the response for an HTTP 403 `application/json` response
+func (r DeleteExtenzionResponse) GetJSON403() *ForbiddenErrorResponseContent {
+	return r.JSON403
+}
+
+// GetJSON404 returns the response for an HTTP 404 `application/json` response
+func (r DeleteExtenzionResponse) GetJSON404() *NotFoundErrorResponseContent {
+	return r.JSON404
+}
+
+// GetJSON500 returns the response for an HTTP 500 `application/json` response
+func (r DeleteExtenzionResponse) GetJSON500() *InternalServerErrorResponseContent {
+	return r.JSON500
+}
+
+// GetJSON503 returns the response for an HTTP 503 `application/json` response
+func (r DeleteExtenzionResponse) GetJSON503() *ServiceUnavailableErrorResponseContent {
+	return r.JSON503
+}
+
+// GetBody returns the raw response body bytes
+func (r DeleteExtenzionResponse) GetBody() []byte {
+	return r.Body
+}
+
+// Status returns HTTPResponse.Status
+func (r DeleteExtenzionResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r DeleteExtenzionResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r DeleteExtenzionResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
 }
 
 type AdvancedSearchResponse struct {
@@ -13769,6 +14049,130 @@ func (r UpdateJournalEntryResponse) StatusCode() int {
 
 // ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
 func (r UpdateJournalEntryResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type DeleteCalendarEventResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	// JSON401 the response for an HTTP 401 `application/json` response
+	JSON401 *UnauthorizedErrorResponseContent
+	// JSON404 the response for an HTTP 404 `application/json` response
+	JSON404 *NotFoundErrorResponseContent
+	// JSON500 the response for an HTTP 500 `application/json` response
+	JSON500 *InternalServerErrorResponseContent
+	// JSON503 the response for an HTTP 503 `application/json` response
+	JSON503 *ServiceUnavailableErrorResponseContent
+}
+
+// GetJSON401 returns the response for an HTTP 401 `application/json` response
+func (r DeleteCalendarEventResponse) GetJSON401() *UnauthorizedErrorResponseContent {
+	return r.JSON401
+}
+
+// GetJSON404 returns the response for an HTTP 404 `application/json` response
+func (r DeleteCalendarEventResponse) GetJSON404() *NotFoundErrorResponseContent {
+	return r.JSON404
+}
+
+// GetJSON500 returns the response for an HTTP 500 `application/json` response
+func (r DeleteCalendarEventResponse) GetJSON500() *InternalServerErrorResponseContent {
+	return r.JSON500
+}
+
+// GetJSON503 returns the response for an HTTP 503 `application/json` response
+func (r DeleteCalendarEventResponse) GetJSON503() *ServiceUnavailableErrorResponseContent {
+	return r.JSON503
+}
+
+// GetBody returns the raw response body bytes
+func (r DeleteCalendarEventResponse) GetBody() []byte {
+	return r.Body
+}
+
+// Status returns HTTPResponse.Status
+func (r DeleteCalendarEventResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r DeleteCalendarEventResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r DeleteCalendarEventResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type DeleteCalendarEventOccurrenceResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	// JSON401 the response for an HTTP 401 `application/json` response
+	JSON401 *UnauthorizedErrorResponseContent
+	// JSON404 the response for an HTTP 404 `application/json` response
+	JSON404 *NotFoundErrorResponseContent
+	// JSON500 the response for an HTTP 500 `application/json` response
+	JSON500 *InternalServerErrorResponseContent
+	// JSON503 the response for an HTTP 503 `application/json` response
+	JSON503 *ServiceUnavailableErrorResponseContent
+}
+
+// GetJSON401 returns the response for an HTTP 401 `application/json` response
+func (r DeleteCalendarEventOccurrenceResponse) GetJSON401() *UnauthorizedErrorResponseContent {
+	return r.JSON401
+}
+
+// GetJSON404 returns the response for an HTTP 404 `application/json` response
+func (r DeleteCalendarEventOccurrenceResponse) GetJSON404() *NotFoundErrorResponseContent {
+	return r.JSON404
+}
+
+// GetJSON500 returns the response for an HTTP 500 `application/json` response
+func (r DeleteCalendarEventOccurrenceResponse) GetJSON500() *InternalServerErrorResponseContent {
+	return r.JSON500
+}
+
+// GetJSON503 returns the response for an HTTP 503 `application/json` response
+func (r DeleteCalendarEventOccurrenceResponse) GetJSON503() *ServiceUnavailableErrorResponseContent {
+	return r.JSON503
+}
+
+// GetBody returns the raw response body bytes
+func (r DeleteCalendarEventOccurrenceResponse) GetBody() []byte {
+	return r.Body
+}
+
+// Status returns HTTPResponse.Status
+func (r DeleteCalendarEventOccurrenceResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r DeleteCalendarEventOccurrenceResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r DeleteCalendarEventOccurrenceResponse) ContentType() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Header.Get("Content-Type")
 	}
@@ -20739,6 +21143,20 @@ func (r GetWorkflowResponse) ContentType() string {
 	return ""
 }
 
+// DeleteExtenzionWithResponse performs a DELETE /accounts/{accountId}/domains/extenzions/{extenzionId} (the `DeleteExtenzion` operationId) request.
+//
+// Delete an extenzion. The id is the extenzion's contact id, the one its app_url
+// carries. Answers 204; forbidden when the caller cannot edit the extenzion.
+//
+// Returns a wrapper object for the known response body format(s).
+func (c *ClientWithResponses) DeleteExtenzionWithResponse(ctx context.Context, accountId int64, extenzionId int64, reqEditors ...RequestEditorFn) (*DeleteExtenzionResponse, error) {
+	rsp, err := c.DeleteExtenzion(ctx, accountId, extenzionId, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseDeleteExtenzionResponse(rsp)
+}
+
 // AdvancedSearchWithResponse performs a GET /advanced_search.json (the `AdvancedSearch` operationId) request.
 //
 // Get the options the advanced search refine form offers.
@@ -21073,6 +21491,35 @@ func (c *ClientWithResponses) UpdateJournalEntryWithResponse(ctx context.Context
 		return nil, err
 	}
 	return ParseUpdateJournalEntryResponse(rsp)
+}
+
+// DeleteCalendarEventWithResponse performs a DELETE /calendar/events/{eventId} (the `DeleteCalendarEvent` operationId) request.
+//
+// Delete a calendar event, cancelling it for every attendee. Answers 204.
+//
+// Returns a wrapper object for the known response body format(s).
+func (c *ClientWithResponses) DeleteCalendarEventWithResponse(ctx context.Context, eventId int64, reqEditors ...RequestEditorFn) (*DeleteCalendarEventResponse, error) {
+	rsp, err := c.DeleteCalendarEvent(ctx, eventId, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseDeleteCalendarEventResponse(rsp)
+}
+
+// DeleteCalendarEventOccurrenceWithResponse performs a DELETE /calendar/events/{eventId}/occurrences/{occurrence} (the `DeleteCalendarEventOccurrence` operationId) request.
+//
+// Delete one day of a repeating event, or that day and every one after it.
+// Answers 204. A single day becomes an exception in the series' schedule; with
+// apply_to_future the series is truncated at the day before, or destroyed if this
+// was its first day.
+//
+// Returns a wrapper object for the known response body format(s).
+func (c *ClientWithResponses) DeleteCalendarEventOccurrenceWithResponse(ctx context.Context, eventId int64, occurrence string, params *DeleteCalendarEventOccurrenceParams, reqEditors ...RequestEditorFn) (*DeleteCalendarEventOccurrenceResponse, error) {
+	rsp, err := c.DeleteCalendarEventOccurrence(ctx, eventId, occurrence, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseDeleteCalendarEventOccurrenceResponse(rsp)
 }
 
 // CreateHabitWithBodyWithResponse performs a POST /calendar/habits.json (the `CreateHabit` operationId) request,
@@ -23054,6 +23501,63 @@ func (c *ClientWithResponses) GetWorkflowWithResponse(ctx context.Context, workf
 	return ParseGetWorkflowResponse(rsp)
 }
 
+// ParseDeleteExtenzionResponse parses an HTTP response from a DeleteExtenzionWithResponse call
+func ParseDeleteExtenzionResponse(rsp *http.Response) (*DeleteExtenzionResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &DeleteExtenzionResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case rsp.StatusCode == 200:
+		break // No content-type
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest UnauthorizedErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest ForbiddenErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFoundErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalServerErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 503:
+		var dest ServiceUnavailableErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON503 = &dest
+
+	}
+
+	return response, nil
+}
+
 // ParseAdvancedSearchResponse parses an HTTP response from a AdvancedSearchWithResponse call
 func ParseAdvancedSearchResponse(rsp *http.Response) (*AdvancedSearchResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
@@ -24084,6 +24588,106 @@ func ParseUpdateJournalEntryResponse(rsp *http.Response) (*UpdateJournalEntryRes
 			return nil, err
 		}
 		response.JSON422 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalServerErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 503:
+		var dest ServiceUnavailableErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON503 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseDeleteCalendarEventResponse parses an HTTP response from a DeleteCalendarEventWithResponse call
+func ParseDeleteCalendarEventResponse(rsp *http.Response) (*DeleteCalendarEventResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &DeleteCalendarEventResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case rsp.StatusCode == 200:
+		break // No content-type
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest UnauthorizedErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFoundErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalServerErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 503:
+		var dest ServiceUnavailableErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON503 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseDeleteCalendarEventOccurrenceResponse parses an HTTP response from a DeleteCalendarEventOccurrenceWithResponse call
+func ParseDeleteCalendarEventOccurrenceResponse(rsp *http.Response) (*DeleteCalendarEventOccurrenceResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &DeleteCalendarEventOccurrenceResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case rsp.StatusCode == 200:
+		break // No content-type
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest UnauthorizedErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFoundErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest InternalServerErrorResponseContent

--- a/go/pkg/hey/calendar_events.go
+++ b/go/pkg/hey/calendar_events.go
@@ -524,8 +524,11 @@ func (s *CalendarEventsService) Delete(ctx context.Context, eventID int64) (err 
 	ctx = s.client.hooks.OnOperationStart(ctx, op)
 	defer func() { s.client.hooks.OnOperationEnd(ctx, op, err, time.Since(start)) }()
 
-	_, err = s.client.DeleteForm(ctx, fmt.Sprintf("/calendar/events/%d", eventID))
-	return err
+	resp, err := s.client.genClient().DeleteCalendarEventWithResponse(ctx, eventID)
+	if err != nil {
+		return err
+	}
+	return CheckResponse(resp.HTTPResponse)
 }
 
 const occurrenceDateLayout = "2006-01-02"
@@ -595,8 +598,13 @@ const (
 	OccurrenceScopeThisAndFollowing OccurrenceScope = "this_and_following"
 )
 
+func (s OccurrenceScope) appliesToFuture() bool {
+	return s == OccurrenceScopeThisAndFollowing
+}
+
+// applyToFuture is the scope as the occurrence form takes it.
 func (s OccurrenceScope) applyToFuture() string {
-	if s == OccurrenceScopeThisAndFollowing {
+	if s.appliesToFuture() {
 		return "1"
 	}
 	return "0"
@@ -667,6 +675,11 @@ func (s *CalendarEventsService) DeleteOccurrence(ctx context.Context, occurrence
 	ctx = s.client.hooks.OnOperationStart(ctx, op)
 	defer func() { s.client.hooks.OnOperationEnd(ctx, op, err, time.Since(start)) }()
 
-	_, err = s.client.DeleteForm(ctx, occurrence.path()+"?apply_to_future="+scope.applyToFuture())
-	return err
+	applyToFuture := scope.appliesToFuture()
+	resp, err := s.client.genClient().DeleteCalendarEventOccurrenceWithResponse(ctx, occurrence.EventID, occurrence.DateParam(),
+		&generated.DeleteCalendarEventOccurrenceParams{ApplyToFuture: &applyToFuture})
+	if err != nil {
+		return err
+	}
+	return CheckResponse(resp.HTTPResponse)
 }

--- a/go/pkg/hey/extenzions.go
+++ b/go/pkg/hey/extenzions.go
@@ -15,9 +15,9 @@ import (
 // ExtenzionsService handles email extenzion operations.
 //
 // Extenzions allow custom email addresses on custom-domain HEY accounts
-// (e.g., sales@yourdomain.com). The endpoints take form-encoded requests. Create and Update
-// post to the .json path, so a current server answers the written extenzion; a server
-// without the JSON branch redirects instead and hands nothing back.
+// (e.g., sales@yourdomain.com). Create and Update take form-encoded requests but post to the
+// .json path, so a current server answers the written extenzion; a server without the JSON
+// branch redirects instead and hands nothing back. Delete is a plain JSON operation.
 type ExtenzionsService struct {
 	client *Client
 }
@@ -151,8 +151,11 @@ func (s *ExtenzionsService) Delete(ctx context.Context, accountID int64, extID i
 	ctx = s.client.hooks.OnOperationStart(ctx, op)
 	defer func() { s.client.hooks.OnOperationEnd(ctx, op, err, time.Since(start)) }()
 
-	_, err = s.client.DeleteForm(ctx, fmt.Sprintf("/accounts/%d/domains/extenzions/%d", accountID, extID))
-	return err
+	resp, err := s.client.genClient().DeleteExtenzionWithResponse(ctx, accountID, extID)
+	if err != nil {
+		return err
+	}
+	return CheckResponse(resp.HTTPResponse)
 }
 
 // extenzionFromFormResponse reads the extenzion a JSON write answers with. A server without

--- a/go/pkg/hey/services_test.go
+++ b/go/pkg/hey/services_test.go
@@ -1837,11 +1837,31 @@ func TestCalendarEventsService_Update_OnAServerWithoutTheJSONBranch(t *testing.T
 	}
 }
 
+// newNoContentTestClient answers a JSON delete with 204 and records what it was asked for.
+func newNoContentTestClient(t *testing.T, wantMethod, wantPath string) (*Client, *url.Values) {
+	t.Helper()
+	var gotQuery url.Values
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != wantMethod {
+			t.Errorf("expected %s, got %s", wantMethod, r.Method)
+		}
+		if r.URL.Path != wantPath {
+			t.Errorf("expected path %s, got %s", wantPath, r.URL.Path)
+		}
+		if accept := r.Header.Get("Accept"); accept != "application/json" {
+			t.Errorf("expected Accept: application/json, got %q", accept)
+		}
+		gotQuery = r.URL.Query()
+		w.WriteHeader(204)
+	}))
+	t.Cleanup(server.Close)
+	return NewClient(&Config{BaseURL: server.URL}, &StaticTokenProvider{Token: "test-token"}, WithMaxRetries(0)), &gotQuery
+}
+
+// The delete asks for the JSON representation HEY serves it in — the .json path with a JSON
+// Accept — rather than the redirect its web form answers with.
 func TestCalendarEventsService_Delete(t *testing.T) {
-	client := newFormTestClient(t, "DELETE", "/calendar/events/%s",
-		nil,
-		"/calendar",
-	)
+	client, _ := newNoContentTestClient(t, "DELETE", "/calendar/events/99.json")
 
 	err := client.CalendarEvents().Delete(context.Background(), 99)
 	if err != nil {
@@ -2227,34 +2247,22 @@ func TestCalendarEventsService_Update_WithoutRepeatLeavesTheScheduleAlone(t *tes
 }
 
 // A delete carries no body, so the scope rides in the query string, as it does in HEY's own
-// occurrence links.
+// occurrence links. Both scopes are sent explicitly: the narrower one is the zero value, and
+// leaving it off would rely on the server's default instead of stating it.
 func TestCalendarEventsService_DeleteOccurrence(t *testing.T) {
 	for scope, wantApplyToFuture := range map[OccurrenceScope]string{
-		OccurrenceScopeThisEvent:        "0",
-		OccurrenceScopeThisAndFollowing: "1",
+		OccurrenceScopeThisEvent:        "false",
+		OccurrenceScopeThisAndFollowing: "true",
 	} {
-		var gotPath, gotApplyToFuture, gotMethod string
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			gotMethod, gotPath = r.Method, r.URL.Path
-			gotApplyToFuture = r.URL.Query().Get("apply_to_future")
-			w.WriteHeader(204)
-		}))
-		t.Cleanup(server.Close)
-		client := NewClient(&Config{BaseURL: server.URL}, &StaticTokenProvider{Token: "test-token"}, WithMaxRetries(0))
+		client, gotQuery := newNoContentTestClient(t, "DELETE", "/calendar/events/153688907/occurrences/2026-08-21.json")
 
 		err := client.CalendarEvents().DeleteOccurrence(context.Background(),
 			EventOccurrence{EventID: 153688907, Date: time.Date(2026, 8, 21, 0, 0, 0, 0, time.UTC)}, scope)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if gotMethod != "DELETE" {
-			t.Errorf("expected DELETE, got %s", gotMethod)
-		}
-		if gotPath != "/calendar/events/153688907/occurrences/2026-08-21.json" {
-			t.Errorf("path = %q", gotPath)
-		}
-		if gotApplyToFuture != wantApplyToFuture {
-			t.Errorf("apply_to_future = %q, want %q for %s", gotApplyToFuture, wantApplyToFuture, scope)
+		if got := gotQuery.Get("apply_to_future"); got != wantApplyToFuture {
+			t.Errorf("apply_to_future = %q, want %q for %s", got, wantApplyToFuture, scope)
 		}
 	}
 }
@@ -2420,10 +2428,7 @@ func TestExtenzionsService_Update_OnAServerWithoutTheJSONBranch(t *testing.T) {
 }
 
 func TestExtenzionsService_Delete(t *testing.T) {
-	client := newFormTestClient(t, "DELETE", "/accounts/%s/domains/extenzions/%s",
-		nil,
-		"/accounts/1/domains/extenzions",
-	)
+	client, _ := newNoContentTestClient(t, "DELETE", "/accounts/1/domains/extenzions/10.json")
 
 	err := client.Extenzions().Delete(context.Background(), 1, 10)
 	if err != nil {

--- a/go/pkg/hey/url-routes.json
+++ b/go/pkg/hey/url-routes.json
@@ -4,6 +4,23 @@
   "generated": true,
   "routes": [
     {
+      "pattern": "/accounts/{accountId}/domains/extenzions/{extenzionId}",
+      "resource": "Extenzions",
+      "operations": {
+        "DELETE": "DeleteExtenzion"
+      },
+      "params": {
+        "accountId": {
+          "role": "parent",
+          "type": "int64"
+        },
+        "extenzionId": {
+          "role": "recording",
+          "type": "int64"
+        }
+      }
+    },
+    {
       "pattern": "/advanced_search",
       "resource": "Search",
       "operations": {
@@ -200,6 +217,36 @@
       "params": {
         "day": {
           "role": "parent",
+          "type": "string"
+        }
+      }
+    },
+    {
+      "pattern": "/calendar/events/{eventId}",
+      "resource": "Calendar Events",
+      "operations": {
+        "DELETE": "DeleteCalendarEvent"
+      },
+      "params": {
+        "eventId": {
+          "role": "recording",
+          "type": "int64"
+        }
+      }
+    },
+    {
+      "pattern": "/calendar/events/{eventId}/occurrences/{occurrence}",
+      "resource": "Calendar Events",
+      "operations": {
+        "DELETE": "DeleteCalendarEventOccurrence"
+      },
+      "params": {
+        "eventId": {
+          "role": "parent",
+          "type": "int64"
+        },
+        "occurrence": {
+          "role": "recording",
           "type": "string"
         }
       }

--- a/openapi.json
+++ b/openapi.json
@@ -14,6 +14,99 @@
     }
   },
   "paths": {
+    "/accounts/{accountId}/domains/extenzions/{extenzionId}": {
+      "delete": {
+        "description": "Delete an extenzion. The id is the extenzion's contact id, the one its app_url\ncarries. Answers 204; forbidden when the caller cannot edit the extenzion.",
+        "operationId": "DeleteExtenzion",
+        "parameters": [
+          {
+            "name": "accountId",
+            "in": "path",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "required": true
+          },
+          {
+            "name": "extenzionId",
+            "in": "path",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "DeleteExtenzion 200 response"
+          },
+          "401": {
+            "description": "UnauthorizedError 401 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedErrorResponseContent"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "ForbiddenError 403 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ForbiddenErrorResponseContent"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFoundError 404 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundErrorResponseContent"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "InternalServerError 500 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerErrorResponseContent"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "ServiceUnavailableError 503 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceUnavailableErrorResponseContent"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Extenzions"
+        ],
+        "x-hey-retry": {
+          "maxAttempts": 2,
+          "baseDelayMs": 1000,
+          "backoff": "exponential",
+          "retryOn": [
+            429,
+            503
+          ]
+        }
+      }
+    },
     "/advanced_search.json": {
       "get": {
         "description": "Get the options the advanced search refine form offers.\n\nAdvanced search: message matches grouped by topic as the search page shows them —\nthe topic, its posting id, and the matching entries as summaries (no bodies; read a\nmessage with GetMessage). Refinements are the same query parameters the page uses.\nThe next page, if any, is a Link header.",
@@ -1754,6 +1847,174 @@
         ],
         "x-hey-retry": {
           "maxAttempts": 2,
+          "baseDelayMs": 1000,
+          "backoff": "exponential",
+          "retryOn": [
+            429,
+            503
+          ]
+        }
+      }
+    },
+    "/calendar/events/{eventId}": {
+      "delete": {
+        "description": "Delete a calendar event, cancelling it for every attendee. Answers 204.",
+        "operationId": "DeleteCalendarEvent",
+        "parameters": [
+          {
+            "name": "eventId",
+            "in": "path",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "DeleteCalendarEvent 200 response"
+          },
+          "401": {
+            "description": "UnauthorizedError 401 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedErrorResponseContent"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFoundError 404 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundErrorResponseContent"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "InternalServerError 500 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerErrorResponseContent"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "ServiceUnavailableError 503 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceUnavailableErrorResponseContent"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Calendar Events"
+        ],
+        "x-hey-retry": {
+          "maxAttempts": 3,
+          "baseDelayMs": 1000,
+          "backoff": "exponential",
+          "retryOn": [
+            429,
+            503
+          ]
+        }
+      }
+    },
+    "/calendar/events/{eventId}/occurrences/{occurrence}": {
+      "delete": {
+        "description": "Delete one day of a repeating event, or that day and every one after it.\nAnswers 204. A single day becomes an exception in the series' schedule; with\napply_to_future the series is truncated at the day before, or destroyed if this\nwas its first day.",
+        "operationId": "DeleteCalendarEventOccurrence",
+        "parameters": [
+          {
+            "name": "eventId",
+            "in": "path",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "required": true
+          },
+          {
+            "name": "occurrence",
+            "in": "path",
+            "description": "The day the occurrence falls on, as YYYY-MM-DD.",
+            "schema": {
+              "type": "string",
+              "description": "The day the occurrence falls on, as YYYY-MM-DD."
+            },
+            "required": true
+          },
+          {
+            "name": "apply_to_future",
+            "in": "query",
+            "description": "Remove this day and every one after it. Off, only this day is removed.",
+            "schema": {
+              "type": "boolean",
+              "description": "Remove this day and every one after it. Off, only this day is removed.",
+              "x-go-type-skip-optional-pointer": false
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "DeleteCalendarEventOccurrence 200 response"
+          },
+          "401": {
+            "description": "UnauthorizedError 401 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedErrorResponseContent"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFoundError 404 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundErrorResponseContent"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "InternalServerError 500 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerErrorResponseContent"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "ServiceUnavailableError 503 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceUnavailableErrorResponseContent"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Calendar Events"
+        ],
+        "x-hey-retry": {
+          "maxAttempts": 3,
           "baseDelayMs": 1000,
           "backoff": "exponential",
           "retryOn": [

--- a/spec/excluded-routes.json
+++ b/spec/excluded-routes.json
@@ -520,11 +520,6 @@
     "reason": "phase-2: calendar events"
   },
   {
-    "method": "DELETE",
-    "path": "/calendar/events/{event_id}/occurrences/{occurrence}",
-    "reason": "phase-2: calendar events"
-  },
-  {
     "method": "PATCH",
     "path": "/calendar/events/{event_id}/occurrences/{occurrence}",
     "reason": "phase-2: calendar events"
@@ -537,11 +532,6 @@
   {
     "method": "POST",
     "path": "/calendar/events/{event_id}/outbound_replies",
-    "reason": "phase-2: calendar events"
-  },
-  {
-    "method": "DELETE",
-    "path": "/calendar/events/{id}",
     "reason": "phase-2: calendar events"
   },
   {

--- a/spec/hey.smithy
+++ b/spec/hey.smithy
@@ -250,6 +250,13 @@ service HEY {
         CreateWorkflowStaging
         MoveWorkflowStaging
         GetTopicPublication
+
+        // Calendar Events
+        DeleteCalendarEvent
+        DeleteCalendarEventOccurrence
+
+        // Extenzions
+        DeleteExtenzion
     ]
 }
 
@@ -2135,6 +2142,31 @@ operation DeleteContactNote {
 }
 
 // =============================================================================
+// EXTENZION OPERATIONS
+// =============================================================================
+
+/// Delete an extenzion. The id is the extenzion's contact id, the one its app_url
+/// carries. Answers 204; forbidden when the caller cannot edit the extenzion.
+@idempotent
+@http(method: "DELETE", uri: "/accounts/{accountId}/domains/extenzions/{extenzionId}")
+@tags(["Extenzions"])
+@heyRetry(maxAttempts: 2, baseDelayMs: 1000, backoff: "exponential", retryOn: [429, 503])
+operation DeleteExtenzion {
+    input: DeleteExtenzionInput
+    errors: [UnauthorizedError, ForbiddenError, NotFoundError, InternalServerError, ServiceUnavailableError]
+}
+
+structure DeleteExtenzionInput {
+    @httpLabel
+    @required
+    accountId: Long
+
+    @httpLabel
+    @required
+    extenzionId: Long
+}
+
+// =============================================================================
 // CALENDAR OPERATIONS
 // =============================================================================
 
@@ -2206,6 +2238,54 @@ structure ToggleCalendarInput {
 structure ToggleCalendarOutput {
     @required
     selection: CalendarSelection
+}
+
+// =============================================================================
+// CALENDAR EVENT OPERATIONS
+// =============================================================================
+
+/// Delete a calendar event, cancelling it for every attendee. Answers 204.
+@idempotent
+@http(method: "DELETE", uri: "/calendar/events/{eventId}")
+@tags(["Calendar Events"])
+@heyRetry(maxAttempts: 3, baseDelayMs: 1000, backoff: "exponential", retryOn: [429, 503])
+operation DeleteCalendarEvent {
+    input: DeleteCalendarEventInput
+    errors: [UnauthorizedError, NotFoundError, InternalServerError, ServiceUnavailableError]
+}
+
+structure DeleteCalendarEventInput {
+    @httpLabel
+    @required
+    eventId: Long
+}
+
+/// Delete one day of a repeating event, or that day and every one after it.
+/// Answers 204. A single day becomes an exception in the series' schedule; with
+/// apply_to_future the series is truncated at the day before, or destroyed if this
+/// was its first day.
+@idempotent
+@http(method: "DELETE", uri: "/calendar/events/{eventId}/occurrences/{occurrence}")
+@tags(["Calendar Events"])
+@heyRetry(maxAttempts: 3, baseDelayMs: 1000, backoff: "exponential", retryOn: [429, 503])
+operation DeleteCalendarEventOccurrence {
+    input: DeleteCalendarEventOccurrenceInput
+    errors: [UnauthorizedError, NotFoundError, InternalServerError, ServiceUnavailableError]
+}
+
+structure DeleteCalendarEventOccurrenceInput {
+    @httpLabel
+    @required
+    eventId: Long
+
+    /// The day the occurrence falls on, as YYYY-MM-DD.
+    @httpLabel
+    @required
+    occurrence: String
+
+    /// Remove this day and every one after it. Off, only this day is removed.
+    @httpQuery("apply_to_future")
+    applyToFuture: Boolean
 }
 
 // =============================================================================

--- a/spec/route-coverage.json
+++ b/spec/route-coverage.json
@@ -116,6 +116,16 @@
   },
   {
     "method": "DELETE",
+    "operationId": "DeleteCalendarEvent",
+    "path": "/calendar/events/{eventId}"
+  },
+  {
+    "method": "DELETE",
+    "operationId": "DeleteCalendarEventOccurrence",
+    "path": "/calendar/events/{eventId}/occurrences/{occurrence}"
+  },
+  {
+    "method": "DELETE",
     "operationId": "DeleteCalendarTodo",
     "path": "/calendar/todos/{todoId}"
   },
@@ -128,6 +138,11 @@
     "method": "DELETE",
     "operationId": "DeleteDraft",
     "path": "/entries/drafts/{entryId}"
+  },
+  {
+    "method": "DELETE",
+    "operationId": "DeleteExtenzion",
+    "path": "/accounts/{accountId}/domains/extenzions/{extenzionId}"
   },
   {
     "method": "DELETE",


### PR DESCRIPTION
`Extenzions.Delete`, `CalendarEvents.Delete` and `CalendarEvents.DeleteOccurrence` went through the form client: no `.json` on the path, `Accept: */*`, and success read off the 302 the web form gets. Haystack has answered all three with a JSON branch (`head :no_content`) since 690048ed92, which the pinned route snapshot (2026-08-21) already carries — so the SDK was impersonating a browser for nothing.

## Change

- Model the three as Smithy operations — `DeleteExtenzion`, `DeleteCalendarEvent`, `DeleteCalendarEventOccurrence` — and call the generated client, which puts `.json` on the path and asks for `application/json`. Wrappers keep their signatures, so hey-cli needs no change.
- The occurrence scope rides in the query as a boolean `apply_to_future` (haystack casts it with `ActiveRecord::Type::Boolean`); both scopes are sent explicitly rather than leaving the narrower one to the server's default.
- `openapi.json`, the generated client, `url-routes.json`, `route-coverage.json` and `behavior-model.json` regenerated; the two calendar routes leave `excluded-routes.json`. The extenzion route was never listed there — the reverse drift filter skips `/accounts/`.

## Not in this PR

The rest of the card's inventory has no JSON representation in haystack yet (workflows, stages, stagings, snippets, clips, collection create/collecting, publications, bulk-reply undo's success branch, time-track categories, HEY World posts): they answer only a redirect or a Turbo Stream, so the SDK can't ask for JSON there until the API grows one. That list is on the card as an `[API]` follow-up. `CalendarEvents.Create/Update/UpdateOccurrence` and `Extenzions.Create/Update` already post to `.json` paths and decode JSON — form-encoded bodies, but not browser impersonation — and are left alone here.

## Tests

- Unit tests for the three deletes assert the `.json` path, `Accept: application/json`, and a 204 answer; the occurrence test covers both scopes' `apply_to_future` value.
- Conformance cases at the HEY layer pin the same wire shape (`calendar-events.json`, new `extenzions.json`).
- `make check` green (176 conformance cases).

Basecamp: [\[SDK\] There art multiple SDK methods that request HTML instead of JSON](https://app.basecamp.com/2914079/buckets/48521764/card_tables/cards/10235565108)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
These three deletes now ask for the JSON branch HEY already serves (`204 No Content`) instead of impersonating a web browser through the form client.

- `Extenzions.Delete`, `CalendarEvents.Delete`, and `CalendarEvents.DeleteOccurrence` now go through the generated client, hitting `.json` paths with `Accept: application/json` and reading success from the 204.
- The occurrence scope is sent as an explicit `apply_to_future` boolean query param; both scopes are stated so the server default isn't relied on.
- Public method signatures are unchanged, so `hey-cli` needs no update.
- Generated artifacts (`openapi.json`, Go client, route/behavior files) are regenerated; unit and conformance tests cover the new wire format.

<sup>Written for commit 025233be468389f585cf3472a9177379d5a498b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-sdk/pull/136?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

