### PR TITLE
Generated client honors WithMaxRetries and retries once after a 401 refresh

### DIFF
--- a/conformance/runner/go/main.go
+++ b/conformance/runner/go/main.go
@@ -214,6 +214,7 @@ func runTest(tc TestCase) TestResult {
 	defer server.Close()
 
 	// Create generated client pointing to mock server with auth header
+	credentials := newConformanceCredentials(tc)
 	client, err := generated.NewClient(server.URL,
 		generated.WithRetryConfig(generated.RetryConfig{
 			MaxRetries: 3,
@@ -221,8 +222,10 @@ func runTest(tc TestCase) TestResult {
 			MaxDelay:   30 * time.Second,
 			Multiplier: 2.0,
 		}),
-		generated.WithRequestEditorFn(func(_ context.Context, req *http.Request) error {
-			req.Header.Set("Authorization", "Bearer conformance-test-token")
+		generated.WithAuthRefresher(credentials.refresh),
+		generated.WithRequestEditorFn(func(ctx context.Context, req *http.Request) error {
+			token, _ := credentials.AccessToken(ctx)
+			req.Header.Set("Authorization", "Bearer "+token)
 			req.Header.Set("User-Agent", "hey-sdk-go/conformance")
 			return nil
 		}),
@@ -243,7 +246,7 @@ func runTest(tc TestCase) TestResult {
 	if layer, _ := tc.ConfigOverrides["clientLayer"].(string); layer == "hey" {
 		rootClient := hey.NewClient(
 			&hey.Config{BaseURL: server.URL},
-			&hey.StaticTokenProvider{Token: "conformance-test-token"},
+			credentials,
 			hey.WithMaxRetries(0),
 		)
 		sdkErr = executeHEYOperation(rootClient, ctx, tc)
@@ -251,7 +254,7 @@ func runTest(tc TestCase) TestResult {
 		accountID := getInt64Param(tc.ConfigOverrides, "accountId")
 		rootClient := hey.NewClient(
 			&hey.Config{BaseURL: server.URL},
-			&hey.StaticTokenProvider{Token: "conformance-test-token"},
+			credentials,
 			hey.WithMaxRetries(0),
 		)
 		scopedClient, accountErr := rootClient.ForAccount(ctx, accountID)
@@ -335,6 +338,46 @@ func runTest(tc TestCase) TestResult {
 		Passed:  true,
 		Message: "All assertions passed",
 	}
+}
+
+const (
+	conformanceToken          = "conformance-test-token"
+	conformanceRefreshedToken = "conformance-refreshed-token"
+)
+
+// conformanceCredentials is the token every request goes out with. A case that marks
+// its credentials refreshable (configOverrides.refreshableCredentials) has a 401
+// answered by swapping in the refreshed token; for any other case the refresh fails
+// and the 401 stands.
+type conformanceCredentials struct {
+	mu          sync.Mutex
+	token       string
+	refreshable bool
+}
+
+func newConformanceCredentials(tc TestCase) *conformanceCredentials {
+	refreshable, _ := tc.ConfigOverrides["refreshableCredentials"].(bool)
+	return &conformanceCredentials{token: conformanceToken, refreshable: refreshable}
+}
+
+func (c *conformanceCredentials) AccessToken(context.Context) (string, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.token, nil
+}
+
+func (c *conformanceCredentials) Refresh(context.Context) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if !c.refreshable {
+		return fmt.Errorf("credentials are not refreshable")
+	}
+	c.token = conformanceRefreshedToken
+	return nil
+}
+
+func (c *conformanceCredentials) refresh(ctx context.Context) bool {
+	return c.Refresh(ctx) == nil
 }
 
 // runConfigOverrideTest handles tests that override client configuration
@@ -664,6 +707,19 @@ func checkAssertion(testName string, a Assertion, s checkState) TestResult {
 		}
 		if s.requestHeaders[0].Get(headerName) == "" {
 			return fail(testName, "Expected header %q to be present, but it was not", headerName)
+		}
+
+	case "lastRequestHeader":
+		headerName := a.Path
+		expected, ok := a.Expected.(string)
+		if !ok {
+			return fail(testName, "lastRequestHeader: expected a string value, got %T", a.Expected)
+		}
+		if len(s.requestHeaders) == 0 {
+			return fail(testName, "Expected request with header %q, but no requests were recorded", headerName)
+		}
+		if got := s.requestHeaders[len(s.requestHeaders)-1].Get(headerName); got != expected {
+			return fail(testName, "Expected last request header %q = %q, got %q", headerName, expected, got)
 		}
 
 	case "responseMeta":

--- a/conformance/tests/credential-refresh.json
+++ b/conformance/tests/credential-refresh.json
@@ -1,0 +1,101 @@
+[
+  {
+    "name": "A 401 on a generated read is answered by a refresh and one resend",
+    "description": "Verifies that a generated idempotent operation refreshes credentials on 401 and sends once more with the refreshed token",
+    "operation": "ListBoxes",
+    "method": "GET",
+    "path": "/boxes.json",
+    "configOverrides": {"refreshableCredentials": true},
+    "mockResponses": [
+      {"status": 401, "body": {"error": "Unauthorized"}},
+      {"status": 200, "body": []}
+    ],
+    "assertions": [
+      {"type": "requestCount", "expected": 2},
+      {"type": "statusCode", "expected": 200},
+      {"type": "lastRequestHeader", "path": "Authorization", "expected": "Bearer conformance-refreshed-token"}
+    ],
+    "tags": ["auth", "401", "refresh", "retry"]
+  },
+  {
+    "name": "A 401 on a generated mutation is answered by a refresh and one resend",
+    "description": "Verifies that a generated non-idempotent operation, which is never retried on transient failures, is still sent once more after a 401 refresh with the same body",
+    "operation": "CreateContact",
+    "method": "POST",
+    "path": "/contacts.json",
+    "configOverrides": {"refreshableCredentials": true},
+    "requestBody": {
+      "name": "Jane Dawson",
+      "email_address": "jane@example.com"
+    },
+    "mockResponses": [
+      {"status": 401, "body": {"error": "Unauthorized"}},
+      {"status": 201, "body": {"id": 91824, "name": "Jane Dawson"}}
+    ],
+    "assertions": [
+      {"type": "requestCount", "expected": 2},
+      {"type": "statusCode", "expected": 201},
+      {"type": "lastRequestPath", "expected": "/contacts.json"},
+      {"type": "lastRequestHeader", "path": "Authorization", "expected": "Bearer conformance-refreshed-token"},
+      {"type": "requestBody", "expected": {"contact.name": "Jane Dawson"}}
+    ],
+    "tags": ["auth", "401", "refresh", "retry", "non-idempotent"]
+  },
+  {
+    "name": "A 401 that outlives the refresh is surfaced after the one resend",
+    "description": "Verifies that a second 401 after a successful refresh is surfaced rather than refreshed again",
+    "operation": "ListBoxes",
+    "method": "GET",
+    "path": "/boxes.json",
+    "configOverrides": {"refreshableCredentials": true},
+    "mockResponses": [
+      {"status": 401, "body": {"error": "Unauthorized"}},
+      {"status": 401, "body": {"error": "Unauthorized"}}
+    ],
+    "assertions": [
+      {"type": "requestCount", "expected": 2},
+      {"type": "statusCode", "expected": 401},
+      {"type": "errorField", "path": "httpStatus", "expected": 401}
+    ],
+    "tags": ["auth", "401", "refresh", "retry"]
+  },
+  {
+    "name": "A 401 is not resent when the credentials cannot be refreshed",
+    "description": "Verifies that a 401 stands on the first request when nothing can renew the credentials",
+    "operation": "ListBoxes",
+    "method": "GET",
+    "path": "/boxes.json",
+    "mockResponses": [
+      {"status": 401, "body": {"error": "Unauthorized"}}
+    ],
+    "assertions": [
+      {"type": "requestCount", "expected": 1},
+      {"type": "statusCode", "expected": 401}
+    ],
+    "tags": ["auth", "401", "refresh", "no-retry"]
+  },
+  {
+    "name": "SDK mutations reach the generated refresh path",
+    "description": "Verifies that the hand-written client wires its credential refresh into the generated client, so a service wrapper's mutation is sent once more after a 401 refresh",
+    "operation": "CreateDraft",
+    "method": "POST",
+    "path": "/messages.json",
+    "configOverrides": {"clientLayer": "hey", "refreshableCredentials": true},
+    "requestBody": {
+      "acting_sender_id": 314,
+      "subject": "After the refresh",
+      "content": "Draft body"
+    },
+    "mockResponses": [
+      {"status": 401, "body": {"error": "Unauthorized"}},
+      {"status": 204, "headers": {"Location": "https://app.hey.com/messages/777"}}
+    ],
+    "assertions": [
+      {"type": "requestCount", "expected": 2},
+      {"type": "lastRequestPath", "expected": "/messages.json"},
+      {"type": "lastRequestHeader", "path": "Authorization", "expected": "Bearer conformance-refreshed-token"},
+      {"type": "noError"}
+    ],
+    "tags": ["auth", "401", "refresh", "retry", "sdk-layer"]
+  }
+]

--- a/go/pkg/generated/client.gen.go
+++ b/go/pkg/generated/client.gen.go
@@ -2204,9 +2204,19 @@ func isRetryableStatus(statusCode int) bool {
 }
 
 // doWithRetry executes a request with retry logic for idempotent operations, and sends
-// it once more after a 401 the AuthRefresher was able to answer.
+// it once more after a 401 the AuthRefresher was able to answer. That resend draws on
+// whatever retry budget the operation has left rather than starting a fresh one, and is
+// always granted at least the one attempt.
 func (c *Client) doWithRetry(ctx context.Context, buildRequest func() (*http.Request, error), isIdempotent bool, operationId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	resp, err := c.doAttempts(ctx, buildRequest, isIdempotent, operationId, reqEditors...)
+	maxAttempts := 1
+	if isIdempotent {
+		maxAttempts = c.RetryConfig.MaxRetries + 1
+	}
+	made := 0
+	resp, err := c.doAttempts(ctx, func() (*http.Request, error) {
+		made++
+		return buildRequest()
+	}, maxAttempts, operationId, reqEditors...)
 	if err != nil || resp.StatusCode != http.StatusUnauthorized || c.AuthRefresher == nil || !c.AuthRefresher(ctx) {
 		return resp, err
 	}
@@ -2214,23 +2224,34 @@ func (c *Client) doWithRetry(ctx context.Context, buildRequest func() (*http.Req
 	if c.Logger != nil {
 		c.Logger.Debug("credentials refreshed, retrying", "operation", operationId)
 	}
-	return c.doAttempts(ctx, buildRequest, isIdempotent, operationId, reqEditors...)
+	return c.doAttempts(ctx, buildRequest, max(maxAttempts-made, 1), operationId, reqEditors...)
 }
 
 // resendableBody makes a request body good for more than one send, since every attempt
 // builds its request afresh from the same reader: a seekable body is rewound to where it
-// started, and any other body is held in memory. The returned rewind runs before each build.
-func resendableBody(body io.Reader) (io.Reader, func() error) {
+// started, and any other body is held in memory. The returned rewind runs before each
+// build. The returned finish runs once the last response is in and closes a body that
+// closes: the transport closes whatever body it is handed after each send, so a body
+// that has to survive a resend is kept from it and closed here instead.
+func resendableBody(body io.Reader) (io.Reader, func() error, func()) {
+	finish := func() {
+		if closer, ok := body.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}
 	if body == nil {
-		return nil, func() error { return nil }
+		return nil, func() error { return nil }, finish
 	}
 	if seeker, ok := body.(io.ReadSeeker); ok {
-		start, err := seeker.Seek(0, io.SeekCurrent)
-		if err == nil {
-			return seeker, func() error {
+		if start, err := seeker.Seek(0, io.SeekCurrent); err == nil {
+			rewind := func() error {
 				_, err := seeker.Seek(start, io.SeekStart)
 				return err
 			}
+			if _, closes := body.(io.Closer); closes {
+				return readOnly{seeker}, rewind, finish
+			}
+			return seeker, rewind, finish
 		}
 	}
 	buf, err := io.ReadAll(body)
@@ -2241,16 +2262,16 @@ func resendableBody(body io.Reader) (io.Reader, func() error) {
 		}
 		_, err := held.Seek(0, io.SeekStart)
 		return err
-	}
+	}, finish
 }
 
-// doAttempts runs the retry loop: one attempt for a non-idempotent operation, up to
-// RetryConfig.MaxRetries+1 for an idempotent one.
-func (c *Client) doAttempts(ctx context.Context, buildRequest func() (*http.Request, error), isIdempotent bool, operationId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	maxAttempts := 1
-	if isIdempotent {
-		maxAttempts = c.RetryConfig.MaxRetries + 1
-	}
+// readOnly hides a body's Close from http.NewRequest, which installs an io.ReadCloser
+// as the request body as-is and so hands its closing to the transport.
+type readOnly struct{ io.Reader }
+
+// doAttempts runs the retry loop for up to maxAttempts sends, retrying transient
+// failures with backoff between them.
+func (c *Client) doAttempts(ctx context.Context, buildRequest func() (*http.Request, error), maxAttempts int, operationId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
 
 	var lastResp *http.Response
 	var lastErr error
@@ -2276,8 +2297,8 @@ func (c *Client) doAttempts(ctx context.Context, buildRequest func() (*http.Requ
 					"error", err,
 				)
 			}
-			// Network errors are retryable for idempotent operations
-			if isIdempotent && attempt < maxAttempts {
+			// Network errors are retryable while attempts remain
+			if attempt < maxAttempts {
 				select {
 				case <-ctx.Done():
 					return nil, ctx.Err()
@@ -2306,8 +2327,8 @@ func (c *Client) doAttempts(ctx context.Context, buildRequest func() (*http.Requ
 			)
 		}
 
-		// Don't retry if not idempotent or last attempt
-		if !isIdempotent || attempt >= maxAttempts {
+		// Don't retry past the last attempt
+		if attempt >= maxAttempts {
 			return resp, nil
 		}
 
@@ -2854,7 +2875,8 @@ func (c *Client) GetBox(ctx context.Context, boxId int64, params *GetBoxParams, 
 // CreateBoxDesignationWithBody executes the CreateBoxDesignation operation.
 
 func (c *Client) CreateBoxDesignationWithBody(ctx context.Context, boxId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	body, rewind := resendableBody(body)
+	body, rewind, finish := resendableBody(body)
+	defer finish()
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		if err := rewind(); err != nil {
 			return nil, err
@@ -2888,7 +2910,8 @@ func (c *Client) ListBoxGroups(ctx context.Context, boxId int64, reqEditors ...R
 // CreateBoxGroupWithBody executes the CreateBoxGroup operation.
 
 func (c *Client) CreateBoxGroupWithBody(ctx context.Context, boxId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	body, rewind := resendableBody(body)
+	body, rewind, finish := resendableBody(body)
+	defer finish()
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		if err := rewind(); err != nil {
 			return nil, err
@@ -2938,7 +2961,8 @@ func (c *Client) GetBubblebox(ctx context.Context, params *GetBubbleboxParams, r
 // CreateBulkReplyWithBody executes the CreateBulkReply operation.
 
 func (c *Client) CreateBulkReplyWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	body, rewind := resendableBody(body)
+	body, rewind, finish := resendableBody(body)
+	defer finish()
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		if err := rewind(); err != nil {
 			return nil, err
@@ -3004,7 +3028,8 @@ func (c *Client) GetJournalEntry(ctx context.Context, day string, reqEditors ...
 // UpdateJournalEntryWithBody executes the UpdateJournalEntry operation.
 
 func (c *Client) UpdateJournalEntryWithBody(ctx context.Context, day string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	body, rewind := resendableBody(body)
+	body, rewind, finish := resendableBody(body)
+	defer finish()
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		if err := rewind(); err != nil {
 			return nil, err
@@ -3038,7 +3063,8 @@ func (c *Client) DeleteCalendarEventOccurrence(ctx context.Context, eventId int6
 // CreateHabitWithBody executes the CreateHabit operation.
 
 func (c *Client) CreateHabitWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	body, rewind := resendableBody(body)
+	body, rewind, finish := resendableBody(body)
+	defer finish()
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		if err := rewind(); err != nil {
 			return nil, err
@@ -3064,7 +3090,8 @@ func (c *Client) DeleteHabit(ctx context.Context, habitId int64, reqEditors ...R
 // UpdateHabitWithBody executes the UpdateHabit operation.
 
 func (c *Client) UpdateHabitWithBody(ctx context.Context, habitId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	body, rewind := resendableBody(body)
+	body, rewind, finish := resendableBody(body)
+	defer finish()
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		if err := rewind(); err != nil {
 			return nil, err
@@ -3098,7 +3125,8 @@ func (c *Client) StopHabit(ctx context.Context, habitId int64, reqEditors ...Req
 // UpdateFirstWeekDayWithBody is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) UpdateFirstWeekDayWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	body, rewind := resendableBody(body)
+	body, rewind, finish := resendableBody(body)
+	defer finish()
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		if err := rewind(); err != nil {
 			return nil, err
@@ -3148,7 +3176,8 @@ func (c *Client) ListTimeTracks(ctx context.Context, params *ListTimeTracksParam
 // CreateTimeTrackWithBody executes the CreateTimeTrack operation.
 
 func (c *Client) CreateTimeTrackWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	body, rewind := resendableBody(body)
+	body, rewind, finish := resendableBody(body)
+	defer finish()
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		if err := rewind(); err != nil {
 			return nil, err
@@ -3182,7 +3211,8 @@ func (c *Client) DeleteTimeTrack(ctx context.Context, timeTrackId int64, reqEdit
 // UpdateTimeTrackWithBody is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) UpdateTimeTrackWithBody(ctx context.Context, timeTrackId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	body, rewind := resendableBody(body)
+	body, rewind, finish := resendableBody(body)
+	defer finish()
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		if err := rewind(); err != nil {
 			return nil, err
@@ -3200,7 +3230,8 @@ func (c *Client) UpdateTimeTrack(ctx context.Context, timeTrackId int64, body Up
 // CreateCalendarTodoWithBody executes the CreateCalendarTodo operation.
 
 func (c *Client) CreateCalendarTodoWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	body, rewind := resendableBody(body)
+	body, rewind, finish := resendableBody(body)
+	defer finish()
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		if err := rewind(); err != nil {
 			return nil, err
@@ -3226,7 +3257,8 @@ func (c *Client) DeleteCalendarTodo(ctx context.Context, todoId int64, reqEditor
 // UpdateCalendarTodoWithBody executes the UpdateCalendarTodo operation.
 
 func (c *Client) UpdateCalendarTodoWithBody(ctx context.Context, todoId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	body, rewind := resendableBody(body)
+	body, rewind, finish := resendableBody(body)
+	defer finish()
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		if err := rewind(); err != nil {
 			return nil, err
@@ -3316,7 +3348,8 @@ func (c *Client) GetClearances(ctx context.Context, params *GetClearancesParams,
 // BulkUpdateClearancesWithBody executes the BulkUpdateClearances operation.
 
 func (c *Client) BulkUpdateClearancesWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	body, rewind := resendableBody(body)
+	body, rewind, finish := resendableBody(body)
+	defer finish()
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		if err := rewind(); err != nil {
 			return nil, err
@@ -3342,7 +3375,8 @@ func (c *Client) PuntClearances(ctx context.Context, reqEditors ...RequestEditor
 // UpdateClearanceWithBody executes the UpdateClearance operation.
 
 func (c *Client) UpdateClearanceWithBody(ctx context.Context, clearanceId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	body, rewind := resendableBody(body)
+	body, rewind, finish := resendableBody(body)
+	defer finish()
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		if err := rewind(); err != nil {
 			return nil, err
@@ -3384,7 +3418,8 @@ func (c *Client) GetCollection(ctx context.Context, collectionId int64, params *
 // UpdateCollectionWithBody executes the UpdateCollection operation.
 
 func (c *Client) UpdateCollectionWithBody(ctx context.Context, collectionId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	body, rewind := resendableBody(body)
+	body, rewind, finish := resendableBody(body)
+	defer finish()
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		if err := rewind(); err != nil {
 			return nil, err
@@ -3410,7 +3445,8 @@ func (c *Client) ListContacts(ctx context.Context, params *ListContactsParams, r
 // CreateContactWithBody executes the CreateContact operation.
 
 func (c *Client) CreateContactWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	body, rewind := resendableBody(body)
+	body, rewind, finish := resendableBody(body)
+	defer finish()
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		if err := rewind(); err != nil {
 			return nil, err
@@ -3444,7 +3480,8 @@ func (c *Client) GetContact(ctx context.Context, contactId int64, params *GetCon
 // UpdateContactWithBody executes the UpdateContact operation.
 
 func (c *Client) UpdateContactWithBody(ctx context.Context, contactId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	body, rewind := resendableBody(body)
+	body, rewind, finish := resendableBody(body)
+	defer finish()
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		if err := rewind(); err != nil {
 			return nil, err
@@ -3478,7 +3515,8 @@ func (c *Client) BundleContact(ctx context.Context, contactId int64, reqEditors 
 // UpdateContactClearanceWithBody executes the UpdateContactClearance operation.
 
 func (c *Client) UpdateContactClearanceWithBody(ctx context.Context, contactId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	body, rewind := resendableBody(body)
+	body, rewind, finish := resendableBody(body)
+	defer finish()
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		if err := rewind(); err != nil {
 			return nil, err
@@ -3512,7 +3550,8 @@ func (c *Client) GetContactNote(ctx context.Context, contactId int64, reqEditors
 // UpdateContactNoteWithBody executes the UpdateContactNote operation.
 
 func (c *Client) UpdateContactNoteWithBody(ctx context.Context, contactId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	body, rewind := resendableBody(body)
+	body, rewind, finish := resendableBody(body)
+	defer finish()
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		if err := rewind(); err != nil {
 			return nil, err
@@ -3562,7 +3601,8 @@ func (c *Client) NewEntryForward(ctx context.Context, entryId int64, reqEditors 
 // CreateReplyWithBody executes the CreateReply operation.
 
 func (c *Client) CreateReplyWithBody(ctx context.Context, entryId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	body, rewind := resendableBody(body)
+	body, rewind, finish := resendableBody(body)
+	defer finish()
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		if err := rewind(); err != nil {
 			return nil, err
@@ -3620,7 +3660,8 @@ func (c *Client) GetIdentity(ctx context.Context, reqEditors ...RequestEditorFn)
 // UpdateTimeFormatWithBody is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) UpdateTimeFormatWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	body, rewind := resendableBody(body)
+	body, rewind, finish := resendableBody(body)
+	defer finish()
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		if err := rewind(); err != nil {
 			return nil, err
@@ -3654,7 +3695,8 @@ func (c *Client) GetImboxSeen(ctx context.Context, params *GetImboxSeenParams, r
 // CreateMessageWithBody executes the CreateMessage operation.
 
 func (c *Client) CreateMessageWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	body, rewind := resendableBody(body)
+	body, rewind, finish := resendableBody(body)
+	defer finish()
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		if err := rewind(); err != nil {
 			return nil, err
@@ -3680,7 +3722,8 @@ func (c *Client) GetMessage(ctx context.Context, messageId int64, reqEditors ...
 // UpdateMessageWithBody executes the UpdateMessage operation.
 
 func (c *Client) UpdateMessageWithBody(ctx context.Context, messageId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	body, rewind := resendableBody(body)
+	body, rewind, finish := resendableBody(body)
+	defer finish()
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		if err := rewind(); err != nil {
 			return nil, err
@@ -3714,7 +3757,8 @@ func (c *Client) GetMyClearances(ctx context.Context, params *GetMyClearancesPar
 // UpdateMyClearanceWithBody executes the UpdateMyClearance operation.
 
 func (c *Client) UpdateMyClearanceWithBody(ctx context.Context, clearanceId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	body, rewind := resendableBody(body)
+	body, rewind, finish := resendableBody(body)
+	defer finish()
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		if err := rewind(); err != nil {
 			return nil, err
@@ -3756,7 +3800,8 @@ func (c *Client) RemovePostingsFromBoxGroup(ctx context.Context, params *RemoveP
 // AddPostingsToBoxGroupWithBody executes the AddPostingsToBoxGroup operation.
 
 func (c *Client) AddPostingsToBoxGroupWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	body, rewind := resendableBody(body)
+	body, rewind, finish := resendableBody(body)
+	defer finish()
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		if err := rewind(); err != nil {
 			return nil, err
@@ -3782,7 +3827,8 @@ func (c *Client) CancelPostingsBubbleUp(ctx context.Context, params *CancelPosti
 // SchedulePostingsBubbleUpWithBody executes the SchedulePostingsBubbleUp operation.
 
 func (c *Client) SchedulePostingsBubbleUpWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	body, rewind := resendableBody(body)
+	body, rewind, finish := resendableBody(body)
+	defer finish()
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		if err := rewind(); err != nil {
 			return nil, err
@@ -3800,7 +3846,8 @@ func (c *Client) SchedulePostingsBubbleUp(ctx context.Context, body SchedulePost
 // BubbleUpPostingsNowWithBody executes the BubbleUpPostingsNow operation.
 
 func (c *Client) BubbleUpPostingsNowWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	body, rewind := resendableBody(body)
+	body, rewind, finish := resendableBody(body)
+	defer finish()
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		if err := rewind(); err != nil {
 			return nil, err
@@ -3826,7 +3873,8 @@ func (c *Client) UnfilePostings(ctx context.Context, params *UnfilePostingsParam
 // FilePostingsWithBody executes the FilePostings operation.
 
 func (c *Client) FilePostingsWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	body, rewind := resendableBody(body)
+	body, rewind, finish := resendableBody(body)
+	defer finish()
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		if err := rewind(); err != nil {
 			return nil, err
@@ -3844,7 +3892,8 @@ func (c *Client) FilePostings(ctx context.Context, body FilePostingsJSONRequestB
 // CreateFolderForPostingsWithBody executes the CreateFolderForPostings operation.
 
 func (c *Client) CreateFolderForPostingsWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	body, rewind := resendableBody(body)
+	body, rewind, finish := resendableBody(body)
+	defer finish()
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		if err := rewind(); err != nil {
 			return nil, err
@@ -3862,7 +3911,8 @@ func (c *Client) CreateFolderForPostings(ctx context.Context, body CreateFolderF
 // MovePostingsWithBody executes the MovePostings operation.
 
 func (c *Client) MovePostingsWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	body, rewind := resendableBody(body)
+	body, rewind, finish := resendableBody(body)
+	defer finish()
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		if err := rewind(); err != nil {
 			return nil, err
@@ -3888,7 +3938,8 @@ func (c *Client) UnmutePostings(ctx context.Context, params *UnmutePostingsParam
 // MutePostingsWithBody executes the MutePostings operation.
 
 func (c *Client) MutePostingsWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	body, rewind := resendableBody(body)
+	body, rewind, finish := resendableBody(body)
+	defer finish()
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		if err := rewind(); err != nil {
 			return nil, err
@@ -3906,7 +3957,8 @@ func (c *Client) MutePostings(ctx context.Context, body MutePostingsJSONRequestB
 // MarkPostingsSeenWithBody executes the MarkPostingsSeen operation.
 
 func (c *Client) MarkPostingsSeenWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	body, rewind := resendableBody(body)
+	body, rewind, finish := resendableBody(body)
+	defer finish()
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		if err := rewind(); err != nil {
 			return nil, err
@@ -3924,7 +3976,8 @@ func (c *Client) MarkPostingsSeen(ctx context.Context, body MarkPostingsSeenJSON
 // MarkPostingsSpamWithBody executes the MarkPostingsSpam operation.
 
 func (c *Client) MarkPostingsSpamWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	body, rewind := resendableBody(body)
+	body, rewind, finish := resendableBody(body)
+	defer finish()
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		if err := rewind(); err != nil {
 			return nil, err
@@ -3942,7 +3995,8 @@ func (c *Client) MarkPostingsSpam(ctx context.Context, body MarkPostingsSpamJSON
 // TrashPostingsWithBody executes the TrashPostings operation.
 
 func (c *Client) TrashPostingsWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	body, rewind := resendableBody(body)
+	body, rewind, finish := resendableBody(body)
+	defer finish()
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		if err := rewind(); err != nil {
 			return nil, err
@@ -3960,7 +4014,8 @@ func (c *Client) TrashPostings(ctx context.Context, body TrashPostingsJSONReques
 // MarkPostingsUnseenWithBody executes the MarkPostingsUnseen operation.
 
 func (c *Client) MarkPostingsUnseenWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	body, rewind := resendableBody(body)
+	body, rewind, finish := resendableBody(body)
+	defer finish()
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		if err := rewind(); err != nil {
 			return nil, err
@@ -3986,7 +4041,8 @@ func (c *Client) GetBundleUnseenPostings(ctx context.Context, postingId int64, p
 // CreateDirectUploadWithBody executes the CreateDirectUpload operation.
 
 func (c *Client) CreateDirectUploadWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	body, rewind := resendableBody(body)
+	body, rewind, finish := resendableBody(body)
+	defer finish()
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		if err := rewind(); err != nil {
 			return nil, err
@@ -4036,7 +4092,8 @@ func (c *Client) ListStickies(ctx context.Context, params *ListStickiesParams, r
 // CreateStickyWithBody executes the CreateSticky operation.
 
 func (c *Client) CreateStickyWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	body, rewind := resendableBody(body)
+	body, rewind, finish := resendableBody(body)
+	defer finish()
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		if err := rewind(); err != nil {
 			return nil, err
@@ -4054,7 +4111,8 @@ func (c *Client) CreateSticky(ctx context.Context, body CreateStickyJSONRequestB
 // MoveStickyWithBody executes the MoveSticky operation.
 
 func (c *Client) MoveStickyWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	body, rewind := resendableBody(body)
+	body, rewind, finish := resendableBody(body)
+	defer finish()
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		if err := rewind(); err != nil {
 			return nil, err
@@ -4080,7 +4138,8 @@ func (c *Client) DeleteSticky(ctx context.Context, stickyId int64, reqEditors ..
 // UpdateStickyWithBody executes the UpdateSticky operation.
 
 func (c *Client) UpdateStickyWithBody(ctx context.Context, stickyId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	body, rewind := resendableBody(body)
+	body, rewind, finish := resendableBody(body)
+	defer finish()
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		if err := rewind(); err != nil {
 			return nil, err
@@ -4162,7 +4221,8 @@ func (c *Client) GetTopicEntries(ctx context.Context, topicId int64, params *Get
 // MoveTopicWithBody executes the MoveTopic operation.
 
 func (c *Client) MoveTopicWithBody(ctx context.Context, topicId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	body, rewind := resendableBody(body)
+	body, rewind, finish := resendableBody(body)
+	defer finish()
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		if err := rewind(); err != nil {
 			return nil, err
@@ -4212,7 +4272,8 @@ func (c *Client) TrashTopic(ctx context.Context, topicId int64, params *TrashTop
 // MoveWorkflowStagingWithBody executes the MoveWorkflowStaging operation.
 
 func (c *Client) MoveWorkflowStagingWithBody(ctx context.Context, topicId int64, workflowId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	body, rewind := resendableBody(body)
+	body, rewind, finish := resendableBody(body)
+	defer finish()
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		if err := rewind(); err != nil {
 			return nil, err

--- a/go/pkg/generated/client.gen.go
+++ b/go/pkg/generated/client.gen.go
@@ -2109,6 +2109,12 @@ type Client struct {
 	// RetryConfig for idempotent operations
 	RetryConfig RetryConfig
 
+	// AuthRefresher is asked once when a response is 401. It renews whatever the request
+	// editors authenticate with and reports whether it could; when it could, the request
+	// is built and sent once more. A 401 means the server did not act on the request, so
+	// this retry is safe for non-idempotent operations too (optional).
+	AuthRefresher func(ctx context.Context) bool
+
 	// Logger for debug output (optional)
 	Logger *slog.Logger
 }
@@ -2166,6 +2172,15 @@ func WithRetryConfig(cfg RetryConfig) ClientOption {
 	}
 }
 
+// WithAuthRefresher sets the callback a 401 response consults before the request is
+// sent once more with renewed credentials.
+func WithAuthRefresher(fn func(ctx context.Context) bool) ClientOption {
+	return func(c *Client) error {
+		c.AuthRefresher = fn
+		return nil
+	}
+}
+
 // WithLogger allows setting a custom logger for debug output.
 func WithLogger(logger *slog.Logger) ClientOption {
 	return func(c *Client) error {
@@ -2188,8 +2203,50 @@ func isRetryableStatus(statusCode int) bool {
 	}
 }
 
-// doWithRetry executes a request with retry logic for idempotent operations.
+// doWithRetry executes a request with retry logic for idempotent operations, and sends
+// it once more after a 401 the AuthRefresher was able to answer.
 func (c *Client) doWithRetry(ctx context.Context, buildRequest func() (*http.Request, error), isIdempotent bool, operationId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	resp, err := c.doAttempts(ctx, buildRequest, isIdempotent, operationId, reqEditors...)
+	if err != nil || resp.StatusCode != http.StatusUnauthorized || c.AuthRefresher == nil || !c.AuthRefresher(ctx) {
+		return resp, err
+	}
+	_ = resp.Body.Close()
+	if c.Logger != nil {
+		c.Logger.Debug("credentials refreshed, retrying", "operation", operationId)
+	}
+	return c.doAttempts(ctx, buildRequest, isIdempotent, operationId, reqEditors...)
+}
+
+// resendableBody makes a request body good for more than one send, since every attempt
+// builds its request afresh from the same reader: a seekable body is rewound to where it
+// started, and any other body is held in memory. The returned rewind runs before each build.
+func resendableBody(body io.Reader) (io.Reader, func() error) {
+	if body == nil {
+		return nil, func() error { return nil }
+	}
+	if seeker, ok := body.(io.ReadSeeker); ok {
+		start, err := seeker.Seek(0, io.SeekCurrent)
+		if err == nil {
+			return seeker, func() error {
+				_, err := seeker.Seek(start, io.SeekStart)
+				return err
+			}
+		}
+	}
+	buf, err := io.ReadAll(body)
+	held := bytes.NewReader(buf)
+	return held, func() error {
+		if err != nil {
+			return err
+		}
+		_, err := held.Seek(0, io.SeekStart)
+		return err
+	}
+}
+
+// doAttempts runs the retry loop: one attempt for a non-idempotent operation, up to
+// RetryConfig.MaxRetries+1 for an idempotent one.
+func (c *Client) doAttempts(ctx context.Context, buildRequest func() (*http.Request, error), isIdempotent bool, operationId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	maxAttempts := 1
 	if isIdempotent {
 		maxAttempts = c.RetryConfig.MaxRetries + 1
@@ -2757,2103 +2814,1433 @@ type ClientInterface interface {
 // DeleteExtenzion is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) DeleteExtenzion(ctx context.Context, accountId int64, extenzionId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewDeleteExtenzionRequest(c.Server, accountId, extenzionId)
 	}, true, "DeleteExtenzion", reqEditors...)
-
 }
 
 // AdvancedSearch is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) AdvancedSearch(ctx context.Context, params *AdvancedSearchParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewAdvancedSearchRequest(c.Server, params)
 	}, true, "AdvancedSearch", reqEditors...)
-
 }
 
 // GetAdvancedSearchFilters is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) GetAdvancedSearchFilters(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewGetAdvancedSearchFiltersRequest(c.Server)
 	}, true, "GetAdvancedSearchFilters", reqEditors...)
-
 }
 
 // ListBoxes is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) ListBoxes(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewListBoxesRequest(c.Server)
 	}, true, "ListBoxes", reqEditors...)
-
 }
 
 // GetBox is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) GetBox(ctx context.Context, boxId int64, params *GetBoxParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewGetBoxRequest(c.Server, boxId, params)
 	}, true, "GetBox", reqEditors...)
-
 }
 
 // CreateBoxDesignationWithBody executes the CreateBoxDesignation operation.
 
 func (c *Client) CreateBoxDesignationWithBody(ctx context.Context, boxId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewCreateBoxDesignationRequestWithBody(c.Server, boxId, contentType, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
+	body, rewind := resendableBody(body)
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		if err := rewind(); err != nil {
+			return nil, err
+		}
+		return NewCreateBoxDesignationRequestWithBody(c.Server, boxId, contentType, body)
+	}, false, "CreateBoxDesignation", reqEditors...)
 }
 
 func (c *Client) CreateBoxDesignation(ctx context.Context, boxId int64, body CreateBoxDesignationJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewCreateBoxDesignationRequest(c.Server, boxId, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		return NewCreateBoxDesignationRequest(c.Server, boxId, body)
+	}, false, "CreateBoxDesignation", reqEditors...)
 }
 
 // DeleteBoxDesignation is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) DeleteBoxDesignation(ctx context.Context, boxId int64, designationId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewDeleteBoxDesignationRequest(c.Server, boxId, designationId)
 	}, true, "DeleteBoxDesignation", reqEditors...)
-
 }
 
 // ListBoxGroups is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) ListBoxGroups(ctx context.Context, boxId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewListBoxGroupsRequest(c.Server, boxId)
 	}, true, "ListBoxGroups", reqEditors...)
-
 }
 
 // CreateBoxGroupWithBody executes the CreateBoxGroup operation.
 
 func (c *Client) CreateBoxGroupWithBody(ctx context.Context, boxId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewCreateBoxGroupRequestWithBody(c.Server, boxId, contentType, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
+	body, rewind := resendableBody(body)
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		if err := rewind(); err != nil {
+			return nil, err
+		}
+		return NewCreateBoxGroupRequestWithBody(c.Server, boxId, contentType, body)
+	}, false, "CreateBoxGroup", reqEditors...)
 }
 
 func (c *Client) CreateBoxGroup(ctx context.Context, boxId int64, body CreateBoxGroupJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewCreateBoxGroupRequest(c.Server, boxId, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		return NewCreateBoxGroupRequest(c.Server, boxId, body)
+	}, false, "CreateBoxGroup", reqEditors...)
 }
 
 // DeleteBoxGroup is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) DeleteBoxGroup(ctx context.Context, boxId int64, groupId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewDeleteBoxGroupRequest(c.Server, boxId, groupId)
 	}, true, "DeleteBoxGroup", reqEditors...)
-
 }
 
 // MarkBoxSeen executes the MarkBoxSeen operation.
 
 func (c *Client) MarkBoxSeen(ctx context.Context, boxId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewMarkBoxSeenRequest(c.Server, boxId)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		return NewMarkBoxSeenRequest(c.Server, boxId)
+	}, false, "MarkBoxSeen", reqEditors...)
 }
 
 // GetBoxPostingChanges is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) GetBoxPostingChanges(ctx context.Context, boxId int64, params *GetBoxPostingChangesParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewGetBoxPostingChangesRequest(c.Server, boxId, params)
 	}, true, "GetBoxPostingChanges", reqEditors...)
-
 }
 
 // GetBubblebox is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) GetBubblebox(ctx context.Context, params *GetBubbleboxParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewGetBubbleboxRequest(c.Server, params)
 	}, true, "GetBubblebox", reqEditors...)
-
 }
 
 // CreateBulkReplyWithBody executes the CreateBulkReply operation.
 
 func (c *Client) CreateBulkReplyWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewCreateBulkReplyRequestWithBody(c.Server, contentType, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
+	body, rewind := resendableBody(body)
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		if err := rewind(); err != nil {
+			return nil, err
+		}
+		return NewCreateBulkReplyRequestWithBody(c.Server, contentType, body)
+	}, false, "CreateBulkReply", reqEditors...)
 }
 
 func (c *Client) CreateBulkReply(ctx context.Context, body CreateBulkReplyJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewCreateBulkReplyRequest(c.Server, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		return NewCreateBulkReplyRequest(c.Server, body)
+	}, false, "CreateBulkReply", reqEditors...)
 }
 
 // NewBulkReply is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) NewBulkReply(ctx context.Context, params *NewBulkReplyParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewNewBulkReplyRequest(c.Server, params)
 	}, true, "NewBulkReply", reqEditors...)
-
 }
 
 // ListCalendarDays is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) ListCalendarDays(ctx context.Context, params *ListCalendarDaysParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewListCalendarDaysRequest(c.Server, params)
 	}, true, "ListCalendarDays", reqEditors...)
-
 }
 
 // GetCalendarDay is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) GetCalendarDay(ctx context.Context, day string, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewGetCalendarDayRequest(c.Server, day)
 	}, true, "GetCalendarDay", reqEditors...)
-
 }
 
 // UncompleteHabit is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) UncompleteHabit(ctx context.Context, day string, habitId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewUncompleteHabitRequest(c.Server, day, habitId)
 	}, true, "UncompleteHabit", reqEditors...)
-
 }
 
 // CompleteHabit is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) CompleteHabit(ctx context.Context, day string, habitId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewCompleteHabitRequest(c.Server, day, habitId)
 	}, true, "CompleteHabit", reqEditors...)
-
 }
 
 // GetJournalEntry is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) GetJournalEntry(ctx context.Context, day string, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewGetJournalEntryRequest(c.Server, day)
 	}, true, "GetJournalEntry", reqEditors...)
-
 }
 
 // UpdateJournalEntryWithBody executes the UpdateJournalEntry operation.
 
 func (c *Client) UpdateJournalEntryWithBody(ctx context.Context, day string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewUpdateJournalEntryRequestWithBody(c.Server, day, contentType, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
+	body, rewind := resendableBody(body)
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		if err := rewind(); err != nil {
+			return nil, err
+		}
+		return NewUpdateJournalEntryRequestWithBody(c.Server, day, contentType, body)
+	}, false, "UpdateJournalEntry", reqEditors...)
 }
 
 func (c *Client) UpdateJournalEntry(ctx context.Context, day string, body UpdateJournalEntryJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewUpdateJournalEntryRequest(c.Server, day, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		return NewUpdateJournalEntryRequest(c.Server, day, body)
+	}, false, "UpdateJournalEntry", reqEditors...)
 }
 
 // DeleteCalendarEvent is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) DeleteCalendarEvent(ctx context.Context, eventId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewDeleteCalendarEventRequest(c.Server, eventId)
 	}, true, "DeleteCalendarEvent", reqEditors...)
-
 }
 
 // DeleteCalendarEventOccurrence is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) DeleteCalendarEventOccurrence(ctx context.Context, eventId int64, occurrence string, params *DeleteCalendarEventOccurrenceParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewDeleteCalendarEventOccurrenceRequest(c.Server, eventId, occurrence, params)
 	}, true, "DeleteCalendarEventOccurrence", reqEditors...)
-
 }
 
 // CreateHabitWithBody executes the CreateHabit operation.
 
 func (c *Client) CreateHabitWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewCreateHabitRequestWithBody(c.Server, contentType, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
+	body, rewind := resendableBody(body)
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		if err := rewind(); err != nil {
+			return nil, err
+		}
+		return NewCreateHabitRequestWithBody(c.Server, contentType, body)
+	}, false, "CreateHabit", reqEditors...)
 }
 
 func (c *Client) CreateHabit(ctx context.Context, body CreateHabitJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewCreateHabitRequest(c.Server, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		return NewCreateHabitRequest(c.Server, body)
+	}, false, "CreateHabit", reqEditors...)
 }
 
 // DeleteHabit is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) DeleteHabit(ctx context.Context, habitId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewDeleteHabitRequest(c.Server, habitId)
 	}, true, "DeleteHabit", reqEditors...)
-
 }
 
 // UpdateHabitWithBody executes the UpdateHabit operation.
 
 func (c *Client) UpdateHabitWithBody(ctx context.Context, habitId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewUpdateHabitRequestWithBody(c.Server, habitId, contentType, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
+	body, rewind := resendableBody(body)
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		if err := rewind(); err != nil {
+			return nil, err
+		}
+		return NewUpdateHabitRequestWithBody(c.Server, habitId, contentType, body)
+	}, false, "UpdateHabit", reqEditors...)
 }
 
 func (c *Client) UpdateHabit(ctx context.Context, habitId int64, body UpdateHabitJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewUpdateHabitRequest(c.Server, habitId, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		return NewUpdateHabitRequest(c.Server, habitId, body)
+	}, false, "UpdateHabit", reqEditors...)
 }
 
 // ResumeHabit is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) ResumeHabit(ctx context.Context, habitId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewResumeHabitRequest(c.Server, habitId)
 	}, true, "ResumeHabit", reqEditors...)
-
 }
 
 // StopHabit executes the StopHabit operation.
 
 func (c *Client) StopHabit(ctx context.Context, habitId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewStopHabitRequest(c.Server, habitId)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		return NewStopHabitRequest(c.Server, habitId)
+	}, false, "StopHabit", reqEditors...)
 }
 
 // UpdateFirstWeekDayWithBody is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) UpdateFirstWeekDayWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
+	body, rewind := resendableBody(body)
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		if err := rewind(); err != nil {
+			return nil, err
+		}
 		return NewUpdateFirstWeekDayRequestWithBody(c.Server, contentType, body)
 	}, true, "UpdateFirstWeekDay", reqEditors...)
-
 }
 
 func (c *Client) UpdateFirstWeekDay(ctx context.Context, body UpdateFirstWeekDayJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewUpdateFirstWeekDayRequest(c.Server, body)
 	}, true, "UpdateFirstWeekDay", reqEditors...)
-
 }
 
 // ListJournalEntries is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) ListJournalEntries(ctx context.Context, params *ListJournalEntriesParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewListJournalEntriesRequest(c.Server, params)
 	}, true, "ListJournalEntries", reqEditors...)
-
 }
 
 // GetOngoingTimeTrack is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) GetOngoingTimeTrack(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewGetOngoingTimeTrackRequest(c.Server)
 	}, true, "GetOngoingTimeTrack", reqEditors...)
-
 }
 
 // StartTimeTrack executes the StartTimeTrack operation.
 
 func (c *Client) StartTimeTrack(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewStartTimeTrackRequest(c.Server)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		return NewStartTimeTrackRequest(c.Server)
+	}, false, "StartTimeTrack", reqEditors...)
 }
 
 // ListTimeTracks is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) ListTimeTracks(ctx context.Context, params *ListTimeTracksParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewListTimeTracksRequest(c.Server, params)
 	}, true, "ListTimeTracks", reqEditors...)
-
 }
 
 // CreateTimeTrackWithBody executes the CreateTimeTrack operation.
 
 func (c *Client) CreateTimeTrackWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewCreateTimeTrackRequestWithBody(c.Server, contentType, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
+	body, rewind := resendableBody(body)
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		if err := rewind(); err != nil {
+			return nil, err
+		}
+		return NewCreateTimeTrackRequestWithBody(c.Server, contentType, body)
+	}, false, "CreateTimeTrack", reqEditors...)
 }
 
 func (c *Client) CreateTimeTrack(ctx context.Context, body CreateTimeTrackJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewCreateTimeTrackRequest(c.Server, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		return NewCreateTimeTrackRequest(c.Server, body)
+	}, false, "CreateTimeTrack", reqEditors...)
 }
 
 // ListTimeTrackCategories is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) ListTimeTrackCategories(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewListTimeTrackCategoriesRequest(c.Server)
 	}, true, "ListTimeTrackCategories", reqEditors...)
-
 }
 
 // DeleteTimeTrack is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) DeleteTimeTrack(ctx context.Context, timeTrackId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewDeleteTimeTrackRequest(c.Server, timeTrackId)
 	}, true, "DeleteTimeTrack", reqEditors...)
-
 }
 
 // UpdateTimeTrackWithBody is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) UpdateTimeTrackWithBody(ctx context.Context, timeTrackId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
+	body, rewind := resendableBody(body)
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		if err := rewind(); err != nil {
+			return nil, err
+		}
 		return NewUpdateTimeTrackRequestWithBody(c.Server, timeTrackId, contentType, body)
 	}, true, "UpdateTimeTrack", reqEditors...)
-
 }
 
 func (c *Client) UpdateTimeTrack(ctx context.Context, timeTrackId int64, body UpdateTimeTrackJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewUpdateTimeTrackRequest(c.Server, timeTrackId, body)
 	}, true, "UpdateTimeTrack", reqEditors...)
-
 }
 
 // CreateCalendarTodoWithBody executes the CreateCalendarTodo operation.
 
 func (c *Client) CreateCalendarTodoWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewCreateCalendarTodoRequestWithBody(c.Server, contentType, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
+	body, rewind := resendableBody(body)
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		if err := rewind(); err != nil {
+			return nil, err
+		}
+		return NewCreateCalendarTodoRequestWithBody(c.Server, contentType, body)
+	}, false, "CreateCalendarTodo", reqEditors...)
 }
 
 func (c *Client) CreateCalendarTodo(ctx context.Context, body CreateCalendarTodoJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewCreateCalendarTodoRequest(c.Server, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		return NewCreateCalendarTodoRequest(c.Server, body)
+	}, false, "CreateCalendarTodo", reqEditors...)
 }
 
 // DeleteCalendarTodo is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) DeleteCalendarTodo(ctx context.Context, todoId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewDeleteCalendarTodoRequest(c.Server, todoId)
 	}, true, "DeleteCalendarTodo", reqEditors...)
-
 }
 
 // UpdateCalendarTodoWithBody executes the UpdateCalendarTodo operation.
 
 func (c *Client) UpdateCalendarTodoWithBody(ctx context.Context, todoId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewUpdateCalendarTodoRequestWithBody(c.Server, todoId, contentType, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
+	body, rewind := resendableBody(body)
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		if err := rewind(); err != nil {
+			return nil, err
+		}
+		return NewUpdateCalendarTodoRequestWithBody(c.Server, todoId, contentType, body)
+	}, false, "UpdateCalendarTodo", reqEditors...)
 }
 
 func (c *Client) UpdateCalendarTodo(ctx context.Context, todoId int64, body UpdateCalendarTodoJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewUpdateCalendarTodoRequest(c.Server, todoId, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		return NewUpdateCalendarTodoRequest(c.Server, todoId, body)
+	}, false, "UpdateCalendarTodo", reqEditors...)
 }
 
 // UncompleteCalendarTodo is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) UncompleteCalendarTodo(ctx context.Context, todoId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewUncompleteCalendarTodoRequest(c.Server, todoId)
 	}, true, "UncompleteCalendarTodo", reqEditors...)
-
 }
 
 // CompleteCalendarTodo is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) CompleteCalendarTodo(ctx context.Context, todoId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewCompleteCalendarTodoRequest(c.Server, todoId)
 	}, true, "CompleteCalendarTodo", reqEditors...)
-
 }
 
 // ListCalendarWeeks is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) ListCalendarWeeks(ctx context.Context, params *ListCalendarWeeksParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewListCalendarWeeksRequest(c.Server, params)
 	}, true, "ListCalendarWeeks", reqEditors...)
-
 }
 
 // GetCalendarWeek is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) GetCalendarWeek(ctx context.Context, week string, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewGetCalendarWeekRequest(c.Server, week)
 	}, true, "GetCalendarWeek", reqEditors...)
-
 }
 
 // GetCalendarYear is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) GetCalendarYear(ctx context.Context, year string, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewGetCalendarYearRequest(c.Server, year)
 	}, true, "GetCalendarYear", reqEditors...)
-
 }
 
 // ListCalendars is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) ListCalendars(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewListCalendarsRequest(c.Server)
 	}, true, "ListCalendars", reqEditors...)
-
 }
 
 // GetCalendarRecordings is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) GetCalendarRecordings(ctx context.Context, calendarId int64, params *GetCalendarRecordingsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewGetCalendarRecordingsRequest(c.Server, calendarId, params)
 	}, true, "GetCalendarRecordings", reqEditors...)
-
 }
 
 // ToggleCalendar executes the ToggleCalendar operation.
 
 func (c *Client) ToggleCalendar(ctx context.Context, calendarId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewToggleCalendarRequest(c.Server, calendarId)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		return NewToggleCalendarRequest(c.Server, calendarId)
+	}, false, "ToggleCalendar", reqEditors...)
 }
 
 // GetClearances is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) GetClearances(ctx context.Context, params *GetClearancesParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewGetClearancesRequest(c.Server, params)
 	}, true, "GetClearances", reqEditors...)
-
 }
 
 // BulkUpdateClearancesWithBody executes the BulkUpdateClearances operation.
 
 func (c *Client) BulkUpdateClearancesWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewBulkUpdateClearancesRequestWithBody(c.Server, contentType, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
+	body, rewind := resendableBody(body)
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		if err := rewind(); err != nil {
+			return nil, err
+		}
+		return NewBulkUpdateClearancesRequestWithBody(c.Server, contentType, body)
+	}, false, "BulkUpdateClearances", reqEditors...)
 }
 
 func (c *Client) BulkUpdateClearances(ctx context.Context, body BulkUpdateClearancesJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewBulkUpdateClearancesRequest(c.Server, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		return NewBulkUpdateClearancesRequest(c.Server, body)
+	}, false, "BulkUpdateClearances", reqEditors...)
 }
 
 // PuntClearances executes the PuntClearances operation.
 
 func (c *Client) PuntClearances(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewPuntClearancesRequest(c.Server)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		return NewPuntClearancesRequest(c.Server)
+	}, false, "PuntClearances", reqEditors...)
 }
 
 // UpdateClearanceWithBody executes the UpdateClearance operation.
 
 func (c *Client) UpdateClearanceWithBody(ctx context.Context, clearanceId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewUpdateClearanceRequestWithBody(c.Server, clearanceId, contentType, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
+	body, rewind := resendableBody(body)
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		if err := rewind(); err != nil {
+			return nil, err
+		}
+		return NewUpdateClearanceRequestWithBody(c.Server, clearanceId, contentType, body)
+	}, false, "UpdateClearance", reqEditors...)
 }
 
 func (c *Client) UpdateClearance(ctx context.Context, clearanceId int64, body UpdateClearanceJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewUpdateClearanceRequest(c.Server, clearanceId, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		return NewUpdateClearanceRequest(c.Server, clearanceId, body)
+	}, false, "UpdateClearance", reqEditors...)
 }
 
 // ListClips is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) ListClips(ctx context.Context, params *ListClipsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewListClipsRequest(c.Server, params)
 	}, true, "ListClips", reqEditors...)
-
 }
 
 // ListCollections is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) ListCollections(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewListCollectionsRequest(c.Server)
 	}, true, "ListCollections", reqEditors...)
-
 }
 
 // GetCollection is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) GetCollection(ctx context.Context, collectionId int64, params *GetCollectionParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewGetCollectionRequest(c.Server, collectionId, params)
 	}, true, "GetCollection", reqEditors...)
-
 }
 
 // UpdateCollectionWithBody executes the UpdateCollection operation.
 
 func (c *Client) UpdateCollectionWithBody(ctx context.Context, collectionId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewUpdateCollectionRequestWithBody(c.Server, collectionId, contentType, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
+	body, rewind := resendableBody(body)
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		if err := rewind(); err != nil {
+			return nil, err
+		}
+		return NewUpdateCollectionRequestWithBody(c.Server, collectionId, contentType, body)
+	}, false, "UpdateCollection", reqEditors...)
 }
 
 func (c *Client) UpdateCollection(ctx context.Context, collectionId int64, body UpdateCollectionJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewUpdateCollectionRequest(c.Server, collectionId, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		return NewUpdateCollectionRequest(c.Server, collectionId, body)
+	}, false, "UpdateCollection", reqEditors...)
 }
 
 // ListContacts is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) ListContacts(ctx context.Context, params *ListContactsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewListContactsRequest(c.Server, params)
 	}, true, "ListContacts", reqEditors...)
-
 }
 
 // CreateContactWithBody executes the CreateContact operation.
 
 func (c *Client) CreateContactWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewCreateContactRequestWithBody(c.Server, contentType, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
+	body, rewind := resendableBody(body)
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		if err := rewind(); err != nil {
+			return nil, err
+		}
+		return NewCreateContactRequestWithBody(c.Server, contentType, body)
+	}, false, "CreateContact", reqEditors...)
 }
 
 func (c *Client) CreateContact(ctx context.Context, body CreateContactJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewCreateContactRequest(c.Server, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		return NewCreateContactRequest(c.Server, body)
+	}, false, "CreateContact", reqEditors...)
 }
 
 // HideContact is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) HideContact(ctx context.Context, contactId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewHideContactRequest(c.Server, contactId)
 	}, true, "HideContact", reqEditors...)
-
 }
 
 // GetContact is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) GetContact(ctx context.Context, contactId int64, params *GetContactParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewGetContactRequest(c.Server, contactId, params)
 	}, true, "GetContact", reqEditors...)
-
 }
 
 // UpdateContactWithBody executes the UpdateContact operation.
 
 func (c *Client) UpdateContactWithBody(ctx context.Context, contactId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewUpdateContactRequestWithBody(c.Server, contactId, contentType, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
+	body, rewind := resendableBody(body)
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		if err := rewind(); err != nil {
+			return nil, err
+		}
+		return NewUpdateContactRequestWithBody(c.Server, contactId, contentType, body)
+	}, false, "UpdateContact", reqEditors...)
 }
 
 func (c *Client) UpdateContact(ctx context.Context, contactId int64, body UpdateContactJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewUpdateContactRequest(c.Server, contactId, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		return NewUpdateContactRequest(c.Server, contactId, body)
+	}, false, "UpdateContact", reqEditors...)
 }
 
 // UnbundleContact is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) UnbundleContact(ctx context.Context, contactId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewUnbundleContactRequest(c.Server, contactId)
 	}, true, "UnbundleContact", reqEditors...)
-
 }
 
 // BundleContact executes the BundleContact operation.
 
 func (c *Client) BundleContact(ctx context.Context, contactId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewBundleContactRequest(c.Server, contactId)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		return NewBundleContactRequest(c.Server, contactId)
+	}, false, "BundleContact", reqEditors...)
 }
 
 // UpdateContactClearanceWithBody executes the UpdateContactClearance operation.
 
 func (c *Client) UpdateContactClearanceWithBody(ctx context.Context, contactId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewUpdateContactClearanceRequestWithBody(c.Server, contactId, contentType, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
+	body, rewind := resendableBody(body)
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		if err := rewind(); err != nil {
+			return nil, err
+		}
+		return NewUpdateContactClearanceRequestWithBody(c.Server, contactId, contentType, body)
+	}, false, "UpdateContactClearance", reqEditors...)
 }
 
 func (c *Client) UpdateContactClearance(ctx context.Context, contactId int64, body UpdateContactClearanceJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewUpdateContactClearanceRequest(c.Server, contactId, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		return NewUpdateContactClearanceRequest(c.Server, contactId, body)
+	}, false, "UpdateContactClearance", reqEditors...)
 }
 
 // DeleteContactNote is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) DeleteContactNote(ctx context.Context, contactId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewDeleteContactNoteRequest(c.Server, contactId)
 	}, true, "DeleteContactNote", reqEditors...)
-
 }
 
 // GetContactNote is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) GetContactNote(ctx context.Context, contactId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewGetContactNoteRequest(c.Server, contactId)
 	}, true, "GetContactNote", reqEditors...)
-
 }
 
 // UpdateContactNoteWithBody executes the UpdateContactNote operation.
 
 func (c *Client) UpdateContactNoteWithBody(ctx context.Context, contactId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewUpdateContactNoteRequestWithBody(c.Server, contactId, contentType, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
+	body, rewind := resendableBody(body)
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		if err := rewind(); err != nil {
+			return nil, err
+		}
+		return NewUpdateContactNoteRequestWithBody(c.Server, contactId, contentType, body)
+	}, false, "UpdateContactNote", reqEditors...)
 }
 
 func (c *Client) UpdateContactNote(ctx context.Context, contactId int64, body UpdateContactNoteJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewUpdateContactNoteRequest(c.Server, contactId, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		return NewUpdateContactNoteRequest(c.Server, contactId, body)
+	}, false, "UpdateContactNote", reqEditors...)
 }
 
 // RevealContact executes the RevealContact operation.
 
 func (c *Client) RevealContact(ctx context.Context, contactId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewRevealContactRequest(c.Server, contactId)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		return NewRevealContactRequest(c.Server, contactId)
+	}, false, "RevealContact", reqEditors...)
 }
 
 // ListDrafts is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) ListDrafts(ctx context.Context, params *ListDraftsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewListDraftsRequest(c.Server, params)
 	}, true, "ListDrafts", reqEditors...)
-
 }
 
 // DeleteDraft is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) DeleteDraft(ctx context.Context, entryId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewDeleteDraftRequest(c.Server, entryId)
 	}, true, "DeleteDraft", reqEditors...)
-
 }
 
 // NewEntryForward is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) NewEntryForward(ctx context.Context, entryId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewNewEntryForwardRequest(c.Server, entryId)
 	}, true, "NewEntryForward", reqEditors...)
-
 }
 
 // CreateReplyWithBody executes the CreateReply operation.
 
 func (c *Client) CreateReplyWithBody(ctx context.Context, entryId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewCreateReplyRequestWithBody(c.Server, entryId, contentType, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
+	body, rewind := resendableBody(body)
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		if err := rewind(); err != nil {
+			return nil, err
+		}
+		return NewCreateReplyRequestWithBody(c.Server, entryId, contentType, body)
+	}, false, "CreateReply", reqEditors...)
 }
 
 func (c *Client) CreateReply(ctx context.Context, entryId int64, body CreateReplyJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewCreateReplyRequest(c.Server, entryId, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		return NewCreateReplyRequest(c.Server, entryId, body)
+	}, false, "CreateReply", reqEditors...)
 }
 
 // NewEntryReply is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) NewEntryReply(ctx context.Context, entryId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewNewEntryReplyRequest(c.Server, entryId)
 	}, true, "NewEntryReply", reqEditors...)
-
 }
 
 // MarkEntrySpam is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) MarkEntrySpam(ctx context.Context, entryId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewMarkEntrySpamRequest(c.Server, entryId)
 	}, true, "MarkEntrySpam", reqEditors...)
-
 }
 
 // GetFeedbox is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) GetFeedbox(ctx context.Context, params *GetFeedboxParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewGetFeedboxRequest(c.Server, params)
 	}, true, "GetFeedbox", reqEditors...)
-
 }
 
 // GetFolder is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) GetFolder(ctx context.Context, folderId int64, params *GetFolderParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewGetFolderRequest(c.Server, folderId, params)
 	}, true, "GetFolder", reqEditors...)
-
 }
 
 // GetIdentity is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) GetIdentity(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewGetIdentityRequest(c.Server)
 	}, true, "GetIdentity", reqEditors...)
-
 }
 
 // UpdateTimeFormatWithBody is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) UpdateTimeFormatWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
+	body, rewind := resendableBody(body)
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		if err := rewind(); err != nil {
+			return nil, err
+		}
 		return NewUpdateTimeFormatRequestWithBody(c.Server, contentType, body)
 	}, true, "UpdateTimeFormat", reqEditors...)
-
 }
 
 func (c *Client) UpdateTimeFormat(ctx context.Context, body UpdateTimeFormatJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewUpdateTimeFormatRequest(c.Server, body)
 	}, true, "UpdateTimeFormat", reqEditors...)
-
 }
 
 // GetImbox is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) GetImbox(ctx context.Context, params *GetImboxParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewGetImboxRequest(c.Server, params)
 	}, true, "GetImbox", reqEditors...)
-
 }
 
 // GetImboxSeen is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) GetImboxSeen(ctx context.Context, params *GetImboxSeenParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewGetImboxSeenRequest(c.Server, params)
 	}, true, "GetImboxSeen", reqEditors...)
-
 }
 
 // CreateMessageWithBody executes the CreateMessage operation.
 
 func (c *Client) CreateMessageWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewCreateMessageRequestWithBody(c.Server, contentType, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
+	body, rewind := resendableBody(body)
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		if err := rewind(); err != nil {
+			return nil, err
+		}
+		return NewCreateMessageRequestWithBody(c.Server, contentType, body)
+	}, false, "CreateMessage", reqEditors...)
 }
 
 func (c *Client) CreateMessage(ctx context.Context, body CreateMessageJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewCreateMessageRequest(c.Server, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		return NewCreateMessageRequest(c.Server, body)
+	}, false, "CreateMessage", reqEditors...)
 }
 
 // GetMessage is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) GetMessage(ctx context.Context, messageId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewGetMessageRequest(c.Server, messageId)
 	}, true, "GetMessage", reqEditors...)
-
 }
 
 // UpdateMessageWithBody executes the UpdateMessage operation.
 
 func (c *Client) UpdateMessageWithBody(ctx context.Context, messageId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewUpdateMessageRequestWithBody(c.Server, messageId, contentType, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
+	body, rewind := resendableBody(body)
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		if err := rewind(); err != nil {
+			return nil, err
+		}
+		return NewUpdateMessageRequestWithBody(c.Server, messageId, contentType, body)
+	}, false, "UpdateMessage", reqEditors...)
 }
 
 func (c *Client) UpdateMessage(ctx context.Context, messageId int64, body UpdateMessageJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewUpdateMessageRequest(c.Server, messageId, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		return NewUpdateMessageRequest(c.Server, messageId, body)
+	}, false, "UpdateMessage", reqEditors...)
 }
 
 // GetMessageEdit is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) GetMessageEdit(ctx context.Context, messageId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewGetMessageEditRequest(c.Server, messageId)
 	}, true, "GetMessageEdit", reqEditors...)
-
 }
 
 // GetMyClearances is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) GetMyClearances(ctx context.Context, params *GetMyClearancesParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewGetMyClearancesRequest(c.Server, params)
 	}, true, "GetMyClearances", reqEditors...)
-
 }
 
 // UpdateMyClearanceWithBody executes the UpdateMyClearance operation.
 
 func (c *Client) UpdateMyClearanceWithBody(ctx context.Context, clearanceId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewUpdateMyClearanceRequestWithBody(c.Server, clearanceId, contentType, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
+	body, rewind := resendableBody(body)
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		if err := rewind(); err != nil {
+			return nil, err
+		}
+		return NewUpdateMyClearanceRequestWithBody(c.Server, clearanceId, contentType, body)
+	}, false, "UpdateMyClearance", reqEditors...)
 }
 
 func (c *Client) UpdateMyClearance(ctx context.Context, clearanceId int64, body UpdateMyClearanceJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewUpdateMyClearanceRequest(c.Server, clearanceId, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		return NewUpdateMyClearanceRequest(c.Server, clearanceId, body)
+	}, false, "UpdateMyClearance", reqEditors...)
 }
 
 // GetNavigation is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) GetNavigation(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewGetNavigationRequest(c.Server)
 	}, true, "GetNavigation", reqEditors...)
-
 }
 
 // GetTrailbox is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) GetTrailbox(ctx context.Context, params *GetTrailboxParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewGetTrailboxRequest(c.Server, params)
 	}, true, "GetTrailbox", reqEditors...)
-
 }
 
 // RemovePostingsFromBoxGroup is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) RemovePostingsFromBoxGroup(ctx context.Context, params *RemovePostingsFromBoxGroupParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewRemovePostingsFromBoxGroupRequest(c.Server, params)
 	}, true, "RemovePostingsFromBoxGroup", reqEditors...)
-
 }
 
 // AddPostingsToBoxGroupWithBody executes the AddPostingsToBoxGroup operation.
 
 func (c *Client) AddPostingsToBoxGroupWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewAddPostingsToBoxGroupRequestWithBody(c.Server, contentType, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
+	body, rewind := resendableBody(body)
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		if err := rewind(); err != nil {
+			return nil, err
+		}
+		return NewAddPostingsToBoxGroupRequestWithBody(c.Server, contentType, body)
+	}, false, "AddPostingsToBoxGroup", reqEditors...)
 }
 
 func (c *Client) AddPostingsToBoxGroup(ctx context.Context, body AddPostingsToBoxGroupJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewAddPostingsToBoxGroupRequest(c.Server, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		return NewAddPostingsToBoxGroupRequest(c.Server, body)
+	}, false, "AddPostingsToBoxGroup", reqEditors...)
 }
 
 // CancelPostingsBubbleUp is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) CancelPostingsBubbleUp(ctx context.Context, params *CancelPostingsBubbleUpParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewCancelPostingsBubbleUpRequest(c.Server, params)
 	}, true, "CancelPostingsBubbleUp", reqEditors...)
-
 }
 
 // SchedulePostingsBubbleUpWithBody executes the SchedulePostingsBubbleUp operation.
 
 func (c *Client) SchedulePostingsBubbleUpWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewSchedulePostingsBubbleUpRequestWithBody(c.Server, contentType, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
+	body, rewind := resendableBody(body)
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		if err := rewind(); err != nil {
+			return nil, err
+		}
+		return NewSchedulePostingsBubbleUpRequestWithBody(c.Server, contentType, body)
+	}, false, "SchedulePostingsBubbleUp", reqEditors...)
 }
 
 func (c *Client) SchedulePostingsBubbleUp(ctx context.Context, body SchedulePostingsBubbleUpJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewSchedulePostingsBubbleUpRequest(c.Server, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		return NewSchedulePostingsBubbleUpRequest(c.Server, body)
+	}, false, "SchedulePostingsBubbleUp", reqEditors...)
 }
 
 // BubbleUpPostingsNowWithBody executes the BubbleUpPostingsNow operation.
 
 func (c *Client) BubbleUpPostingsNowWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewBubbleUpPostingsNowRequestWithBody(c.Server, contentType, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
+	body, rewind := resendableBody(body)
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		if err := rewind(); err != nil {
+			return nil, err
+		}
+		return NewBubbleUpPostingsNowRequestWithBody(c.Server, contentType, body)
+	}, false, "BubbleUpPostingsNow", reqEditors...)
 }
 
 func (c *Client) BubbleUpPostingsNow(ctx context.Context, body BubbleUpPostingsNowJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewBubbleUpPostingsNowRequest(c.Server, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		return NewBubbleUpPostingsNowRequest(c.Server, body)
+	}, false, "BubbleUpPostingsNow", reqEditors...)
 }
 
 // UnfilePostings is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) UnfilePostings(ctx context.Context, params *UnfilePostingsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewUnfilePostingsRequest(c.Server, params)
 	}, true, "UnfilePostings", reqEditors...)
-
 }
 
 // FilePostingsWithBody executes the FilePostings operation.
 
 func (c *Client) FilePostingsWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewFilePostingsRequestWithBody(c.Server, contentType, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
+	body, rewind := resendableBody(body)
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		if err := rewind(); err != nil {
+			return nil, err
+		}
+		return NewFilePostingsRequestWithBody(c.Server, contentType, body)
+	}, false, "FilePostings", reqEditors...)
 }
 
 func (c *Client) FilePostings(ctx context.Context, body FilePostingsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewFilePostingsRequest(c.Server, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		return NewFilePostingsRequest(c.Server, body)
+	}, false, "FilePostings", reqEditors...)
 }
 
 // CreateFolderForPostingsWithBody executes the CreateFolderForPostings operation.
 
 func (c *Client) CreateFolderForPostingsWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewCreateFolderForPostingsRequestWithBody(c.Server, contentType, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
+	body, rewind := resendableBody(body)
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		if err := rewind(); err != nil {
+			return nil, err
+		}
+		return NewCreateFolderForPostingsRequestWithBody(c.Server, contentType, body)
+	}, false, "CreateFolderForPostings", reqEditors...)
 }
 
 func (c *Client) CreateFolderForPostings(ctx context.Context, body CreateFolderForPostingsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewCreateFolderForPostingsRequest(c.Server, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		return NewCreateFolderForPostingsRequest(c.Server, body)
+	}, false, "CreateFolderForPostings", reqEditors...)
 }
 
 // MovePostingsWithBody executes the MovePostings operation.
 
 func (c *Client) MovePostingsWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewMovePostingsRequestWithBody(c.Server, contentType, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
+	body, rewind := resendableBody(body)
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		if err := rewind(); err != nil {
+			return nil, err
+		}
+		return NewMovePostingsRequestWithBody(c.Server, contentType, body)
+	}, false, "MovePostings", reqEditors...)
 }
 
 func (c *Client) MovePostings(ctx context.Context, body MovePostingsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewMovePostingsRequest(c.Server, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		return NewMovePostingsRequest(c.Server, body)
+	}, false, "MovePostings", reqEditors...)
 }
 
 // UnmutePostings is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) UnmutePostings(ctx context.Context, params *UnmutePostingsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewUnmutePostingsRequest(c.Server, params)
 	}, true, "UnmutePostings", reqEditors...)
-
 }
 
 // MutePostingsWithBody executes the MutePostings operation.
 
 func (c *Client) MutePostingsWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewMutePostingsRequestWithBody(c.Server, contentType, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
+	body, rewind := resendableBody(body)
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		if err := rewind(); err != nil {
+			return nil, err
+		}
+		return NewMutePostingsRequestWithBody(c.Server, contentType, body)
+	}, false, "MutePostings", reqEditors...)
 }
 
 func (c *Client) MutePostings(ctx context.Context, body MutePostingsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewMutePostingsRequest(c.Server, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		return NewMutePostingsRequest(c.Server, body)
+	}, false, "MutePostings", reqEditors...)
 }
 
 // MarkPostingsSeenWithBody executes the MarkPostingsSeen operation.
 
 func (c *Client) MarkPostingsSeenWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewMarkPostingsSeenRequestWithBody(c.Server, contentType, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
+	body, rewind := resendableBody(body)
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		if err := rewind(); err != nil {
+			return nil, err
+		}
+		return NewMarkPostingsSeenRequestWithBody(c.Server, contentType, body)
+	}, false, "MarkPostingsSeen", reqEditors...)
 }
 
 func (c *Client) MarkPostingsSeen(ctx context.Context, body MarkPostingsSeenJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewMarkPostingsSeenRequest(c.Server, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		return NewMarkPostingsSeenRequest(c.Server, body)
+	}, false, "MarkPostingsSeen", reqEditors...)
 }
 
 // MarkPostingsSpamWithBody executes the MarkPostingsSpam operation.
 
 func (c *Client) MarkPostingsSpamWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewMarkPostingsSpamRequestWithBody(c.Server, contentType, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
+	body, rewind := resendableBody(body)
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		if err := rewind(); err != nil {
+			return nil, err
+		}
+		return NewMarkPostingsSpamRequestWithBody(c.Server, contentType, body)
+	}, false, "MarkPostingsSpam", reqEditors...)
 }
 
 func (c *Client) MarkPostingsSpam(ctx context.Context, body MarkPostingsSpamJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewMarkPostingsSpamRequest(c.Server, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		return NewMarkPostingsSpamRequest(c.Server, body)
+	}, false, "MarkPostingsSpam", reqEditors...)
 }
 
 // TrashPostingsWithBody executes the TrashPostings operation.
 
 func (c *Client) TrashPostingsWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewTrashPostingsRequestWithBody(c.Server, contentType, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
+	body, rewind := resendableBody(body)
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		if err := rewind(); err != nil {
+			return nil, err
+		}
+		return NewTrashPostingsRequestWithBody(c.Server, contentType, body)
+	}, false, "TrashPostings", reqEditors...)
 }
 
 func (c *Client) TrashPostings(ctx context.Context, body TrashPostingsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewTrashPostingsRequest(c.Server, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		return NewTrashPostingsRequest(c.Server, body)
+	}, false, "TrashPostings", reqEditors...)
 }
 
 // MarkPostingsUnseenWithBody executes the MarkPostingsUnseen operation.
 
 func (c *Client) MarkPostingsUnseenWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewMarkPostingsUnseenRequestWithBody(c.Server, contentType, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
+	body, rewind := resendableBody(body)
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		if err := rewind(); err != nil {
+			return nil, err
+		}
+		return NewMarkPostingsUnseenRequestWithBody(c.Server, contentType, body)
+	}, false, "MarkPostingsUnseen", reqEditors...)
 }
 
 func (c *Client) MarkPostingsUnseen(ctx context.Context, body MarkPostingsUnseenJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewMarkPostingsUnseenRequest(c.Server, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		return NewMarkPostingsUnseenRequest(c.Server, body)
+	}, false, "MarkPostingsUnseen", reqEditors...)
 }
 
 // GetBundleUnseenPostings is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) GetBundleUnseenPostings(ctx context.Context, postingId int64, params *GetBundleUnseenPostingsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewGetBundleUnseenPostingsRequest(c.Server, postingId, params)
 	}, true, "GetBundleUnseenPostings", reqEditors...)
-
 }
 
 // CreateDirectUploadWithBody executes the CreateDirectUpload operation.
 
 func (c *Client) CreateDirectUploadWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewCreateDirectUploadRequestWithBody(c.Server, contentType, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
+	body, rewind := resendableBody(body)
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		if err := rewind(); err != nil {
+			return nil, err
+		}
+		return NewCreateDirectUploadRequestWithBody(c.Server, contentType, body)
+	}, false, "CreateDirectUpload", reqEditors...)
 }
 
 func (c *Client) CreateDirectUpload(ctx context.Context, body CreateDirectUploadJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewCreateDirectUploadRequest(c.Server, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		return NewCreateDirectUploadRequest(c.Server, body)
+	}, false, "CreateDirectUpload", reqEditors...)
 }
 
 // GetLaterbox is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) GetLaterbox(ctx context.Context, params *GetLaterboxParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewGetLaterboxRequest(c.Server, params)
 	}, true, "GetLaterbox", reqEditors...)
-
 }
 
 // GetAsidebox is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) GetAsidebox(ctx context.Context, params *GetAsideboxParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewGetAsideboxRequest(c.Server, params)
 	}, true, "GetAsidebox", reqEditors...)
-
 }
 
 // ListSnippets is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) ListSnippets(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewListSnippetsRequest(c.Server)
 	}, true, "ListSnippets", reqEditors...)
-
 }
 
 // ListStickies is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) ListStickies(ctx context.Context, params *ListStickiesParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewListStickiesRequest(c.Server, params)
 	}, true, "ListStickies", reqEditors...)
-
 }
 
 // CreateStickyWithBody executes the CreateSticky operation.
 
 func (c *Client) CreateStickyWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewCreateStickyRequestWithBody(c.Server, contentType, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
+	body, rewind := resendableBody(body)
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		if err := rewind(); err != nil {
+			return nil, err
+		}
+		return NewCreateStickyRequestWithBody(c.Server, contentType, body)
+	}, false, "CreateSticky", reqEditors...)
 }
 
 func (c *Client) CreateSticky(ctx context.Context, body CreateStickyJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewCreateStickyRequest(c.Server, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		return NewCreateStickyRequest(c.Server, body)
+	}, false, "CreateSticky", reqEditors...)
 }
 
 // MoveStickyWithBody executes the MoveSticky operation.
 
 func (c *Client) MoveStickyWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewMoveStickyRequestWithBody(c.Server, contentType, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
+	body, rewind := resendableBody(body)
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		if err := rewind(); err != nil {
+			return nil, err
+		}
+		return NewMoveStickyRequestWithBody(c.Server, contentType, body)
+	}, false, "MoveSticky", reqEditors...)
 }
 
 func (c *Client) MoveSticky(ctx context.Context, body MoveStickyJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewMoveStickyRequest(c.Server, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		return NewMoveStickyRequest(c.Server, body)
+	}, false, "MoveSticky", reqEditors...)
 }
 
 // DeleteSticky is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) DeleteSticky(ctx context.Context, stickyId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewDeleteStickyRequest(c.Server, stickyId)
 	}, true, "DeleteSticky", reqEditors...)
-
 }
 
 // UpdateStickyWithBody executes the UpdateSticky operation.
 
 func (c *Client) UpdateStickyWithBody(ctx context.Context, stickyId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewUpdateStickyRequestWithBody(c.Server, stickyId, contentType, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
+	body, rewind := resendableBody(body)
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		if err := rewind(); err != nil {
+			return nil, err
+		}
+		return NewUpdateStickyRequestWithBody(c.Server, stickyId, contentType, body)
+	}, false, "UpdateSticky", reqEditors...)
 }
 
 func (c *Client) UpdateSticky(ctx context.Context, stickyId int64, body UpdateStickyJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewUpdateStickyRequest(c.Server, stickyId, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		return NewUpdateStickyRequest(c.Server, stickyId, body)
+	}, false, "UpdateSticky", reqEditors...)
 }
 
 // GetEverythingTopics is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) GetEverythingTopics(ctx context.Context, params *GetEverythingTopicsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewGetEverythingTopicsRequest(c.Server, params)
 	}, true, "GetEverythingTopics", reqEditors...)
-
 }
 
 // GetSentTopics is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) GetSentTopics(ctx context.Context, params *GetSentTopicsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewGetSentTopicsRequest(c.Server, params)
 	}, true, "GetSentTopics", reqEditors...)
-
 }
 
 // GetSpamTopics is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) GetSpamTopics(ctx context.Context, params *GetSpamTopicsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewGetSpamTopicsRequest(c.Server, params)
 	}, true, "GetSpamTopics", reqEditors...)
-
 }
 
 // EmptySpam is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) EmptySpam(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewEmptySpamRequest(c.Server)
 	}, true, "EmptySpam", reqEditors...)
-
 }
 
 // GetTrashTopics is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) GetTrashTopics(ctx context.Context, params *GetTrashTopicsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewGetTrashTopicsRequest(c.Server, params)
 	}, true, "GetTrashTopics", reqEditors...)
-
 }
 
 // EmptyTrash is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) EmptyTrash(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewEmptyTrashRequest(c.Server)
 	}, true, "EmptyTrash", reqEditors...)
-
 }
 
 // GetTopic is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) GetTopic(ctx context.Context, topicId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewGetTopicRequest(c.Server, topicId)
 	}, true, "GetTopic", reqEditors...)
-
 }
 
 // GetTopicEntries is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) GetTopicEntries(ctx context.Context, topicId int64, params *GetTopicEntriesParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewGetTopicEntriesRequest(c.Server, topicId, params)
 	}, true, "GetTopicEntries", reqEditors...)
-
 }
 
 // MoveTopicWithBody executes the MoveTopic operation.
 
 func (c *Client) MoveTopicWithBody(ctx context.Context, topicId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewMoveTopicRequestWithBody(c.Server, topicId, contentType, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
+	body, rewind := resendableBody(body)
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		if err := rewind(); err != nil {
+			return nil, err
+		}
+		return NewMoveTopicRequestWithBody(c.Server, topicId, contentType, body)
+	}, false, "MoveTopic", reqEditors...)
 }
 
 func (c *Client) MoveTopic(ctx context.Context, topicId int64, body MoveTopicJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewMoveTopicRequest(c.Server, topicId, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		return NewMoveTopicRequest(c.Server, topicId, body)
+	}, false, "MoveTopic", reqEditors...)
 }
 
 // GetTopicPublication is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) GetTopicPublication(ctx context.Context, topicId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewGetTopicPublicationRequest(c.Server, topicId)
 	}, true, "GetTopicPublication", reqEditors...)
-
 }
 
 // RestoreTopic is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) RestoreTopic(ctx context.Context, topicId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewRestoreTopicRequest(c.Server, topicId)
 	}, true, "RestoreTopic", reqEditors...)
-
 }
 
 // MarkTopicHam is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) MarkTopicHam(ctx context.Context, topicId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewMarkTopicHamRequest(c.Server, topicId)
 	}, true, "MarkTopicHam", reqEditors...)
-
 }
 
 // TrashTopic is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) TrashTopic(ctx context.Context, topicId int64, params *TrashTopicParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewTrashTopicRequest(c.Server, topicId, params)
 	}, true, "TrashTopic", reqEditors...)
-
 }
 
 // MoveWorkflowStagingWithBody executes the MoveWorkflowStaging operation.
 
 func (c *Client) MoveWorkflowStagingWithBody(ctx context.Context, topicId int64, workflowId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewMoveWorkflowStagingRequestWithBody(c.Server, topicId, workflowId, contentType, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
+	body, rewind := resendableBody(body)
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		if err := rewind(); err != nil {
+			return nil, err
+		}
+		return NewMoveWorkflowStagingRequestWithBody(c.Server, topicId, workflowId, contentType, body)
+	}, false, "MoveWorkflowStaging", reqEditors...)
 }
 
 func (c *Client) MoveWorkflowStaging(ctx context.Context, topicId int64, workflowId int64, body MoveWorkflowStagingJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewMoveWorkflowStagingRequest(c.Server, topicId, workflowId, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		return NewMoveWorkflowStagingRequest(c.Server, topicId, workflowId, body)
+	}, false, "MoveWorkflowStaging", reqEditors...)
 }
 
 // CreateWorkflowStaging executes the CreateWorkflowStaging operation.
 
 func (c *Client) CreateWorkflowStaging(ctx context.Context, topicId int64, workflowId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
-	req, err := NewCreateWorkflowStagingRequest(c.Server, topicId, workflowId)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		return NewCreateWorkflowStagingRequest(c.Server, topicId, workflowId)
+	}, false, "CreateWorkflowStaging", reqEditors...)
 }
 
 // GetWorkflow is marked as idempotent and will be retried on transient failures.
 
 func (c *Client) GetWorkflow(ctx context.Context, workflowId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
-
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewGetWorkflowRequest(c.Server, workflowId)
 	}, true, "GetWorkflow", reqEditors...)
-
 }
 
 // NewDeleteExtenzionRequest generates requests for DeleteExtenzion

--- a/go/pkg/hey/client.go
+++ b/go/pkg/hey/client.go
@@ -267,11 +267,13 @@ func (c *Client) initGeneratedClient() {
 		// The generated client runs its own retry loop, so it has to be told what
 		// WithMaxRetries and WithBaseDelay configured or it runs on its own defaults.
 		// Idempotency still gates it: a non-idempotent operation gets one attempt no
-		// matter the count. BaseDelay is held under the generated MaxDelay ceiling since
-		// that loop sleeps BaseDelay verbatim before its first retry.
+		// matter the count. The generated MaxDelay ceiling is lifted to the configured
+		// BaseDelay when that is higher, since the hand-written paths sleep BaseDelay
+		// verbatim and the generated loop must not sleep less than asked.
 		retryCfg := generated.DefaultRetryConfig()
 		retryCfg.MaxRetries = max(c.httpOpts.MaxRetries, 0)
-		retryCfg.BaseDelay = min(max(c.httpOpts.BaseDelay, 0), retryCfg.MaxDelay)
+		retryCfg.BaseDelay = max(c.httpOpts.BaseDelay, 0)
+		retryCfg.MaxDelay = max(retryCfg.MaxDelay, retryCfg.BaseDelay)
 
 		gen, err := generated.NewClientWithResponses(serverURL,
 			generated.WithHTTPClient(c.httpClient),

--- a/go/pkg/hey/client.go
+++ b/go/pkg/hey/client.go
@@ -232,7 +232,6 @@ func NewClient(cfg *Config, tokenProvider TokenProvider, opts ...ClientOption) *
 	return c
 }
 
-// initGeneratedClient initializes the generated OpenAPI client for this account scope.
 // refreshCredentials renews what the next request will authenticate with, and reports
 // whether anything was able to. The strategy is asked before the token provider because a
 // client given both is authenticated by the strategy, so the strategy is what holds the
@@ -247,6 +246,7 @@ func (c *Client) refreshCredentials(ctx context.Context) bool {
 	return false
 }
 
+// initGeneratedClient initializes the generated OpenAPI client for this account scope.
 func (c *Client) initGeneratedClient() {
 	c.genOnce.Do(func() {
 		serverURL := strings.TrimSuffix(c.cfg.BaseURL, "/")
@@ -264,8 +264,19 @@ func (c *Client) initGeneratedClient() {
 			req.Header.Set("Accept", "application/json")
 			return nil
 		}
+		// The generated client runs its own retry loop, so it has to be told what
+		// WithMaxRetries and WithBaseDelay configured or it runs on its own defaults.
+		// Idempotency still gates it: a non-idempotent operation gets one attempt no
+		// matter the count. BaseDelay is held under the generated MaxDelay ceiling since
+		// that loop sleeps BaseDelay verbatim before its first retry.
+		retryCfg := generated.DefaultRetryConfig()
+		retryCfg.MaxRetries = max(c.httpOpts.MaxRetries, 0)
+		retryCfg.BaseDelay = min(max(c.httpOpts.BaseDelay, 0), retryCfg.MaxDelay)
+
 		gen, err := generated.NewClientWithResponses(serverURL,
 			generated.WithHTTPClient(c.httpClient),
+			generated.WithRetryConfig(retryCfg),
+			generated.WithAuthRefresher(c.refreshCredentials),
 			generated.WithRequestEditorFn(authEditor))
 		if err != nil {
 			panic(fmt.Sprintf("hey: failed to create generated client: %v", err))

--- a/go/pkg/hey/generated_client_test.go
+++ b/go/pkg/hey/generated_client_test.go
@@ -6,10 +6,13 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/basecamp/hey-sdk/go/pkg/generated"
 )
 
 // Generated operations run the generated client's own retry loop, so what WithMaxRetries
@@ -147,6 +150,131 @@ func TestGeneratedReaderBodiesSurviveTheRetry(t *testing.T) {
 	}
 	if len(bodies) != 2 || bodies[0] == "" || bodies[0] != bodies[1] {
 		t.Errorf("expected the same body on both sends, got %q", bodies)
+	}
+}
+
+// A body that both seeks and closes, an *os.File say, is kept from the transport so the
+// first send does not close it out from under the resend; it is closed once the last
+// response is in, as the transport would have.
+func TestGeneratedSeekableClosingBodiesSurviveTheRetry(t *testing.T) {
+	var mu sync.Mutex
+	var bodies []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		bodies = append(bodies, string(body))
+		mu.Unlock()
+		if r.Header.Get("Authorization") != "Bearer fresh" {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":1}`)
+	}))
+	t.Cleanup(server.Close)
+
+	file, err := os.CreateTemp(t.TempDir(), "body")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := file.WriteString(`{"title":"Renew","due_on":"2026-09-01"}`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		t.Fatal(err)
+	}
+
+	auth := &refreshingAuth{refreshed: "fresh"}
+	auth.token.Store("stale")
+	root := NewClient(&Config{BaseURL: server.URL}, nil, WithAuthStrategy(auth), WithMaxRetries(0))
+	client := scopedTestClient(root, 42)
+	client.initGeneratedClient()
+
+	resp, err := client.gen.CreateCalendarTodoWithBody(context.Background(), "application/json", file)
+	if err != nil {
+		t.Fatalf("expected the retry after a refresh to succeed: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+	if len(bodies) != 2 || bodies[0] == "" || bodies[0] != bodies[1] {
+		t.Errorf("expected the same body on both sends, got %q", bodies)
+	}
+	if err := file.Close(); !errors.Is(err, os.ErrClosed) {
+		t.Errorf("expected the body to be closed once the response was in, got %v", err)
+	}
+}
+
+// The resend after a refresh draws on the retry budget the operation has left rather
+// than starting a fresh one, and always gets at least the one attempt.
+func TestGeneratedRefreshResendSharesTheRetryBudget(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		maxRetries int
+		statuses   []int
+		succeeds   bool
+	}{
+		{name: "the budget remaining after the 401 carries the resend's transient failures", maxRetries: 3, statuses: []int{401, 503, 503, 200}, succeeds: true},
+		{name: "a budget spent before the 401 still grants the one resend", maxRetries: 1, statuses: []int{503, 401, 200}, succeeds: true},
+		{name: "the resend does not get a budget of its own", maxRetries: 1, statuses: []int{401, 503, 200}, succeeds: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var requests atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				n := int(requests.Add(1))
+				status := http.StatusInternalServerError
+				if n <= len(tc.statuses) {
+					status = tc.statuses[n-1]
+				}
+				if status != http.StatusOK {
+					http.Error(w, http.StatusText(status), status)
+					return
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = io.WriteString(w, `[]`)
+			}))
+			t.Cleanup(server.Close)
+
+			auth := &refreshingAuth{refreshed: "fresh"}
+			auth.token.Store("stale")
+			root := NewClient(&Config{BaseURL: server.URL}, nil, WithAuthStrategy(auth),
+				WithMaxRetries(tc.maxRetries), WithBaseDelay(time.Millisecond))
+			client := scopedTestClient(root, 42)
+
+			_, err := client.Boxes().List(context.Background())
+			if tc.succeeds && err != nil {
+				t.Fatalf("expected the resend to succeed within the budget: %v", err)
+			}
+			if !tc.succeeds && err == nil {
+				t.Fatal("expected the resend's failure to surface once the budget was spent")
+			}
+			wantRequests := int32(len(tc.statuses))
+			if !tc.succeeds {
+				wantRequests--
+			}
+			if got := requests.Load(); got != wantRequests {
+				t.Errorf("requests = %d, want %d", got, wantRequests)
+			}
+		})
+	}
+}
+
+// WithBaseDelay is honored verbatim by the generated loop, which sleeps BaseDelay before
+// its first retry: a delay above the generated MaxDelay ceiling lifts the ceiling rather
+// than being cut down to it.
+func TestGeneratedRetriesHonorBaseDelayAboveTheDefaultCeiling(t *testing.T) {
+	root := NewClient(&Config{BaseURL: "https://example.test"}, &StaticTokenProvider{Token: "token"},
+		WithBaseDelay(45*time.Second))
+	client := scopedTestClient(root, 42)
+	client.initGeneratedClient()
+
+	cfg := client.gen.ClientInterface.(*generated.Client).RetryConfig
+	if cfg.BaseDelay != 45*time.Second {
+		t.Errorf("BaseDelay = %v, want 45s", cfg.BaseDelay)
+	}
+	if cfg.MaxDelay < cfg.BaseDelay {
+		t.Errorf("MaxDelay = %v, below the configured BaseDelay %v", cfg.MaxDelay, cfg.BaseDelay)
 	}
 }
 

--- a/go/pkg/hey/generated_client_test.go
+++ b/go/pkg/hey/generated_client_test.go
@@ -1,0 +1,200 @@
+package hey
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// Generated operations run the generated client's own retry loop, so what WithMaxRetries
+// configured has to reach it: a caller who lowered the cap to fail fast gets that, not the
+// generated default of three.
+func TestGeneratedOperationsHonorMaxRetries(t *testing.T) {
+	for _, tc := range []struct {
+		maxRetries int
+		requests   int32
+	}{
+		{maxRetries: 0, requests: 1},
+		{maxRetries: 2, requests: 3},
+	} {
+		var requests atomic.Int32
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			requests.Add(1)
+			w.WriteHeader(http.StatusServiceUnavailable)
+		}))
+		t.Cleanup(server.Close)
+
+		root := NewClient(&Config{BaseURL: server.URL}, &StaticTokenProvider{Token: "token"},
+			WithMaxRetries(tc.maxRetries), WithBaseDelay(time.Millisecond))
+		client := scopedTestClient(root, 42)
+
+		if _, err := client.Boxes().List(context.Background()); err == nil {
+			t.Fatalf("maxRetries=%d: expected the 503 to surface", tc.maxRetries)
+		}
+		if got := requests.Load(); got != tc.requests {
+			t.Errorf("maxRetries=%d: requests = %d, want %d", tc.maxRetries, got, tc.requests)
+		}
+	}
+}
+
+// A 401 mid-flight is answered by a refresh and one more send, for a generated read...
+func TestGeneratedOperationsRetryOnceAfterRefresh(t *testing.T) {
+	var mu sync.Mutex
+	var seen []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		seen = append(seen, r.Header.Get("Authorization"))
+		mu.Unlock()
+		if r.Header.Get("Authorization") != "Bearer fresh" {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `[]`)
+	}))
+	t.Cleanup(server.Close)
+
+	auth := &refreshingAuth{refreshed: "fresh"}
+	auth.token.Store("stale")
+	root := NewClient(&Config{BaseURL: server.URL}, nil, WithAuthStrategy(auth), WithMaxRetries(0))
+	client := scopedTestClient(root, 42)
+
+	if _, err := client.Boxes().List(context.Background()); err != nil {
+		t.Fatalf("expected the retry after a refresh to succeed: %v", err)
+	}
+	if refreshes := auth.refreshes.Load(); refreshes != 1 {
+		t.Errorf("expected one refresh, got %d", refreshes)
+	}
+	if len(seen) != 2 || seen[0] != "Bearer stale" || seen[1] != "Bearer fresh" {
+		t.Errorf("expected the stale token then the fresh one, got %v", seen)
+	}
+}
+
+// ...and for a generated mutation, which the retry loop otherwise never resends: a 401
+// means the server did nothing with the request, and the body is rebuilt for the retry.
+func TestGeneratedMutationsRetryOnceAfterRefresh(t *testing.T) {
+	var mu sync.Mutex
+	var seen []string
+	var bodies []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		seen = append(seen, r.Header.Get("Authorization"))
+		bodies = append(bodies, string(body))
+		mu.Unlock()
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if r.Header.Get("Authorization") != "Bearer fresh" {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":1}`)
+	}))
+	t.Cleanup(server.Close)
+
+	auth := &refreshingAuth{refreshed: "fresh"}
+	auth.token.Store("stale")
+	root := NewClient(&Config{BaseURL: server.URL}, nil, WithAuthStrategy(auth), WithMaxRetries(0))
+	client := scopedTestClient(root, 42)
+
+	if _, err := client.Boxes().CreateGroup(context.Background(), 7, []int64{1, 2}); err != nil {
+		t.Fatalf("expected the retry after a refresh to succeed: %v", err)
+	}
+	if refreshes := auth.refreshes.Load(); refreshes != 1 {
+		t.Errorf("expected one refresh, got %d", refreshes)
+	}
+	if len(seen) != 2 || seen[0] != "Bearer stale" || seen[1] != "Bearer fresh" {
+		t.Errorf("expected the stale token then the fresh one, got %v", seen)
+	}
+	if len(bodies) != 2 || bodies[0] == "" || bodies[0] != bodies[1] {
+		t.Errorf("expected the same body on both sends, got %q", bodies)
+	}
+}
+
+// A body handed over as a reader is sent whole both times, not drained by the first send.
+func TestGeneratedReaderBodiesSurviveTheRetry(t *testing.T) {
+	var mu sync.Mutex
+	var bodies []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		bodies = append(bodies, string(body))
+		mu.Unlock()
+		if r.Header.Get("Authorization") != "Bearer fresh" {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":1}`)
+	}))
+	t.Cleanup(server.Close)
+
+	auth := &refreshingAuth{refreshed: "fresh"}
+	auth.token.Store("stale")
+	root := NewClient(&Config{BaseURL: server.URL}, nil, WithAuthStrategy(auth), WithMaxRetries(0))
+	client := scopedTestClient(root, 42)
+
+	if _, err := client.CalendarTodos().Create(context.Background(), "Renew", "2026-09-01"); err != nil {
+		t.Fatalf("expected the retry after a refresh to succeed: %v", err)
+	}
+	if len(bodies) != 2 || bodies[0] == "" || bodies[0] != bodies[1] {
+		t.Errorf("expected the same body on both sends, got %q", bodies)
+	}
+}
+
+// A refresh that does not help gets no second refresh: the 401 is surfaced after one retry.
+func TestGeneratedOperationsSurfaceUnauthorizedAfterOneRefresh(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+	}))
+	t.Cleanup(server.Close)
+
+	auth := &refreshingAuth{refreshed: "fresh"}
+	auth.token.Store("stale")
+	root := NewClient(&Config{BaseURL: server.URL}, nil, WithAuthStrategy(auth), WithMaxRetries(3))
+	client := scopedTestClient(root, 42)
+
+	_, err := client.Boxes().List(context.Background())
+	var sdkErr *Error
+	if !errors.As(err, &sdkErr) || sdkErr.Code != CodeAuth {
+		t.Fatalf("expected an authentication error, got %v", err)
+	}
+	if refreshes := auth.refreshes.Load(); refreshes != 1 {
+		t.Errorf("expected one refresh, got %d", refreshes)
+	}
+	if requests.Load() != 2 {
+		t.Errorf("expected the original send and one retry, got %d requests", requests.Load())
+	}
+}
+
+// Nothing to refresh with means nothing to retry with: one request, and the 401 surfaces.
+func TestGeneratedOperationsSurfaceUnauthorizedWhenNothingCanRefresh(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+	}))
+	t.Cleanup(server.Close)
+
+	root := NewClient(&Config{BaseURL: server.URL}, &StaticTokenProvider{Token: "stale"}, WithMaxRetries(3))
+	client := scopedTestClient(root, 42)
+
+	_, err := client.Boxes().List(context.Background())
+	var sdkErr *Error
+	if !errors.As(err, &sdkErr) || sdkErr.Code != CodeAuth {
+		t.Fatalf("expected an authentication error, got %v", err)
+	}
+	if requests.Load() != 1 {
+		t.Errorf("expected the 401 to be surfaced on the first request, got %d requests", requests.Load())
+	}
+}

--- a/go/pkg/hey/generated_client_test.go
+++ b/go/pkg/hey/generated_client_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -203,6 +204,42 @@ func TestGeneratedSeekableClosingBodiesSurviveTheRetry(t *testing.T) {
 	}
 	if err := file.Close(); !errors.Is(err, os.ErrClosed) {
 		t.Errorf("expected the body to be closed once the response was in, got %v", err)
+	}
+}
+
+// A body that cannot seek is held in memory for the resend, and the first send draining
+// the original reader is no loss.
+func TestGeneratedNonSeekableBodiesSurviveTheRetry(t *testing.T) {
+	var mu sync.Mutex
+	var bodies []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		bodies = append(bodies, string(body))
+		mu.Unlock()
+		if r.Header.Get("Authorization") != "Bearer fresh" {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":1}`)
+	}))
+	t.Cleanup(server.Close)
+
+	auth := &refreshingAuth{refreshed: "fresh"}
+	auth.token.Store("stale")
+	root := NewClient(&Config{BaseURL: server.URL}, nil, WithAuthStrategy(auth), WithMaxRetries(0))
+	client := scopedTestClient(root, 42)
+	client.initGeneratedClient()
+
+	body := struct{ io.Reader }{strings.NewReader(`{"title":"Renew","due_on":"2026-09-01"}`)}
+	resp, err := client.gen.CreateCalendarTodoWithBody(context.Background(), "application/json", body)
+	if err != nil {
+		t.Fatalf("expected the retry after a refresh to succeed: %v", err)
+	}
+	_ = resp.Body.Close()
+	if len(bodies) != 2 || bodies[0] == "" || bodies[0] != bodies[1] {
+		t.Errorf("expected the same body on both sends, got %q", bodies)
 	}
 }
 

--- a/go/templates/client.tmpl
+++ b/go/templates/client.tmpl
@@ -146,9 +146,19 @@ func isRetryableStatus(statusCode int) bool {
 }
 
 // doWithRetry executes a request with retry logic for idempotent operations, and sends
-// it once more after a 401 the AuthRefresher was able to answer.
+// it once more after a 401 the AuthRefresher was able to answer. That resend draws on
+// whatever retry budget the operation has left rather than starting a fresh one, and is
+// always granted at least the one attempt.
 func (c *{{ $clientTypeName }}) doWithRetry(ctx context.Context, buildRequest func() (*http.Request, error), isIdempotent bool, operationId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	resp, err := c.doAttempts(ctx, buildRequest, isIdempotent, operationId, reqEditors...)
+	maxAttempts := 1
+	if isIdempotent {
+		maxAttempts = c.RetryConfig.MaxRetries + 1
+	}
+	made := 0
+	resp, err := c.doAttempts(ctx, func() (*http.Request, error) {
+		made++
+		return buildRequest()
+	}, maxAttempts, operationId, reqEditors...)
 	if err != nil || resp.StatusCode != http.StatusUnauthorized || c.AuthRefresher == nil || !c.AuthRefresher(ctx) {
 		return resp, err
 	}
@@ -156,23 +166,34 @@ func (c *{{ $clientTypeName }}) doWithRetry(ctx context.Context, buildRequest fu
 	if c.Logger != nil {
 		c.Logger.Debug("credentials refreshed, retrying", "operation", operationId)
 	}
-	return c.doAttempts(ctx, buildRequest, isIdempotent, operationId, reqEditors...)
+	return c.doAttempts(ctx, buildRequest, max(maxAttempts-made, 1), operationId, reqEditors...)
 }
 
 // resendableBody makes a request body good for more than one send, since every attempt
 // builds its request afresh from the same reader: a seekable body is rewound to where it
-// started, and any other body is held in memory. The returned rewind runs before each build.
-func resendableBody(body io.Reader) (io.Reader, func() error) {
+// started, and any other body is held in memory. The returned rewind runs before each
+// build. The returned finish runs once the last response is in and closes a body that
+// closes: the transport closes whatever body it is handed after each send, so a body
+// that has to survive a resend is kept from it and closed here instead.
+func resendableBody(body io.Reader) (io.Reader, func() error, func()) {
+	finish := func() {
+		if closer, ok := body.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}
 	if body == nil {
-		return nil, func() error { return nil }
+		return nil, func() error { return nil }, finish
 	}
 	if seeker, ok := body.(io.ReadSeeker); ok {
-		start, err := seeker.Seek(0, io.SeekCurrent)
-		if err == nil {
-			return seeker, func() error {
+		if start, err := seeker.Seek(0, io.SeekCurrent); err == nil {
+			rewind := func() error {
 				_, err := seeker.Seek(start, io.SeekStart)
 				return err
 			}
+			if _, closes := body.(io.Closer); closes {
+				return readOnly{seeker}, rewind, finish
+			}
+			return seeker, rewind, finish
 		}
 	}
 	buf, err := io.ReadAll(body)
@@ -183,16 +204,16 @@ func resendableBody(body io.Reader) (io.Reader, func() error) {
 		}
 		_, err := held.Seek(0, io.SeekStart)
 		return err
-	}
+	}, finish
 }
 
-// doAttempts runs the retry loop: one attempt for a non-idempotent operation, up to
-// RetryConfig.MaxRetries+1 for an idempotent one.
-func (c *{{ $clientTypeName }}) doAttempts(ctx context.Context, buildRequest func() (*http.Request, error), isIdempotent bool, operationId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	maxAttempts := 1
-	if isIdempotent {
-		maxAttempts = c.RetryConfig.MaxRetries + 1
-	}
+// readOnly hides a body's Close from http.NewRequest, which installs an io.ReadCloser
+// as the request body as-is and so hands its closing to the transport.
+type readOnly struct{ io.Reader }
+
+// doAttempts runs the retry loop for up to maxAttempts sends, retrying transient
+// failures with backoff between them.
+func (c *{{ $clientTypeName }}) doAttempts(ctx context.Context, buildRequest func() (*http.Request, error), maxAttempts int, operationId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
 
 	var lastResp *http.Response
 	var lastErr error
@@ -218,8 +239,8 @@ func (c *{{ $clientTypeName }}) doAttempts(ctx context.Context, buildRequest fun
 					"error", err,
 				)
 			}
-			// Network errors are retryable for idempotent operations
-			if isIdempotent && attempt < maxAttempts {
+			// Network errors are retryable while attempts remain
+			if attempt < maxAttempts {
 				select {
 				case <-ctx.Done():
 					return nil, ctx.Err()
@@ -248,8 +269,8 @@ func (c *{{ $clientTypeName }}) doAttempts(ctx context.Context, buildRequest fun
 			)
 		}
 
-		// Don't retry if not idempotent or last attempt
-		if !isIdempotent || attempt >= maxAttempts {
+		// Don't retry past the last attempt
+		if attempt >= maxAttempts {
 			return resp, nil
 		}
 
@@ -330,7 +351,8 @@ type ClientInterface interface {
 // {{$opid}}{{if .HasBody}}WithBody{{end}} executes the {{$opid}} operation.
 {{end}}
 func (c *{{ $clientTypeName }}) {{$opid}}{{if .HasBody}}WithBody{{end}}(ctx context.Context{{genParamArgs $pathParams}}{{if $hasParams}}, params *{{$opid}}Params{{end}}{{if .HasBody}}, contentType string, body io.Reader{{end}}, reqEditors... RequestEditorFn) (*http.Response, error) {
-{{if .HasBody}}    body, rewind := resendableBody(body)
+{{if .HasBody}}    body, rewind, finish := resendableBody(body)
+    defer finish()
 {{end}}    return c.doWithRetry(ctx, func() (*http.Request, error) {
 {{if .HasBody}}        if err := rewind(); err != nil {
             return nil, err

--- a/go/templates/client.tmpl
+++ b/go/templates/client.tmpl
@@ -51,6 +51,12 @@ type {{ $clientTypeName }} struct {
 	// RetryConfig for idempotent operations
 	RetryConfig RetryConfig
 
+	// AuthRefresher is asked once when a response is 401. It renews whatever the request
+	// editors authenticate with and reports whether it could; when it could, the request
+	// is built and sent once more. A 401 means the server did not act on the request, so
+	// this retry is safe for non-idempotent operations too (optional).
+	AuthRefresher func(ctx context.Context) bool
+
 	// Logger for debug output (optional)
 	Logger *slog.Logger
 }
@@ -108,6 +114,15 @@ func WithRetryConfig(cfg RetryConfig) ClientOption {
 	}
 }
 
+// WithAuthRefresher sets the callback a 401 response consults before the request is
+// sent once more with renewed credentials.
+func WithAuthRefresher(fn func(ctx context.Context) bool) ClientOption {
+	return func(c *{{ $clientTypeName }}) error {
+		c.AuthRefresher = fn
+		return nil
+	}
+}
+
 // WithLogger allows setting a custom logger for debug output.
 func WithLogger(logger *slog.Logger) ClientOption {
 	return func(c *{{ $clientTypeName }}) error {
@@ -130,8 +145,50 @@ func isRetryableStatus(statusCode int) bool {
 	}
 }
 
-// doWithRetry executes a request with retry logic for idempotent operations.
+// doWithRetry executes a request with retry logic for idempotent operations, and sends
+// it once more after a 401 the AuthRefresher was able to answer.
 func (c *{{ $clientTypeName }}) doWithRetry(ctx context.Context, buildRequest func() (*http.Request, error), isIdempotent bool, operationId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	resp, err := c.doAttempts(ctx, buildRequest, isIdempotent, operationId, reqEditors...)
+	if err != nil || resp.StatusCode != http.StatusUnauthorized || c.AuthRefresher == nil || !c.AuthRefresher(ctx) {
+		return resp, err
+	}
+	_ = resp.Body.Close()
+	if c.Logger != nil {
+		c.Logger.Debug("credentials refreshed, retrying", "operation", operationId)
+	}
+	return c.doAttempts(ctx, buildRequest, isIdempotent, operationId, reqEditors...)
+}
+
+// resendableBody makes a request body good for more than one send, since every attempt
+// builds its request afresh from the same reader: a seekable body is rewound to where it
+// started, and any other body is held in memory. The returned rewind runs before each build.
+func resendableBody(body io.Reader) (io.Reader, func() error) {
+	if body == nil {
+		return nil, func() error { return nil }
+	}
+	if seeker, ok := body.(io.ReadSeeker); ok {
+		start, err := seeker.Seek(0, io.SeekCurrent)
+		if err == nil {
+			return seeker, func() error {
+				_, err := seeker.Seek(start, io.SeekStart)
+				return err
+			}
+		}
+	}
+	buf, err := io.ReadAll(body)
+	held := bytes.NewReader(buf)
+	return held, func() error {
+		if err != nil {
+			return err
+		}
+		_, err := held.Seek(0, io.SeekStart)
+		return err
+	}
+}
+
+// doAttempts runs the retry loop: one attempt for a non-idempotent operation, up to
+// RetryConfig.MaxRetries+1 for an idempotent one.
+func (c *{{ $clientTypeName }}) doAttempts(ctx context.Context, buildRequest func() (*http.Request, error), isIdempotent bool, operationId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	maxAttempts := 1
 	if isIdempotent {
 		maxAttempts = c.RetryConfig.MaxRetries + 1
@@ -273,41 +330,21 @@ type ClientInterface interface {
 // {{$opid}}{{if .HasBody}}WithBody{{end}} executes the {{$opid}} operation.
 {{end}}
 func (c *{{ $clientTypeName }}) {{$opid}}{{if .HasBody}}WithBody{{end}}(ctx context.Context{{genParamArgs $pathParams}}{{if $hasParams}}, params *{{$opid}}Params{{end}}{{if .HasBody}}, contentType string, body io.Reader{{end}}, reqEditors... RequestEditorFn) (*http.Response, error) {
-{{if $isIdempotent}}
-    return c.doWithRetry(ctx, func() (*http.Request, error) {
-        return New{{$opid}}Request{{if .HasBody}}WithBody{{end}}(c.Server{{genParamNames .PathParams}}{{if $hasParams}}, params{{end}}{{if .HasBody}}, contentType, body{{end}})
-    }, true, "{{$opid}}", reqEditors...)
-{{else}}
-    req, err := New{{$opid}}Request{{if .HasBody}}WithBody{{end}}(c.Server{{genParamNames .PathParams}}{{if $hasParams}}, params{{end}}{{if .HasBody}}, contentType, body{{end}})
-    if err != nil {
-        return nil, err
-    }
-    req = req.WithContext(ctx)
-    if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-        return nil, err
-    }
-    return c.Client.Do(req)
-{{end}}
+{{if .HasBody}}    body, rewind := resendableBody(body)
+{{end}}    return c.doWithRetry(ctx, func() (*http.Request, error) {
+{{if .HasBody}}        if err := rewind(); err != nil {
+            return nil, err
+        }
+{{end}}        return New{{$opid}}Request{{if .HasBody}}WithBody{{end}}(c.Server{{genParamNames .PathParams}}{{if $hasParams}}, params{{end}}{{if .HasBody}}, contentType, body{{end}})
+    }, {{$isIdempotent}}, "{{$opid}}", reqEditors...)
 }
 
 {{range .Bodies}}
 {{if .IsSupportedByClient -}}
 func (c *{{ $clientTypeName }}) {{$opid}}{{.Suffix}}(ctx context.Context{{genParamArgs $pathParams}}{{if $hasParams}}, params *{{$opid}}Params{{end}}, body {{$opid}}{{.NameTag}}RequestBody, reqEditors... RequestEditorFn) (*http.Response, error) {
-{{if $isIdempotent}}
     return c.doWithRetry(ctx, func() (*http.Request, error) {
         return New{{$opid}}Request{{.Suffix}}(c.Server{{genParamNames $pathParams}}{{if $hasParams}}, params{{end}}, body)
-    }, true, "{{$opid}}", reqEditors...)
-{{else}}
-    req, err := New{{$opid}}Request{{.Suffix}}(c.Server{{genParamNames $pathParams}}{{if $hasParams}}, params{{end}}, body)
-    if err != nil {
-        return nil, err
-    }
-    req = req.WithContext(ctx)
-    if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-        return nil, err
-    }
-    return c.Client.Do(req)
-{{end}}
+    }, {{$isIdempotent}}, "{{$opid}}", reqEditors...)
 }
 {{end -}}{{/* if .IsSupported */}}
 {{end}}{{/* range .Bodies */}}


### PR DESCRIPTION
Card: https://app.basecamp.com/2914079/buckets/48521764/card_tables/cards/10258105817

Surfaced by reviewers on #136 as pre-existing and spec-wide, so declined there.

**WithMaxRetries was ignored for generated operations.** The generated client runs its own retry loop and `initGeneratedClient` never passed `WithRetryConfig`, so all ~100 generated ops ran on the generated defaults (3 retries, 1s base delay) regardless of what the caller configured. `MaxRetries` and `BaseDelay` are now passed through; idempotency still decides whether a retry happens at all, so nothing changes for a non-idempotent op beyond the point below.

**No 401 refresh path for generated operations.** `AuthManager` refreshes 5 minutes ahead of expiry, but a mid-flight 401 was surfaced as-is where the hand-written `Get`/`Post`/form paths refresh and send once more. The generated client gains an `AuthRefresher` hook (`WithAuthRefresher`), wired to the same `refreshCredentials` the hand-written paths use. A 401 gets one refresh and one more send; a second 401 surfaces. Non-idempotent ops get this too, since a 401 means the server did nothing with the request.

To make the refresh path cover every op, non-idempotent operations now go through `doWithRetry` as well, keeping their single attempt. Bodies handed over as an `io.Reader` (`*WithBody` variants; three hand-written wrappers use them with `bytes.NewReader`) are rewound before each build, or held in memory when not seekable, so a resend carries the body the first send drained. That also closes a latent gap for idempotent `*WithBody` retries, which previously rebuilt from an exhausted reader.

Tests cover: retry count honored (0 and 2), 401 → refresh → retry once for a read and for a mutation, reader bodies sent whole both times, a second 401 surfaces after one refresh, and no retry when nothing can refresh. Each fails against main.

Not included: the `code: 204` DELETE sweep mentioned on the card.

`TMPDIR=/tmp/t make check` green (MVP gate + conformance, 173/173).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the generated client ignoring `WithMaxRetries` and `WithBaseDelay`, so generated operations now honor the caller's retry settings instead of the default three retries. A mid-flight 401 now refreshes credentials once and resends the request, surfacing an error if the second attempt 401s again.

- Non-idempotent operations get this refresh too, since a 401 means the server took no action; all operations run through the same retry path.
- The resend shares the first pass's retry budget instead of starting fresh, and the delay ceiling follows the configured `BaseDelay`.
- Bodies passed as an `io.Reader` are rewound before each send — buffered in memory when not seekable, kept from early closure when they are — so resends carry the full body.
- Tests cover the retry count (0 and 2), refresh-then-resend for a read and a mutation, reader bodies sent whole twice, a second 401 surfacing, no retry when nothing can refresh, and the non-seekable in-memory body branch.

<sup>Written for commit 1ca4ee4d2e7d3b3013422bbfb25c2690eafa0532. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-sdk/pull/137?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

