### PR TITLE
Form requests retry once after a 401 refresh instead of recursing

### DIFF
--- a/conformance/runner/go/main.go
+++ b/conformance/runner/go/main.go
@@ -672,32 +672,22 @@ func checkAssertion(testName string, a Assertion, s checkState) TestResult {
 			}
 		}
 
-	case "requestForm":
+	case "requestForm", "lastRequestForm":
 		// expected: {"field": value, ...}; a null value asserts the field is absent.
+		// requestForm reads the first request's body, lastRequestForm the last's.
 		expected, ok := a.Expected.(map[string]interface{})
 		if !ok {
-			return fail(testName, "requestForm: expected an object, got %T", a.Expected)
+			return fail(testName, "%s: expected an object, got %T", a.Type, a.Expected)
 		}
 		if len(s.requestBodies) == 0 {
 			return fail(testName, "Expected a request, but none were recorded")
 		}
-		values, err := url.ParseQuery(string(s.requestBodies[0]))
-		if err != nil {
-			return fail(testName, "requestForm: request body is not form encoded: %v", err)
+		body := s.requestBodies[0]
+		if a.Type == "lastRequestForm" {
+			body = s.requestBodies[len(s.requestBodies)-1]
 		}
-		for field, want := range expected {
-			if want == nil {
-				if values.Has(field) {
-					return fail(testName, "Expected form field %q to be absent, got %q", field, values.Get(field))
-				}
-				continue
-			}
-			if !values.Has(field) {
-				return fail(testName, "Expected form field %q = %v, but it is absent", field, want)
-			}
-			if got := values.Get(field); got != fmt.Sprint(want) {
-				return fail(testName, "Expected form field %q = %v, got %q", field, want, got)
-			}
+		if err := matchFormFields(body, expected); err != nil {
+			return fail(testName, "%s: %v", a.Type, err)
 		}
 
 	case "headerPresent":
@@ -908,6 +898,27 @@ func compareValues(testName, label string, expected, actual interface{}) *TestRe
 	default:
 		r := fail(testName, "Unsupported type combination for %s: expected %T, actual %T", label, expected, actual)
 		return &r
+	}
+	return nil
+}
+
+// matchFormFields checks a form-encoded body against expected fields; a nil expectation
+// asserts the field is absent.
+func matchFormFields(body []byte, expected map[string]interface{}) error {
+	values, err := url.ParseQuery(string(body))
+	if err != nil {
+		return fmt.Errorf("request body is not form encoded: %w", err)
+	}
+	for field, want := range expected {
+		switch {
+		case want == nil && values.Has(field):
+			return fmt.Errorf("expected form field %q to be absent, got %q", field, values.Get(field))
+		case want == nil:
+		case !values.Has(field):
+			return fmt.Errorf("expected form field %q = %v, but it is absent", field, want)
+		case values.Get(field) != fmt.Sprint(want):
+			return fmt.Errorf("expected form field %q = %v, got %q", field, want, values.Get(field))
+		}
 	}
 	return nil
 }

--- a/conformance/tests/credential-refresh.json
+++ b/conformance/tests/credential-refresh.json
@@ -122,7 +122,7 @@
       {"type": "requestCount", "expected": 2},
       {"type": "lastRequestPath", "expected": "/calendar/events/99.json"},
       {"type": "lastRequestHeader", "path": "Authorization", "expected": "Bearer conformance-refreshed-token"},
-      {"type": "requestForm", "expected": {"calendar_event[summary]": "After the refresh"}},
+      {"type": "lastRequestForm", "expected": {"calendar_event[summary]": "After the refresh"}},
       {"type": "noError"}
     ],
     "tags": ["auth", "401", "refresh", "retry", "sdk-layer", "form"]

--- a/conformance/tests/credential-refresh.json
+++ b/conformance/tests/credential-refresh.json
@@ -97,5 +97,61 @@
       {"type": "noError"}
     ],
     "tags": ["auth", "401", "refresh", "retry", "sdk-layer"]
+  },
+  {
+    "name": "A 401 on an SDK form request is answered by a refresh and one resend",
+    "description": "Verifies that the hand-written client's form path, which does not go through the generated client, sends a form request once more after a 401 refresh with the refreshed token",
+    "operation": "UpdateCalendarEvent",
+    "method": "PATCH",
+    "path": "/calendar/events/{eventId}.json",
+    "pathParams": {"eventId": 99},
+    "configOverrides": {"clientLayer": "hey", "refreshableCredentials": true},
+    "requestBody": {
+      "title": "After the refresh",
+      "starts_at": "2026-09-02",
+      "ends_at": "2026-09-02",
+      "all_day": true,
+      "start_time": "",
+      "end_time": ""
+    },
+    "mockResponses": [
+      {"status": 401, "body": {"error": "Unauthorized"}},
+      {"status": 200, "body": {"id": 99, "title": "After the refresh", "type": "Calendar::Event", "all_day": true}}
+    ],
+    "assertions": [
+      {"type": "requestCount", "expected": 2},
+      {"type": "lastRequestPath", "expected": "/calendar/events/99.json"},
+      {"type": "lastRequestHeader", "path": "Authorization", "expected": "Bearer conformance-refreshed-token"},
+      {"type": "requestForm", "expected": {"calendar_event[summary]": "After the refresh"}},
+      {"type": "noError"}
+    ],
+    "tags": ["auth", "401", "refresh", "retry", "sdk-layer", "form"]
+  },
+  {
+    "name": "A 401 that outlives the refresh on an SDK form request is surfaced after the one resend",
+    "description": "Verifies that the hand-written client's form path surfaces a second 401 after a successful refresh as an auth error rather than refreshing again",
+    "operation": "UpdateCalendarEvent",
+    "method": "PATCH",
+    "path": "/calendar/events/{eventId}.json",
+    "pathParams": {"eventId": 99},
+    "configOverrides": {"clientLayer": "hey", "refreshableCredentials": true},
+    "requestBody": {
+      "title": "After the refresh",
+      "starts_at": "2026-09-02",
+      "ends_at": "2026-09-02",
+      "all_day": true,
+      "start_time": "",
+      "end_time": ""
+    },
+    "mockResponses": [
+      {"status": 401, "body": {"error": "Unauthorized"}},
+      {"status": 401, "body": {"error": "Unauthorized"}}
+    ],
+    "assertions": [
+      {"type": "requestCount", "expected": 2},
+      {"type": "lastRequestHeader", "path": "Authorization", "expected": "Bearer conformance-refreshed-token"},
+      {"type": "errorCode", "expected": "auth_required"}
+    ],
+    "tags": ["auth", "401", "refresh", "retry", "sdk-layer", "form"]
   }
 ]

--- a/go/pkg/hey/auth_strategy_test.go
+++ b/go/pkg/hey/auth_strategy_test.go
@@ -2,8 +2,11 @@ package hey
 
 import (
 	"context"
+	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"sync/atomic"
 	"testing"
 )
@@ -72,5 +75,75 @@ func TestUnauthorizedIsSurfacedWhenNothingCanRefresh(t *testing.T) {
 	}
 	if requests.Load() != 1 {
 		t.Errorf("expected the 401 to be surfaced on the first request, got %d requests", requests.Load())
+	}
+}
+
+// The form path holds its body as bytes so the one resend after a refresh carries it again.
+func TestFormUnauthorizedIsRetriedAfterTheStrategyRefreshes(t *testing.T) {
+	var seen []string
+	var bodies []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen = append(seen, r.Header.Get("Authorization"))
+		body, _ := io.ReadAll(r.Body)
+		bodies = append(bodies, string(body))
+		if r.Header.Get("Authorization") != "Bearer fresh" {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		http.Redirect(w, r, "/things/42", http.StatusSeeOther)
+	}))
+	t.Cleanup(srv.Close)
+
+	auth := &refreshingAuth{refreshed: "fresh"}
+	auth.token.Store("stale")
+	client := NewClient(&Config{BaseURL: srv.URL}, nil, WithAuthStrategy(auth))
+
+	resp, err := client.PostForm(context.Background(), "/things", url.Values{"name": {"x"}})
+	if err != nil {
+		t.Fatalf("expected the retry after a refresh to succeed: %v", err)
+	}
+	if id, err := resp.ExtractID(); err != nil || id != 42 {
+		t.Errorf("expected the redirect to be captured, got %+v (%v)", resp, err)
+	}
+	if refreshes := auth.refreshes.Load(); refreshes != 1 {
+		t.Errorf("expected one refresh, got %d", refreshes)
+	}
+	if len(seen) != 2 || seen[0] != "Bearer stale" || seen[1] != "Bearer fresh" {
+		t.Errorf("expected the stale token then the fresh one, got %v", seen)
+	}
+	if len(bodies) != 2 || bodies[0] != "name=x" || bodies[1] != "name=x" {
+		t.Errorf("expected the body to be sent again on the retry, got %q", bodies)
+	}
+}
+
+// A refresh that does not help gets no second refresh on the form path either: the 401 is
+// surfaced after one resend rather than recursing for as long as refreshes keep succeeding.
+func TestFormUnauthorizedIsSurfacedAfterOneRefresh(t *testing.T) {
+	var requests atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// Answer anything past the one permitted resend with a status the test can tell
+		// apart from the 401, so an unbounded retry fails instead of hanging.
+		if requests.Add(1) > 2 {
+			http.Error(w, "too many attempts", http.StatusTeapot)
+			return
+		}
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+	}))
+	t.Cleanup(srv.Close)
+
+	auth := &refreshingAuth{refreshed: "fresh"}
+	auth.token.Store("stale")
+	client := NewClient(&Config{BaseURL: srv.URL}, nil, WithAuthStrategy(auth))
+
+	_, err := client.PostForm(context.Background(), "/things", url.Values{"name": {"x"}})
+	var apiErr *Error
+	if !errors.As(err, &apiErr) || apiErr.Code != CodeAuth {
+		t.Fatalf("expected an authentication error, got %v", err)
+	}
+	if refreshes := auth.refreshes.Load(); refreshes != 1 {
+		t.Errorf("expected one refresh, got %d", refreshes)
+	}
+	if requests.Load() != 2 {
+		t.Errorf("expected the original request and one resend, got %d requests", requests.Load())
 	}
 }

--- a/go/pkg/hey/auth_strategy_test.go
+++ b/go/pkg/hey/auth_strategy_test.go
@@ -78,7 +78,19 @@ func TestUnauthorizedIsSurfacedWhenNothingCanRefresh(t *testing.T) {
 	}
 }
 
-// The form path holds its body as bytes so the one resend after a refresh carries it again.
+// attemptRecordingHooks keeps the attempt number each request went out with.
+type attemptRecordingHooks struct {
+	NoopHooks
+	attempts []int
+}
+
+func (h *attemptRecordingHooks) OnRequestStart(ctx context.Context, info RequestInfo) context.Context {
+	h.attempts = append(h.attempts, info.Attempt)
+	return ctx
+}
+
+// The form path holds its body as bytes so the one resend after a refresh carries it again,
+// and reports itself as the second attempt.
 func TestFormUnauthorizedIsRetriedAfterTheStrategyRefreshes(t *testing.T) {
 	var seen []string
 	var bodies []string
@@ -96,11 +108,15 @@ func TestFormUnauthorizedIsRetriedAfterTheStrategyRefreshes(t *testing.T) {
 
 	auth := &refreshingAuth{refreshed: "fresh"}
 	auth.token.Store("stale")
-	client := NewClient(&Config{BaseURL: srv.URL}, nil, WithAuthStrategy(auth))
+	hooks := &attemptRecordingHooks{}
+	client := NewClient(&Config{BaseURL: srv.URL}, nil, WithAuthStrategy(auth), WithHooks(hooks))
 
 	resp, err := client.PostForm(context.Background(), "/things", url.Values{"name": {"x"}})
 	if err != nil {
 		t.Fatalf("expected the retry after a refresh to succeed: %v", err)
+	}
+	if len(hooks.attempts) != 2 || hooks.attempts[0] != 1 || hooks.attempts[1] != 2 {
+		t.Errorf("expected the requests to report attempts 1 and 2, got %v", hooks.attempts)
 	}
 	if id, err := resp.ExtractID(); err != nil || id != 42 {
 		t.Errorf("expected the redirect to be captured, got %+v (%v)", resp, err)

--- a/go/pkg/hey/client.go
+++ b/go/pkg/hey/client.go
@@ -448,13 +448,26 @@ func (c *Client) doFormRequest(ctx context.Context, method, path string, values 
 
 // doBodyRequest executes a request whose response is a redirect rather than a document, and
 // captures that redirect instead of following it. The body is held as bytes so a retry after
-// a token refresh can send it again.
+// a token refresh can send it again. Like doRequestURL's mutations, it retries exactly once,
+// and only after a 401 that a refresh answered.
 func (c *Client) doBodyRequest(ctx context.Context, method, path, contentType string, body []byte) (*FormResponse, error) {
 	reqURL, err := c.buildURL(path)
 	if err != nil {
 		return nil, err
 	}
 
+	resp, err := c.sendBodyRequest(ctx, method, reqURL, contentType, body, 1)
+	if apiErr, ok := err.(*Error); ok && apiErr.Retryable && apiErr.Code == CodeAuth {
+		c.logger.Debug("token refreshed, retrying form request", "method", method)
+		return c.sendBodyRequest(ctx, method, reqURL, contentType, body, 2)
+	}
+	return resp, err
+}
+
+// sendBodyRequest sends one attempt of doBodyRequest. A 401 on the first attempt that a
+// credential refresh answers comes back as a retryable auth error, as singleRequest reports
+// it, so the caller decides whether to resend; any other 401 is surfaced as the failure.
+func (c *Client) sendBodyRequest(ctx context.Context, method, reqURL, contentType string, body []byte, attempt int) (*FormResponse, error) {
 	var bodyReader io.Reader
 	if body != nil {
 		bodyReader = bytes.NewReader(body)
@@ -511,9 +524,12 @@ func (c *Client) doBodyRequest(ctx context.Context, method, path, contentType st
 		return &FormResponse{StatusCode: resp.StatusCode, Body: string(responseBody)}, nil
 
 	case resp.StatusCode == http.StatusUnauthorized:
-		// Try token refresh and retry once
-		if c.refreshCredentials(ctx) {
-			return c.doBodyRequest(ctx, method, path, contentType, body)
+		if attempt == 1 && c.refreshCredentials(ctx) {
+			return nil, &Error{
+				Code:      CodeAuth,
+				Message:   "Token refreshed",
+				Retryable: true,
+			}
 		}
 		return nil, ErrAuth("Authentication failed")
 

--- a/go/pkg/hey/client.go
+++ b/go/pkg/hey/client.go
@@ -468,6 +468,8 @@ func (c *Client) doBodyRequest(ctx context.Context, method, path, contentType st
 // credential refresh answers comes back as a retryable auth error, as singleRequest reports
 // it, so the caller decides whether to resend; any other 401 is surfaced as the failure.
 func (c *Client) sendBodyRequest(ctx context.Context, method, reqURL, contentType string, body []byte, attempt int) (*FormResponse, error) {
+	ctx = contextWithAttempt(ctx, attempt)
+
 	var bodyReader io.Reader
 	if body != nil {
 		bodyReader = bytes.NewReader(body)


### PR DESCRIPTION
Hand-written `doBodyRequest` answered a 401 by refreshing credentials and calling itself again with no attempt guard. A strategy whose refresh keeps succeeding against a server that keeps answering 401 recursed without bound. `doRequestURL`/`singleRequest` and the generated client's `doWithRetry` already cap the refresh retry at one attempt; this brings the form/multipart path in line.

`doBodyRequest` now sends through a single-attempt `sendBodyRequest`, which reports a refreshed first-attempt 401 as a retryable auth error exactly as `singleRequest` does. The caller resends once on that signal; a second 401 surfaces as the auth error.

`sendBodyRequest` also puts the attempt number on the request context as `singleRequest` does, so the resend reports itself to `OnRequestStart`/`OnRequestEnd` as attempt 2.

Tests (`auth_strategy_test.go`): 401 then redirect after refresh succeeds with the body resent and the hooks seeing attempts 1 and 2; 401 twice with a refresh that succeeds surfaces `CodeAuth` after one refresh and one resend. The second test fails against the previous code (the server caps attempts with a 418 so it fails rather than hangs).

Conformance (`credential-refresh.json`): two `clientLayer: "hey"` cases drive `UpdateCalendarEvent` through the form path, one resent once with the refreshed token and form body after a 401 refresh, one surfacing `auth_required` when the 401 outlives the refresh.

Card: https://app.basecamp.com/2914079/buckets/48521764/card_tables/cards/10258150962

One concern: `doBodyRequest` does not call `hooks.OnRetry` for the resend, where `doRequestURL` does for its mutation retry. Kept out of scope here since the form path never fired hooks; happy to add it if you'd rather the two paths match on that too.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Form requests (the form/multipart path) now retry exactly once after a 401 refresh instead of recursing without bound. The old behavior could loop forever when a refresh kept succeeding against a server that kept answering 401; the new behavior matches the JSON/URL path (`doRequestURL`/`singleRequest`), and the resend reports itself as attempt 2 so hooks observe it correctly.

- A second 401 after a successful refresh is surfaced as a retryable auth error (`CodeAuth`), not retried again.
- The form body is resent on the retry, and the attempt number is placed on the request context so `OnRequestStart`/`OnRequestEnd` see attempt 2, consistent with `singleRequest`.
- Conformance pins both outcomes: a refresh-answered 401 is resent once with the refreshed token and body, and a 401 that outlives the refresh surfaces `auth_required` after that one resend. The runner's new `lastRequestForm` assertion reads the last request's body so the resend's form is what's checked.
- Unlike `doRequestURL`, the resend does not fire `hooks.OnRetry`; that difference is kept out of scope.

<sup>Written for commit 6d3916d89b8c2eb6911f8b0a04f953d7d72b2a37. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-sdk/pull/138?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

