### PR TITLE
Generated client retries and refresh resends fire Hooks.OnRetry

### DIFF
--- a/go/pkg/generated/client.gen.go
+++ b/go/pkg/generated/client.gen.go
@@ -2242,11 +2242,7 @@ func (c *Client) doWithRetry(ctx context.Context, buildRequest func() (*http.Req
 	if isIdempotent {
 		maxAttempts = c.RetryConfig.MaxRetries + 1
 	}
-	made := 0
-	resp, err := c.doAttempts(ctx, func() (*http.Request, error) {
-		made++
-		return buildRequest()
-	}, 1, maxAttempts, operationId, reqEditors...)
+	resp, req, err := c.doAttempts(ctx, buildRequest, 1, maxAttempts, operationId, reqEditors...)
 	if err != nil || resp.StatusCode != http.StatusUnauthorized || c.AuthRefresher == nil || !c.AuthRefresher(ctx) {
 		return resp, err
 	}
@@ -2254,10 +2250,12 @@ func (c *Client) doWithRetry(ctx context.Context, buildRequest func() (*http.Req
 	if c.Logger != nil {
 		c.Logger.Debug("credentials refreshed, retrying", "operation", operationId)
 	}
-	if c.RetryHook != nil {
-		c.RetryHook(ctx, Retry{Request: resp.Request, Attempt: made + 1, Response: resp})
+	failed := AttemptFromContext(req.Context())
+	if err := c.announce(ctx, Retry{Request: req, Attempt: failed + 1, Response: resp}); err != nil {
+		return nil, err
 	}
-	return c.doAttempts(ctx, buildRequest, made+1, made+max(maxAttempts-made, 1), operationId, reqEditors...)
+	resp, _, err = c.doAttempts(ctx, buildRequest, failed+1, failed+max(maxAttempts-failed, 1), operationId, reqEditors...)
+	return resp, err
 }
 
 // ContextWithAttempt marks the context a request is sent with as the given attempt of its
@@ -2321,22 +2319,26 @@ func resendableBody(body io.Reader) (io.Reader, func() error, func()) {
 type readOnly struct{ io.Reader }
 
 // doAttempts runs the retry loop for the sends numbered first through last, retrying
-// transient failures with backoff between them.
-func (c *Client) doAttempts(ctx context.Context, buildRequest func() (*http.Request, error), first, last int, operationId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+// transient failures with backoff between them. Along with the last response it returns
+// the request that response answered, as the editors left it: a transport is free to
+// leave Response.Request unset, so the loop does not rely on it.
+func (c *Client) doAttempts(ctx context.Context, buildRequest func() (*http.Request, error), first, last int, operationId string, reqEditors ...RequestEditorFn) (*http.Response, *http.Request, error) {
 
 	var lastResp *http.Response
+	var lastReq *http.Request
 	var lastErr error
 	delay := c.RetryConfig.BaseDelay
 
 	for attempt := first; attempt <= last; attempt++ {
 		req, err := buildRequest()
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		req = req.WithContext(ContextWithAttempt(ctx, attempt))
 		if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-			return nil, err
+			return nil, nil, err
 		}
+		lastReq = req
 
 		resp, err := c.Client.Do(req)
 		if err != nil {
@@ -2351,17 +2353,17 @@ func (c *Client) doAttempts(ctx context.Context, buildRequest func() (*http.Requ
 			// Network errors are retryable while attempts remain
 			if attempt < last {
 				if err := c.resend(ctx, Retry{Request: req, Attempt: attempt + 1, Err: err}, delay); err != nil {
-					return nil, err
+					return nil, nil, err
 				}
 				delay = c.nextDelay(delay)
 				continue
 			}
-			return nil, err
+			return nil, nil, err
 		}
 
 		// Success or non-retryable status
 		if !isRetryableStatus(resp.StatusCode) {
-			return resp, nil
+			return resp, req, nil
 		}
 
 		lastResp = resp
@@ -2375,7 +2377,7 @@ func (c *Client) doAttempts(ctx context.Context, buildRequest func() (*http.Requ
 
 		// Don't retry past the last attempt
 		if attempt >= last {
-			return resp, nil
+			return resp, req, nil
 		}
 
 		// Close body before retry
@@ -2392,27 +2394,33 @@ func (c *Client) doAttempts(ctx context.Context, buildRequest func() (*http.Requ
 		}
 
 		if err := c.resend(ctx, Retry{Request: req, Attempt: attempt + 1, Response: resp}, retryDelay); err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		delay = c.nextDelay(delay)
 	}
 
 	if lastErr != nil {
-		return nil, lastErr
+		return nil, nil, lastErr
 	}
-	return lastResp, nil
+	return lastResp, lastReq, nil
+}
+
+// announce tells the RetryHook about the attempt about to be made, and reports the context
+// done if the hook cancelled it, so that no request goes out on a dead context.
+func (c *Client) announce(ctx context.Context, retry Retry) error {
+	if c.RetryHook != nil {
+		c.RetryHook(ctx, retry)
+	}
+	return ctx.Err()
 }
 
 // resend announces the attempt about to be made to the RetryHook and waits out the delay
 // before it, with jitter, unless the context is done first.
 func (c *Client) resend(ctx context.Context, retry Retry, delay time.Duration) error {
-	if c.RetryHook != nil {
-		c.RetryHook(ctx, retry)
-	}
-	// The hook may have cancelled the context. A select with both cases ready picks one
-	// pseudo-randomly, so with an already-elapsed delay the timer could win and one more
-	// request go out on a dead context; check the context first, where nothing competes.
-	if err := ctx.Err(); err != nil {
+	// A select with both cases ready picks one pseudo-randomly, so with an already-elapsed
+	// delay the timer could win over a context the hook cancelled; announce checks the
+	// context first, where nothing competes.
+	if err := c.announce(ctx, retry); err != nil {
 		return err
 	}
 	select {

--- a/go/pkg/generated/client.gen.go
+++ b/go/pkg/generated/client.gen.go
@@ -2115,8 +2115,30 @@ type Client struct {
 	// this retry is safe for non-idempotent operations too (optional).
 	AuthRefresher func(ctx context.Context) bool
 
+	// RetryHook is told about each resend before it is made (optional).
+	RetryHook RetryHook
+
 	// Logger for debug output (optional)
 	Logger *slog.Logger
+}
+
+// RetryHook is told about a resend before it is made. It is not called for a failure that
+// is not resent.
+type RetryHook func(ctx context.Context, retry Retry)
+
+// Retry describes a resend about to be made.
+type Retry struct {
+	// Request is the request that just went out, as the editors left it.
+	Request *http.Request
+	// Attempt is the number of the attempt about to be made, counting from 1 across the
+	// whole operation, refresh resend included.
+	Attempt int
+	// Response is what the last attempt was answered with, its body already closed: a
+	// status the client retries on, or the 401 a credential refresh answered. It is nil
+	// when the attempt failed in the transport instead.
+	Response *http.Response
+	// Err is the transport's error when the last attempt never got a response.
+	Err error
 }
 
 // ClientOption allows setting custom parameters during construction
@@ -2181,6 +2203,14 @@ func WithAuthRefresher(fn func(ctx context.Context) bool) ClientOption {
 	}
 }
 
+// WithRetryHook sets the callback told about each resend before it is made.
+func WithRetryHook(fn RetryHook) ClientOption {
+	return func(c *Client) error {
+		c.RetryHook = fn
+		return nil
+	}
+}
+
 // WithLogger allows setting a custom logger for debug output.
 func WithLogger(logger *slog.Logger) ClientOption {
 	return func(c *Client) error {
@@ -2216,7 +2246,7 @@ func (c *Client) doWithRetry(ctx context.Context, buildRequest func() (*http.Req
 	resp, err := c.doAttempts(ctx, func() (*http.Request, error) {
 		made++
 		return buildRequest()
-	}, maxAttempts, operationId, reqEditors...)
+	}, 1, maxAttempts, operationId, reqEditors...)
 	if err != nil || resp.StatusCode != http.StatusUnauthorized || c.AuthRefresher == nil || !c.AuthRefresher(ctx) {
 		return resp, err
 	}
@@ -2224,8 +2254,29 @@ func (c *Client) doWithRetry(ctx context.Context, buildRequest func() (*http.Req
 	if c.Logger != nil {
 		c.Logger.Debug("credentials refreshed, retrying", "operation", operationId)
 	}
-	return c.doAttempts(ctx, buildRequest, max(maxAttempts-made, 1), operationId, reqEditors...)
+	if c.RetryHook != nil {
+		c.RetryHook(ctx, Retry{Request: resp.Request, Attempt: made + 1, Response: resp})
+	}
+	return c.doAttempts(ctx, buildRequest, made+1, made+max(maxAttempts-made, 1), operationId, reqEditors...)
 }
+
+// ContextWithAttempt marks the context a request is sent with as the given attempt of its
+// operation, counting from 1, so a transport underneath the client can tell a resend from
+// a first send.
+func ContextWithAttempt(ctx context.Context, attempt int) context.Context {
+	return context.WithValue(ctx, attemptKey{}, attempt)
+}
+
+// AttemptFromContext reports which attempt of its operation a request is, or 1 when the
+// context does not say.
+func AttemptFromContext(ctx context.Context) int {
+	if attempt, ok := ctx.Value(attemptKey{}).(int); ok {
+		return attempt
+	}
+	return 1
+}
+
+type attemptKey struct{}
 
 // resendableBody makes a request body good for more than one send, since every attempt
 // builds its request afresh from the same reader: a seekable body is rewound to where it
@@ -2269,20 +2320,20 @@ func resendableBody(body io.Reader) (io.Reader, func() error, func()) {
 // as the request body as-is and so hands its closing to the transport.
 type readOnly struct{ io.Reader }
 
-// doAttempts runs the retry loop for up to maxAttempts sends, retrying transient
-// failures with backoff between them.
-func (c *Client) doAttempts(ctx context.Context, buildRequest func() (*http.Request, error), maxAttempts int, operationId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+// doAttempts runs the retry loop for the sends numbered first through last, retrying
+// transient failures with backoff between them.
+func (c *Client) doAttempts(ctx context.Context, buildRequest func() (*http.Request, error), first, last int, operationId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
 
 	var lastResp *http.Response
 	var lastErr error
 	delay := c.RetryConfig.BaseDelay
 
-	for attempt := 1; attempt <= maxAttempts; attempt++ {
+	for attempt := first; attempt <= last; attempt++ {
 		req, err := buildRequest()
 		if err != nil {
 			return nil, err
 		}
-		req = req.WithContext(ctx)
+		req = req.WithContext(ContextWithAttempt(ctx, attempt))
 		if err := c.applyEditors(ctx, req, reqEditors); err != nil {
 			return nil, err
 		}
@@ -2298,16 +2349,11 @@ func (c *Client) doAttempts(ctx context.Context, buildRequest func() (*http.Requ
 				)
 			}
 			// Network errors are retryable while attempts remain
-			if attempt < maxAttempts {
-				select {
-				case <-ctx.Done():
-					return nil, ctx.Err()
-				case <-time.After(delay + time.Duration(rand.Int63n(int64(100*time.Millisecond)))):
+			if attempt < last {
+				if err := c.resend(ctx, Retry{Request: req, Attempt: attempt + 1, Err: err}, delay); err != nil {
+					return nil, err
 				}
-				delay = time.Duration(float64(delay) * c.RetryConfig.Multiplier)
-				if delay > c.RetryConfig.MaxDelay {
-					delay = c.RetryConfig.MaxDelay
-				}
+				delay = c.nextDelay(delay)
 				continue
 			}
 			return nil, err
@@ -2328,7 +2374,7 @@ func (c *Client) doAttempts(ctx context.Context, buildRequest func() (*http.Requ
 		}
 
 		// Don't retry past the last attempt
-		if attempt >= maxAttempts {
+		if attempt >= last {
 			return resp, nil
 		}
 
@@ -2345,21 +2391,41 @@ func (c *Client) doAttempts(ctx context.Context, buildRequest func() (*http.Requ
 			}
 		}
 
-		select {
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		case <-time.After(retryDelay + time.Duration(rand.Int63n(int64(100*time.Millisecond)))):
+		if err := c.resend(ctx, Retry{Request: req, Attempt: attempt + 1, Response: resp}, retryDelay); err != nil {
+			return nil, err
 		}
-		delay = time.Duration(float64(delay) * c.RetryConfig.Multiplier)
-		if delay > c.RetryConfig.MaxDelay {
-			delay = c.RetryConfig.MaxDelay
-		}
+		delay = c.nextDelay(delay)
 	}
 
 	if lastErr != nil {
 		return nil, lastErr
 	}
 	return lastResp, nil
+}
+
+// resend announces the attempt about to be made to the RetryHook and waits out the delay
+// before it, with jitter, unless the context is done first.
+func (c *Client) resend(ctx context.Context, retry Retry, delay time.Duration) error {
+	if c.RetryHook != nil {
+		c.RetryHook(ctx, retry)
+	}
+	// The hook may have cancelled the context. A select with both cases ready picks one
+	// pseudo-randomly, so with an already-elapsed delay the timer could win and one more
+	// request go out on a dead context; check the context first, where nothing competes.
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(delay + time.Duration(rand.Int63n(int64(100*time.Millisecond)))):
+		return nil
+	}
+}
+
+// nextDelay grows the backoff delay for the following resend, up to the configured ceiling.
+func (c *Client) nextDelay(delay time.Duration) time.Duration {
+	return min(time.Duration(float64(delay)*c.RetryConfig.Multiplier), c.RetryConfig.MaxDelay)
 }
 
 // The interface specification for the client above.

--- a/go/pkg/hey/client.go
+++ b/go/pkg/hey/client.go
@@ -275,10 +275,27 @@ func (c *Client) initGeneratedClient() {
 		retryCfg.BaseDelay = max(c.httpOpts.BaseDelay, 0)
 		retryCfg.MaxDelay = max(retryCfg.MaxDelay, retryCfg.BaseDelay)
 
+		// The generated loop announces each resend the way doRequestURL does: the attempt
+		// that failed in the request info, the one about to be made alongside, the URL as
+		// the account-scoped transport will send it, and the failure as the SDK's error.
+		retryHook := func(ctx context.Context, retry generated.Retry) {
+			url := retry.Request.URL.String()
+			if scoped, err := c.accountScopedURL(url); err == nil {
+				url = scoped
+			}
+			cause := retry.Err
+			if retry.Response != nil {
+				cause = CheckResponse(retry.Response)
+			}
+			info := RequestInfo{Method: retry.Request.Method, URL: url, Attempt: retry.Attempt - 1}
+			c.hooks.OnRetry(ctx, info, retry.Attempt, cause)
+		}
+
 		gen, err := generated.NewClientWithResponses(serverURL,
 			generated.WithHTTPClient(c.httpClient),
 			generated.WithRetryConfig(retryCfg),
 			generated.WithAuthRefresher(c.refreshCredentials),
+			generated.WithRetryHook(retryHook),
 			generated.WithRequestEditorFn(authEditor))
 		if err != nil {
 			panic(fmt.Sprintf("hey: failed to create generated client: %v", err))

--- a/go/pkg/hey/client.go
+++ b/go/pkg/hey/client.go
@@ -283,12 +283,8 @@ func (c *Client) initGeneratedClient() {
 			if scoped, err := c.accountScopedURL(url); err == nil {
 				url = scoped
 			}
-			cause := retry.Err
-			if retry.Response != nil {
-				cause = CheckResponse(retry.Response)
-			}
 			info := RequestInfo{Method: retry.Request.Method, URL: url, Attempt: retry.Attempt - 1}
-			c.hooks.OnRetry(ctx, info, retry.Attempt, cause)
+			c.hooks.OnRetry(ctx, info, retry.Attempt, retryCause(retry))
 		}
 
 		gen, err := generated.NewClientWithResponses(serverURL,
@@ -302,6 +298,22 @@ func (c *Client) initGeneratedClient() {
 		}
 		c.gen = gen
 	})
+}
+
+// retryCause is the failure a generated resend answers, as the hand-written path reports
+// it to OnRetry: a transport failure as the SDK's network error, a response as CheckResponse
+// classifies it, and the 401 a credential refresh answered as the retryable authentication
+// error singleRequest hands doRequestURL, since the resend is the SDK's own doing.
+func retryCause(retry generated.Retry) error {
+	if retry.Response == nil {
+		return ErrNetwork(retry.Err)
+	}
+	cause := CheckResponse(retry.Response)
+	if authErr, ok := cause.(*Error); ok && authErr.Code == CodeAuth {
+		authErr.Message = "Token refreshed"
+		authErr.Retryable = true
+	}
+	return cause
 }
 
 // withJSONExtension appends ".json" to a request path whose last segment has no

--- a/go/pkg/hey/generated_client_test.go
+++ b/go/pkg/hey/generated_client_test.go
@@ -363,3 +363,219 @@ func TestGeneratedOperationsSurfaceUnauthorizedWhenNothingCanRefresh(t *testing.
 		t.Errorf("expected the 401 to be surfaced on the first request, got %d requests", requests.Load())
 	}
 }
+
+// The generated retry loop reports its resends the way doRequestURL does: OnRetry before
+// each one, told the attempt that failed and the one about to be made, and the transport
+// told which attempt each send is.
+func TestGeneratedRetriesFireOnRetry(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if requests.Add(1) < 3 {
+			http.Error(w, "unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `[]`)
+	}))
+	t.Cleanup(server.Close)
+
+	hooks := &retryRecordingHooks{}
+	root := NewClient(&Config{BaseURL: server.URL}, &StaticTokenProvider{Token: "token"},
+		WithHooks(hooks), WithMaxRetries(2), WithBaseDelay(time.Millisecond))
+	client := scopedTestClient(root, 42)
+
+	if _, err := client.Boxes().List(context.Background()); err != nil {
+		t.Fatalf("expected the third attempt to succeed: %v", err)
+	}
+	retries := hooks.retryCalls()
+	if len(retries) != 2 {
+		t.Fatalf("expected OnRetry before each of the two resends, got %d calls", len(retries))
+	}
+	for i, retry := range retries {
+		failed := i + 1
+		if retry.info.Attempt != failed || retry.attempt != failed+1 {
+			t.Errorf("retry %d: told attempt %d failed and %d is next, want %d and %d", i, retry.info.Attempt, retry.attempt, failed, failed+1)
+		}
+		if retry.info.Method != http.MethodGet {
+			t.Errorf("retry %d: method = %q, want GET", i, retry.info.Method)
+		}
+		var sdkErr *Error
+		if !errors.As(retry.err, &sdkErr) || sdkErr.HTTPStatus != http.StatusServiceUnavailable || !sdkErr.Retryable {
+			t.Errorf("retry %d: expected the 503 as a retryable SDK error, got %v", i, retry.err)
+		}
+	}
+	if got := hooks.startAttempts(); len(got) != 3 || got[0] != 1 || got[1] != 2 || got[2] != 3 {
+		t.Errorf("expected the transport to see attempts 1, 2, 3, got %v", got)
+	}
+	if starts := hooks.startURLs(); retries[0].info.URL != starts[0] || !strings.Contains(retries[0].info.URL, "42") {
+		t.Errorf("expected OnRetry to carry the URL the transport sends, %q, got %q", starts[0], retries[0].info.URL)
+	}
+}
+
+// A resend after a credential refresh is a retry too, reported as attempt 2 with the
+// authentication error that prompted it...
+func TestGeneratedRefreshResendFiresOnRetry(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer fresh" {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":1}`)
+	}))
+	t.Cleanup(server.Close)
+
+	hooks := &retryRecordingHooks{}
+	auth := &refreshingAuth{refreshed: "fresh"}
+	auth.token.Store("stale")
+	root := NewClient(&Config{BaseURL: server.URL}, nil, WithAuthStrategy(auth), WithHooks(hooks), WithMaxRetries(0))
+	client := scopedTestClient(root, 42)
+
+	if _, err := client.Boxes().CreateGroup(context.Background(), 7, []int64{1, 2}); err != nil {
+		t.Fatalf("expected the resend after a refresh to succeed: %v", err)
+	}
+	retries := hooks.retryCalls()
+	if len(retries) != 1 {
+		t.Fatalf("expected OnRetry once, before the resend, got %d calls", len(retries))
+	}
+	retry := retries[0]
+	if retry.info.Attempt != 1 || retry.attempt != 2 || retry.info.Method != http.MethodPost {
+		t.Errorf("expected attempt 1 of the POST to be reported failed and 2 next, got %+v next %d", retry.info, retry.attempt)
+	}
+	var sdkErr *Error
+	if !errors.As(retry.err, &sdkErr) || sdkErr.Code != CodeAuth {
+		t.Errorf("expected the 401 as an authentication error, got %v", retry.err)
+	}
+	if got := hooks.startAttempts(); len(got) != 2 || got[0] != 1 || got[1] != 2 {
+		t.Errorf("expected the transport to see attempts 1, 2, got %v", got)
+	}
+}
+
+// ...and the attempts after it keep counting from where the operation was, not from 1.
+func TestGeneratedRetryAttemptsCountAcrossTheRefresh(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Header.Get("Authorization") != "Bearer fresh":
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+		case requests.Add(1) < 2:
+			http.Error(w, "unavailable", http.StatusServiceUnavailable)
+		default:
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `[]`)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	hooks := &retryRecordingHooks{}
+	auth := &refreshingAuth{refreshed: "fresh"}
+	auth.token.Store("stale")
+	root := NewClient(&Config{BaseURL: server.URL}, nil, WithAuthStrategy(auth), WithHooks(hooks),
+		WithMaxRetries(3), WithBaseDelay(time.Millisecond))
+	client := scopedTestClient(root, 42)
+
+	if _, err := client.Boxes().List(context.Background()); err != nil {
+		t.Fatalf("expected the operation to succeed on its third attempt: %v", err)
+	}
+	retries := hooks.retryCalls()
+	next := make([]int, 0, len(retries))
+	for _, retry := range retries {
+		next = append(next, retry.attempt)
+	}
+	if len(next) != 2 || next[0] != 2 || next[1] != 3 {
+		t.Errorf("expected OnRetry for attempts 2 and 3, got %v", next)
+	}
+	if got := hooks.startAttempts(); len(got) != 3 || got[0] != 1 || got[1] != 2 || got[2] != 3 {
+		t.Errorf("expected the transport to see attempts 1, 2, 3, got %v", got)
+	}
+}
+
+// OnRetry is for a resend that happens: a send that succeeds, a failure past the budget
+// and a 401 nothing can refresh all go unreported.
+func TestGeneratedSendsWithoutResendDoNotFireOnRetry(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		status int
+	}{
+		{name: "a first send that succeeds", status: http.StatusOK},
+		{name: "a failure with no budget to resend on", status: http.StatusServiceUnavailable},
+		{name: "a 401 nothing can refresh", status: http.StatusUnauthorized},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				if tc.status != http.StatusOK {
+					http.Error(w, http.StatusText(tc.status), tc.status)
+					return
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = io.WriteString(w, `[]`)
+			}))
+			t.Cleanup(server.Close)
+
+			hooks := &retryRecordingHooks{}
+			root := NewClient(&Config{BaseURL: server.URL}, &StaticTokenProvider{Token: "token"}, WithHooks(hooks), WithMaxRetries(0))
+			client := scopedTestClient(root, 42)
+
+			_, _ = client.Boxes().List(context.Background())
+			if retries := hooks.retryCalls(); len(retries) != 0 {
+				t.Errorf("expected no OnRetry, got %d calls", len(retries))
+			}
+			if got := hooks.startAttempts(); len(got) != 1 || got[0] != 1 {
+				t.Errorf("expected one send, attempt 1, got %v", got)
+			}
+		})
+	}
+}
+
+type retryCall struct {
+	info    RequestInfo
+	attempt int
+	err     error
+}
+
+// retryRecordingHooks keeps what the hooks were told about each send and each resend.
+type retryRecordingHooks struct {
+	NoopHooks
+	mu      sync.Mutex
+	starts  []RequestInfo
+	retries []retryCall
+}
+
+func (h *retryRecordingHooks) OnRequestStart(ctx context.Context, info RequestInfo) context.Context {
+	h.mu.Lock()
+	h.starts = append(h.starts, info)
+	h.mu.Unlock()
+	return ctx
+}
+
+func (h *retryRecordingHooks) OnRetry(_ context.Context, info RequestInfo, attempt int, err error) {
+	h.mu.Lock()
+	h.retries = append(h.retries, retryCall{info: info, attempt: attempt, err: err})
+	h.mu.Unlock()
+}
+
+func (h *retryRecordingHooks) retryCalls() []retryCall {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return append([]retryCall(nil), h.retries...)
+}
+
+func (h *retryRecordingHooks) startAttempts() []int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	attempts := make([]int, 0, len(h.starts))
+	for _, start := range h.starts {
+		attempts = append(attempts, start.Attempt)
+	}
+	return attempts
+}
+
+func (h *retryRecordingHooks) startURLs() []string {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	urls := make([]string, 0, len(h.starts))
+	for _, start := range h.starts {
+		urls = append(urls, start.URL)
+	}
+	return urls
+}

--- a/go/pkg/hey/generated_client_test.go
+++ b/go/pkg/hey/generated_client_test.go
@@ -443,11 +443,125 @@ func TestGeneratedRefreshResendFiresOnRetry(t *testing.T) {
 		t.Errorf("expected attempt 1 of the POST to be reported failed and 2 next, got %+v next %d", retry.info, retry.attempt)
 	}
 	var sdkErr *Error
-	if !errors.As(retry.err, &sdkErr) || sdkErr.Code != CodeAuth {
-		t.Errorf("expected the 401 as an authentication error, got %v", retry.err)
+	if !errors.As(retry.err, &sdkErr) || sdkErr.Code != CodeAuth || !sdkErr.Retryable {
+		t.Errorf("expected the 401 as a retryable authentication error, as doRequestURL reports its refresh, got %v", retry.err)
 	}
 	if got := hooks.startAttempts(); len(got) != 2 || got[0] != 1 || got[1] != 2 {
 		t.Errorf("expected the transport to see attempts 1, 2, got %v", got)
+	}
+}
+
+// A failure in the transport is reported as the SDK's network error, as doRequestURL
+// reports it, so a hook can classify it and see it marked retryable.
+func TestGeneratedTransportFailuresFireOnRetryAsNetworkErrors(t *testing.T) {
+	transport := &scriptedTransport{turns: []func() (*http.Response, error){
+		func() (*http.Response, error) { return nil, errors.New("connection reset") },
+		func() (*http.Response, error) { return scriptedResponse(http.StatusOK, `[]`), nil },
+	}}
+	hooks := &retryRecordingHooks{}
+	root := NewClient(&Config{BaseURL: "https://app.hey.test"}, &StaticTokenProvider{Token: "token"},
+		WithTransport(transport), WithHooks(hooks), WithMaxRetries(1), WithBaseDelay(time.Millisecond))
+	client := scopedTestClient(root, 42)
+
+	if _, err := client.Boxes().List(context.Background()); err != nil {
+		t.Fatalf("expected the second attempt to succeed: %v", err)
+	}
+	retries := hooks.retryCalls()
+	if len(retries) != 1 {
+		t.Fatalf("expected OnRetry once, before the resend, got %d calls", len(retries))
+	}
+	retry := retries[0]
+	if retry.info.Attempt != 1 || retry.attempt != 2 || retry.info.Method != http.MethodGet {
+		t.Errorf("expected attempt 1 of the GET to be reported failed and 2 next, got %+v next %d", retry.info, retry.attempt)
+	}
+	var sdkErr *Error
+	if !errors.As(retry.err, &sdkErr) || sdkErr.Code != CodeNetwork || !sdkErr.Retryable {
+		t.Errorf("expected the transport failure as a retryable network error, got %v", retry.err)
+	}
+	if !strings.Contains(retry.err.Error(), "connection reset") {
+		t.Errorf("expected the network error to carry the transport's cause, got %v", retry.err)
+	}
+}
+
+// A transport is free to leave Response.Request unset, as a test or adapter transport
+// that builds its own responses does; the refresh resend reports the request it sent
+// regardless.
+func TestGeneratedRefreshResendFiresOnRetryWhenTheTransportDropsTheRequest(t *testing.T) {
+	transport := &scriptedTransport{turns: []func() (*http.Response, error){
+		func() (*http.Response, error) { return scriptedResponse(http.StatusUnauthorized, `unauthorized`), nil },
+		func() (*http.Response, error) { return scriptedResponse(http.StatusOK, `[]`), nil },
+	}}
+	hooks := &retryRecordingHooks{}
+	auth := &refreshingAuth{refreshed: "fresh"}
+	auth.token.Store("stale")
+	root := NewClient(&Config{BaseURL: "https://app.hey.test"}, nil,
+		WithTransport(transport), WithAuthStrategy(auth), WithHooks(hooks), WithMaxRetries(0))
+	client := scopedTestClient(root, 42)
+
+	if _, err := client.Boxes().List(context.Background()); err != nil {
+		t.Fatalf("expected the resend after a refresh to succeed: %v", err)
+	}
+	retries := hooks.retryCalls()
+	if len(retries) != 1 {
+		t.Fatalf("expected OnRetry once, before the resend, got %d calls", len(retries))
+	}
+	retry := retries[0]
+	if retry.info.Method != http.MethodGet || !strings.Contains(retry.info.URL, "42") || retry.attempt != 2 {
+		t.Errorf("expected the GET the transport was sent, scoped to the account, as attempt 2, got %+v next %d", retry.info, retry.attempt)
+	}
+}
+
+// A hook that cancels the context on the refresh resend stops it before the transport
+// is asked, as it does an ordinary retry.
+func TestGeneratedRefreshResendStopsWhenTheHookCancels(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+	}))
+	t.Cleanup(server.Close)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	hooks := &retryRecordingHooks{onRetry: func() { cancel() }}
+	auth := &refreshingAuth{refreshed: "fresh"}
+	auth.token.Store("stale")
+	root := NewClient(&Config{BaseURL: server.URL}, nil, WithAuthStrategy(auth), WithHooks(hooks), WithMaxRetries(0))
+	client := scopedTestClient(root, 42)
+
+	_, err := client.Boxes().List(ctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected the cancellation to be surfaced, got %v", err)
+	}
+	if got := hooks.startAttempts(); len(got) != 1 || got[0] != 1 {
+		t.Errorf("expected the transport to see only the first send, got %v", got)
+	}
+	if retries := hooks.retryCalls(); len(retries) != 1 {
+		t.Errorf("expected OnRetry once, for the resend that was then cancelled, got %d calls", len(retries))
+	}
+}
+
+// scriptedTransport answers each round trip from a script, the way a test or adapter
+// transport does: responses it built itself, with Response.Request unset, or errors.
+type scriptedTransport struct {
+	mu    sync.Mutex
+	turns []func() (*http.Response, error)
+}
+
+func (t *scriptedTransport) RoundTrip(*http.Request) (*http.Response, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if len(t.turns) == 0 {
+		return nil, errors.New("scriptedTransport: no turn left")
+	}
+	turn := t.turns[0]
+	t.turns = t.turns[1:]
+	return turn()
+}
+
+func scriptedResponse(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Header:     http.Header{"Content-Type": {"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(body)),
 	}
 }
 
@@ -539,6 +653,7 @@ type retryRecordingHooks struct {
 	mu      sync.Mutex
 	starts  []RequestInfo
 	retries []retryCall
+	onRetry func()
 }
 
 func (h *retryRecordingHooks) OnRequestStart(ctx context.Context, info RequestInfo) context.Context {
@@ -552,6 +667,9 @@ func (h *retryRecordingHooks) OnRetry(_ context.Context, info RequestInfo, attem
 	h.mu.Lock()
 	h.retries = append(h.retries, retryCall{info: info, attempt: attempt, err: err})
 	h.mu.Unlock()
+	if h.onRetry != nil {
+		h.onRetry()
+	}
 }
 
 func (h *retryRecordingHooks) retryCalls() []retryCall {

--- a/go/pkg/hey/http.go
+++ b/go/pkg/hey/http.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"net/http"
 	"time"
+
+	"github.com/basecamp/hey-sdk/go/pkg/generated"
 )
 
 // Default values for HTTP client configuration.
@@ -154,22 +156,16 @@ func newDefaultTransport() http.RoundTripper {
 	return t
 }
 
-// attemptKey is the context key for tracking request attempt number.
-type attemptKey struct{}
-
-// contextWithAttempt adds the request attempt number to the context.
+// contextWithAttempt adds the request attempt number to the context. The generated client
+// owns the key, since its retry loop marks its own sends and the transport underneath
+// both clients reads the one mark.
 func contextWithAttempt(ctx context.Context, attempt int) context.Context {
-	return context.WithValue(ctx, attemptKey{}, attempt)
+	return generated.ContextWithAttempt(ctx, attempt)
 }
 
 // attemptFromContext extracts the attempt number from context (defaults to 1).
 func attemptFromContext(ctx context.Context) int {
-	if v := ctx.Value(attemptKey{}); v != nil {
-		if attempt, ok := v.(int); ok {
-			return attempt
-		}
-	}
-	return 1
+	return generated.AttemptFromContext(ctx)
 }
 
 // loggingTransport wraps an http.RoundTripper to log requests and responses,

--- a/go/templates/client.tmpl
+++ b/go/templates/client.tmpl
@@ -184,11 +184,7 @@ func (c *{{ $clientTypeName }}) doWithRetry(ctx context.Context, buildRequest fu
 	if isIdempotent {
 		maxAttempts = c.RetryConfig.MaxRetries + 1
 	}
-	made := 0
-	resp, err := c.doAttempts(ctx, func() (*http.Request, error) {
-		made++
-		return buildRequest()
-	}, 1, maxAttempts, operationId, reqEditors...)
+	resp, req, err := c.doAttempts(ctx, buildRequest, 1, maxAttempts, operationId, reqEditors...)
 	if err != nil || resp.StatusCode != http.StatusUnauthorized || c.AuthRefresher == nil || !c.AuthRefresher(ctx) {
 		return resp, err
 	}
@@ -196,10 +192,12 @@ func (c *{{ $clientTypeName }}) doWithRetry(ctx context.Context, buildRequest fu
 	if c.Logger != nil {
 		c.Logger.Debug("credentials refreshed, retrying", "operation", operationId)
 	}
-	if c.RetryHook != nil {
-		c.RetryHook(ctx, Retry{Request: resp.Request, Attempt: made + 1, Response: resp})
+	failed := AttemptFromContext(req.Context())
+	if err := c.announce(ctx, Retry{Request: req, Attempt: failed + 1, Response: resp}); err != nil {
+		return nil, err
 	}
-	return c.doAttempts(ctx, buildRequest, made+1, made+max(maxAttempts-made, 1), operationId, reqEditors...)
+	resp, _, err = c.doAttempts(ctx, buildRequest, failed+1, failed+max(maxAttempts-failed, 1), operationId, reqEditors...)
+	return resp, err
 }
 
 // ContextWithAttempt marks the context a request is sent with as the given attempt of its
@@ -263,22 +261,26 @@ func resendableBody(body io.Reader) (io.Reader, func() error, func()) {
 type readOnly struct{ io.Reader }
 
 // doAttempts runs the retry loop for the sends numbered first through last, retrying
-// transient failures with backoff between them.
-func (c *{{ $clientTypeName }}) doAttempts(ctx context.Context, buildRequest func() (*http.Request, error), first, last int, operationId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+// transient failures with backoff between them. Along with the last response it returns
+// the request that response answered, as the editors left it: a transport is free to
+// leave Response.Request unset, so the loop does not rely on it.
+func (c *{{ $clientTypeName }}) doAttempts(ctx context.Context, buildRequest func() (*http.Request, error), first, last int, operationId string, reqEditors ...RequestEditorFn) (*http.Response, *http.Request, error) {
 
 	var lastResp *http.Response
+	var lastReq *http.Request
 	var lastErr error
 	delay := c.RetryConfig.BaseDelay
 
 	for attempt := first; attempt <= last; attempt++ {
 		req, err := buildRequest()
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		req = req.WithContext(ContextWithAttempt(ctx, attempt))
 		if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-			return nil, err
+			return nil, nil, err
 		}
+		lastReq = req
 
 		resp, err := c.Client.Do(req)
 		if err != nil {
@@ -293,17 +295,17 @@ func (c *{{ $clientTypeName }}) doAttempts(ctx context.Context, buildRequest fun
 			// Network errors are retryable while attempts remain
 			if attempt < last {
 				if err := c.resend(ctx, Retry{Request: req, Attempt: attempt + 1, Err: err}, delay); err != nil {
-					return nil, err
+					return nil, nil, err
 				}
 				delay = c.nextDelay(delay)
 				continue
 			}
-			return nil, err
+			return nil, nil, err
 		}
 
 		// Success or non-retryable status
 		if !isRetryableStatus(resp.StatusCode) {
-			return resp, nil
+			return resp, req, nil
 		}
 
 		lastResp = resp
@@ -317,7 +319,7 @@ func (c *{{ $clientTypeName }}) doAttempts(ctx context.Context, buildRequest fun
 
 		// Don't retry past the last attempt
 		if attempt >= last {
-			return resp, nil
+			return resp, req, nil
 		}
 
 		// Close body before retry
@@ -334,27 +336,33 @@ func (c *{{ $clientTypeName }}) doAttempts(ctx context.Context, buildRequest fun
 		}
 
 		if err := c.resend(ctx, Retry{Request: req, Attempt: attempt + 1, Response: resp}, retryDelay); err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		delay = c.nextDelay(delay)
 	}
 
 	if lastErr != nil {
-		return nil, lastErr
+		return nil, nil, lastErr
 	}
-	return lastResp, nil
+	return lastResp, lastReq, nil
+}
+
+// announce tells the RetryHook about the attempt about to be made, and reports the context
+// done if the hook cancelled it, so that no request goes out on a dead context.
+func (c *{{ $clientTypeName }}) announce(ctx context.Context, retry Retry) error {
+	if c.RetryHook != nil {
+		c.RetryHook(ctx, retry)
+	}
+	return ctx.Err()
 }
 
 // resend announces the attempt about to be made to the RetryHook and waits out the delay
 // before it, with jitter, unless the context is done first.
 func (c *{{ $clientTypeName }}) resend(ctx context.Context, retry Retry, delay time.Duration) error {
-	if c.RetryHook != nil {
-		c.RetryHook(ctx, retry)
-	}
-	// The hook may have cancelled the context. A select with both cases ready picks one
-	// pseudo-randomly, so with an already-elapsed delay the timer could win and one more
-	// request go out on a dead context; check the context first, where nothing competes.
-	if err := ctx.Err(); err != nil {
+	// A select with both cases ready picks one pseudo-randomly, so with an already-elapsed
+	// delay the timer could win over a context the hook cancelled; announce checks the
+	// context first, where nothing competes.
+	if err := c.announce(ctx, retry); err != nil {
 		return err
 	}
 	select {

--- a/go/templates/client.tmpl
+++ b/go/templates/client.tmpl
@@ -57,8 +57,30 @@ type {{ $clientTypeName }} struct {
 	// this retry is safe for non-idempotent operations too (optional).
 	AuthRefresher func(ctx context.Context) bool
 
+	// RetryHook is told about each resend before it is made (optional).
+	RetryHook RetryHook
+
 	// Logger for debug output (optional)
 	Logger *slog.Logger
+}
+
+// RetryHook is told about a resend before it is made. It is not called for a failure that
+// is not resent.
+type RetryHook func(ctx context.Context, retry Retry)
+
+// Retry describes a resend about to be made.
+type Retry struct {
+	// Request is the request that just went out, as the editors left it.
+	Request *http.Request
+	// Attempt is the number of the attempt about to be made, counting from 1 across the
+	// whole operation, refresh resend included.
+	Attempt int
+	// Response is what the last attempt was answered with, its body already closed: a
+	// status the client retries on, or the 401 a credential refresh answered. It is nil
+	// when the attempt failed in the transport instead.
+	Response *http.Response
+	// Err is the transport's error when the last attempt never got a response.
+	Err error
 }
 
 // ClientOption allows setting custom parameters during construction
@@ -123,6 +145,14 @@ func WithAuthRefresher(fn func(ctx context.Context) bool) ClientOption {
 	}
 }
 
+// WithRetryHook sets the callback told about each resend before it is made.
+func WithRetryHook(fn RetryHook) ClientOption {
+	return func(c *{{ $clientTypeName }}) error {
+		c.RetryHook = fn
+		return nil
+	}
+}
+
 // WithLogger allows setting a custom logger for debug output.
 func WithLogger(logger *slog.Logger) ClientOption {
 	return func(c *{{ $clientTypeName }}) error {
@@ -158,7 +188,7 @@ func (c *{{ $clientTypeName }}) doWithRetry(ctx context.Context, buildRequest fu
 	resp, err := c.doAttempts(ctx, func() (*http.Request, error) {
 		made++
 		return buildRequest()
-	}, maxAttempts, operationId, reqEditors...)
+	}, 1, maxAttempts, operationId, reqEditors...)
 	if err != nil || resp.StatusCode != http.StatusUnauthorized || c.AuthRefresher == nil || !c.AuthRefresher(ctx) {
 		return resp, err
 	}
@@ -166,8 +196,29 @@ func (c *{{ $clientTypeName }}) doWithRetry(ctx context.Context, buildRequest fu
 	if c.Logger != nil {
 		c.Logger.Debug("credentials refreshed, retrying", "operation", operationId)
 	}
-	return c.doAttempts(ctx, buildRequest, max(maxAttempts-made, 1), operationId, reqEditors...)
+	if c.RetryHook != nil {
+		c.RetryHook(ctx, Retry{Request: resp.Request, Attempt: made + 1, Response: resp})
+	}
+	return c.doAttempts(ctx, buildRequest, made+1, made+max(maxAttempts-made, 1), operationId, reqEditors...)
 }
+
+// ContextWithAttempt marks the context a request is sent with as the given attempt of its
+// operation, counting from 1, so a transport underneath the client can tell a resend from
+// a first send.
+func ContextWithAttempt(ctx context.Context, attempt int) context.Context {
+	return context.WithValue(ctx, attemptKey{}, attempt)
+}
+
+// AttemptFromContext reports which attempt of its operation a request is, or 1 when the
+// context does not say.
+func AttemptFromContext(ctx context.Context) int {
+	if attempt, ok := ctx.Value(attemptKey{}).(int); ok {
+		return attempt
+	}
+	return 1
+}
+
+type attemptKey struct{}
 
 // resendableBody makes a request body good for more than one send, since every attempt
 // builds its request afresh from the same reader: a seekable body is rewound to where it
@@ -211,20 +262,20 @@ func resendableBody(body io.Reader) (io.Reader, func() error, func()) {
 // as the request body as-is and so hands its closing to the transport.
 type readOnly struct{ io.Reader }
 
-// doAttempts runs the retry loop for up to maxAttempts sends, retrying transient
-// failures with backoff between them.
-func (c *{{ $clientTypeName }}) doAttempts(ctx context.Context, buildRequest func() (*http.Request, error), maxAttempts int, operationId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+// doAttempts runs the retry loop for the sends numbered first through last, retrying
+// transient failures with backoff between them.
+func (c *{{ $clientTypeName }}) doAttempts(ctx context.Context, buildRequest func() (*http.Request, error), first, last int, operationId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
 
 	var lastResp *http.Response
 	var lastErr error
 	delay := c.RetryConfig.BaseDelay
 
-	for attempt := 1; attempt <= maxAttempts; attempt++ {
+	for attempt := first; attempt <= last; attempt++ {
 		req, err := buildRequest()
 		if err != nil {
 			return nil, err
 		}
-		req = req.WithContext(ctx)
+		req = req.WithContext(ContextWithAttempt(ctx, attempt))
 		if err := c.applyEditors(ctx, req, reqEditors); err != nil {
 			return nil, err
 		}
@@ -240,16 +291,11 @@ func (c *{{ $clientTypeName }}) doAttempts(ctx context.Context, buildRequest fun
 				)
 			}
 			// Network errors are retryable while attempts remain
-			if attempt < maxAttempts {
-				select {
-				case <-ctx.Done():
-					return nil, ctx.Err()
-				case <-time.After(delay + time.Duration(rand.Int63n(int64(100*time.Millisecond)))):
+			if attempt < last {
+				if err := c.resend(ctx, Retry{Request: req, Attempt: attempt + 1, Err: err}, delay); err != nil {
+					return nil, err
 				}
-				delay = time.Duration(float64(delay) * c.RetryConfig.Multiplier)
-				if delay > c.RetryConfig.MaxDelay {
-					delay = c.RetryConfig.MaxDelay
-				}
+				delay = c.nextDelay(delay)
 				continue
 			}
 			return nil, err
@@ -270,7 +316,7 @@ func (c *{{ $clientTypeName }}) doAttempts(ctx context.Context, buildRequest fun
 		}
 
 		// Don't retry past the last attempt
-		if attempt >= maxAttempts {
+		if attempt >= last {
 			return resp, nil
 		}
 
@@ -287,21 +333,41 @@ func (c *{{ $clientTypeName }}) doAttempts(ctx context.Context, buildRequest fun
 			}
 		}
 
-		select {
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		case <-time.After(retryDelay + time.Duration(rand.Int63n(int64(100*time.Millisecond)))):
+		if err := c.resend(ctx, Retry{Request: req, Attempt: attempt + 1, Response: resp}, retryDelay); err != nil {
+			return nil, err
 		}
-		delay = time.Duration(float64(delay) * c.RetryConfig.Multiplier)
-		if delay > c.RetryConfig.MaxDelay {
-			delay = c.RetryConfig.MaxDelay
-		}
+		delay = c.nextDelay(delay)
 	}
 
 	if lastErr != nil {
 		return nil, lastErr
 	}
 	return lastResp, nil
+}
+
+// resend announces the attempt about to be made to the RetryHook and waits out the delay
+// before it, with jitter, unless the context is done first.
+func (c *{{ $clientTypeName }}) resend(ctx context.Context, retry Retry, delay time.Duration) error {
+	if c.RetryHook != nil {
+		c.RetryHook(ctx, retry)
+	}
+	// The hook may have cancelled the context. A select with both cases ready picks one
+	// pseudo-randomly, so with an already-elapsed delay the timer could win and one more
+	// request go out on a dead context; check the context first, where nothing competes.
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(delay + time.Duration(rand.Int63n(int64(100*time.Millisecond)))):
+		return nil
+	}
+}
+
+// nextDelay grows the backoff delay for the following resend, up to the configured ceiling.
+func (c *{{ $clientTypeName }}) nextDelay(delay time.Duration) time.Duration {
+	return min(time.Duration(float64(delay)*c.RetryConfig.Multiplier), c.RetryConfig.MaxDelay)
 }
 
 // The interface specification for the client above.


### PR DESCRIPTION
Card: https://app.basecamp.com/2914079/buckets/48521764/card_tables/cards/10258170882

Follow-up filed during #137's review.

**Generated retries were invisible to `Hooks.OnRetry`.** The generated client's retry loop, and after #137 its resend after a 401 refresh, fired no hook and left every send marked attempt 1 in the request context, so metrics and traces saw a retried generated operation as a single first attempt while the hand-written `doRequestURL` path reports its resend as attempt 2.

The generated client gains a `RetryHook` (`WithRetryHook`), told about each resend before it is made with a `Retry`: the request as the editors left it, the number of the attempt about to be made, and either the response the last attempt was answered with (body closed) or the transport error — `http.Client.Do`'s own shape, so the SDK can classify it with `CheckResponse` and hook consumers see the same `*hey.Error` the hand-written path hands them. The hook fires only for a resend that happens: a failure past the budget, a 401 nothing can refresh, and a first send that succeeds stay silent, as in `doRequestURL` and basecamp-sdk's loop. Because the hook runs just before the wait, the context is checked before the select as basecamp-sdk does, so a hook that cancels does not lose a coin flip to an elapsed timer and send once more on a dead context.

`initGeneratedClient` adapts it onto `hooks.OnRetry` with the hand-written contract: `RequestInfo{Attempt: failed}`, the next attempt alongside, and the URL as the account-scoped transport will send it.

Attempts now count across the whole operation, refresh resend included (`doAttempts` runs a numbered range rather than a count), and each send's context carries its attempt. The generated package owns that context key (`ContextWithAttempt`/`AttemptFromContext`), since its loop is one of the two writers; `hey`'s `contextWithAttempt`/`attemptFromContext` delegate to it, so the logging transport's `OnRequestStart` reports the right attempt for both clients.

Tests cover: a 503 retried twice fires `OnRetry` for attempts 2 and 3 with the failed attempt, the retryable SDK error and the transport's URL, and the transport sees attempts 1–3; a refresh resend fires once as attempt 2 with the auth error; attempts keep counting across a refresh (401, 503, 200 → OnRetry for 2 and 3); and no `OnRetry` for a first send that succeeds, a 503 with no budget, or a 401 nothing can refresh. The three positives fail with the hook disconnected.

`TMPDIR=/tmp/t make check` green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the generated client so retries and refresh resends fire `Hooks.OnRetry`; they previously fired no hook and left every send marked attempt 1 in the request context.

- The generated client gains a `RetryHook` that runs before each resend with the request, the attempt number about to be sent, and the response or transport error that prompted it.
- Failures match the hand-written contract: transport errors reach `OnRetry` as the SDK's network error and a refresh's 401 as a retryable authentication error.
- Attempts count across the whole operation, refresh resend included, and each send carries its attempt in the request context.
- The hook fires only when a resend happens, reports the request the loop sent rather than `Response.Request`, and a hook that cancels stops the resend before the transport is asked.

<sup>Written for commit c4c806bdbff64047b0570b5a630e3bbac168df5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-sdk/pull/139?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

