### PR TITLE
Generated client reads revalidate through the response cache

### DIFF
--- a/conformance/runner/go/main.go
+++ b/conformance/runner/go/main.go
@@ -39,6 +39,10 @@ type TestCase struct {
 	Assertions      []Assertion            `json:"assertions"`
 	Tags            []string               `json:"tags"`
 	ConfigOverrides map[string]interface{} `json:"configOverrides"`
+	// RepeatOperation invokes the operation this many times against one client, for
+	// behavior that only shows across calls — a cached read revalidating, say. Zero
+	// means once.
+	RepeatOperation int `json:"repeatOperation"`
 }
 
 // MockResponse defines a single mock HTTP response.
@@ -244,12 +248,30 @@ func runTest(tc TestCase) TestResult {
 	var sdkResp *http.Response
 	var sdkErr error
 	if layer, _ := tc.ConfigOverrides["clientLayer"].(string); layer == "hey" {
+		options := []hey.ClientOption{hey.WithMaxRetries(0)}
+		if enabled, _ := tc.ConfigOverrides["cacheEnabled"].(bool); enabled {
+			cacheDir, tmpErr := os.MkdirTemp("", "hey-conformance-cache")
+			if tmpErr != nil {
+				return TestResult{
+					Name:    tc.Name,
+					Passed:  false,
+					Message: fmt.Sprintf("Failed to create cache dir: %v", tmpErr),
+				}
+			}
+			defer func() { _ = os.RemoveAll(cacheDir) }()
+			options = append(options, hey.WithCache(hey.NewCache(cacheDir)))
+		}
 		rootClient := hey.NewClient(
 			&hey.Config{BaseURL: server.URL},
 			credentials,
-			hey.WithMaxRetries(0),
+			options...,
 		)
-		sdkErr = executeHEYOperation(rootClient, ctx, tc)
+		for range max(tc.RepeatOperation, 1) {
+			sdkErr = executeHEYOperation(rootClient, ctx, tc)
+			if sdkErr != nil {
+				break
+			}
+		}
 	} else if _, scoped := tc.ConfigOverrides["accountId"]; scoped {
 		accountID := getInt64Param(tc.ConfigOverrides, "accountId")
 		rootClient := hey.NewClient(
@@ -1553,6 +1575,9 @@ func executeOperation(client *generated.Client, ctx context.Context, tc TestCase
 
 func executeHEYOperation(client *hey.Client, ctx context.Context, tc TestCase) error {
 	switch tc.Operation {
+	case "ListBoxes":
+		_, err := client.Boxes().List(ctx)
+		return err
 	case "UpdateCalendarEvent":
 		eventID := getInt64Param(tc.PathParams, "eventId")
 		_, err := client.CalendarEvents().Update(ctx, eventID, hey.UpdateCalendarEventParams{

--- a/conformance/runner/go/main.go
+++ b/conformance/runner/go/main.go
@@ -292,7 +292,9 @@ func runTest(tc TestCase) TestResult {
 
 	// Capture response body for responseBody assertions
 	var responseBodyBytes []byte
-	if heyResult != nil {
+	// A failed read hands back a typed nil, which is a non-nil interface: only a
+	// successful operation's result is a response body.
+	if sdkErr == nil && heyResult != nil {
 		responseBodyBytes, _ = json.Marshal(heyResult)
 	}
 	if sdkResp != nil && sdkResp.Body != nil {

--- a/conformance/runner/go/main.go
+++ b/conformance/runner/go/main.go
@@ -247,6 +247,7 @@ func runTest(tc TestCase) TestResult {
 	ctx := context.Background()
 	var sdkResp *http.Response
 	var sdkErr error
+	var heyResult interface{}
 	if layer, _ := tc.ConfigOverrides["clientLayer"].(string); layer == "hey" {
 		options := []hey.ClientOption{hey.WithMaxRetries(0)}
 		if enabled, _ := tc.ConfigOverrides["cacheEnabled"].(bool); enabled {
@@ -267,7 +268,7 @@ func runTest(tc TestCase) TestResult {
 			options...,
 		)
 		for range max(tc.RepeatOperation, 1) {
-			sdkErr = executeHEYOperation(rootClient, ctx, tc)
+			heyResult, sdkErr = executeHEYOperation(rootClient, ctx, tc)
 			if sdkErr != nil {
 				break
 			}
@@ -291,6 +292,9 @@ func runTest(tc TestCase) TestResult {
 
 	// Capture response body for responseBody assertions
 	var responseBodyBytes []byte
+	if heyResult != nil {
+		responseBodyBytes, _ = json.Marshal(heyResult)
+	}
 	if sdkResp != nil && sdkResp.Body != nil {
 		var readErr error
 		responseBodyBytes, readErr = io.ReadAll(sdkResp.Body)
@@ -1573,11 +1577,12 @@ func executeOperation(client *generated.Client, ctx context.Context, tc TestCase
 	}
 }
 
-func executeHEYOperation(client *hey.Client, ctx context.Context, tc TestCase) error {
+// executeHEYOperation runs a HEY-layer operation. A read hands back what it parsed so a
+// responseBody assertion can see it; a mutation hands back nil.
+func executeHEYOperation(client *hey.Client, ctx context.Context, tc TestCase) (interface{}, error) {
 	switch tc.Operation {
 	case "ListBoxes":
-		_, err := client.Boxes().List(ctx)
-		return err
+		return client.Boxes().List(ctx)
 	case "UpdateCalendarEvent":
 		eventID := getInt64Param(tc.PathParams, "eventId")
 		_, err := client.CalendarEvents().Update(ctx, eventID, hey.UpdateCalendarEventParams{
@@ -1588,20 +1593,20 @@ func executeHEYOperation(client *hey.Client, ctx context.Context, tc TestCase) e
 			StartTime: getStringPtrParam(tc.RequestBody, "start_time"),
 			EndTime:   getStringPtrParam(tc.RequestBody, "end_time"),
 		})
-		return err
+		return nil, err
 	case "DeleteCalendarEvent":
-		return client.CalendarEvents().Delete(ctx, getInt64Param(tc.PathParams, "eventId"))
+		return nil, client.CalendarEvents().Delete(ctx, getInt64Param(tc.PathParams, "eventId"))
 	case "DeleteCalendarEventOccurrence":
 		occurrence, err := hey.ParseOccurrenceID(getStringParam(tc.PathParams, "occurrenceId"))
 		if err != nil {
-			return err
+			return nil, err
 		}
-		return client.CalendarEvents().DeleteOccurrence(ctx, occurrence, hey.OccurrenceScope(getStringParam(tc.RequestBody, "scope")))
+		return nil, client.CalendarEvents().DeleteOccurrence(ctx, occurrence, hey.OccurrenceScope(getStringParam(tc.RequestBody, "scope")))
 	case "DeleteExtenzion":
-		return client.Extenzions().Delete(ctx, getInt64Param(tc.PathParams, "accountId"), getInt64Param(tc.PathParams, "extenzionId"))
+		return nil, client.Extenzions().Delete(ctx, getInt64Param(tc.PathParams, "accountId"), getInt64Param(tc.PathParams, "extenzionId"))
 	case "CreateReply":
 		entryID := getInt64Param(tc.PathParams, "entryId")
-		return client.Entries().CreateReply(ctx, entryID,
+		return nil, client.Entries().CreateReply(ctx, entryID,
 			getInt64Param(tc.RequestBody, "acting_sender_id"),
 			getStringParam(tc.RequestBody, "subject"),
 			getStringParam(tc.RequestBody, "content"),
@@ -1617,18 +1622,18 @@ func executeHEYOperation(client *hey.Client, ctx context.Context, tc TestCase) e
 			getStringSliceParam(tc.RequestBody, "to"),
 			getStringSliceParam(tc.RequestBody, "cc"),
 			getStringSliceParam(tc.RequestBody, "bcc"))
-		return err
+		return nil, err
 	case "CreateDraft":
 		_, err := client.Messages().CreateDraft(ctx, draftContentParam(tc.RequestBody))
-		return err
+		return nil, err
 	case "UpdateDraft":
 		entryID := getInt64Param(tc.PathParams, "entryId")
-		return client.Messages().UpdateDraft(ctx, entryID, draftContentParam(tc.RequestBody))
+		return nil, client.Messages().UpdateDraft(ctx, entryID, draftContentParam(tc.RequestBody))
 	case "SendDraft":
 		entryID := getInt64Param(tc.PathParams, "entryId")
-		return client.Messages().SendDraft(ctx, entryID, draftContentParam(tc.RequestBody))
+		return nil, client.Messages().SendDraft(ctx, entryID, draftContentParam(tc.RequestBody))
 	default:
-		return fmt.Errorf("HEY client conformance does not support operation: %s", tc.Operation)
+		return nil, fmt.Errorf("HEY client conformance does not support operation: %s", tc.Operation)
 	}
 }
 

--- a/conformance/tests/cache-revalidation.json
+++ b/conformance/tests/cache-revalidation.json
@@ -1,0 +1,173 @@
+[
+  {
+    "name": "Cache-enabled generated read revalidates and parses the 304 from the cache",
+    "description": "A cache-enabled client's second read of an unchanged resource goes out conditional on the stored ETag and parses the 304 as the cached 200",
+    "operation": "ListBoxes",
+    "method": "GET",
+    "path": "/boxes.json",
+    "configOverrides": {
+      "clientLayer": "hey",
+      "cacheEnabled": true
+    },
+    "repeatOperation": 2,
+    "mockResponses": [
+      {
+        "status": 200,
+        "headers": {
+          "ETag": "\"v1\""
+        },
+        "body": [
+          {
+            "id": 7,
+            "name": "Imbox"
+          }
+        ]
+      },
+      {
+        "status": 304,
+        "headers": {
+          "ETag": "\"v1\""
+        }
+      }
+    ],
+    "assertions": [
+      {
+        "type": "requestCount",
+        "expected": 2
+      },
+      {
+        "type": "lastRequestHeader",
+        "path": "If-None-Match",
+        "expected": "\"v1\""
+      },
+      {
+        "type": "noError"
+      }
+    ],
+    "tags": [
+      "cache",
+      "revalidation"
+    ]
+  },
+  {
+    "name": "Cache-enabled generated read follows a changed resource's new ETag",
+    "description": "A changed resource answers the conditional request with a fresh 200 and the cache follows: the next read revalidates against the new ETag",
+    "operation": "ListBoxes",
+    "method": "GET",
+    "path": "/boxes.json",
+    "configOverrides": {
+      "clientLayer": "hey",
+      "cacheEnabled": true
+    },
+    "repeatOperation": 3,
+    "mockResponses": [
+      {
+        "status": 200,
+        "headers": {
+          "ETag": "\"v1\""
+        },
+        "body": [
+          {
+            "id": 7,
+            "name": "Imbox"
+          }
+        ]
+      },
+      {
+        "status": 200,
+        "headers": {
+          "ETag": "\"v2\""
+        },
+        "body": [
+          {
+            "id": 7,
+            "name": "Imbox"
+          },
+          {
+            "id": 8,
+            "name": "The Feed"
+          }
+        ]
+      },
+      {
+        "status": 304,
+        "headers": {
+          "ETag": "\"v2\""
+        }
+      }
+    ],
+    "assertions": [
+      {
+        "type": "requestCount",
+        "expected": 3
+      },
+      {
+        "type": "lastRequestHeader",
+        "path": "If-None-Match",
+        "expected": "\"v2\""
+      },
+      {
+        "type": "noError"
+      }
+    ],
+    "tags": [
+      "cache",
+      "revalidation"
+    ]
+  },
+  {
+    "name": "Client without a cache never sends a conditional request",
+    "description": "With no cache configured, repeated generated reads carry no If-None-Match and fetch every answer in full",
+    "operation": "ListBoxes",
+    "method": "GET",
+    "path": "/boxes.json",
+    "configOverrides": {
+      "clientLayer": "hey"
+    },
+    "repeatOperation": 2,
+    "mockResponses": [
+      {
+        "status": 200,
+        "headers": {
+          "ETag": "\"v1\""
+        },
+        "body": [
+          {
+            "id": 7,
+            "name": "Imbox"
+          }
+        ]
+      },
+      {
+        "status": 200,
+        "headers": {
+          "ETag": "\"v1\""
+        },
+        "body": [
+          {
+            "id": 7,
+            "name": "Imbox"
+          }
+        ]
+      }
+    ],
+    "assertions": [
+      {
+        "type": "requestCount",
+        "expected": 2
+      },
+      {
+        "type": "lastRequestHeader",
+        "path": "If-None-Match",
+        "expected": ""
+      },
+      {
+        "type": "noError"
+      }
+    ],
+    "tags": [
+      "cache",
+      "revalidation"
+    ]
+  }
+]

--- a/conformance/tests/cache-revalidation.json
+++ b/conformance/tests/cache-revalidation.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "Cache-enabled generated read revalidates and parses the 304 from the cache",
-    "description": "A cache-enabled client's second read of an unchanged resource goes out conditional on the stored ETag and parses the 304 as the cached 200",
+    "description": "A cache-enabled client's second read of an unchanged resource goes out conditional on the stored ETag and parses the 304 as the cached 200, answering with the stored boxes",
     "operation": "ListBoxes",
     "method": "GET",
     "path": "/boxes.json",
@@ -41,6 +41,16 @@
         "expected": "\"v1\""
       },
       {
+        "type": "responseBody",
+        "path": "0.id",
+        "expected": 7
+      },
+      {
+        "type": "responseBody",
+        "path": "0.name",
+        "expected": "Imbox"
+      },
+      {
         "type": "noError"
       }
     ],
@@ -51,7 +61,7 @@
   },
   {
     "name": "Cache-enabled generated read follows a changed resource's new ETag",
-    "description": "A changed resource answers the conditional request with a fresh 200 and the cache follows: the next read revalidates against the new ETag",
+    "description": "A changed resource answers the conditional request with a fresh 200 and the cache follows: the next read revalidates against the new ETag and answers with the new body",
     "operation": "ListBoxes",
     "method": "GET",
     "path": "/boxes.json",
@@ -105,6 +115,16 @@
         "type": "lastRequestHeader",
         "path": "If-None-Match",
         "expected": "\"v2\""
+      },
+      {
+        "type": "responseBody",
+        "path": "1.id",
+        "expected": 8
+      },
+      {
+        "type": "responseBody",
+        "path": "1.name",
+        "expected": "The Feed"
       },
       {
         "type": "noError"

--- a/go/pkg/hey/client.go
+++ b/go/pkg/hey/client.go
@@ -287,8 +287,16 @@ func (c *Client) initGeneratedClient() {
 			c.hooks.OnRetry(ctx, info, retry.Attempt, retryCause(retry))
 		}
 
+		// A client with a response cache sends generated requests through it, so the
+		// generated operations revalidate with If-None-Match and read 304s from the
+		// cache the way the hand-written paths do.
+		var doer generated.HttpRequestDoer = c.httpClient
+		if c.cache != nil {
+			doer = &cachingDoer{client: c}
+		}
+
 		gen, err := generated.NewClientWithResponses(serverURL,
-			generated.WithHTTPClient(c.httpClient),
+			generated.WithHTTPClient(doer),
 			generated.WithRetryConfig(retryCfg),
 			generated.WithAuthRefresher(c.refreshCredentials),
 			generated.WithRetryHook(retryHook),

--- a/go/pkg/hey/generated_cache.go
+++ b/go/pkg/hey/generated_cache.go
@@ -1,0 +1,99 @@
+package hey
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"strconv"
+)
+
+// cachingDoer sends the generated client's requests through the response cache the way
+// singleRequest does for hand-written ones: a GET whose URL and credentials have a cached
+// body goes out conditional on its ETag, a 304 is answered from the cache, and a fresh 200
+// bearing an ETag replaces what was stored. Only JSON API reads participate: form and
+// document representations pass through untouched, as does any request whose context
+// bypasses the cache and any request without an Authorization header to key by.
+type cachingDoer struct {
+	client *Client
+}
+
+func (d *cachingDoer) Do(req *http.Request) (*http.Response, error) {
+	c := d.client
+	authorization := req.Header.Get("Authorization")
+	if req.Method != http.MethodGet || authorization == "" ||
+		req.Header.Get("Accept") != "application/json" || noCacheFromContext(req.Context()) {
+		return c.httpClient.Do(req)
+	}
+
+	// The request goes out conditional only when the cache can answer the 304 it may
+	// draw: an ETag without its body, or a body the current buffer bound would refuse,
+	// is no better than a miss.
+	key := c.cache.Key(req.URL.String(), authorization)
+	var cached []byte
+	if etag := c.cache.GetETag(key); etag != "" {
+		if body := c.cache.GetBody(key); body != nil && int64(len(body)) <= c.bufferBound(req) {
+			cached = body
+			req.Header.Set("If-None-Match", etag)
+			c.logger.Debug("cache conditional request", "etag", etag)
+		}
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return resp, err
+	}
+
+	switch {
+	case resp.StatusCode == http.StatusNotModified && cached != nil:
+		c.logger.Debug("cache hit", "status", 304)
+		_ = resp.Body.Close()
+		return cachedResponse(req, resp, cached), nil
+	case resp.StatusCode == http.StatusOK:
+		if etag := resp.Header.Get("ETag"); etag != "" {
+			d.store(key, etag, resp)
+		}
+	}
+	return resp, nil
+}
+
+// store reads the response body to cache it and hands the response back a fresh reader. A
+// read failure is kept for the caller's own read to surface: the round trip succeeded, and
+// an error returned here would send the generated retry loop after a response it already
+// has — a body that broke the limit would be refetched at full size once per attempt.
+func (d *cachingDoer) store(key, etag string, resp *http.Response) {
+	body, err := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if err != nil {
+		resp.Body = io.NopCloser(&errorReader{err: err})
+		return
+	}
+	_ = d.client.cache.Set(key, body, etag)
+	d.client.logger.Debug("cache stored", "etag", etag)
+	resp.Body = io.NopCloser(bytes.NewReader(body))
+}
+
+// cachedResponse answers a 304 with the body stored from the 200 it revalidated. The
+// generated parsers choose a shape by status code and Content-Type, and a 304 carries
+// neither for the representation it confirms, so the response reports the JSON the
+// cache holds.
+func cachedResponse(req *http.Request, notModified *http.Response, body []byte) *http.Response {
+	header := notModified.Header.Clone()
+	header.Set("Content-Type", "application/json")
+	header.Set("Content-Length", strconv.Itoa(len(body)))
+	return &http.Response{
+		Status:        "200 OK",
+		StatusCode:    http.StatusOK,
+		Proto:         notModified.Proto,
+		ProtoMajor:    notModified.ProtoMajor,
+		ProtoMinor:    notModified.ProtoMinor,
+		Header:        header,
+		Body:          io.NopCloser(bytes.NewReader(body)),
+		ContentLength: int64(len(body)),
+		Request:       req,
+	}
+}
+
+// errorReader delivers a body read failure to the reader the response is parsed with.
+type errorReader struct{ err error }
+
+func (r *errorReader) Read([]byte) (int, error) { return 0, r.err }

--- a/go/pkg/hey/generated_cache.go
+++ b/go/pkg/hey/generated_cache.go
@@ -60,10 +60,11 @@ func (d *cachingDoer) Do(req *http.Request) (*http.Response, error) {
 // read failure is kept for the caller's own read to surface: the round trip succeeded, and
 // an error returned here would send the generated retry loop after a response it already
 // has — a body that broke the limit would be refetched at full size once per attempt. A
-// body past the bound is handed back unstored: the read guard would refuse to serve it,
-// so writing it would spend disk on an entry no request could ever use. Such a body
-// reaches here only on a client whose custom transport carries no cap; the built
-// transport fails the read at the limit first.
+// body past the bound is handed back unstored, and whatever the key held is dropped: the
+// read guard would refuse to serve the new body, so writing it would spend disk on an
+// entry no request could use, and the old entry no longer describes the resource, so
+// the next read goes out unconditional. Such a body reaches here only on a client whose
+// custom transport carries no cap; the built transport fails the read at the limit first.
 func (d *cachingDoer) store(key, etag string, resp *http.Response, bound int64) {
 	body, err := io.ReadAll(resp.Body)
 	_ = resp.Body.Close()
@@ -74,6 +75,8 @@ func (d *cachingDoer) store(key, etag string, resp *http.Response, bound int64) 
 	if int64(len(body)) <= bound {
 		_ = d.client.cache.Set(key, body, etag)
 		d.client.logger.Debug("cache stored", "etag", etag)
+	} else {
+		_ = d.client.cache.Invalidate(key)
 	}
 	resp.Body = io.NopCloser(bytes.NewReader(body))
 }

--- a/go/pkg/hey/generated_cache.go
+++ b/go/pkg/hey/generated_cache.go
@@ -50,7 +50,7 @@ func (d *cachingDoer) Do(req *http.Request) (*http.Response, error) {
 		return cachedResponse(req, resp, cached), nil
 	case resp.StatusCode == http.StatusOK:
 		if etag := resp.Header.Get("ETag"); etag != "" {
-			d.store(key, etag, resp)
+			d.store(key, etag, resp, c.bufferBound(req))
 		}
 	}
 	return resp, nil
@@ -59,16 +59,22 @@ func (d *cachingDoer) Do(req *http.Request) (*http.Response, error) {
 // store reads the response body to cache it and hands the response back a fresh reader. A
 // read failure is kept for the caller's own read to surface: the round trip succeeded, and
 // an error returned here would send the generated retry loop after a response it already
-// has — a body that broke the limit would be refetched at full size once per attempt.
-func (d *cachingDoer) store(key, etag string, resp *http.Response) {
+// has — a body that broke the limit would be refetched at full size once per attempt. A
+// body past the bound is handed back unstored: the read guard would refuse to serve it,
+// so writing it would spend disk on an entry no request could ever use. Such a body
+// reaches here only on a client whose custom transport carries no cap; the built
+// transport fails the read at the limit first.
+func (d *cachingDoer) store(key, etag string, resp *http.Response, bound int64) {
 	body, err := io.ReadAll(resp.Body)
 	_ = resp.Body.Close()
 	if err != nil {
 		resp.Body = io.NopCloser(&errorReader{err: err})
 		return
 	}
-	_ = d.client.cache.Set(key, body, etag)
-	d.client.logger.Debug("cache stored", "etag", etag)
+	if int64(len(body)) <= bound {
+		_ = d.client.cache.Set(key, body, etag)
+		d.client.logger.Debug("cache stored", "etag", etag)
+	}
 	resp.Body = io.NopCloser(bytes.NewReader(body))
 }
 

--- a/go/pkg/hey/generated_cache_test.go
+++ b/go/pkg/hey/generated_cache_test.go
@@ -273,36 +273,51 @@ func TestGeneratedOperationsBypassTheCacheForPostingChanges(t *testing.T) {
 }
 
 // A custom transport carries no body cap, so store can read a body past the configured
-// bound. The read guard would never serve such an entry, so it is not written: the
-// answer still parses in full, and the next read goes out unconditional.
+// bound. The read guard would never serve such an entry, so it is not written — and an
+// entry the key held from a smaller earlier answer is dropped with it: the answer still
+// parses in full, the cache is left empty, and the next read goes out unconditional.
 func TestGeneratedOperationsDoNotCacheABodyPastTheBound(t *testing.T) {
-	backend := &boxServer{etag: `"v1"`,
-		body: `[{"id":7,"name":"` + strings.Repeat("x", 2048) + `"}]`}
+	backend := &boxServer{etag: `"v1"`, body: `[{"id":7,"name":"Imbox"}]`}
 	server := httptest.NewServer(backend.handler())
 	t.Cleanup(server.Close)
 
+	cacheDir := t.TempDir()
 	root := NewClient(&Config{BaseURL: server.URL}, &StaticTokenProvider{Token: "token"},
 		WithHTTPClient(&http.Client{}), WithMaxResponseBodyBytes(1024),
-		WithMaxRetries(0), WithCache(NewCache(t.TempDir())))
+		WithMaxRetries(0), WithCache(NewCache(cacheDir)))
 	client := scopedTestClient(root, 42)
+
+	if _, err := client.Boxes().List(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	backend.mu.Lock()
+	backend.etag = `"v2"`
+	backend.body = `[{"id":7,"name":"` + strings.Repeat("x", 2048) + `"}]`
+	backend.mu.Unlock()
 
 	for range 2 {
 		boxes, err := client.Boxes().List(context.Background())
 		if err != nil {
 			t.Fatal(err)
 		}
-		if boxes == nil || len(*boxes) != 1 {
+		if boxes == nil || len(*boxes) != 1 || len((*boxes)[0].Name) != 2048 {
 			t.Fatalf("boxes = %v, want the oversized box parsed in full", boxes)
 		}
 	}
 
 	backend.mu.Lock()
 	defer backend.mu.Unlock()
-	if want := []string{"", ""}; fmt.Sprint(backend.conditionals) != fmt.Sprint(want) {
-		t.Errorf("conditionals = %v, want no conditional requests for an unstored body", backend.conditionals)
+	if want := []string{"", `"v1"`, ""}; fmt.Sprint(backend.conditionals) != fmt.Sprint(want) {
+		t.Errorf("conditionals = %v, want %v: an unstored body leaves nothing to revalidate", backend.conditionals, want)
 	}
-	if backend.bodiesServed != 2 {
+	if backend.bodiesServed != 3 {
 		t.Errorf("bodies served = %d, want every answer in full", backend.bodiesServed)
+	}
+	if entries, err := os.ReadDir(filepath.Join(cacheDir, "responses")); err == nil && len(entries) > 0 {
+		t.Errorf("cache holds %d entries, want none after a body past the bound", len(entries))
+	}
+	if etag := root.cache.GetETag(root.cache.Key(server.URL+"/boxes.json?"+filteredAccountIDParameter+"=42", "Bearer token")); etag != "" {
+		t.Errorf("cached etag = %q, want the earlier entry dropped", etag)
 	}
 }
 

--- a/go/pkg/hey/generated_cache_test.go
+++ b/go/pkg/hey/generated_cache_test.go
@@ -2,12 +2,14 @@ package hey
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"sync"
+	"sync/atomic"
 	"testing"
 )
 
@@ -217,6 +219,64 @@ func TestGeneratedOperationsCacheEachAccountSeparately(t *testing.T) {
 		if fmt.Sprint(requests) != fmt.Sprint(want) {
 			t.Errorf("account %s conditionals = %v, want %v", account, requests, want)
 		}
+	}
+}
+
+// A body the cap refuses fails inside store's read, and the failure is kept for the
+// generated parser's own read to surface: the caller gets the error after exactly one
+// request, because an error from Do would send the retry loop after a response it
+// already has.
+func TestGeneratedOperationsDoNotRetryABodyTheCacheFailedToRead(t *testing.T) {
+	client, hits := newCappedTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("ETag", `"v1"`)
+		serveOversizedJSON(false)(w, r)
+	}, WithCache(NewCache(t.TempDir())))
+
+	_, err := client.Messages().Get(context.Background(), 1)
+	if !errors.Is(err, ErrResponseTooLarge) {
+		t.Fatalf("err = %v, want ErrResponseTooLarge through the cache-enabled generated client", err)
+	}
+	if hits.Load() != 1 {
+		t.Errorf("server saw %d requests, want 1: a refused body must not be retried", hits.Load())
+	}
+}
+
+// HEY regenerates pagination headers on every response — geared_pagination sets
+// X-Total-Count and Link in an after_action that runs on 304s too — so a revalidated
+// read takes its pagination state from the 304 itself and the synthesized 200
+// carries it through to the wrappers that parse those headers.
+func TestGeneratedOperationsReadPaginationHeadersFromTheRevalidation(t *testing.T) {
+	var bodiesServed atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("ETag", `"v1"`)
+		w.Header().Set("X-Total-Count", "7")
+		w.Header().Set("Link", `<http://`+r.Host+r.URL.Path+`?page=abc123>; rel="next"`)
+		if r.Header.Get("If-None-Match") == `"v1"` {
+			w.WriteHeader(http.StatusNotModified)
+			return
+		}
+		bodiesServed.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"id":1,"name":"Receipts"}`)
+	}))
+	t.Cleanup(server.Close)
+
+	root := NewClient(&Config{BaseURL: server.URL}, &StaticTokenProvider{Token: "token"},
+		WithMaxRetries(0), WithCache(NewCache(t.TempDir())))
+	client := scopedTestClient(root, 42)
+
+	for call := range 2 {
+		page, err := client.Folders().GetPage(context.Background(), 1, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if page.TotalCount != 7 || page.NextPage != "abc123" {
+			t.Errorf("call %d: TotalCount = %d, NextPage = %q, want 7 and %q",
+				call, page.TotalCount, page.NextPage, "abc123")
+		}
+	}
+	if bodiesServed.Load() != 1 {
+		t.Errorf("bodies served = %d, want the second read answered from the cache", bodiesServed.Load())
 	}
 }
 

--- a/go/pkg/hey/generated_cache_test.go
+++ b/go/pkg/hey/generated_cache_test.go
@@ -242,6 +242,36 @@ func TestGeneratedOperationsDoNotRetryABodyTheCacheFailedToRead(t *testing.T) {
 	}
 }
 
+// Change feeds advance their cursor on every read, so their URLs never repeat and a
+// cached response could never be revalidated: the posting changes feed bypasses the
+// cache the way the calendar feeds do, and a long-running watch stores nothing.
+func TestGeneratedOperationsBypassTheCacheForPostingChanges(t *testing.T) {
+	backend := &boxServer{etag: `"v1"`, body: `{"added":[],"updated":[],"deleted":[]}`}
+	server := httptest.NewServer(backend.handler())
+	t.Cleanup(server.Close)
+
+	cacheDir := t.TempDir()
+	root := NewClient(&Config{BaseURL: server.URL}, &StaticTokenProvider{Token: "token"},
+		WithMaxRetries(0), WithCache(NewCache(cacheDir)))
+	client := scopedTestClient(root, 42)
+
+	cursor := PostingChangesCursor{Since: "2026-01-01T00:00:00Z"}
+	for range 2 {
+		if _, err := client.Postings().Changes(context.Background(), 7, cursor); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	if want := []string{"", ""}; fmt.Sprint(backend.conditionals) != fmt.Sprint(want) {
+		t.Errorf("conditionals = %v, want the changes feed uncached", backend.conditionals)
+	}
+	if entries, err := os.ReadDir(filepath.Join(cacheDir, "responses")); err == nil && len(entries) > 0 {
+		t.Errorf("cache holds %d entries, want none for an advancing cursor", len(entries))
+	}
+}
+
 // A custom transport carries no body cap, so store can read a body past the configured
 // bound. The read guard would never serve such an entry, so it is not written: the
 // answer still parses in full, and the next read goes out unconditional.

--- a/go/pkg/hey/generated_cache_test.go
+++ b/go/pkg/hey/generated_cache_test.go
@@ -1,0 +1,248 @@
+package hey
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+// boxServer answers ListBoxes with an ETag-versioned body: a conditional request
+// naming the current version draws a 304, anything else the full body. It records
+// the If-None-Match header of every request and counts the bodies it served.
+type boxServer struct {
+	mu           sync.Mutex
+	etag         string
+	body         string
+	conditionals []string
+	bodiesServed int
+}
+
+func (s *boxServer) handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		s.conditionals = append(s.conditionals, r.Header.Get("If-None-Match"))
+		w.Header().Set("ETag", s.etag)
+		if r.Header.Get("If-None-Match") == s.etag {
+			w.WriteHeader(http.StatusNotModified)
+			return
+		}
+		s.bodiesServed++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, s.body)
+	}
+}
+
+// A generated read revalidates with the ETag its last answer carried, and a 304 is
+// answered from the cache: the server sends the body once, and every later call parses
+// the stored copy.
+func TestGeneratedOperationsRevalidateWithETags(t *testing.T) {
+	backend := &boxServer{etag: `"v1"`, body: `[{"id":7,"name":"Imbox"}]`}
+	server := httptest.NewServer(backend.handler())
+	t.Cleanup(server.Close)
+
+	root := NewClient(&Config{BaseURL: server.URL}, &StaticTokenProvider{Token: "token"},
+		WithMaxRetries(0), WithCache(NewCache(t.TempDir())))
+	client := scopedTestClient(root, 42)
+
+	for range 3 {
+		boxes, err := client.Boxes().List(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if boxes == nil || len(*boxes) != 1 || (*boxes)[0].Name != "Imbox" {
+			t.Fatalf("boxes = %v, want the Imbox", boxes)
+		}
+	}
+
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	if want := []string{"", `"v1"`, `"v1"`}; fmt.Sprint(backend.conditionals) != fmt.Sprint(want) {
+		t.Errorf("conditionals = %v, want %v", backend.conditionals, want)
+	}
+	if backend.bodiesServed != 1 {
+		t.Errorf("bodies served = %d, want 1", backend.bodiesServed)
+	}
+}
+
+// A changed resource answers the conditional request with a fresh 200, and the cache
+// follows: the next call revalidates against the new ETag and reads the new body.
+func TestGeneratedOperationsRefreshTheCacheWhenTheResourceChanges(t *testing.T) {
+	backend := &boxServer{etag: `"v1"`, body: `[{"id":7,"name":"Imbox"}]`}
+	server := httptest.NewServer(backend.handler())
+	t.Cleanup(server.Close)
+
+	root := NewClient(&Config{BaseURL: server.URL}, &StaticTokenProvider{Token: "token"},
+		WithMaxRetries(0), WithCache(NewCache(t.TempDir())))
+	client := scopedTestClient(root, 42)
+
+	if _, err := client.Boxes().List(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	backend.mu.Lock()
+	backend.etag = `"v2"`
+	backend.body = `[{"id":7,"name":"Imbox"},{"id":8,"name":"The Feed"}]`
+	backend.mu.Unlock()
+
+	for range 2 {
+		boxes, err := client.Boxes().List(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if boxes == nil || len(*boxes) != 2 {
+			t.Fatalf("boxes = %v, want both boxes after the change", boxes)
+		}
+	}
+
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	if want := []string{"", `"v1"`, `"v2"`}; fmt.Sprint(backend.conditionals) != fmt.Sprint(want) {
+		t.Errorf("conditionals = %v, want %v", backend.conditionals, want)
+	}
+	if backend.bodiesServed != 2 {
+		t.Errorf("bodies served = %d, want one per version", backend.bodiesServed)
+	}
+}
+
+// An ETag whose body the cache no longer holds cannot answer a 304, so the request
+// goes out unconditional and the fresh 200 restores the entry.
+func TestGeneratedOperationsSkipConditionalRequestsWithoutACachedBody(t *testing.T) {
+	backend := &boxServer{etag: `"v1"`, body: `[{"id":7,"name":"Imbox"}]`}
+	server := httptest.NewServer(backend.handler())
+	t.Cleanup(server.Close)
+
+	cacheDir := t.TempDir()
+	root := NewClient(&Config{BaseURL: server.URL}, &StaticTokenProvider{Token: "token"},
+		WithMaxRetries(0), WithCache(NewCache(cacheDir)))
+	client := scopedTestClient(root, 42)
+
+	if _, err := client.Boxes().List(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.RemoveAll(filepath.Join(cacheDir, "responses")); err != nil {
+		t.Fatal(err)
+	}
+
+	boxes, err := client.Boxes().List(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if boxes == nil || len(*boxes) != 1 {
+		t.Fatalf("boxes = %v, want the refetched Imbox", boxes)
+	}
+
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	if want := []string{"", ""}; fmt.Sprint(backend.conditionals) != fmt.Sprint(want) {
+		t.Errorf("conditionals = %v, want unconditional requests", backend.conditionals)
+	}
+	if backend.bodiesServed != 2 {
+		t.Errorf("bodies served = %d, want a refetch", backend.bodiesServed)
+	}
+}
+
+// Authentication that sets no Authorization header leaves the cache without a
+// credential to key by, so generated reads never go out conditional — the same
+// stance the hand-written path takes.
+func TestGeneratedOperationsWithoutAuthorizationBypassTheResponseCache(t *testing.T) {
+	backend := &boxServer{etag: `"v1"`, body: `[{"id":7,"name":"Imbox"}]`}
+	server := httptest.NewServer(backend.handler())
+	t.Cleanup(server.Close)
+
+	root := NewClient(&Config{BaseURL: server.URL}, nil,
+		WithAuthStrategy(testHeaderAuth{identity: "personal"}),
+		WithMaxRetries(0), WithCache(NewCache(t.TempDir())))
+	client := scopedTestClient(root, 42)
+
+	for range 2 {
+		if _, err := client.Boxes().List(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	if want := []string{"", ""}; fmt.Sprint(backend.conditionals) != fmt.Sprint(want) {
+		t.Errorf("conditionals = %v, want caching bypassed", backend.conditionals)
+	}
+}
+
+// Accounts share one cache but not entries: the account filter each scoped client
+// stamps on its URLs keys them apart, so a 304 for one account can never answer
+// with another account's boxes.
+func TestGeneratedOperationsCacheEachAccountSeparately(t *testing.T) {
+	var mu sync.Mutex
+	conditionals := map[string][]string{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		account := r.URL.Query().Get(filteredAccountIDParameter)
+		mu.Lock()
+		conditionals[account] = append(conditionals[account], r.Header.Get("If-None-Match"))
+		mu.Unlock()
+		etag := `"account-` + account + `"`
+		w.Header().Set("ETag", etag)
+		if r.Header.Get("If-None-Match") == etag {
+			w.WriteHeader(http.StatusNotModified)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w, `[{"id":%s,"name":"Imbox"}]`, account)
+	}))
+	t.Cleanup(server.Close)
+
+	root := NewClient(&Config{BaseURL: server.URL}, &StaticTokenProvider{Token: "token"},
+		WithMaxRetries(0), WithCache(NewCache(t.TempDir())))
+	personal := scopedTestClient(root, 42)
+	work := scopedTestClient(root, 43)
+
+	for _, client := range []*Client{personal, work, personal, work} {
+		boxes, err := client.Boxes().List(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if boxes == nil || len(*boxes) != 1 || (*boxes)[0].Id != client.accountID {
+			t.Fatalf("account %d read another account's boxes: %v", client.accountID, boxes)
+		}
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	for account, requests := range conditionals {
+		want := []string{"", `"account-` + account + `"`}
+		if fmt.Sprint(requests) != fmt.Sprint(want) {
+			t.Errorf("account %s conditionals = %v, want %v", account, requests, want)
+		}
+	}
+}
+
+// A client without a cache sends generated requests untouched: no conditional
+// headers, every answer fetched in full.
+func TestGeneratedOperationsWithoutACacheSendPlainRequests(t *testing.T) {
+	backend := &boxServer{etag: `"v1"`, body: `[{"id":7,"name":"Imbox"}]`}
+	server := httptest.NewServer(backend.handler())
+	t.Cleanup(server.Close)
+
+	root := NewClient(&Config{BaseURL: server.URL}, &StaticTokenProvider{Token: "token"},
+		WithMaxRetries(0))
+	client := scopedTestClient(root, 42)
+
+	for range 2 {
+		if _, err := client.Boxes().List(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	if want := []string{"", ""}; fmt.Sprint(backend.conditionals) != fmt.Sprint(want) {
+		t.Errorf("conditionals = %v, want no conditional requests", backend.conditionals)
+	}
+	if backend.bodiesServed != 2 {
+		t.Errorf("bodies served = %d, want every answer in full", backend.bodiesServed)
+	}
+}

--- a/go/pkg/hey/generated_cache_test.go
+++ b/go/pkg/hey/generated_cache_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -238,6 +239,40 @@ func TestGeneratedOperationsDoNotRetryABodyTheCacheFailedToRead(t *testing.T) {
 	}
 	if hits.Load() != 1 {
 		t.Errorf("server saw %d requests, want 1: a refused body must not be retried", hits.Load())
+	}
+}
+
+// A custom transport carries no body cap, so store can read a body past the configured
+// bound. The read guard would never serve such an entry, so it is not written: the
+// answer still parses in full, and the next read goes out unconditional.
+func TestGeneratedOperationsDoNotCacheABodyPastTheBound(t *testing.T) {
+	backend := &boxServer{etag: `"v1"`,
+		body: `[{"id":7,"name":"` + strings.Repeat("x", 2048) + `"}]`}
+	server := httptest.NewServer(backend.handler())
+	t.Cleanup(server.Close)
+
+	root := NewClient(&Config{BaseURL: server.URL}, &StaticTokenProvider{Token: "token"},
+		WithHTTPClient(&http.Client{}), WithMaxResponseBodyBytes(1024),
+		WithMaxRetries(0), WithCache(NewCache(t.TempDir())))
+	client := scopedTestClient(root, 42)
+
+	for range 2 {
+		boxes, err := client.Boxes().List(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if boxes == nil || len(*boxes) != 1 {
+			t.Fatalf("boxes = %v, want the oversized box parsed in full", boxes)
+		}
+	}
+
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	if want := []string{"", ""}; fmt.Sprint(backend.conditionals) != fmt.Sprint(want) {
+		t.Errorf("conditionals = %v, want no conditional requests for an unstored body", backend.conditionals)
+	}
+	if backend.bodiesServed != 2 {
+		t.Errorf("bodies served = %d, want every answer in full", backend.bodiesServed)
 	}
 }
 

--- a/go/pkg/hey/postings.go
+++ b/go/pkg/hey/postings.go
@@ -437,7 +437,10 @@ func (s *PostingsService) Changes(ctx context.Context, boxID int64, cursor Posti
 	defer func() { s.client.hooks.OnOperationEnd(ctx, op, err, time.Since(start)) }()
 
 	s.client.initGeneratedClient()
-	resp, err := s.client.gen.GetBoxPostingChangesWithResponse(ctx, boxID, cursor.params())
+	// Cursor URLs never repeat, so a cached response would never be revalidated —
+	// a long-running watch would grow the cache one dead entry per read. The
+	// calendar change feeds take the same stance.
+	resp, err := s.client.gen.GetBoxPostingChangesWithResponse(contextWithoutCache(ctx), boxID, cursor.params())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The client's ETag cache only ever served the hand-written request path: `initGeneratedClient` handed the generated client the raw `http.Client`, so every generated operation — most of the API surface — refetched full bodies on every call, while the generated package's own `CachingTransport` sat unwired. HEY serves ETags broadly (`fresh_when` on topics, boxes, contacts, calendar, and the Rack conditional-GET default behind everything else) and answers `If-None-Match` with 304s; the client just never sent one.

A client with a cache now routes generated requests through a caching Doer with the same contract as the hand-written path:

- A JSON API GET keyed by URL and Authorization goes out conditional when the cache holds both the ETag and its body — an ETag without its body, or a body over the buffer bound, is treated as a miss so a 304 can always be answered.
- A 304 is answered from the cache as the 200 it revalidated, with the `Content-Type` the generated parsers switch on.
- A fresh 200 bearing an ETag replaces what was stored.
- Form and document representations, requests whose context bypasses the cache, and requests without an Authorization header to key by pass through untouched — the stance the hand-written path already takes.
- Account-scoped URLs carry their account filter by the time the Doer sees them, so accounts keep distinct entries in the shared cache.

A body read failure while storing is kept for the caller's own read to surface, so the generated retry loop never resends a response it already has (a body over the transport cap would otherwise be refetched at full size once per attempt).

A client without a cache is unchanged: the generated client keeps the raw `http.Client`. Enabling the cache in the CLI lands separately in hey-cli.

Card: https://app.basecamp.com/2914079/buckets/48521764/card_tables/cards/10240004704

`TMPDIR=/tmp/t make check` green (183/183).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes generated client requests through the response cache so generated operations revalidate with ETags and read 304s from the cache, matching the hand-written path. Previously the cache only served hand-written requests, so generated operations refetched full bodies on every call; clients without a cache are unchanged. Conformance cases pin this contract with repeated reads against one client: a second read goes conditional and parses the 304, a changed resource's fresh ETag replaces the stored one, and a no-cache client never sends `If-None-Match`.

- A JSON GET keyed by URL and Authorization goes out conditional when the cache holds both the ETag and its body; a 304 is answered from the cache as the 200 it revalidated, carrying the 304's regenerated pagination headers (`X-Total-Count`, `Link`) through.
- A fresh 200 bearing an ETag replaces the stored copy.
- Form and document requests, requests without an Authorization header, requests whose context bypasses the cache, and the posting changes feed — whose cursor URLs never repeat — pass through untouched; account-scoped URLs keep distinct cache entries.
- A body read failure while storing surfaces on the caller's own read, so the retry loop never resends a response it already has; a body past the buffer bound is handed back unstored and invalidates the key's earlier entry, so the next read goes out unconditional.

<sup>Written for commit 1ac046fa20f9474987d652ade3b6d9b0d6c90bef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-sdk/pull/140?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

