### PR TITLE
Add workflow stage reader

### DIFF
--- a/behavior-model.json
+++ b/behavior-model.json
@@ -951,6 +951,19 @@
         ]
       }
     },
+    "GetWorkflowStage": {
+      "idempotent": false,
+      "readonly": true,
+      "retry": {
+        "backoff": "exponential",
+        "base_delay_ms": 1000,
+        "max": 3,
+        "retry_on": [
+          429,
+          503
+        ]
+      }
+    },
     "HideContact": {
       "idempotent": true,
       "readonly": false,

--- a/conformance/runner/go/main.go
+++ b/conformance/runner/go/main.go
@@ -209,8 +209,14 @@ func runTest(tc TestCase) TestResult {
 		// Set status code
 		w.WriteHeader(status)
 
-		// Write body
+		// Write body. HTML fixtures are already wire text; JSON fixtures are structured values.
 		if resp.Body != nil {
+			if strings.HasPrefix(w.Header().Get("Content-Type"), "text/html") {
+				if html, ok := resp.Body.(string); ok {
+					_, _ = io.WriteString(w, html)
+					return
+				}
+			}
 			bodyBytes, _ := json.Marshal(resp.Body)
 			_, _ = w.Write(bodyBytes)
 		}
@@ -1253,6 +1259,8 @@ func executeOperation(client *generated.Client, ctx context.Context, tc TestCase
 		return client.ListSnippets(ctx)
 	case "GetWorkflow":
 		return client.GetWorkflow(ctx, getInt64Param(tc.PathParams, "workflowId"))
+	case "GetWorkflowStage":
+		return client.GetWorkflowStage(ctx, getInt64Param(tc.PathParams, "workflowId"), getInt64Param(tc.PathParams, "stageId"))
 	case "CreateWorkflowStaging":
 		return client.CreateWorkflowStaging(
 			ctx,
@@ -1585,6 +1593,8 @@ func executeHEYOperation(client *hey.Client, ctx context.Context, tc TestCase) (
 	switch tc.Operation {
 	case "ListBoxes":
 		return client.Boxes().List(ctx)
+	case "GetWorkflowStage":
+		return client.Workflows().GetStage(ctx, getInt64Param(tc.PathParams, "workflowId"), getInt64Param(tc.PathParams, "stageId"))
 	case "UpdateCalendarEvent":
 		eventID := getInt64Param(tc.PathParams, "eventId")
 		_, err := client.CalendarEvents().Update(ctx, eventID, hey.UpdateCalendarEventParams{

--- a/conformance/tests/paths.json
+++ b/conformance/tests/paths.json
@@ -3474,6 +3474,51 @@
     ]
   },
   {
+    "name": "GetWorkflowStage uses the HTML workflow stage path",
+    "description": "Verifies that GetWorkflowStage requests a stage as HTML through the generated route.",
+    "operation": "GetWorkflowStage",
+    "method": "GET",
+    "path": "/workflows/{workflowId}/stages/{stageId}",
+    "pathParams": {
+      "workflowId": 8801,
+      "stageId": 5512
+    },
+    "configOverrides": {
+      "clientLayer": "hey"
+    },
+    "mockResponses": [
+      {
+        "status": 200,
+        "headers": {
+          "Content-Type": "text/html; charset=utf-8"
+        },
+        "body": "<section id=\"container_workflow_stage_5512\"></section>"
+      }
+    ],
+    "assertions": [
+      {
+        "type": "requestPath",
+        "expected": "/workflows/8801/stages/5512"
+      },
+      {
+        "type": "requestMethod",
+        "expected": "GET"
+      },
+      {
+        "type": "lastRequestHeader",
+        "path": "Accept",
+        "expected": "text/html"
+      },
+      {
+        "type": "noError"
+      }
+    ],
+    "tags": [
+      "path",
+      "workflows"
+    ]
+  },
+  {
     "name": "CreateWorkflowStaging uses the topic workflow stagings path",
     "description": "Verifies that CreateWorkflowStaging adds a topic through its workflow staging resource",
     "operation": "CreateWorkflowStaging",

--- a/go/pkg/generated/client.gen.go
+++ b/go/pkg/generated/client.gen.go
@@ -869,6 +869,9 @@ type GetTrashTopicsResponseContent = TopicListResponse
 // GetWorkflowResponseContent Workflow — email workflow/label
 type GetWorkflowResponseContent = Workflow
 
+// GetWorkflowStageOutputPayload defines model for GetWorkflowStageOutputPayload.
+type GetWorkflowStageOutputPayload = string
+
 // HabitPayload defines model for HabitPayload.
 type HabitPayload struct {
 	Color string `json:"color,omitempty"`
@@ -2904,6 +2907,9 @@ type ClientInterface interface {
 
 	// GetWorkflow request
 	GetWorkflow(ctx context.Context, workflowId int64, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetWorkflowStage request
+	GetWorkflowStage(ctx context.Context, workflowId int64, stageId int64, reqEditors ...RequestEditorFn) (*http.Response, error)
 }
 
 // DeleteExtenzion is marked as idempotent and will be retried on transient failures.
@@ -4376,6 +4382,14 @@ func (c *Client) GetWorkflow(ctx context.Context, workflowId int64, reqEditors .
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewGetWorkflowRequest(c.Server, workflowId)
 	}, true, "GetWorkflow", reqEditors...)
+}
+
+// GetWorkflowStage is marked as idempotent and will be retried on transient failures.
+
+func (c *Client) GetWorkflowStage(ctx context.Context, workflowId int64, stageId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		return NewGetWorkflowStageRequest(c.Server, workflowId, stageId)
+	}, true, "GetWorkflowStage", reqEditors...)
 }
 
 // NewDeleteExtenzionRequest generates requests for DeleteExtenzion
@@ -10057,6 +10071,47 @@ func NewGetWorkflowRequest(server string, workflowId int64) (*http.Request, erro
 	return req, nil
 }
 
+// NewGetWorkflowStageRequest generates requests for GetWorkflowStage
+func NewGetWorkflowStageRequest(server string, workflowId int64, stageId int64) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "workflowId", runtime.ParamLocationPath, workflowId)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "stageId", runtime.ParamLocationPath, stageId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/workflows/%s/stages/%s", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 func (c *Client) applyEditors(ctx context.Context, req *http.Request, additionalEditors []RequestEditorFn) error {
 	for _, r := range c.RequestEditors {
 		if err := r(ctx, req); err != nil {
@@ -10212,6 +10267,7 @@ var operationMetadata = map[string]OperationMetadata{
 	"MoveWorkflowStaging":           {Idempotent: false, HasSensitiveParams: false},
 	"CreateWorkflowStaging":         {Idempotent: false, HasSensitiveParams: false},
 	"GetWorkflow":                   {Idempotent: true, HasSensitiveParams: false},
+	"GetWorkflowStage":              {Idempotent: true, HasSensitiveParams: false},
 }
 
 // GetOperationMetadata returns metadata for the given operation ID.
@@ -12168,6 +12224,13 @@ type ClientWithResponsesInterface interface {
 	//
 	// Returns a wrapper object for the known response body format(s).
 	GetWorkflowWithResponse(ctx context.Context, workflowId int64, reqEditors ...RequestEditorFn) (*GetWorkflowResponse, error)
+
+	// GetWorkflowStageWithResponse performs a GET /workflows/{workflowId}/stages/{stageId} (the `GetWorkflowStage` operationId) request.
+	//
+	// A workflow stage and its cards, served as HTML by HEY.
+	//
+	// Returns a wrapper object for the known response body format(s).
+	GetWorkflowStageWithResponse(ctx context.Context, workflowId int64, stageId int64, reqEditors ...RequestEditorFn) (*GetWorkflowStageResponse, error)
 }
 
 type DeleteExtenzionResponse struct {
@@ -20665,6 +20728,68 @@ func (r GetWorkflowResponse) ContentType() string {
 	return ""
 }
 
+type GetWorkflowStageResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	// JSON401 the response for an HTTP 401 `application/json` response
+	JSON401 *UnauthorizedErrorResponseContent
+	// JSON404 the response for an HTTP 404 `application/json` response
+	JSON404 *NotFoundErrorResponseContent
+	// JSON500 the response for an HTTP 500 `application/json` response
+	JSON500 *InternalServerErrorResponseContent
+	// JSON503 the response for an HTTP 503 `application/json` response
+	JSON503 *ServiceUnavailableErrorResponseContent
+}
+
+// GetJSON401 returns the response for an HTTP 401 `application/json` response
+func (r GetWorkflowStageResponse) GetJSON401() *UnauthorizedErrorResponseContent {
+	return r.JSON401
+}
+
+// GetJSON404 returns the response for an HTTP 404 `application/json` response
+func (r GetWorkflowStageResponse) GetJSON404() *NotFoundErrorResponseContent {
+	return r.JSON404
+}
+
+// GetJSON500 returns the response for an HTTP 500 `application/json` response
+func (r GetWorkflowStageResponse) GetJSON500() *InternalServerErrorResponseContent {
+	return r.JSON500
+}
+
+// GetJSON503 returns the response for an HTTP 503 `application/json` response
+func (r GetWorkflowStageResponse) GetJSON503() *ServiceUnavailableErrorResponseContent {
+	return r.JSON503
+}
+
+// GetBody returns the raw response body bytes
+func (r GetWorkflowStageResponse) GetBody() []byte {
+	return r.Body
+}
+
+// Status returns HTTPResponse.Status
+func (r GetWorkflowStageResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetWorkflowStageResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r GetWorkflowStageResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
 // DeleteExtenzionWithResponse performs a DELETE /accounts/{accountId}/domains/extenzions/{extenzionId} (the `DeleteExtenzion` operationId) request.
 //
 // Delete an extenzion. The id is the extenzion's contact id, the one its app_url
@@ -23021,6 +23146,19 @@ func (c *ClientWithResponses) GetWorkflowWithResponse(ctx context.Context, workf
 		return nil, err
 	}
 	return ParseGetWorkflowResponse(rsp)
+}
+
+// GetWorkflowStageWithResponse performs a GET /workflows/{workflowId}/stages/{stageId} (the `GetWorkflowStage` operationId) request.
+//
+// A workflow stage and its cards, served as HTML by HEY.
+//
+// Returns a wrapper object for the known response body format(s).
+func (c *ClientWithResponses) GetWorkflowStageWithResponse(ctx context.Context, workflowId int64, stageId int64, reqEditors ...RequestEditorFn) (*GetWorkflowStageResponse, error) {
+	rsp, err := c.GetWorkflowStage(ctx, workflowId, stageId, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetWorkflowStageResponse(rsp)
 }
 
 // ParseDeleteExtenzionResponse parses an HTTP response from a DeleteExtenzionWithResponse call
@@ -29697,6 +29835,53 @@ func ParseGetWorkflowResponse(rsp *http.Response) (*GetWorkflowResponse, error) 
 		}
 		response.JSON200 = &dest
 
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest UnauthorizedErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFoundErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalServerErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 503:
+		var dest ServiceUnavailableErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON503 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetWorkflowStageResponse parses an HTTP response from a GetWorkflowStageWithResponse call
+func ParseGetWorkflowStageResponse(rsp *http.Response) (*GetWorkflowStageResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetWorkflowStageResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
 		var dest UnauthorizedErrorResponseContent
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {

--- a/go/pkg/hey/services_test.go
+++ b/go/pkg/hey/services_test.go
@@ -3702,18 +3702,30 @@ func TestWorkflowsService_Stages(t *testing.T) {
 }
 
 func TestWorkflowsService_GetStage(t *testing.T) {
-	client := newServiceTestClient(t, map[string]string{
-		"/workflows/8801/stages/5512": `<section id="container_workflow_stage_5512"><h2>Applied</h2><div class="workflow__card" id="topic_4471829" data-identifier="91"><h3>Application</h3><p class="card__detail">3 emails</p></div></section>`,
-	})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/workflows/8801/stages/5512" {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		if got := r.Header.Get("Accept"); got != "text/html" {
+			t.Fatalf("expected Accept text/html, got %q", got)
+		}
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_, _ = w.Write([]byte(`<section id="container_workflow_stage_5512"><h2>Applied<span class="u-for-screen-reader"> stage</span></h2><div class="workflow__card" id="topic_4471829" data-identifier="91"><h3>Application<span class="u-for-screen-reader">Thread: Application</span></h3><p class="card__detail"><span class="u-for-screen-reader">,</span>3 emails</p></div><div class="workflow__card" id="topic_4471830" data-identifier="92"></div><div id="topic_not-a-number" data-identifier="93"></div><div id="topic_4471831" data-identifier="not-a-number"></div></section>`))
+	}))
+	t.Cleanup(server.Close)
+	client := NewClient(&Config{BaseURL: server.URL}, &StaticTokenProvider{Token: "test-token"}, WithMaxRetries(0))
 	stage, err := client.Workflows().GetStage(context.Background(), 8801, 5512)
 	if err != nil {
 		t.Fatalf("GetStage: %v", err)
 	}
-	if stage == nil || stage.ID != 5512 || stage.Name != "Applied" || len(stage.Topics) != 1 {
+	if stage == nil || stage.ID != 5512 || stage.Name != "Applied" || len(stage.Topics) != 2 {
 		t.Fatalf("unexpected stage: %+v", stage)
 	}
 	if topic := stage.Topics[0]; topic.TopicID != 4471829 || topic.StagingID != 91 || topic.Subject != "Application" || topic.EntryCount != 3 {
 		t.Errorf("unexpected topic: %+v", topic)
+	}
+	if topic := stage.Topics[1]; topic.TopicID != 4471830 || topic.StagingID != 92 || topic.Subject != "" || topic.EntryCount != 0 {
+		t.Errorf("unexpected sparse topic: %+v", topic)
 	}
 }
 

--- a/go/pkg/hey/services_test.go
+++ b/go/pkg/hey/services_test.go
@@ -3701,6 +3701,22 @@ func TestWorkflowsService_Stages(t *testing.T) {
 	}
 }
 
+func TestWorkflowsService_GetStage(t *testing.T) {
+	client := newServiceTestClient(t, map[string]string{
+		"/workflows/8801/stages/5512": `<section id="container_workflow_stage_5512"><h2>Applied</h2><div class="workflow__card" id="topic_4471829" data-identifier="91"><h3>Application</h3><p class="card__detail">3 emails</p></div></section>`,
+	})
+	stage, err := client.Workflows().GetStage(context.Background(), 8801, 5512)
+	if err != nil {
+		t.Fatalf("GetStage: %v", err)
+	}
+	if stage == nil || stage.ID != 5512 || stage.Name != "Applied" || len(stage.Topics) != 1 {
+		t.Fatalf("unexpected stage: %+v", stage)
+	}
+	if topic := stage.Topics[0]; topic.TopicID != 4471829 || topic.StagingID != 91 || topic.Subject != "Application" || topic.EntryCount != 3 {
+		t.Errorf("unexpected topic: %+v", topic)
+	}
+}
+
 func TestWorkflowsService_Writes(t *testing.T) {
 	creator := newFormTestClient(t, "POST", "/workflows", func(t *testing.T, values url.Values) {
 		t.Helper()

--- a/go/pkg/hey/url-routes.json
+++ b/go/pkg/hey/url-routes.json
@@ -1128,6 +1128,23 @@
           "type": "int64"
         }
       }
+    },
+    {
+      "pattern": "/workflows/{workflowId}/stages/{stageId}",
+      "resource": "Workflows",
+      "operations": {
+        "GET": "GetWorkflowStage"
+      },
+      "params": {
+        "stageId": {
+          "role": "recording",
+          "type": "int64"
+        },
+        "workflowId": {
+          "role": "parent",
+          "type": "int64"
+        }
+      }
     }
   ]
 }

--- a/go/pkg/hey/workflows.go
+++ b/go/pkg/hey/workflows.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
@@ -118,16 +119,26 @@ func (s *WorkflowsService) Stages(ctx context.Context, workflowID int64) ([]gene
 	return workflow.Stages, nil
 }
 
-// GetStage reads the threads in one workflow stage. HEY currently serves this resource as
-// HTML rather than JSON, so this is deliberately kept in the SDK's workflow compatibility layer.
+// GetStage reads the threads in one workflow stage. HEY serves this resource as HTML.
 func (s *WorkflowsService) GetStage(ctx context.Context, workflowID, stageID int64) (result *WorkflowStageView, err error) {
 	op := OperationInfo{Service: "Workflows", Operation: "GetWorkflowStage", ResourceType: "workflow_stage", IsMutation: false, ResourceID: stageID}
 	err = s.client.instrument(ctx, op, func(ctx context.Context) error {
-		resp, rerr := s.client.GetHTML(ctx, fmt.Sprintf("/workflows/%d/stages/%d", workflowID, stageID))
+		resp, rerr := s.client.genClient().GetWorkflowStageWithResponse(ctx, workflowID, stageID, func(_ context.Context, req *http.Request) error {
+			req.URL.Path = strings.TrimSuffix(req.URL.Path, ".json")
+			if req.URL.RawPath != "" {
+				req.URL.RawPath = strings.TrimSuffix(req.URL.RawPath, ".json")
+			}
+			req.Header.Del("Content-Type")
+			req.Header.Set("Accept", "text/html")
+			return nil
+		})
 		if rerr != nil {
 			return rerr
 		}
-		result, err = parseWorkflowStageHTML(resp.Data, stageID)
+		if cerr := CheckResponse(resp.HTTPResponse); cerr != nil {
+			return cerr
+		}
+		result, err = parseWorkflowStageHTML(resp.Body, stageID)
 		return err
 	})
 	return result, err
@@ -146,25 +157,37 @@ func parseWorkflowStageHTML(source []byte, wantStageID int64) (*WorkflowStageVie
 	}
 	result := &WorkflowStageView{ID: wantStageID}
 	if heading := findNode(stage, func(n *html.Node) bool { return n.Type == html.ElementNode && n.Data == "h2" }); heading != nil {
-		result.Name = nodeText(heading)
+		result.Name = visibleNodeText(heading)
 	}
 	var walk func(*html.Node)
 	walk = func(n *html.Node) {
 		if n.Type == html.ElementNode && strings.HasPrefix(attr(n, "id"), "topic_") {
-			topicID, _ := strconv.ParseInt(strings.TrimPrefix(attr(n, "id"), "topic_"), 10, 64)
-			stagingID, _ := strconv.ParseInt(attr(n, "data-identifier"), 10, 64)
-			if topicID != 0 {
-				topic := WorkflowStageTopic{TopicID: topicID, StagingID: stagingID}
-				if title := findNode(n, func(x *html.Node) bool { return x.Type == html.ElementNode && x.Data == "h3" }); title != nil {
-					topic.Subject = nodeText(title)
-				}
-				if detail := findNode(n, func(x *html.Node) bool {
-					return x.Type == html.ElementNode && x.Data == "p" && strings.Contains(attr(x, "class"), "card__detail")
-				}); detail != nil {
-					fmt.Sscanf(nodeText(detail), "%d", &topic.EntryCount)
-				}
-				result.Topics = append(result.Topics, topic)
+			topicID, topicErr := strconv.ParseInt(strings.TrimPrefix(attr(n, "id"), "topic_"), 10, 64)
+			if topicErr != nil || topicID <= 0 {
+				return
 			}
+			stagingID, stagingErr := strconv.ParseInt(attr(n, "data-identifier"), 10, 64)
+			if stagingErr != nil || stagingID <= 0 {
+				return
+			}
+			topic := WorkflowStageTopic{StagingID: stagingID, TopicID: topicID}
+			if title := findNode(n, func(x *html.Node) bool { return x.Type == html.ElementNode && x.Data == "h3" }); title != nil {
+				topic.Subject = visibleNodeText(title)
+			}
+			if detail := findNode(n, func(x *html.Node) bool {
+				return x.Type == html.ElementNode && x.Data == "p" && strings.Contains(attr(x, "class"), "card__detail")
+			}); detail != nil {
+				fields := strings.Fields(visibleNodeText(detail))
+				if len(fields) == 0 {
+					return
+				}
+				entryCount, countErr := strconv.Atoi(fields[0])
+				if countErr != nil || entryCount < 0 {
+					return
+				}
+				topic.EntryCount = entryCount
+			}
+			result.Topics = append(result.Topics, topic)
 			return
 		}
 		for child := n.FirstChild; child != nil; child = child.NextSibling {
@@ -194,10 +217,13 @@ func attr(node *html.Node, name string) string {
 	}
 	return ""
 }
-func nodeText(node *html.Node) string {
+func visibleNodeText(node *html.Node) string {
 	var b strings.Builder
 	var walk func(*html.Node)
 	walk = func(n *html.Node) {
+		if n.Type == html.ElementNode && isVisuallyHidden(n) {
+			return
+		}
 		if n.Type == html.TextNode {
 			b.WriteString(n.Data)
 		}
@@ -207,6 +233,16 @@ func nodeText(node *html.Node) string {
 	}
 	walk(node)
 	return strings.Join(strings.Fields(b.String()), " ")
+}
+
+func isVisuallyHidden(node *html.Node) bool {
+	for _, class := range strings.Fields(attr(node, "class")) {
+		switch class {
+		case "sr-only", "screen-reader-only", "u-for-screen-reader", "visually-hidden":
+			return true
+		}
+	}
+	return false
 }
 
 // Create adds a workflow. accountID of zero leaves the server to pick your first account.

--- a/go/pkg/hey/workflows.go
+++ b/go/pkg/hey/workflows.go
@@ -8,6 +8,8 @@ import (
 	"strconv"
 	"strings"
 
+	"golang.org/x/net/html"
+
 	"github.com/basecamp/hey-sdk/go/pkg/generated"
 )
 
@@ -29,6 +31,22 @@ type Workflow struct {
 	ID          int64
 	Name        string
 	AccountName string
+}
+
+// WorkflowStageTopic is a thread card in a workflow stage.
+// StagingID identifies the workflow membership; TopicID identifies the email thread.
+type WorkflowStageTopic struct {
+	StagingID  int64
+	TopicID    int64
+	Subject    string
+	EntryCount int
+}
+
+// WorkflowStageView is the stage page HEY renders, including its thread cards.
+type WorkflowStageView struct {
+	ID     int64
+	Name   string
+	Topics []WorkflowStageTopic
 }
 
 // List returns the workflows on an account.
@@ -98,6 +116,97 @@ func (s *WorkflowsService) Stages(ctx context.Context, workflowID int64) ([]gene
 		return nil, err
 	}
 	return workflow.Stages, nil
+}
+
+// GetStage reads the threads in one workflow stage. HEY currently serves this resource as
+// HTML rather than JSON, so this is deliberately kept in the SDK's workflow compatibility layer.
+func (s *WorkflowsService) GetStage(ctx context.Context, workflowID, stageID int64) (result *WorkflowStageView, err error) {
+	op := OperationInfo{Service: "Workflows", Operation: "GetWorkflowStage", ResourceType: "workflow_stage", IsMutation: false, ResourceID: stageID}
+	err = s.client.instrument(ctx, op, func(ctx context.Context) error {
+		resp, rerr := s.client.GetHTML(ctx, fmt.Sprintf("/workflows/%d/stages/%d", workflowID, stageID))
+		if rerr != nil {
+			return rerr
+		}
+		result, err = parseWorkflowStageHTML(resp.Data, stageID)
+		return err
+	})
+	return result, err
+}
+
+func parseWorkflowStageHTML(source []byte, wantStageID int64) (*WorkflowStageView, error) {
+	doc, err := html.Parse(strings.NewReader(string(source)))
+	if err != nil {
+		return nil, fmt.Errorf("parse workflow stage: %w", err)
+	}
+	stage := findNode(doc, func(n *html.Node) bool {
+		return n.Type == html.ElementNode && attr(n, "id") == fmt.Sprintf("container_workflow_stage_%d", wantStageID)
+	})
+	if stage == nil {
+		return nil, fmt.Errorf("workflow stage %d not found", wantStageID)
+	}
+	result := &WorkflowStageView{ID: wantStageID}
+	if heading := findNode(stage, func(n *html.Node) bool { return n.Type == html.ElementNode && n.Data == "h2" }); heading != nil {
+		result.Name = nodeText(heading)
+	}
+	var walk func(*html.Node)
+	walk = func(n *html.Node) {
+		if n.Type == html.ElementNode && strings.HasPrefix(attr(n, "id"), "topic_") {
+			topicID, _ := strconv.ParseInt(strings.TrimPrefix(attr(n, "id"), "topic_"), 10, 64)
+			stagingID, _ := strconv.ParseInt(attr(n, "data-identifier"), 10, 64)
+			if topicID != 0 {
+				topic := WorkflowStageTopic{TopicID: topicID, StagingID: stagingID}
+				if title := findNode(n, func(x *html.Node) bool { return x.Type == html.ElementNode && x.Data == "h3" }); title != nil {
+					topic.Subject = nodeText(title)
+				}
+				if detail := findNode(n, func(x *html.Node) bool {
+					return x.Type == html.ElementNode && x.Data == "p" && strings.Contains(attr(x, "class"), "card__detail")
+				}); detail != nil {
+					fmt.Sscanf(nodeText(detail), "%d", &topic.EntryCount)
+				}
+				result.Topics = append(result.Topics, topic)
+			}
+			return
+		}
+		for child := n.FirstChild; child != nil; child = child.NextSibling {
+			walk(child)
+		}
+	}
+	walk(stage)
+	return result, nil
+}
+
+func findNode(node *html.Node, match func(*html.Node) bool) *html.Node {
+	if match(node) {
+		return node
+	}
+	for child := node.FirstChild; child != nil; child = child.NextSibling {
+		if found := findNode(child, match); found != nil {
+			return found
+		}
+	}
+	return nil
+}
+func attr(node *html.Node, name string) string {
+	for _, value := range node.Attr {
+		if value.Key == name {
+			return value.Val
+		}
+	}
+	return ""
+}
+func nodeText(node *html.Node) string {
+	var b strings.Builder
+	var walk func(*html.Node)
+	walk = func(n *html.Node) {
+		if n.Type == html.TextNode {
+			b.WriteString(n.Data)
+		}
+		for c := n.FirstChild; c != nil; c = c.NextSibling {
+			walk(c)
+		}
+	}
+	walk(node)
+	return strings.Join(strings.Fields(b.String()), " ")
 }
 
 // Create adds a workflow. accountID of zero leaves the server to pick your first account.

--- a/openapi.json
+++ b/openapi.json
@@ -10371,6 +10371,87 @@
           ]
         }
       }
+    },
+    "/workflows/{workflowId}/stages/{stageId}": {
+      "get": {
+        "description": "A workflow stage and its cards, served as HTML by HEY.",
+        "operationId": "GetWorkflowStage",
+        "parameters": [
+          {
+            "name": "workflowId",
+            "in": "path",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "required": true
+          },
+          {
+            "name": "stageId",
+            "in": "path",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "GetWorkflowStage 200 response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetWorkflowStageOutputPayload"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "UnauthorizedError 401 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedErrorResponseContent"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFoundError 404 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundErrorResponseContent"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "InternalServerError 500 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerErrorResponseContent"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "ServiceUnavailableError 503 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceUnavailableErrorResponseContent"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Workflows"
+        ]
+      }
     }
   },
   "components": {
@@ -12332,6 +12413,10 @@
       },
       "GetWorkflowResponseContent": {
         "$ref": "#/components/schemas/Workflow"
+      },
+      "GetWorkflowStageOutputPayload": {
+        "type": "string",
+        "contentEncoding": "byte"
       },
       "HabitPayload": {
         "type": "object",

--- a/spec/excluded-routes.json
+++ b/spec/excluded-routes.json
@@ -3510,11 +3510,6 @@
     "reason": "phase-2: workflow stages"
   },
   {
-    "method": "GET",
-    "path": "/workflows/{workflow_id}/stages/{id}",
-    "reason": "phase-2: workflow stages"
-  },
-  {
     "method": "PATCH",
     "path": "/workflows/{workflow_id}/stages/{id}",
     "reason": "phase-2: workflow stages"

--- a/spec/hey.smithy
+++ b/spec/hey.smithy
@@ -247,6 +247,7 @@ service HEY {
         ListClips
         ListSnippets
         GetWorkflow
+        GetWorkflowStage
         CreateWorkflowStaging
         MoveWorkflowStaging
         GetTopicPublication
@@ -453,6 +454,9 @@ structure WorkflowStage {
     id: Long
     name: String
 }
+
+@mediaType("text/html")
+blob WorkflowStageHTML
 
 list WorkflowStageList {
     member: WorkflowStage
@@ -4457,6 +4461,31 @@ operation GetWorkflow {
     input: GetWorkflowInput
     output: GetWorkflowOutput
     errors: [UnauthorizedError, NotFoundError, InternalServerError, ServiceUnavailableError]
+}
+
+/// A workflow stage and its cards, served as HTML by HEY.
+@readonly
+@http(method: "GET", uri: "/workflows/{workflowId}/stages/{stageId}")
+@tags(["Workflows"])
+operation GetWorkflowStage {
+    input: GetWorkflowStageInput
+    output: GetWorkflowStageOutput
+    errors: [UnauthorizedError, NotFoundError, InternalServerError, ServiceUnavailableError]
+}
+
+structure GetWorkflowStageInput {
+    @httpLabel
+    @required
+    workflowId: Long
+    @httpLabel
+    @required
+    stageId: Long
+}
+
+structure GetWorkflowStageOutput {
+    @httpPayload
+    @required
+    body: WorkflowStageHTML
 }
 
 structure GetWorkflowInput {

--- a/spec/route-coverage.json
+++ b/spec/route-coverage.json
@@ -350,6 +350,11 @@
     "path": "/workflows/{workflowId}"
   },
   {
+    "method": "GET",
+    "operationId": "GetWorkflowStage",
+    "path": "/workflows/{workflowId}/stages/{stageId}"
+  },
+  {
     "method": "DELETE",
     "operationId": "HideContact",
     "path": "/contacts/{contactId}"


### PR DESCRIPTION
Adds the generated `GetWorkflowStage` HTML operation and parses its stage cards into thread metadata.

CLI: https://github.com/basecamp/hey-cli/pull/380