### PR TITLE
Read a Set Aside group with its postings

### DIFF
--- a/behavior-model.json
+++ b/behavior-model.json
@@ -483,6 +483,10 @@
     },
     "GetBoxGroup": {
       "idempotent": false,
+      "pagination": {
+        "style": "link",
+        "totalCountHeader": "X-Total-Count"
+      },
       "readonly": true,
       "retry": {
         "backoff": "exponential",

--- a/behavior-model.json
+++ b/behavior-model.json
@@ -481,6 +481,19 @@
         ]
       }
     },
+    "GetBoxGroup": {
+      "idempotent": false,
+      "readonly": true,
+      "retry": {
+        "backoff": "exponential",
+        "base_delay_ms": 1000,
+        "max": 3,
+        "retry_on": [
+          429,
+          503
+        ]
+      }
+    },
     "GetBoxPostingChanges": {
       "idempotent": false,
       "pagination": {

--- a/conformance/runner/go/main.go
+++ b/conformance/runner/go/main.go
@@ -1482,6 +1482,10 @@ func executeOperation(client *generated.Client, ctx context.Context, tc TestCase
 	case "ListBoxGroups":
 		boxId := getInt64Param(tc.PathParams, "boxId")
 		return client.ListBoxGroups(ctx, boxId)
+	case "GetBoxGroup":
+		boxId := getInt64Param(tc.PathParams, "boxId")
+		groupId := getInt64Param(tc.PathParams, "groupId")
+		return client.GetBoxGroup(ctx, boxId, groupId, nil)
 	case "CreateBoxGroup":
 		boxId := getInt64Param(tc.PathParams, "boxId")
 		body := generated.CreateBoxGroupJSONRequestBody{

--- a/conformance/tests/paths.json
+++ b/conformance/tests/paths.json
@@ -2687,6 +2687,40 @@
     ]
   },
   {
+    "name": "GetBoxGroup uses /boxes/{boxId}/groups/{groupId} path",
+    "description": "Verifies that GetBoxGroup constructs the URL path /boxes/{boxId}/groups/{groupId}",
+    "operation": "GetBoxGroup",
+    "method": "GET",
+    "path": "/boxes/{boxId}/groups/{groupId}",
+    "pathParams": {
+      "boxId": 24090,
+      "groupId": 9
+    },
+    "mockResponses": [
+      {
+        "status": 200,
+        "body": {
+          "id": 9,
+          "box_id": 24090,
+          "postings": []
+        }
+      }
+    ],
+    "assertions": [
+      {
+        "type": "requestPath",
+        "expected": "/boxes/24090/groups/9"
+      },
+      {
+        "type": "noError"
+      }
+    ],
+    "tags": [
+      "path",
+      "boxes"
+    ]
+  },
+  {
     "name": "DeleteBoxGroup uses /boxes/{boxId}/groups/{groupId} path",
     "description": "Verifies that DeleteBoxGroup constructs the URL path /boxes/{boxId}/groups/{groupId}",
     "operation": "DeleteBoxGroup",

--- a/go/pkg/generated/client.gen.go
+++ b/go/pkg/generated/client.gen.go
@@ -110,6 +110,13 @@ type BoxGroup struct {
 	Id int64 `json:"id"`
 }
 
+// BoxGroupWithPostings BoxGroupWithPostings — a Set Aside group with one page of the postings in it
+type BoxGroupWithPostings struct {
+	BoxId    int64     `json:"box_id,omitempty"`
+	Id       int64     `json:"id"`
+	Postings []Posting `json:"postings,omitempty"`
+}
+
 // BoxGroupsResponse BoxGroupsResponse — the wrapper the groups index answers with
 type BoxGroupsResponse struct {
 	BoxGroups []BoxGroup `json:"box_groups,omitempty"`
@@ -737,6 +744,9 @@ type GetAdvancedSearchFiltersResponseContent = AdvancedSearchFilters
 // The API can return fields at root level or nested under a `box` key.
 // SDK response decoders normalize the nested variant to flat before decoding.
 type GetAsideboxResponseContent = BoxShowResponse
+
+// GetBoxGroupResponseContent BoxGroupWithPostings — a Set Aside group with one page of the postings in it
+type GetBoxGroupResponseContent = BoxGroupWithPostings
 
 // GetBoxPostingChangesResponseContent defines model for GetBoxPostingChangesResponseContent.
 type GetBoxPostingChangesResponseContent struct {
@@ -1741,6 +1751,11 @@ type GetBoxParams struct {
 	Page *string `form:"page,omitempty" json:"page,omitempty"`
 }
 
+// GetBoxGroupParams defines parameters for GetBoxGroup.
+type GetBoxGroupParams struct {
+	Page *string `form:"page,omitempty" json:"page,omitempty"`
+}
+
 // GetBoxPostingChangesParams defines parameters for GetBoxPostingChanges.
 type GetBoxPostingChangesParams struct {
 	Since   string  `form:"since" json:"since"`
@@ -2472,6 +2487,9 @@ type ClientInterface interface {
 	// DeleteBoxGroup request
 	DeleteBoxGroup(ctx context.Context, boxId int64, groupId int64, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// GetBoxGroup request
+	GetBoxGroup(ctx context.Context, boxId int64, groupId int64, params *GetBoxGroupParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// MarkBoxSeen request
 	MarkBoxSeen(ctx context.Context, boxId int64, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -3006,6 +3024,14 @@ func (c *Client) DeleteBoxGroup(ctx context.Context, boxId int64, groupId int64,
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewDeleteBoxGroupRequest(c.Server, boxId, groupId)
 	}, true, "DeleteBoxGroup", reqEditors...)
+}
+
+// GetBoxGroup is marked as idempotent and will be retried on transient failures.
+
+func (c *Client) GetBoxGroup(ctx context.Context, boxId int64, groupId int64, params *GetBoxGroupParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		return NewGetBoxGroupRequest(c.Server, boxId, groupId, params)
+	}, true, "GetBoxGroup", reqEditors...)
 }
 
 // MarkBoxSeen executes the MarkBoxSeen operation.
@@ -4973,6 +4999,69 @@ func NewDeleteBoxGroupRequest(server string, boxId int64, groupId int64) (*http.
 	}
 
 	req, err := http.NewRequest("DELETE", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewGetBoxGroupRequest generates requests for GetBoxGroup
+func NewGetBoxGroupRequest(server string, boxId int64, groupId int64, params *GetBoxGroupParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "boxId", runtime.ParamLocationPath, boxId)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "groupId", runtime.ParamLocationPath, groupId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/boxes/%s/groups/%s", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.Page != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "page", runtime.ParamLocationQuery, *params.Page); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -10093,6 +10182,7 @@ var operationMetadata = map[string]OperationMetadata{
 	"ListBoxGroups":                 {Idempotent: true, HasSensitiveParams: false},
 	"CreateBoxGroup":                {Idempotent: false, HasSensitiveParams: false},
 	"DeleteBoxGroup":                {Idempotent: true, HasSensitiveParams: false},
+	"GetBoxGroup":                   {Idempotent: true, HasSensitiveParams: false},
 	"MarkBoxSeen":                   {Idempotent: false, HasSensitiveParams: false},
 	"GetBoxPostingChanges":          {Idempotent: true, HasSensitiveParams: false},
 	"GetBubblebox":                  {Idempotent: true, HasSensitiveParams: false},
@@ -10918,6 +11008,16 @@ type ClientWithResponsesInterface interface {
 	//
 	// Returns a wrapper object for the known response body format(s).
 	DeleteBoxGroupWithResponse(ctx context.Context, boxId int64, groupId int64, reqEditors ...RequestEditorFn) (*DeleteBoxGroupResponse, error)
+
+	// GetBoxGroupWithResponse performs a GET /boxes/{boxId}/groups/{groupId} (the `GetBoxGroup` operationId) request.
+	//
+	// Read one Set Aside group with the postings in it.
+	//
+	// The postings are paged like a folder's: newest observed first, 30 to a page, with the
+	// next page in the Link header and the total in X-Total-Count.
+	//
+	// Returns a wrapper object for the known response body format(s).
+	GetBoxGroupWithResponse(ctx context.Context, boxId int64, groupId int64, params *GetBoxGroupParams, reqEditors ...RequestEditorFn) (*GetBoxGroupResponse, error)
 
 	// MarkBoxSeenWithResponse performs a POST /boxes/{boxId}/observation.json (the `MarkBoxSeen` operationId) request.
 	//
@@ -12819,6 +12919,75 @@ func (r DeleteBoxGroupResponse) StatusCode() int {
 
 // ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
 func (r DeleteBoxGroupResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type GetBoxGroupResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	// JSON200 the response for an HTTP 200 `application/json` response
+	JSON200 *GetBoxGroupResponseContent
+	// JSON401 the response for an HTTP 401 `application/json` response
+	JSON401 *UnauthorizedErrorResponseContent
+	// JSON404 the response for an HTTP 404 `application/json` response
+	JSON404 *NotFoundErrorResponseContent
+	// JSON500 the response for an HTTP 500 `application/json` response
+	JSON500 *InternalServerErrorResponseContent
+	// JSON503 the response for an HTTP 503 `application/json` response
+	JSON503 *ServiceUnavailableErrorResponseContent
+}
+
+// GetJSON200 returns the response for an HTTP 200 `application/json` response
+func (r GetBoxGroupResponse) GetJSON200() *GetBoxGroupResponseContent {
+	return r.JSON200
+}
+
+// GetJSON401 returns the response for an HTTP 401 `application/json` response
+func (r GetBoxGroupResponse) GetJSON401() *UnauthorizedErrorResponseContent {
+	return r.JSON401
+}
+
+// GetJSON404 returns the response for an HTTP 404 `application/json` response
+func (r GetBoxGroupResponse) GetJSON404() *NotFoundErrorResponseContent {
+	return r.JSON404
+}
+
+// GetJSON500 returns the response for an HTTP 500 `application/json` response
+func (r GetBoxGroupResponse) GetJSON500() *InternalServerErrorResponseContent {
+	return r.JSON500
+}
+
+// GetJSON503 returns the response for an HTTP 503 `application/json` response
+func (r GetBoxGroupResponse) GetJSON503() *ServiceUnavailableErrorResponseContent {
+	return r.JSON503
+}
+
+// GetBody returns the raw response body bytes
+func (r GetBoxGroupResponse) GetBody() []byte {
+	return r.Body
+}
+
+// Status returns HTTPResponse.Status
+func (r GetBoxGroupResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetBoxGroupResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r GetBoxGroupResponse) ContentType() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Header.Get("Content-Type")
 	}
@@ -20831,6 +21000,22 @@ func (c *ClientWithResponses) DeleteBoxGroupWithResponse(ctx context.Context, bo
 	return ParseDeleteBoxGroupResponse(rsp)
 }
 
+// GetBoxGroupWithResponse performs a GET /boxes/{boxId}/groups/{groupId} (the `GetBoxGroup` operationId) request.
+//
+// Read one Set Aside group with the postings in it.
+//
+// The postings are paged like a folder's: newest observed first, 30 to a page, with the
+// next page in the Link header and the total in X-Total-Count.
+//
+// Returns a wrapper object for the known response body format(s).
+func (c *ClientWithResponses) GetBoxGroupWithResponse(ctx context.Context, boxId int64, groupId int64, params *GetBoxGroupParams, reqEditors ...RequestEditorFn) (*GetBoxGroupResponse, error) {
+	rsp, err := c.GetBoxGroup(ctx, boxId, groupId, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetBoxGroupResponse(rsp)
+}
+
 // MarkBoxSeenWithResponse performs a POST /boxes/{boxId}/observation.json (the `MarkBoxSeen` operationId) request.
 //
 // Mark everything in a box as seen. The work is queued, so the effect is eventually consistent.
@@ -23506,6 +23691,60 @@ func ParseDeleteBoxGroupResponse(rsp *http.Response) (*DeleteBoxGroupResponse, e
 	switch {
 	case rsp.StatusCode == 200:
 		break // No content-type
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest UnauthorizedErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFoundErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalServerErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 503:
+		var dest ServiceUnavailableErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON503 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetBoxGroupResponse parses an HTTP response from a GetBoxGroupWithResponse call
+func ParseGetBoxGroupResponse(rsp *http.Response) (*GetBoxGroupResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetBoxGroupResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest GetBoxGroupResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
 		var dest UnauthorizedErrorResponseContent

--- a/go/pkg/hey/boxes.go
+++ b/go/pkg/hey/boxes.go
@@ -293,6 +293,48 @@ func (s *BoxesService) ListGroups(ctx context.Context, boxID int64) (result *gen
 	return result, err
 }
 
+// BoxGroupPage is one page of a Set Aside group's postings with the cursor to the next page
+// and the group's total posting count.
+type BoxGroupPage struct {
+	Group      *generated.BoxGroupWithPostings
+	NextPage   string
+	TotalCount int
+}
+
+// GetGroup returns a Set Aside group with the requested page of its postings.
+func (s *BoxesService) GetGroup(ctx context.Context, boxID, groupID int64, params *generated.GetBoxGroupParams) (*generated.BoxGroupWithPostings, error) {
+	page, err := s.GetGroupPage(ctx, boxID, groupID, params)
+	if err != nil || page == nil {
+		return nil, err
+	}
+	return page.Group, nil
+}
+
+// GetGroupPage returns a Set Aside group page with its next cursor and total posting count.
+func (s *BoxesService) GetGroupPage(ctx context.Context, boxID, groupID int64, params *generated.GetBoxGroupParams) (result *BoxGroupPage, err error) {
+	op := OperationInfo{
+		Service: "Boxes", Operation: "GetBoxGroup",
+		ResourceType: "box_group", IsMutation: false, ResourceID: groupID,
+	}
+
+	err = s.client.instrument(ctx, op, func(ctx context.Context) error {
+		resp, rerr := s.client.genClient().GetBoxGroupWithResponse(ctx, boxID, groupID, params)
+		if rerr != nil {
+			return rerr
+		}
+		if cerr := CheckResponse(resp.HTTPResponse); cerr != nil {
+			return cerr
+		}
+		result = &BoxGroupPage{Group: resp.JSON200}
+		if resp.HTTPResponse != nil {
+			result.TotalCount, _ = strconv.Atoi(resp.HTTPResponse.Header.Get("X-Total-Count"))
+			result.NextPage = gearedPageFromLink(resp.HTTPResponse.Header.Get("Link"))
+		}
+		return nil
+	})
+	return result, err
+}
+
 // CreateGroup gathers a selection of postings into a new Set Aside group.
 func (s *BoxesService) CreateGroup(ctx context.Context, boxID int64, postingIDs []int64) (result *generated.BoxGroup, err error) {
 	op := OperationInfo{

--- a/go/pkg/hey/services_test.go
+++ b/go/pkg/hey/services_test.go
@@ -2821,6 +2821,49 @@ func TestBoxesService_ListGroups(t *testing.T) {
 	}
 }
 
+func TestBoxesService_GetGroupPage(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/boxes/5/groups/11.json" {
+			t.Errorf("path = %q, want /boxes/5/groups/11.json", r.URL.Path)
+		}
+		if page := r.URL.Query().Get("page"); page != "current-cursor" {
+			t.Errorf("page = %q, want current-cursor", page)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Total-Count", "150")
+		w.Header().Set("Link", `<http://`+r.Host+`/boxes/5/groups/11.json?page=next-cursor>; rel="next"`)
+		_, _ = io.WriteString(w, `{"id":11,"box_id":5,"postings":[{"id":1,"kind":"topic","box_group_id":11}]}`)
+	}))
+	t.Cleanup(server.Close)
+
+	client := NewClient(&Config{BaseURL: server.URL}, &StaticTokenProvider{Token: "test-token"}, WithMaxRetries(0))
+	cursor := "current-cursor"
+	page, err := client.Boxes().GetGroupPage(context.Background(), 5, 11, &generated.GetBoxGroupParams{Page: &cursor})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if page.Group == nil || page.Group.Id != 11 || page.Group.BoxId != 5 || page.TotalCount != 150 || page.NextPage != "next-cursor" {
+		t.Errorf("unexpected group page: %+v", page)
+	}
+	if len(page.Group.Postings) != 1 || page.Group.Postings[0].BoxGroupId != 11 {
+		t.Errorf("unexpected postings: %+v", page.Group.Postings)
+	}
+}
+
+func TestBoxesService_GetGroup(t *testing.T) {
+	client := newServiceTestClient(t, map[string]string{
+		"/boxes/%s/groups/%s.json": `{"id":11,"box_id":5,"postings":[]}`,
+	})
+
+	group, err := client.Boxes().GetGroup(context.Background(), 5, 11, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if group.Id != 11 || len(group.Postings) != 0 {
+		t.Errorf("expected empty group 11, got %+v", group)
+	}
+}
+
 func TestBoxesService_CreateGroup(t *testing.T) {
 	client := newRequestTestClient(t, "POST", "/boxes/%s/groups.json", func(t *testing.T, r *http.Request) {
 		t.Helper()

--- a/go/pkg/hey/url-routes.json
+++ b/go/pkg/hey/url-routes.json
@@ -105,7 +105,8 @@
       "pattern": "/boxes/{boxId}/groups/{groupId}",
       "resource": "Boxes",
       "operations": {
-        "DELETE": "DeleteBoxGroup"
+        "DELETE": "DeleteBoxGroup",
+        "GET": "GetBoxGroup"
       },
       "params": {
         "boxId": {

--- a/go/pkg/hey/version.go
+++ b/go/pkg/hey/version.go
@@ -1,7 +1,7 @@
 package hey
 
 // Version is the current version of the HEY Go SDK.
-const Version = "0.28.1"
+const Version = "0.29.0"
 
 // APIVersion is the HEY API version this SDK targets.
 const APIVersion = "2026-08-21"

--- a/openapi.json
+++ b/openapi.json
@@ -921,6 +921,102 @@
             503
           ]
         }
+      },
+      "get": {
+        "description": "Read one Set Aside group with the postings in it.\n\nThe postings are paged like a folder's: newest observed first, 30 to a page, with the\nnext page in the Link header and the total in X-Total-Count.",
+        "operationId": "GetBoxGroup",
+        "parameters": [
+          {
+            "name": "boxId",
+            "in": "path",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "required": true
+          },
+          {
+            "name": "groupId",
+            "in": "path",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "required": true
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "x-go-type-skip-optional-pointer": false
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "GetBoxGroup 200 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetBoxGroupResponseContent"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "UnauthorizedError 401 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedErrorResponseContent"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFoundError 404 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundErrorResponseContent"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "InternalServerError 500 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerErrorResponseContent"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "ServiceUnavailableError 503 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceUnavailableErrorResponseContent"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Boxes"
+        ],
+        "x-hey-retry": {
+          "maxAttempts": 3,
+          "baseDelayMs": 1000,
+          "backoff": "exponential",
+          "retryOn": [
+            429,
+            503
+          ]
+        }
       }
     },
     "/boxes/{boxId}/observation.json": {
@@ -10632,6 +10728,29 @@
           "id"
         ]
       },
+      "BoxGroupWithPostings": {
+        "type": "object",
+        "description": "BoxGroupWithPostings — a Set Aside group with one page of the postings in it",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "box_id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "postings": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Posting"
+            }
+          }
+        },
+        "required": [
+          "id"
+        ]
+      },
       "BoxGroupsResponse": {
         "type": "object",
         "description": "BoxGroupsResponse — the wrapper the groups index answers with",
@@ -12195,6 +12314,9 @@
       },
       "GetAsideboxResponseContent": {
         "$ref": "#/components/schemas/BoxShowResponse"
+      },
+      "GetBoxGroupResponseContent": {
+        "$ref": "#/components/schemas/BoxGroupWithPostings"
       },
       "GetBoxPostingChangesResponseContent": {
         "type": "object",

--- a/openapi.json
+++ b/openapi.json
@@ -1008,6 +1008,10 @@
         "tags": [
           "Boxes"
         ],
+        "x-hey-pagination": {
+          "style": "link",
+          "totalCountHeader": "X-Total-Count"
+        },
         "x-hey-retry": {
           "maxAttempts": 3,
           "baseDelayMs": 1000,

--- a/spec/excluded-routes.json
+++ b/spec/excluded-routes.json
@@ -1830,11 +1830,6 @@
     "reason": "phase-2: mobile triage surface"
   },
   {
-    "method": "GET",
-    "path": "/boxes/{box_id}/groups/{id}",
-    "reason": "phase-2: mobile triage surface"
-  },
-  {
     "method": "PATCH",
     "path": "/boxes/{box_id}/groups/{id}",
     "reason": "phase-2: mobile triage surface"

--- a/spec/hey.smithy
+++ b/spec/hey.smithy
@@ -214,6 +214,7 @@ service HEY {
         CreateBoxDesignation
         DeleteBoxDesignation
         ListBoxGroups
+        GetBoxGroup
         CreateBoxGroup
         DeleteBoxGroup
         MarkBoxSeen
@@ -3069,6 +3070,15 @@ structure BoxGroupsResponse {
     box_groups: BoxGroupList
 }
 
+/// BoxGroupWithPostings — a Set Aside group with one page of the postings in it
+structure BoxGroupWithPostings {
+    @required
+    id: Long
+
+    box_id: Long
+    postings: PostingList
+}
+
 /// FolderWithPostings — folder detail with the postings filed in it
 structure FolderWithPostings {
     @required
@@ -3897,6 +3907,38 @@ structure BoxGroupsInput {
 structure ListBoxGroupsOutput {
     @required
     response: BoxGroupsResponse
+}
+
+/// Read one Set Aside group with the postings in it.
+///
+/// The postings are paged like a folder's: newest observed first, 30 to a page, with the
+/// next page in the Link header and the total in X-Total-Count.
+@readonly
+@http(method: "GET", uri: "/boxes/{boxId}/groups/{groupId}")
+@tags(["Boxes"])
+@heyRetry(maxAttempts: 3, baseDelayMs: 1000, backoff: "exponential", retryOn: [429, 503])
+operation GetBoxGroup {
+    input: GetBoxGroupInput
+    output: GetBoxGroupOutput
+    errors: [UnauthorizedError, NotFoundError, InternalServerError, ServiceUnavailableError]
+}
+
+structure GetBoxGroupInput {
+    @httpLabel
+    @required
+    boxId: Long
+
+    @httpLabel
+    @required
+    groupId: Long
+
+    @httpQuery("page")
+    page: String
+}
+
+structure GetBoxGroupOutput {
+    @required
+    group: BoxGroupWithPostings
 }
 
 /// Create a Set Aside group out of a selection of postings.

--- a/spec/hey.smithy
+++ b/spec/hey.smithy
@@ -3917,6 +3917,7 @@ structure ListBoxGroupsOutput {
 @http(method: "GET", uri: "/boxes/{boxId}/groups/{groupId}")
 @tags(["Boxes"])
 @heyRetry(maxAttempts: 3, baseDelayMs: 1000, backoff: "exponential", retryOn: [429, 503])
+@heyPagination(style: "link", totalCountHeader: "X-Total-Count")
 operation GetBoxGroup {
     input: GetBoxGroupInput
     output: GetBoxGroupOutput

--- a/spec/route-coverage.json
+++ b/spec/route-coverage.json
@@ -191,6 +191,11 @@
   },
   {
     "method": "GET",
+    "operationId": "GetBoxGroup",
+    "path": "/boxes/{boxId}/groups/{groupId}"
+  },
+  {
+    "method": "GET",
     "operationId": "GetBoxPostingChanges",
     "path": "/boxes/{boxId}/postings/changes.json"
   },

--- a/spec/shape-fingerprint.json
+++ b/spec/shape-fingerprint.json
@@ -14,6 +14,7 @@
   "GetAdvancedSearchFilters": "b0cde27b441e5b00a350a4942174e9b4f82791f1c4c236eaf7fc9d7a5d514881",
   "GetAsidebox": "675d22b32c429ae536d4a4248a0c0c30d62adca2852fbb1d0defb12b7563521f",
   "GetBox": "373b5de0c686345126ca4da129f6991776936ecc1fa1e00fae00cd45cb6436e9",
+  "GetBoxGroup": "e6f66a509d16f42616f114b5ace017cc7d2163e8fa9939b66d2eae9fc0d1b925",
   "GetBoxPostingChanges": "003137f72b12fc7232fc2127316479999c0d0edcc0f89d53cb07eed1c3854ac1",
   "GetBubblebox": "b736b44d157cb75c0e50a75feb2be37c8f9988024aa8c6503ab7bde347560cce",
   "GetBundleUnseenPostings": "1dc0e7a2eb92b998bfee38c6e93ad8c9f417fa805c88f7acd1ed9f0711a32ec3",


### PR DESCRIPTION
`GET /boxes/{boxId}/groups/{groupId}` answers a Set Aside group's `id`, `box_id` and one page of its `postings`, paged like a folder with the next cursor in the `Link` header and the total in `X-Total-Count`.

- `Boxes().GetGroupPage(ctx, boxID, groupID, params)` reads a page and answers a `BoxGroupPage` with `NextPage` and `TotalCount`, the shape `Folders().GetPage` uses.
- `Boxes().GetGroup` answers the group alone for callers that do not page.
- The route's "phase-2" entry in `spec/excluded-routes.json` is removed; it is modelled now.
- Bumps the version to 0.29.0 in a separate commit, per CONTRIBUTING.

Until now the only way to learn what a group held was to walk every page of Set Aside and count the postings whose `box_group_id` matched, which is dozens of requests on a Set Aside big enough to need groups. hey-cli's `hey set-aside group list|view` moves onto this read.

`make check` passes; conformance 187/187 with a path case for the new operation.