### PR TITLE
State the real reason the release action tracks main

### DIFF
--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: basecamp/sdk/actions/release-orchestrate@main # zizmor: ignore[unpinned-uses] -- internal composite action tracking main; subpath actions cannot be SHA-pinned
+      - uses: basecamp/sdk/actions/release-orchestrate@main # zizmor: ignore[unpinned-uses] -- internal action tracking main by design (basecamp/sdk AGENTS.md); basecamp/sdk has no tags for Dependabot to advance a pin
         with:
           version: ${{ github.event.inputs.tag || github.ref_name }}
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The zizmor ignore on the `basecamp/sdk/actions/release-orchestrate@main` step said subpath actions cannot be SHA-pinned. They can (`owner/repo/path@sha` is valid), so the comment gave the next reader a wrong reason to stop and no way to judge whether the trade-off still holds.

The actual reason: [basecamp/sdk AGENTS.md](https://github.com/basecamp/sdk/blob/main/AGENTS.md) documents `actions/**` as referenced live and unversioned on purpose, so release-tooling changes reach every SDK without a bump PR per repo, and basecamp/sdk carries no tags, so a SHA pin would be a manual chore Dependabot cannot advance. Code-scanning alert [#20](https://github.com/basecamp/hey-sdk/security/code-scanning/20) (`actions/unpinned-tag`) on this line is dismissed as won't-fix with that reasoning; this makes the file say the same thing.

No behaviour change. `zizmor` and `actionlint` pass on the file.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `zizmor` ignore comment on the `basecamp/sdk/actions/release-orchestrate@main` step so it states the real reason for tracking `main`, not the false claim that subpath actions cannot be SHA-pinned.

- Documents that `basecamp/sdk` references `actions/**` live and unversioned per its AGENTS.md, and that the repo has no tags for Dependabot to advance a pin.
- Aligns the comment with the dismissed code-scanning alert reasoning.
- No behavior change; `zizmor` and `actionlint` still pass.

<sup>Written for commit c86469424e105ccd00346dfee4a14cd63491587c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-sdk/pull/150?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

