### PR TITLE
Bump version to 0.30.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Requires Go 1.26 or newer.
 The Rust crate is not published; depend on it from the repository:
 
 ```toml
-hey-sdk = { git = "https://github.com/basecamp/hey-sdk", version = "0.29" }
+hey-sdk = { git = "https://github.com/basecamp/hey-sdk", version = "0.30" }
 ```
 
 ## Authenticate

--- a/conformance/runner/rust/Cargo.lock
+++ b/conformance/runner/rust/Cargo.lock
@@ -421,7 +421,7 @@ dependencies = [
 
 [[package]]
 name = "hey-sdk"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "async-trait",
  "base64 0.23.1",

--- a/go/pkg/hey/version.go
+++ b/go/pkg/hey/version.go
@@ -1,7 +1,7 @@
 package hey
 
 // Version is the current version of the HEY Go SDK.
-const Version = "0.29.0"
+const Version = "0.30.0"
 
 // APIVersion is the HEY API version this SDK targets.
 const APIVersion = "2026-08-21"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -454,7 +454,7 @@ checksum = "e17592d60ebacc7d5e169f4663c5f84f9161cc90328abcfe8456f41e4dfcb284"
 
 [[package]]
 name = "hey-sdk"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "async-trait",
  "base64 0.23.1",

--- a/rust/hey-sdk/Cargo.toml
+++ b/rust/hey-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hey-sdk"
-version = "0.29.0"
+version = "0.30.0"
 description = "Rust client for the HEY API, generated from the Smithy model in spec/"
 readme = "README.md"
 publish = false

--- a/rust/hey-sdk/README.md
+++ b/rust/hey-sdk/README.md
@@ -8,7 +8,7 @@ The crate is not on crates.io. Depend on it from the repository:
 
 ```toml
 [dependencies]
-hey-sdk = { git = "https://github.com/basecamp/hey-sdk", version = "0.29" }
+hey-sdk = { git = "https://github.com/basecamp/hey-sdk", version = "0.30" }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 ```
 

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -36,6 +36,18 @@ if ! grep -Fxq "version = \"$VERSION\"" "$CARGO_FILE"; then
   exit 1
 fi
 
+# The READMEs tell a consumer which minor to request alongside the git source, and Cargo
+# rejects a fetched crate that fails that requirement, so the constraint moves with the
+# version.
+MINOR="${VERSION%.*}"
+for README in "$REPO_ROOT/README.md" "$REPO_ROOT/rust/hey-sdk/README.md"; do
+  sedi "s|\(hey-sdk = { git = \"https://github.com/basecamp/hey-sdk\", version = \"\)[0-9.]*\"|\1$MINOR\"|" "$README"
+  if ! grep -Fq "hey-sdk = { git = \"https://github.com/basecamp/hey-sdk\", version = \"$MINOR\" }" "$README"; then
+    echo "ERROR: Rust constraint substitution did not match in $README" >&2
+    exit 1
+  fi
+done
+
 # Cargo.lock records the package version too, and both lockfiles are checked in, so a
 # --locked build only agrees once they carry the new one. A bump that cannot refresh them
 # is a bump that breaks the build, so cargo is required and neither update may fail.
@@ -47,4 +59,4 @@ fi
 (cd "$REPO_ROOT/rust" && cargo update -q -w --offline)
 (cd "$REPO_ROOT/conformance/runner/rust" && cargo update -q -w --offline)
 
-echo "Done. Bumped 2 files to $VERSION."
+echo "Done. Bumped version.go, Cargo.toml and the READMEs to $VERSION."


### PR DESCRIPTION
## Summary

Bump the SDK version to 0.30.0 for the v0.30.0 release, carrying everything merged since v0.29.0:

- #145 Rust SDK
- #141 Workflow stage reader (`WorkflowsService.GetStage`)
- #153 Gates repaired after #141 (generator support for HTML reads)
- #94 Generated operation retry policies
- #133 422 validation messages surfaced from SendDraft and UpdateDraft
- #151 Retry-After dates rounded up to the whole second
- #95, #143 dependency bumps

New exported surface (#141, #145) makes this a minor bump rather than 0.29.1.

Rebased onto main at b349a3d (#153), which is green.

## Test plan

- [x] `make bump VERSION=0.30.0`
- [x] `GOWORK=off go build ./... && go vet ./...` in go/
- [x] `cargo check --locked` in rust/ and conformance/runner/rust/