### PR TITLE
Make the gates green after the workflow stage reader

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -214,9 +214,12 @@ jobs:
         # Compares go/pkg/hey — the sole exported package (internal/ is not public API).
         # Each apidiff invocation runs inside its respective module directory so
         # go list can resolve the package.
+        # The base checkout is throwaway, so tidy its module before loading it: a main
+        # whose go.mod a merge left untidy would otherwise yield no baseline at all,
+        # and the PR repairing it could never pass here.
         run: |
           echo "Checking Go SDK API compatibility..."
-          (cd base/go && apidiff -w /tmp/base.api ./pkg/hey)
+          (cd base/go && go mod tidy && apidiff -w /tmp/base.api ./pkg/hey)
           CHANGES=$(cd go && apidiff -incompatible /tmp/base.api ./pkg/hey 2>/tmp/apidiff.stderr) || status=$?
           status=${status:-0}
           if [ "$status" -ne 0 ]; then

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,11 @@ place the generator writes the type (the struct, the aliases built from it, the 
 signatures) and nowhere else: a type name never goes on the wire, so Go and the fixtures
 are untouched.
 
+An operation whose 2xx body is `text/html` rather than JSON — a workflow stage — becomes a
+method that asks for the page as HEY serves it (no `.json` suffix, `Accept: text/html`) and
+answers the body as a `String`. Reading anything out of that page is a hand-written
+convenience's job, as `go/pkg/hey` does for the same route.
+
 `rs-check-drift` runs the generator in `--check` mode, so stale generated code fails the
 gate.
 

--- a/conformance/runner/go/go.mod
+++ b/conformance/runner/go/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/oapi-codegen/runtime v1.7.0 // indirect
 	github.com/zalando/go-keyring v0.2.8 // indirect
+	golang.org/x/net v0.58.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 )
 

--- a/conformance/runner/go/go.sum
+++ b/conformance/runner/go/go.sum
@@ -27,6 +27,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/zalando/go-keyring v0.2.8 h1:6sD/Ucpl7jNq10rM2pgqTs0sZ9V3qMrqfIIy5YPccHs=
 github.com/zalando/go-keyring v0.2.8/go.mod h1:tsMo+VpRq5NGyKfxoBVjCuMrG47yj8cmakZDO5QGii0=
+golang.org/x/net v0.58.0 h1:ynWG7rqYi4ccpTEuPZ2QGWHktVEM9DMCj9yzDE0Q7To=
+golang.org/x/net v0.58.0/go.mod h1:YwCddHnFlT7eLQqVprV19OnhLGtc5xOKgE0RyqgfWAU=
 golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
 golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/conformance/runner/rust/src/assertions.rs
+++ b/conformance/runner/rust/src/assertions.rs
@@ -188,7 +188,7 @@ fn last_status(run: &Run) -> u16 {
 
 fn check_request_path(run: &Run, assertion: &Assertion, which: Which) -> Result<(), String> {
     let expected = expected_string(assertion, "requestPath")?;
-    let expected = if run.case.serves_html() {
+    let expected = if run.case.asks_for_html() {
         expected.to_string()
     } else {
         with_json_extension(expected)

--- a/conformance/runner/rust/src/assertions.rs
+++ b/conformance/runner/rust/src/assertions.rs
@@ -187,7 +187,12 @@ fn last_status(run: &Run) -> u16 {
 }
 
 fn check_request_path(run: &Run, assertion: &Assertion, which: Which) -> Result<(), String> {
-    let expected = with_json_extension(expected_string(assertion, "requestPath")?);
+    let expected = expected_string(assertion, "requestPath")?;
+    let expected = if run.case.serves_html() {
+        expected.to_string()
+    } else {
+        with_json_extension(expected)
+    };
     let actual = which.pick(&run.recorded.paths).ok_or_else(no_requests)?;
     if *actual == expected {
         Ok(())
@@ -199,9 +204,10 @@ fn check_request_path(run: &Run, assertion: &Assertion, which: Which) -> Result<
     }
 }
 
-/// HEY answers JSON to paths ending in `.json`, and this SDK always puts the extension back
-/// on a path — modelled or raw — whose last segment has none. So the expected path is
-/// normalised the same way and matched exactly: one answer rather than two.
+/// HEY answers JSON to paths ending in `.json`, and this SDK puts the extension back on a
+/// path — modelled or raw — whose last segment has none. So the expected path is normalised
+/// the same way and matched exactly: one answer rather than two. A page HEY serves as HTML
+/// is the exception: the SDK asks for it as written, so the fixture's path stands.
 ///
 /// The fixtures are shared with the Go runner, which drives the raw generated client and
 /// therefore sees the bare paths; this one drives the full client, which is why the

--- a/conformance/runner/rust/src/fixtures.rs
+++ b/conformance/runner/rust/src/fixtures.rs
@@ -47,6 +47,20 @@ pub struct MockResponse {
     pub delay: u64,
 }
 
+impl MockResponse {
+    pub fn content_type(&self) -> Option<&str> {
+        self.headers
+            .iter()
+            .find(|(name, _)| name.eq_ignore_ascii_case("content-type"))
+            .map(|(_, value)| value.as_str())
+    }
+
+    pub fn serves_html(&self) -> bool {
+        self.content_type()
+            .is_some_and(|value| value.starts_with("text/html"))
+    }
+}
+
 #[derive(Debug, Default, Deserialize)]
 #[serde(default)]
 pub struct Assertion {
@@ -65,6 +79,11 @@ impl TestCase {
 
     pub fn runs(&self) -> u32 {
         self.repeat_operation.max(1)
+    }
+
+    /// Whether the case reads a page HEY serves as HTML rather than a JSON document.
+    pub fn serves_html(&self) -> bool {
+        self.mock_responses.iter().any(MockResponse::serves_html)
     }
 
     /// Whether the case looks at what the SDK does with the `Link` header. Following it

--- a/conformance/runner/rust/src/fixtures.rs
+++ b/conformance/runner/rust/src/fixtures.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 
 use hey_sdk::DateTime;
+use hey_sdk::routes::ROUTES;
 use serde::Deserialize;
 use serde_json::{Map, Value};
 
@@ -81,9 +82,13 @@ impl TestCase {
         self.repeat_operation.max(1)
     }
 
-    /// Whether the case reads a page HEY serves as HTML rather than a JSON document.
-    pub fn serves_html(&self) -> bool {
-        self.mock_responses.iter().any(MockResponse::serves_html)
+    /// Whether the case's operation reads a page HEY serves as HTML, which the SDK asks
+    /// for as written rather than with a `.json` suffix. The route says so, whatever the
+    /// mock answers: an error case for such an operation mocks JSON and still goes there.
+    pub fn asks_for_html(&self) -> bool {
+        ROUTES
+            .iter()
+            .any(|route| route.id == self.operation && route.html)
     }
 
     /// Whether the case looks at what the SDK does with the `Link` header. Following it

--- a/conformance/runner/rust/src/operations.rs
+++ b/conformance/runner/rust/src/operations.rs
@@ -1055,6 +1055,15 @@ async fn execute_hey_operation(client: &Client, case: &TestCase) -> Result<Outco
             )
             .await
         }
+        "GetWorkflowStage" => json(
+            client
+                .workflows()
+                .get_stage(
+                    int64_param(path, "workflowId"),
+                    int64_param(path, "stageId"),
+                )
+                .await?,
+        ),
         "UpdateCalendarEvent" => {
             client
                 .calendar_events()

--- a/conformance/runner/rust/src/server.rs
+++ b/conformance/runner/rust/src/server.rs
@@ -8,6 +8,7 @@ use axum::extract::{Request, State};
 use axum::http::header::CONTENT_TYPE;
 use axum::http::{HeaderMap, Response, StatusCode};
 use axum::response::IntoResponse;
+use serde_json::Value;
 use tokio::net::TcpListener;
 use tokio::task::JoinHandle;
 
@@ -142,13 +143,12 @@ fn serve(mock: &MockResponse) -> Response<Body> {
     for (name, value) in &mock.headers {
         response = response.header(name, value);
     }
-    let typed = response
-        .headers_ref()
-        .is_some_and(|headers| headers.contains_key(CONTENT_TYPE));
-    if !typed {
+    if mock.content_type().is_none() {
         response = response.header(CONTENT_TYPE, "application/json");
     }
+    // An HTML fixture is already wire text; a JSON fixture is a structured value.
     let body = match &mock.body {
+        Some(Value::String(text)) if mock.serves_html() => Body::from(text.clone()),
         Some(body) => Body::from(serde_json::to_vec(body).unwrap_or_default()),
         None => Body::empty(),
     };

--- a/go/go.mod
+++ b/go/go.mod
@@ -5,6 +5,7 @@ go 1.26
 require (
 	github.com/oapi-codegen/runtime v1.7.0
 	github.com/zalando/go-keyring v0.2.8
+	golang.org/x/net v0.58.0
 )
 
 require (

--- a/rust/generator/names.toml
+++ b/rust/generator/names.toml
@@ -77,6 +77,7 @@ workflows = "workflow"
 # Operations that act on something other than their service's noun.
 [operation_resource_types]
 CreateBoxGroup = "box_group"
+GetWorkflowStage = "workflow_stage"
 CreateReply = "reply"
 CreateTimeTrackCategory = "category"
 CreateTopicCollecting = "collecting"

--- a/rust/generator/src/emit/routes.rs
+++ b/rust/generator/src/emit/routes.rs
@@ -1,7 +1,7 @@
 use std::fmt::Write;
 
 use crate::emit::HEADER;
-use crate::model::{Model, Operation, Pagination, ParamKind, ParamRole};
+use crate::model::{Model, Operation, Pagination, ParamKind, ParamRole, Response};
 use crate::naming::constant_name;
 
 pub fn render(model: &Model) -> String {
@@ -60,6 +60,12 @@ fn render_route(out: &mut String, operation: &Operation) {
     out.push_str("    ],\n");
     writeln!(out, "    idempotent: {},", operation.idempotent).unwrap();
     writeln!(out, "    readonly: {},", operation.readonly).unwrap();
+    writeln!(
+        out,
+        "    html: {},",
+        matches!(operation.response, Response::Html(_))
+    )
+    .unwrap();
     writeln!(out, "    empty_on: &{:?},", operation.empty_on).unwrap();
     let pagination = match operation.pagination {
         Pagination::None => "None",

--- a/rust/generator/src/emit/services.rs
+++ b/rust/generator/src/emit/services.rs
@@ -133,6 +133,7 @@ fn render_method(out: &mut String, operation: &Operation) {
     let binding = if operation.query_params.is_empty()
         && operation.body.is_none()
         && named_record.is_none()
+        && !matches!(operation.response, Response::Html(_))
     {
         "let"
     } else {
@@ -174,6 +175,9 @@ fn render_method(out: &mut String, operation: &Operation) {
     if operation.body.is_some() {
         out.push_str("        operation.json(body)?;\n");
     }
+    if matches!(operation.response, Response::Html(_)) {
+        out.push_str("        operation.html_representation();\n");
+    }
     writeln!(
         out,
         "        self.client.{}(operation).await",
@@ -209,7 +213,7 @@ fn resource_id(param: &PathParam) -> String {
 }
 
 fn uses_types(operation: &Operation) -> bool {
-    operation.body.is_some() || matches!(operation.response, Response::Json(_))
+    operation.body.is_some() || matches!(operation.response, Response::Json(_) | Response::Html(_))
 }
 
 /// A paginated read answers a [`Page`], whichever style it paginates in. A window read is
@@ -230,6 +234,7 @@ fn return_type(operation: &Operation) -> String {
         (Response::Json(name), true, _) => format!("Page<{name}>"),
         (Response::Json(name), _, false) => format!("Option<{name}>"),
         (Response::Json(name), _, true) => name.clone(),
+        (Response::Html(name), _, _) => name.clone(),
     }
 }
 
@@ -243,6 +248,7 @@ fn send_method(operation: &Operation) -> &'static str {
         (Response::Json(_), true, _) => "send_page",
         (Response::Json(_), _, false) => "send_optional",
         (Response::Json(_), _, true) => "send",
+        (Response::Html(_), _, _) => "send_text",
     }
 }
 

--- a/rust/generator/src/emit/services.rs
+++ b/rust/generator/src/emit/services.rs
@@ -133,7 +133,6 @@ fn render_method(out: &mut String, operation: &Operation) {
     let binding = if operation.query_params.is_empty()
         && operation.body.is_none()
         && named_record.is_none()
-        && !matches!(operation.response, Response::Html(_))
     {
         "let"
     } else {
@@ -174,9 +173,6 @@ fn render_method(out: &mut String, operation: &Operation) {
     }
     if operation.body.is_some() {
         out.push_str("        operation.json(body)?;\n");
-    }
-    if matches!(operation.response, Response::Html(_)) {
-        out.push_str("        operation.html_representation();\n");
     }
     writeln!(
         out,

--- a/rust/generator/src/model.rs
+++ b/rust/generator/src/model.rs
@@ -141,6 +141,8 @@ pub enum ParamKind {
 pub enum Response {
     Empty,
     Json(String),
+    /// A page HEY serves as HTML, with the name of the `String` alias the schema became.
+    Html(String),
 }
 
 #[derive(Clone, Copy, PartialEq)]
@@ -411,10 +413,19 @@ fn response_of(operation: &Value, naming: &Naming) -> Result<Response, String> {
         .ok_or("operation has no responses")?;
     for (status, response) in responses {
         if status.starts_with('2') {
+            let content = &response["content"];
             return Ok(
-                match response["content"]["application/json"]["schema"]["$ref"].as_str() {
-                    Some(reference) => Response::Json(naming.type_for(&reference_name(reference))),
-                    None => Response::Empty,
+                match (
+                    content["application/json"]["schema"]["$ref"].as_str(),
+                    content["text/html"]["schema"]["$ref"].as_str(),
+                ) {
+                    (Some(reference), _) => {
+                        Response::Json(naming.type_for(&reference_name(reference)))
+                    }
+                    (None, Some(reference)) => {
+                        Response::Html(naming.type_for(&reference_name(reference)))
+                    }
+                    (None, None) => Response::Empty,
                 },
             );
         }

--- a/rust/hey-sdk/src/client.rs
+++ b/rust/hey-sdk/src/client.rs
@@ -341,6 +341,13 @@ impl Client {
         self.execute(operation).await.map(|_| ())
     }
 
+    /// Sends an operation and reads its body as text: the HTML page a route serves no
+    /// JSON for.
+    pub async fn send_text(&self, operation: Operation) -> Result<String, Error> {
+        let response = self.execute(operation).await?;
+        Ok(String::from_utf8_lossy(&response.body).into_owned())
+    }
+
     /// Sends an operation that answers a status meaning "nothing there" with `None`.
     pub async fn send_optional<T: DeserializeOwned>(
         &self,
@@ -1213,6 +1220,29 @@ mod tests {
         assert_eq!(sent.len(), 2);
         assert_eq!(sent[1].1, "https://hey.test/new.json");
         assert_eq!(sent[1].2[AUTHORIZATION], "Bearer secret");
+    }
+
+    #[tokio::test]
+    async fn an_html_read_asks_for_the_page_as_hey_serves_it() {
+        let http = Canned::new(|_| {
+            answer(
+                200,
+                r#"<section id="container_workflow_stage_5512"></section>"#,
+            )
+        });
+        let client = client_over(http.clone());
+
+        let page = client.workflows().get_stage(8801, 5512).await.unwrap();
+
+        assert_eq!(
+            page,
+            r#"<section id="container_workflow_stage_5512"></section>"#
+        );
+        let sent = http.sent();
+        assert_eq!(sent.len(), 1);
+        assert_eq!(sent[0].1, "https://hey.test/workflows/8801/stages/5512");
+        assert_eq!(sent[0].2[ACCEPT], "text/html");
+        assert_eq!(sent[0].2[AUTHORIZATION], "Bearer secret");
     }
 
     #[tokio::test]

--- a/rust/hey-sdk/src/generated/routes.rs
+++ b/rust/hey-sdk/src/generated/routes.rs
@@ -14,6 +14,7 @@ pub static ADD_POSTINGS_TO_BOX_GROUP: Route = Route {
     params: &[],
     idempotent: false,
     readonly: false,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -34,6 +35,7 @@ pub static ADVANCED_SEARCH: Route = Route {
     params: &[],
     idempotent: true,
     readonly: true,
+    html: false,
     empty_on: &[],
     pagination: Pagination::Link,
     retry: Retry {
@@ -54,6 +56,7 @@ pub static BUBBLE_UP_POSTINGS_NOW: Route = Route {
     params: &[],
     idempotent: false,
     readonly: false,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -74,6 +77,7 @@ pub static BULK_UPDATE_CLEARANCES: Route = Route {
     params: &[],
     idempotent: false,
     readonly: false,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -98,6 +102,7 @@ pub static BUNDLE_CONTACT: Route = Route {
     }],
     idempotent: false,
     readonly: false,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -118,6 +123,7 @@ pub static CANCEL_POSTINGS_BUBBLE_UP: Route = Route {
     params: &[],
     idempotent: true,
     readonly: false,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -142,6 +148,7 @@ pub static COMPLETE_CALENDAR_TODO: Route = Route {
     }],
     idempotent: true,
     readonly: false,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -173,6 +180,7 @@ pub static COMPLETE_HABIT: Route = Route {
     ],
     idempotent: true,
     readonly: false,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -197,6 +205,7 @@ pub static CREATE_BOX_DESIGNATION: Route = Route {
     }],
     idempotent: false,
     readonly: false,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -221,6 +230,7 @@ pub static CREATE_BOX_GROUP: Route = Route {
     }],
     idempotent: false,
     readonly: false,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -241,6 +251,7 @@ pub static CREATE_BULK_REPLY: Route = Route {
     params: &[],
     idempotent: false,
     readonly: false,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -261,6 +272,7 @@ pub static CREATE_CALENDAR_TODO: Route = Route {
     params: &[],
     idempotent: false,
     readonly: false,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -281,6 +293,7 @@ pub static CREATE_CONTACT: Route = Route {
     params: &[],
     idempotent: false,
     readonly: false,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -301,6 +314,7 @@ pub static CREATE_DIRECT_UPLOAD: Route = Route {
     params: &[],
     idempotent: false,
     readonly: false,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -321,6 +335,7 @@ pub static CREATE_FOLDER_FOR_POSTINGS: Route = Route {
     params: &[],
     idempotent: false,
     readonly: false,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -341,6 +356,7 @@ pub static CREATE_HABIT: Route = Route {
     params: &[],
     idempotent: false,
     readonly: false,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -361,6 +377,7 @@ pub static CREATE_MESSAGE: Route = Route {
     params: &[],
     idempotent: false,
     readonly: false,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -385,6 +402,7 @@ pub static CREATE_REPLY: Route = Route {
     }],
     idempotent: false,
     readonly: false,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -405,6 +423,7 @@ pub static CREATE_STICKY: Route = Route {
     params: &[],
     idempotent: false,
     readonly: false,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -425,6 +444,7 @@ pub static CREATE_TIME_TRACK: Route = Route {
     params: &[],
     idempotent: false,
     readonly: false,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -456,6 +476,7 @@ pub static CREATE_WORKFLOW_STAGING: Route = Route {
     ],
     idempotent: false,
     readonly: false,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -487,6 +508,7 @@ pub static DELETE_BOX_DESIGNATION: Route = Route {
     ],
     idempotent: true,
     readonly: false,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -518,6 +540,7 @@ pub static DELETE_BOX_GROUP: Route = Route {
     ],
     idempotent: true,
     readonly: false,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -542,6 +565,7 @@ pub static DELETE_CALENDAR_EVENT: Route = Route {
     }],
     idempotent: true,
     readonly: false,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -573,6 +597,7 @@ pub static DELETE_CALENDAR_EVENT_OCCURRENCE: Route = Route {
     ],
     idempotent: true,
     readonly: false,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -597,6 +622,7 @@ pub static DELETE_CALENDAR_TODO: Route = Route {
     }],
     idempotent: true,
     readonly: false,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -621,6 +647,7 @@ pub static DELETE_CONTACT_NOTE: Route = Route {
     }],
     idempotent: true,
     readonly: false,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -645,6 +672,7 @@ pub static DELETE_DRAFT: Route = Route {
     }],
     idempotent: true,
     readonly: false,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -676,6 +704,7 @@ pub static DELETE_EXTENZION: Route = Route {
     ],
     idempotent: true,
     readonly: false,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -700,6 +729,7 @@ pub static DELETE_HABIT: Route = Route {
     }],
     idempotent: true,
     readonly: false,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -724,6 +754,7 @@ pub static DELETE_STICKY: Route = Route {
     }],
     idempotent: true,
     readonly: false,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -748,6 +779,7 @@ pub static DELETE_TIME_TRACK: Route = Route {
     }],
     idempotent: true,
     readonly: false,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -768,6 +800,7 @@ pub static EMPTY_SPAM: Route = Route {
     params: &[],
     idempotent: true,
     readonly: false,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -788,6 +821,7 @@ pub static EMPTY_TRASH: Route = Route {
     params: &[],
     idempotent: true,
     readonly: false,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -808,6 +842,7 @@ pub static FILE_POSTINGS: Route = Route {
     params: &[],
     idempotent: false,
     readonly: false,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -828,6 +863,7 @@ pub static GET_ADVANCED_SEARCH_FILTERS: Route = Route {
     params: &[],
     idempotent: true,
     readonly: true,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -848,6 +884,7 @@ pub static GET_ASIDEBOX: Route = Route {
     params: &[],
     idempotent: true,
     readonly: true,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -872,6 +909,7 @@ pub static GET_BOX: Route = Route {
     }],
     idempotent: true,
     readonly: true,
+    html: false,
     empty_on: &[],
     pagination: Pagination::Link,
     retry: Retry {
@@ -903,6 +941,7 @@ pub static GET_BOX_GROUP: Route = Route {
     ],
     idempotent: true,
     readonly: true,
+    html: false,
     empty_on: &[],
     pagination: Pagination::Link,
     retry: Retry {
@@ -927,6 +966,7 @@ pub static GET_BOX_POSTING_CHANGES: Route = Route {
     }],
     idempotent: true,
     readonly: true,
+    html: false,
     empty_on: &[],
     pagination: Pagination::Link,
     retry: Retry {
@@ -947,6 +987,7 @@ pub static GET_BUBBLEBOX: Route = Route {
     params: &[],
     idempotent: true,
     readonly: true,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -971,6 +1012,7 @@ pub static GET_BUNDLE_UNSEEN_POSTINGS: Route = Route {
     }],
     idempotent: true,
     readonly: true,
+    html: false,
     empty_on: &[],
     pagination: Pagination::Link,
     retry: Retry {
@@ -995,6 +1037,7 @@ pub static GET_CALENDAR_DAY: Route = Route {
     }],
     idempotent: true,
     readonly: true,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -1019,6 +1062,7 @@ pub static GET_CALENDAR_RECORDINGS: Route = Route {
     }],
     idempotent: true,
     readonly: true,
+    html: false,
     empty_on: &[],
     pagination: Pagination::Window,
     retry: Retry {
@@ -1043,6 +1087,7 @@ pub static GET_CALENDAR_WEEK: Route = Route {
     }],
     idempotent: true,
     readonly: true,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -1067,6 +1112,7 @@ pub static GET_CALENDAR_YEAR: Route = Route {
     }],
     idempotent: true,
     readonly: true,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -1087,6 +1133,7 @@ pub static GET_CLEARANCES: Route = Route {
     params: &[],
     idempotent: true,
     readonly: true,
+    html: false,
     empty_on: &[],
     pagination: Pagination::Link,
     retry: Retry {
@@ -1111,6 +1158,7 @@ pub static GET_COLLECTION: Route = Route {
     }],
     idempotent: true,
     readonly: true,
+    html: false,
     empty_on: &[],
     pagination: Pagination::Link,
     retry: Retry {
@@ -1135,6 +1183,7 @@ pub static GET_CONTACT: Route = Route {
     }],
     idempotent: true,
     readonly: true,
+    html: false,
     empty_on: &[],
     pagination: Pagination::Link,
     retry: Retry {
@@ -1159,6 +1208,7 @@ pub static GET_CONTACT_NOTE: Route = Route {
     }],
     idempotent: true,
     readonly: true,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -1179,6 +1229,7 @@ pub static GET_EVERYTHING_TOPICS: Route = Route {
     params: &[],
     idempotent: true,
     readonly: true,
+    html: false,
     empty_on: &[],
     pagination: Pagination::Link,
     retry: Retry {
@@ -1199,6 +1250,7 @@ pub static GET_FEEDBOX: Route = Route {
     params: &[],
     idempotent: true,
     readonly: true,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -1223,6 +1275,7 @@ pub static GET_FOLDER: Route = Route {
     }],
     idempotent: true,
     readonly: true,
+    html: false,
     empty_on: &[],
     pagination: Pagination::Link,
     retry: Retry {
@@ -1243,6 +1296,7 @@ pub static GET_IDENTITY: Route = Route {
     params: &[],
     idempotent: true,
     readonly: true,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -1263,6 +1317,7 @@ pub static GET_IMBOX: Route = Route {
     params: &[],
     idempotent: true,
     readonly: true,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -1283,6 +1338,7 @@ pub static GET_IMBOX_SEEN: Route = Route {
     params: &[],
     idempotent: true,
     readonly: true,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -1307,6 +1363,7 @@ pub static GET_JOURNAL_ENTRY: Route = Route {
     }],
     idempotent: true,
     readonly: true,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -1327,6 +1384,7 @@ pub static GET_LATERBOX: Route = Route {
     params: &[],
     idempotent: true,
     readonly: true,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -1351,6 +1409,7 @@ pub static GET_MESSAGE: Route = Route {
     }],
     idempotent: true,
     readonly: true,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -1375,6 +1434,7 @@ pub static GET_MESSAGE_EDIT: Route = Route {
     }],
     idempotent: true,
     readonly: true,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -1395,6 +1455,7 @@ pub static GET_MY_CLEARANCES: Route = Route {
     params: &[],
     idempotent: true,
     readonly: true,
+    html: false,
     empty_on: &[],
     pagination: Pagination::Link,
     retry: Retry {
@@ -1415,6 +1476,7 @@ pub static GET_NAVIGATION: Route = Route {
     params: &[],
     idempotent: true,
     readonly: true,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -1435,6 +1497,7 @@ pub static GET_ONGOING_TIME_TRACK: Route = Route {
     params: &[],
     idempotent: true,
     readonly: true,
+    html: false,
     empty_on: &[404],
     pagination: Pagination::None,
     retry: Retry {
@@ -1455,6 +1518,7 @@ pub static GET_SENT_TOPICS: Route = Route {
     params: &[],
     idempotent: true,
     readonly: true,
+    html: false,
     empty_on: &[],
     pagination: Pagination::Link,
     retry: Retry {
@@ -1475,6 +1539,7 @@ pub static GET_SPAM_TOPICS: Route = Route {
     params: &[],
     idempotent: true,
     readonly: true,
+    html: false,
     empty_on: &[],
     pagination: Pagination::Link,
     retry: Retry {
@@ -1499,6 +1564,7 @@ pub static GET_TOPIC: Route = Route {
     }],
     idempotent: true,
     readonly: true,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -1523,6 +1589,7 @@ pub static GET_TOPIC_ENTRIES: Route = Route {
     }],
     idempotent: true,
     readonly: true,
+    html: false,
     empty_on: &[],
     pagination: Pagination::Link,
     retry: Retry {
@@ -1547,6 +1614,7 @@ pub static GET_TOPIC_PUBLICATION: Route = Route {
     }],
     idempotent: true,
     readonly: true,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -1567,6 +1635,7 @@ pub static GET_TRAILBOX: Route = Route {
     params: &[],
     idempotent: true,
     readonly: true,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -1587,6 +1656,7 @@ pub static GET_TRASH_TOPICS: Route = Route {
     params: &[],
     idempotent: true,
     readonly: true,
+    html: false,
     empty_on: &[],
     pagination: Pagination::Link,
     retry: Retry {
@@ -1611,6 +1681,7 @@ pub static GET_WORKFLOW: Route = Route {
     }],
     idempotent: true,
     readonly: true,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -1627,7 +1698,7 @@ pub static GET_WORKFLOW_STAGE: Route = Route {
     path: "/workflows/{workflowId}/stages/{stageId}",
     pattern: "/workflows/{workflowId}/stages/{stageId}",
     resource: "Workflows",
-    resource_type: "workflow",
+    resource_type: "workflow_stage",
     params: &[
         RouteParam {
             name: "workflowId",
@@ -1642,6 +1713,7 @@ pub static GET_WORKFLOW_STAGE: Route = Route {
     ],
     idempotent: true,
     readonly: true,
+    html: true,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -1666,6 +1738,7 @@ pub static HIDE_CONTACT: Route = Route {
     }],
     idempotent: true,
     readonly: false,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -1690,6 +1763,7 @@ pub static LIST_BOX_GROUPS: Route = Route {
     }],
     idempotent: true,
     readonly: true,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -1710,6 +1784,7 @@ pub static LIST_BOXES: Route = Route {
     params: &[],
     idempotent: true,
     readonly: true,
+    html: false,
     empty_on: &[],
     pagination: Pagination::Link,
     retry: Retry {
@@ -1730,6 +1805,7 @@ pub static LIST_CALENDAR_DAYS: Route = Route {
     params: &[],
     idempotent: true,
     readonly: true,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -1750,6 +1826,7 @@ pub static LIST_CALENDAR_WEEKS: Route = Route {
     params: &[],
     idempotent: true,
     readonly: true,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -1770,6 +1847,7 @@ pub static LIST_CALENDARS: Route = Route {
     params: &[],
     idempotent: true,
     readonly: true,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -1790,6 +1868,7 @@ pub static LIST_CLIPS: Route = Route {
     params: &[],
     idempotent: true,
     readonly: true,
+    html: false,
     empty_on: &[],
     pagination: Pagination::Link,
     retry: Retry {
@@ -1810,6 +1889,7 @@ pub static LIST_COLLECTIONS: Route = Route {
     params: &[],
     idempotent: true,
     readonly: true,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -1830,6 +1910,7 @@ pub static LIST_CONTACTS: Route = Route {
     params: &[],
     idempotent: true,
     readonly: true,
+    html: false,
     empty_on: &[],
     pagination: Pagination::Link,
     retry: Retry {
@@ -1850,6 +1931,7 @@ pub static LIST_DRAFTS: Route = Route {
     params: &[],
     idempotent: true,
     readonly: true,
+    html: false,
     empty_on: &[],
     pagination: Pagination::Link,
     retry: Retry {
@@ -1870,6 +1952,7 @@ pub static LIST_JOURNAL_ENTRIES: Route = Route {
     params: &[],
     idempotent: true,
     readonly: true,
+    html: false,
     empty_on: &[],
     pagination: Pagination::Link,
     retry: Retry {
@@ -1890,6 +1973,7 @@ pub static LIST_SNIPPETS: Route = Route {
     params: &[],
     idempotent: true,
     readonly: true,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -1910,6 +1994,7 @@ pub static LIST_STICKIES: Route = Route {
     params: &[],
     idempotent: true,
     readonly: true,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -1930,6 +2015,7 @@ pub static LIST_TIME_TRACK_CATEGORIES: Route = Route {
     params: &[],
     idempotent: true,
     readonly: true,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -1950,6 +2036,7 @@ pub static LIST_TIME_TRACKS: Route = Route {
     params: &[],
     idempotent: true,
     readonly: true,
+    html: false,
     empty_on: &[],
     pagination: Pagination::Link,
     retry: Retry {
@@ -1974,6 +2061,7 @@ pub static MARK_BOX_SEEN: Route = Route {
     }],
     idempotent: false,
     readonly: false,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -1998,6 +2086,7 @@ pub static MARK_ENTRY_SPAM: Route = Route {
     }],
     idempotent: true,
     readonly: false,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -2018,6 +2107,7 @@ pub static MARK_POSTINGS_SEEN: Route = Route {
     params: &[],
     idempotent: false,
     readonly: false,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -2038,6 +2128,7 @@ pub static MARK_POSTINGS_SPAM: Route = Route {
     params: &[],
     idempotent: false,
     readonly: false,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -2058,6 +2149,7 @@ pub static MARK_POSTINGS_UNSEEN: Route = Route {
     params: &[],
     idempotent: false,
     readonly: false,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -2082,6 +2174,7 @@ pub static MARK_TOPIC_HAM: Route = Route {
     }],
     idempotent: true,
     readonly: false,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -2102,6 +2195,7 @@ pub static MOVE_POSTINGS: Route = Route {
     params: &[],
     idempotent: false,
     readonly: false,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -2122,6 +2216,7 @@ pub static MOVE_STICKY: Route = Route {
     params: &[],
     idempotent: false,
     readonly: false,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -2146,6 +2241,7 @@ pub static MOVE_TOPIC: Route = Route {
     }],
     idempotent: false,
     readonly: false,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -2177,6 +2273,7 @@ pub static MOVE_WORKFLOW_STAGING: Route = Route {
     ],
     idempotent: false,
     readonly: false,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -2197,6 +2294,7 @@ pub static MUTE_POSTINGS: Route = Route {
     params: &[],
     idempotent: false,
     readonly: false,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -2217,6 +2315,7 @@ pub static NEW_BULK_REPLY: Route = Route {
     params: &[],
     idempotent: true,
     readonly: true,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -2241,6 +2340,7 @@ pub static NEW_ENTRY_FORWARD: Route = Route {
     }],
     idempotent: true,
     readonly: true,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -2265,6 +2365,7 @@ pub static NEW_ENTRY_REPLY: Route = Route {
     }],
     idempotent: true,
     readonly: true,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -2285,6 +2386,7 @@ pub static PUNT_CLEARANCES: Route = Route {
     params: &[],
     idempotent: false,
     readonly: false,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -2305,6 +2407,7 @@ pub static REMOVE_POSTINGS_FROM_BOX_GROUP: Route = Route {
     params: &[],
     idempotent: true,
     readonly: false,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -2329,6 +2432,7 @@ pub static RESTORE_TOPIC: Route = Route {
     }],
     idempotent: true,
     readonly: false,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -2353,6 +2457,7 @@ pub static RESUME_HABIT: Route = Route {
     }],
     idempotent: true,
     readonly: false,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -2377,6 +2482,7 @@ pub static REVEAL_CONTACT: Route = Route {
     }],
     idempotent: false,
     readonly: false,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -2397,6 +2503,7 @@ pub static SCHEDULE_POSTINGS_BUBBLE_UP: Route = Route {
     params: &[],
     idempotent: false,
     readonly: false,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -2417,6 +2524,7 @@ pub static START_TIME_TRACK: Route = Route {
     params: &[],
     idempotent: false,
     readonly: false,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -2441,6 +2549,7 @@ pub static STOP_HABIT: Route = Route {
     }],
     idempotent: false,
     readonly: false,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -2465,6 +2574,7 @@ pub static TOGGLE_CALENDAR: Route = Route {
     }],
     idempotent: false,
     readonly: false,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -2485,6 +2595,7 @@ pub static TRASH_POSTINGS: Route = Route {
     params: &[],
     idempotent: false,
     readonly: false,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -2509,6 +2620,7 @@ pub static TRASH_TOPIC: Route = Route {
     }],
     idempotent: true,
     readonly: false,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -2533,6 +2645,7 @@ pub static UNBUNDLE_CONTACT: Route = Route {
     }],
     idempotent: true,
     readonly: false,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -2557,6 +2670,7 @@ pub static UNCOMPLETE_CALENDAR_TODO: Route = Route {
     }],
     idempotent: true,
     readonly: false,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -2588,6 +2702,7 @@ pub static UNCOMPLETE_HABIT: Route = Route {
     ],
     idempotent: true,
     readonly: false,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -2608,6 +2723,7 @@ pub static UNFILE_POSTINGS: Route = Route {
     params: &[],
     idempotent: true,
     readonly: false,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -2628,6 +2744,7 @@ pub static UNMUTE_POSTINGS: Route = Route {
     params: &[],
     idempotent: true,
     readonly: false,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -2652,6 +2769,7 @@ pub static UPDATE_CALENDAR_TODO: Route = Route {
     }],
     idempotent: false,
     readonly: false,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -2676,6 +2794,7 @@ pub static UPDATE_CLEARANCE: Route = Route {
     }],
     idempotent: false,
     readonly: false,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -2700,6 +2819,7 @@ pub static UPDATE_COLLECTION: Route = Route {
     }],
     idempotent: false,
     readonly: false,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -2724,6 +2844,7 @@ pub static UPDATE_CONTACT: Route = Route {
     }],
     idempotent: false,
     readonly: false,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -2748,6 +2869,7 @@ pub static UPDATE_CONTACT_CLEARANCE: Route = Route {
     }],
     idempotent: false,
     readonly: false,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -2772,6 +2894,7 @@ pub static UPDATE_CONTACT_NOTE: Route = Route {
     }],
     idempotent: false,
     readonly: false,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -2792,6 +2915,7 @@ pub static UPDATE_FIRST_WEEK_DAY: Route = Route {
     params: &[],
     idempotent: true,
     readonly: false,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -2816,6 +2940,7 @@ pub static UPDATE_HABIT: Route = Route {
     }],
     idempotent: false,
     readonly: false,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -2840,6 +2965,7 @@ pub static UPDATE_JOURNAL_ENTRY: Route = Route {
     }],
     idempotent: false,
     readonly: false,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -2864,6 +2990,7 @@ pub static UPDATE_MESSAGE: Route = Route {
     }],
     idempotent: false,
     readonly: false,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -2888,6 +3015,7 @@ pub static UPDATE_MY_CLEARANCE: Route = Route {
     }],
     idempotent: false,
     readonly: false,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -2912,6 +3040,7 @@ pub static UPDATE_STICKY: Route = Route {
     }],
     idempotent: false,
     readonly: false,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -2932,6 +3061,7 @@ pub static UPDATE_TIME_FORMAT: Route = Route {
     params: &[],
     idempotent: true,
     readonly: false,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {
@@ -2956,6 +3086,7 @@ pub static UPDATE_TIME_TRACK: Route = Route {
     }],
     idempotent: true,
     readonly: false,
+    html: false,
     empty_on: &[],
     pagination: Pagination::None,
     retry: Retry {

--- a/rust/hey-sdk/src/generated/routes.rs
+++ b/rust/hey-sdk/src/generated/routes.rs
@@ -1620,6 +1620,37 @@ pub static GET_WORKFLOW: Route = Route {
     },
 };
 
+pub static GET_WORKFLOW_STAGE: Route = Route {
+    id: "GetWorkflowStage",
+    service: "Workflows",
+    method: Method::GET,
+    path: "/workflows/{workflowId}/stages/{stageId}",
+    pattern: "/workflows/{workflowId}/stages/{stageId}",
+    resource: "Workflows",
+    resource_type: "workflow",
+    params: &[
+        RouteParam {
+            name: "workflowId",
+            role: ParamRole::Parent,
+            kind: ParamKind::Int64,
+        },
+        RouteParam {
+            name: "stageId",
+            role: ParamRole::Recording,
+            kind: ParamKind::Int64,
+        },
+    ],
+    idempotent: true,
+    readonly: true,
+    empty_on: &[],
+    pagination: Pagination::None,
+    retry: Retry {
+        max: 3,
+        base_delay_ms: 1000,
+        retry_on: &[429, 503],
+    },
+};
+
 pub static HIDE_CONTACT: Route = Route {
     id: "HideContact",
     service: "Contacts",
@@ -3007,6 +3038,7 @@ pub static ROUTES: &[&Route] = &[
     &GET_TRAILBOX,
     &GET_TRASH_TOPICS,
     &GET_WORKFLOW,
+    &GET_WORKFLOW_STAGE,
     &HIDE_CONTACT,
     &LIST_BOX_GROUPS,
     &LIST_BOXES,

--- a/rust/hey-sdk/src/generated/services/workflows.rs
+++ b/rust/hey-sdk/src/generated/services/workflows.rs
@@ -39,6 +39,20 @@ impl<'a> Workflows<'a> {
         self.client.send(operation).await
     }
 
+    /// A workflow stage and its cards, served as HTML by HEY.
+    pub async fn get_stage(
+        &self,
+        workflow_id: i64,
+        stage_id: i64,
+    ) -> Result<GetWorkflowStageOutputPayload, Error> {
+        let mut operation = self
+            .client
+            .operation(&routes::GET_WORKFLOW_STAGE, &[&workflow_id, &stage_id]);
+        operation.resource_id(stage_id);
+        operation.html_representation();
+        self.client.send_text(operation).await
+    }
+
     /// Move a staged topic to a workflow stage.
     pub async fn move_staging(
         &self,

--- a/rust/hey-sdk/src/generated/services/workflows.rs
+++ b/rust/hey-sdk/src/generated/services/workflows.rs
@@ -49,7 +49,6 @@ impl<'a> Workflows<'a> {
             .client
             .operation(&routes::GET_WORKFLOW_STAGE, &[&workflow_id, &stage_id]);
         operation.resource_id(stage_id);
-        operation.html_representation();
         self.client.send_text(operation).await
     }
 

--- a/rust/hey-sdk/src/generated/types.rs
+++ b/rust/hey-sdk/src/generated/types.rs
@@ -1264,6 +1264,8 @@ pub type GetTrashTopicsResponseContent = TopicListResponse;
 
 pub type GetWorkflowResponseContent = Workflow;
 
+pub type GetWorkflowStageOutputPayload = String;
+
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct HabitPayload {
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/rust/hey-sdk/src/operation.rs
+++ b/rust/hey-sdk/src/operation.rs
@@ -224,6 +224,12 @@ impl Operation {
         self.without_json_suffix().accept("*/*")
     }
 
+    /// Asks for the HTML page a route serves no JSON for: no `.json` suffix, and
+    /// `text/html`, which is what HEY answers a workflow stage with.
+    pub fn html_representation(&mut self) -> &mut Operation {
+        self.without_json_suffix().accept("text/html")
+    }
+
     /// Sends this without announcing an operation: no gate, no start, no end. For a request
     /// made inside another operation — the read-back a write needs to answer with the record
     /// it wrote — so the hooks hear about that operation once rather than twice.

--- a/rust/hey-sdk/src/operation.rs
+++ b/rust/hey-sdk/src/operation.rs
@@ -62,8 +62,12 @@ impl Operation {
             body: None,
             idempotent: route.idempotent,
             empty_on: route.empty_on,
-            accept: "application/json",
-            json_suffix: true,
+            accept: if route.html {
+                "text/html"
+            } else {
+                "application/json"
+            },
+            json_suffix: !route.html,
             no_cache: false,
             capture_redirects: false,
             quiet: false,
@@ -222,12 +226,6 @@ impl Operation {
     /// and no preference about what comes back.
     pub fn form_representation(&mut self) -> &mut Operation {
         self.without_json_suffix().accept("*/*")
-    }
-
-    /// Asks for the HTML page a route serves no JSON for: no `.json` suffix, and
-    /// `text/html`, which is what HEY answers a workflow stage with.
-    pub fn html_representation(&mut self) -> &mut Operation {
-        self.without_json_suffix().accept("text/html")
     }
 
     /// Sends this without announcing an operation: no gate, no start, no end. For a request

--- a/rust/hey-sdk/src/route.rs
+++ b/rust/hey-sdk/src/route.rs
@@ -23,6 +23,9 @@ pub struct Route {
     pub idempotent: bool,
     /// The route only reads; nothing it does changes anything.
     pub readonly: bool,
+    /// The route answers a page as HTML rather than a JSON document, so it is asked for as
+    /// written — no `.json` suffix — with `Accept: text/html`.
+    pub html: bool,
     pub empty_on: &'static [u16],
     pub pagination: Pagination,
     pub retry: Retry,

--- a/rust/hey-sdk/tests/routes.rs
+++ b/rust/hey-sdk/tests/routes.rs
@@ -40,6 +40,6 @@ fn the_router_names_the_operation_a_pasted_url_refers_to() {
 fn every_modelled_route_is_listed_once() {
     let ids: HashSet<&str> = ROUTES.iter().map(|route| route.id).collect();
 
-    assert_eq!(ROUTES.len(), 130);
+    assert_eq!(ROUTES.len(), 131);
     assert_eq!(ids.len(), ROUTES.len());
 }


### PR DESCRIPTION
Main has been red since #141 (Add workflow stage reader) merged: [run 34435818422](https://github.com/basecamp/hey-sdk/actions/runs/34435818422). It was a first-time contributor PR, so its check runs sat in `action_required` and main is the first place these gates saw the change. Three jobs failed outright and the two conformance jobs were skipped behind them. Each below with root cause and fix, all reproduced locally before and after.

**Go Tests** (`go build ./...`: "updates to go.mod needed") and **Go Lint** (golangci-lint: "no go files to analyze"), same cause
`go/pkg/hey/workflows.go` imports `golang.org/x/net/html` and `go/go.mod` never declared it. Fix: `go mod tidy` in `go/` (adds the direct requirement; `go.sum` already carried the module via the oapi-codegen tool graph) and in `conformance/runner/go` (indirect requirement plus sum entries), which is what the skipped **Conformance Tests** job would have failed on next.

**Rust Tests** (`make rs-check-drift`: `routes.rs`, `services/workflows.rs`, `types.rs` stale)
#141 never ran `make rs-generate`. Regenerating alone was not enough: `GetWorkflowStage` is the first modelled route whose 2xx is `text/html`, and the generator only knew JSON or empty, so it emitted a `get_stage` that returned `()` and would have sent `/stages/{id}.json` with a JSON `Accept`. Fix at the generator: `rust/generator/src/model.rs` reads a `text/html` 2xx as `Response::Html`, `emit/services.rs` emits a method that calls the new `Operation::html_representation()` (no `.json` suffix, `Accept: text/html`) and returns the page as a `String` through the new `Client::send_text`. `rust/hey-sdk/src/generated` is regenerated from that. `rust/hey-sdk/tests/routes.rs` pins the modelled-route count, which #141 moved from 130 to 131. A unit test covers the generated read's path, `Accept` and body.

**Conformance Tests (Rust)** (skipped in the run; `FAIL: GetWorkflowStage uses the HTML workflow stage path` locally)
The fixture #141 added to `conformance/tests/paths.json` got a dispatch arm in the Go runner only. `conformance/runner/rust` gains the arm, serves an HTML fixture body as wire text the way the Go runner's patch already does, and stops appending `.json` to the expected path of a case whose mock is `text/html`, since the SDK asks for such a page as written.

Not a #141 behavior defect: the Go `Workflows().GetStage` and its HTML parsing do what the fixture and its unit test say. What #141 left behind is a Rust parity gap: `workflows().get_stage()` now returns the stage page as HTML, but nothing on the Rust side parses it into the stage name and thread cards the Go `WorkflowStageView` carries. That is a feature to follow, not a gate fix, so it is not in here.

Not in here either: #151 (Retry-After second-boundary flake) is already on main, and none of the failures in the run were that.

Local gate state on this branch: `make smithy-check behavior-model-check url-routes-check drift-check-mvp go-check go-check-drift rs-check rs-check-drift` all pass; Go conformance 191/191; Rust conformance 190/190.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the gates that went red on main after #141 merged: the Go SDK was missing a declared dependency, the Rust SDK wasn't regenerated for the new HTML-answering route, and the Rust conformance runner didn't know how to exercise it.

- Adds `golang.org/x/net` to `go/go.mod` and `conformance/runner/go/go.mod`.
- Teaches the Rust generator about `text/html` 2xx responses: the `Route` now carries an `html` flag, so the generated `get_stage` asks for the page as served (no `.json`, `Accept: text/html`) and returns the body as a `String`; the read is named `workflow_stage`.
- Regenerates `rust/hey-sdk/src/generated` and updates the route count test to 131.
- Extends the Rust conformance runner with the `GetWorkflowStage` arm, serves HTML fixture bodies as wire text, and decides the path from `route.html` rather than the mock's content type.
- The Rust SDK returns the stage page as raw HTML; parsing it into the stage view is a follow-up.
- The API compatibility job now tidies its base checkout before reading the baseline, so it no longer fails on a PR that fixes main's untidy `go.mod`.

<sup>Written for commit 71285d0028612c5e4607f51390514ebe56b45215. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-sdk/pull/153?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

**API Compatibility** (`apidiff`: "updates to go.mod needed" while loading `base/go`)
This one fails on the base checkout, not the head: the job builds its baseline from `main`'s `go/pkg/hey`, and main's `go.mod` is the thing this PR fixes, so `apidiff -w` fails before comparing anything. Run locally with a tidied main as the baseline, `apidiff -incompatible` reports nothing: no public-surface change, from this PR or from #141. Fix: the job tidies the throwaway base checkout before reading its surface (`.github/workflows/test.yml`), so a main left untidy by a merge that skipped this gate still yields a baseline and the PR repairing it can pass.

Second commit, after review: `Route` carries `html`, so the client, the emitter and the Rust conformance runner all read "this route answers HTML" from the route table rather than each deciding it; and `GetWorkflowStage` reports `workflow_stage` to the hooks, as the Go wrapper does.
