### PR TITLE
Build the Rust crate on its MSRV, without its default feature, and as docs.rs would

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,11 +54,10 @@ jobs:
         with:
           persist-credentials: false
 
+      # rust-toolchain.toml names the toolchain and its components, and rustup on the
+      # runner installs it, so this job runs on exactly what a laptop does.
       - name: Set up Rust
-        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
-        with:
-          toolchain: stable
-          components: clippy, rustfmt
+        run: rustup toolchain install && rustup show
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2 # zizmor: ignore[cache-poisoning] -- cache is branch-isolated; fork PRs cannot write to this cache
@@ -67,11 +66,91 @@ jobs:
             rust
             conformance/runner/rust
 
+      # fmt, clippy, tests and docs with all features, then clippy and the tests again
+      # with the shipped HTTP client off. The same target a developer runs.
       - name: Format, lint and test
         run: make rs-check
 
       - name: Check generated code is up to date
         run: make rs-check-drift
+
+  msrv-rust:
+    name: Rust MSRV
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # The floor the crate promises is `rust-version` in rust/Cargo.toml; a bump there is
+      # what moves this job. The generator and the conformance runner are tooling and float
+      # on the pinned stable, so only the library is built here.
+      - name: Read rust-version
+        id: msrv
+        run: |
+          version=$(sed -n 's/^rust-version = "\(.*\)"$/\1/p' rust/Cargo.toml)
+          if [ -z "$version" ]; then
+            echo "::error::rust/Cargo.toml has no [workspace.package] rust-version"
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Rust ${{ steps.msrv.outputs.version }}
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
+        with:
+          toolchain: ${{ steps.msrv.outputs.version }}
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2 # zizmor: ignore[cache-poisoning] -- cache is branch-isolated; fork PRs cannot write to this cache
+        env:
+          RUSTUP_TOOLCHAIN: ${{ steps.msrv.outputs.version }}
+        with:
+          workspaces: rust
+
+      # RUSTUP_TOOLCHAIN outranks rust-toolchain.toml, which would otherwise pick the
+      # pinned stable back up.
+      - name: Build the library on its rust-version
+        working-directory: rust
+        env:
+          RUSTUP_TOOLCHAIN: ${{ steps.msrv.outputs.version }}
+        run: |
+          cargo --version
+          cargo build -p hey-sdk --locked --all-features
+          cargo build -p hey-sdk --locked --no-default-features
+
+  docs-rust:
+    name: Rust docs.rs build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Rust nightly
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
+        with:
+          toolchain: nightly
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2 # zizmor: ignore[cache-poisoning] -- cache is branch-isolated; fork PRs cannot write to this cache
+        env:
+          RUSTUP_TOOLCHAIN: nightly
+        with:
+          workspaces: rust
+
+      # What docs.rs will do with the crate: nightly rustdoc with `--cfg docsrs`, so a
+      # feature-gated item's badge renders and a nightly-only doc lint is heard here rather
+      # than after the publish. Not a required check on main; nightly is nightly.
+      - name: Build the docs as docs.rs would
+        working-directory: rust
+        env:
+          RUSTUP_TOOLCHAIN: nightly
+          RUSTDOCFLAGS: --cfg docsrs -D warnings
+        run: cargo doc -p hey-sdk --no-deps --all-features --locked
 
   lint-go:
     name: Go Lint
@@ -150,9 +229,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Rust
-        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
-        with:
-          toolchain: stable
+        run: rustup toolchain install && rustup show
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2 # zizmor: ignore[cache-poisoning] -- cache is branch-isolated; fork PRs cannot write to this cache

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,9 @@
+# The toolchain `cargo` picks up in this repository, for rustup users and for CI alike. An
+# exact stable rather than the channel, so rustfmt and clippy agree on every machine and a
+# new clippy lint lands through a bump here rather than on an unrelated pull request. Bump
+# it when a new stable is out. The crate's own floor is `rust-version` in rust/Cargo.toml,
+# which the MSRV job builds against.
+[toolchain]
+channel = "1.98.1"
+components = ["clippy", "rustfmt"]
+profile = "minimal"

--- a/rust/Makefile
+++ b/rust/Makefile
@@ -26,20 +26,28 @@ fmt-check:
 
 .PHONY: lint
 lint:
-	$(CARGO) clippy --workspace --all-targets -- -D warnings
+	$(CARGO) clippy --workspace --all-targets --all-features --locked -- -D warnings
 
 .PHONY: test
 test:
-	$(CARGO) test --workspace
+	$(CARGO) test --workspace --all-features --locked
+
+# The crate with the shipped HTTP client off. The library has to build without it, and the
+# test suite has to pass through a transport of the caller's own (tests/support), since that
+# is what the feature promises. The doctests are left out: they show the shipped client.
+.PHONY: no-default-features
+no-default-features:
+	$(CARGO) clippy -p hey-sdk --all-targets --no-default-features --locked -- -D warnings
+	$(CARGO) test -p hey-sdk --lib --tests --no-default-features --locked
 
 # Broken intra-doc links fail the build
 .PHONY: doc
 doc:
-	RUSTDOCFLAGS="-D warnings" $(CARGO) doc -p hey-sdk --no-deps
+	RUSTDOCFLAGS="-D warnings" $(CARGO) doc -p hey-sdk --no-deps --all-features --locked
 
-# Run all checks (local development gate)
+# Run all checks: the same steps as CI's test-rust job, in the same order
 .PHONY: check
-check: fmt-check lint test doc
+check: fmt-check lint test no-default-features doc
 
 .PHONY: clean
 clean:
@@ -49,12 +57,13 @@ clean:
 help:
 	@echo "HEY Rust SDK Makefile targets:"
 	@echo ""
-	@echo "  generate        Regenerate src/generated from openapi.json"
-	@echo "  generate-check  Verify src/generated is up to date"
-	@echo "  fmt             Format code"
-	@echo "  fmt-check       Check formatting"
-	@echo "  lint            Run clippy with warnings denied"
-	@echo "  test            Run all tests"
-	@echo "  doc             Build the crate docs"
-	@echo "  check           fmt-check + lint + test + doc"
-	@echo "  clean           Remove build artifacts"
+	@echo "  generate             Regenerate src/generated from openapi.json"
+	@echo "  generate-check       Verify src/generated is up to date"
+	@echo "  fmt                  Format code"
+	@echo "  fmt-check            Check formatting"
+	@echo "  lint                 Run clippy with warnings denied"
+	@echo "  test                 Run all tests"
+	@echo "  no-default-features  Lint and test the crate without the shipped HTTP client"
+	@echo "  doc                  Build the crate docs"
+	@echo "  check                fmt-check + lint + test + no-default-features + doc"
+	@echo "  clean                Remove build artifacts"

--- a/rust/hey-sdk/src/oauth.rs
+++ b/rust/hey-sdk/src/oauth.rs
@@ -361,7 +361,9 @@ struct TokenErrorResponse {
 #[cfg(test)]
 mod tests {
     use serde_json::json;
+    #[cfg(feature = "reqwest")]
     use wiremock::matchers::{body_string_contains, header, method, path};
+    #[cfg(feature = "reqwest")]
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     use super::*;
@@ -459,6 +461,7 @@ mod tests {
         assert!(!url.query().unwrap().contains("scope"));
     }
 
+    #[cfg(feature = "reqwest")]
     #[tokio::test]
     async fn discover_reads_the_well_known_document() {
         let server = MockServer::start().await;
@@ -487,6 +490,7 @@ mod tests {
         assert_eq!(None, metadata.registration_endpoint);
     }
 
+    #[cfg(feature = "reqwest")]
     #[tokio::test]
     async fn discover_reports_the_failing_status() {
         let server = MockServer::start().await;
@@ -504,6 +508,7 @@ mod tests {
         assert_eq!(Some("no such server"), error.hint());
     }
 
+    #[cfg(feature = "reqwest")]
     #[tokio::test]
     async fn exchange_trades_a_code_for_a_token() {
         let server = MockServer::start().await;
@@ -564,6 +569,7 @@ mod tests {
         assert_eq!(token.expires_at, restored.expires_at);
     }
 
+    #[cfg(feature = "reqwest")]
     #[tokio::test]
     async fn exchange_reports_the_server_error() {
         let server = MockServer::start().await;
@@ -592,6 +598,7 @@ mod tests {
         assert_eq!(Some(400), error.http_status());
     }
 
+    #[cfg(feature = "reqwest")]
     #[tokio::test]
     async fn exchange_wants_its_required_fields() {
         let error = OAuthClient::default()
@@ -603,6 +610,7 @@ mod tests {
         assert_eq!("token endpoint is required", error.message());
     }
 
+    #[cfg(feature = "reqwest")]
     #[tokio::test]
     async fn exchange_wants_an_install_id() {
         let request = ExchangeRequest {
@@ -620,6 +628,7 @@ mod tests {
         assert_eq!("install ID is required", error.message());
     }
 
+    #[cfg(feature = "reqwest")]
     #[tokio::test]
     async fn refresh_trades_a_refresh_token_for_a_token() {
         let server = MockServer::start().await;
@@ -651,6 +660,7 @@ mod tests {
         assert!(token.expires_at.is_some());
     }
 
+    #[cfg(feature = "reqwest")]
     #[tokio::test]
     async fn refresh_reports_an_unparsable_error_body() {
         let server = MockServer::start().await;
@@ -675,6 +685,7 @@ mod tests {
         assert_eq!(Some("upstream is down"), error.hint());
     }
 
+    #[cfg(feature = "reqwest")]
     #[tokio::test]
     async fn a_plain_http_token_endpoint_is_refused() {
         let request = RefreshRequest {

--- a/rust/hey-sdk/src/services/entries.rs
+++ b/rust/hey-sdk/src/services/entries.rs
@@ -85,7 +85,8 @@ fn reply_payload(reply: &ReplyContent) -> ReplyMessagePayload {
     }
 }
 
-#[cfg(test)]
+// Wire tests on the shipped HTTP client; without the `reqwest` feature there is none.
+#[cfg(all(test, feature = "reqwest"))]
 mod tests {
     use serde_json::{Value, json};
     use wiremock::matchers::{method, path};

--- a/rust/hey-sdk/src/services/messages.rs
+++ b/rust/hey-sdk/src/services/messages.rs
@@ -223,7 +223,8 @@ pub(crate) fn entry_id_from_location(response: &Response) -> Result<i64, Error> 
     }
 }
 
-#[cfg(test)]
+// Wire tests on the shipped HTTP client; without the `reqwest` feature there is none.
+#[cfg(all(test, feature = "reqwest"))]
 mod tests {
     use std::time::Duration;
 

--- a/rust/hey-sdk/tests/body_limit.rs
+++ b/rust/hey-sdk/tests/body_limit.rs
@@ -49,6 +49,7 @@ async fn a_streamed_body_is_refused_the_moment_it_passes_the_cap() {
     let address = serve_one_chunked_answer(vec![b'x'; 4096]).await;
     let client = Client::builder(Config::default().with_base_url(address))
         .token_provider(StaticTokenProvider::new(TOKEN))
+        .http_client(support::http_client())
         .max_response_body_bytes(1024)
         .base_delay(Duration::from_millis(1))
         .max_jitter(Duration::ZERO)

--- a/rust/hey-sdk/tests/client_pipeline.rs
+++ b/rust/hey-sdk/tests/client_pipeline.rs
@@ -709,6 +709,7 @@ async fn an_id_beyond_double_precision_survives_the_round_trip() {
 fn the_builder_refuses_a_client_it_could_not_use_safely() {
     let insecure = Client::builder(Config::default().with_base_url("http://evil.example.com"))
         .token_provider(StaticTokenProvider::new(TOKEN))
+        .http_client(support::http_client())
         .build()
         .err()
         .unwrap();
@@ -720,11 +721,16 @@ fn the_builder_refuses_a_client_it_could_not_use_safely() {
 
     let local = Client::builder(Config::default().with_base_url("http://127.0.0.1:1"))
         .token_provider(StaticTokenProvider::new(TOKEN))
+        .http_client(support::http_client())
         .build()
         .unwrap();
     assert_eq!(local.base_url().as_str(), "http://127.0.0.1:1/");
 
-    let anonymous = Client::builder(Config::default()).build().err().unwrap();
+    let anonymous = Client::builder(Config::default())
+        .http_client(support::http_client())
+        .build()
+        .err()
+        .unwrap();
     assert_eq!(anonymous.code(), ErrorCode::Usage);
     assert_eq!(
         anonymous.message(),

--- a/rust/hey-sdk/tests/form.rs
+++ b/rust/hey-sdk/tests/form.rs
@@ -4,7 +4,9 @@ use std::sync::Mutex;
 
 use async_trait::async_trait;
 use bytes::Bytes;
-use hey_sdk::http::{ReqwestClient, StatusCode};
+#[cfg(feature = "reqwest")]
+use hey_sdk::http::ReqwestClient;
+use hey_sdk::http::StatusCode;
 use hey_sdk::{Error, ErrorCode, FormResponse, TokenProvider};
 use wiremock::matchers::{header, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -216,6 +218,7 @@ fn the_id_is_the_rightmost_numeric_segment_of_the_redirect() {
 /// A caller's own HTTP client replaces the one ordinary requests go out on, not the one the
 /// form requests use: that one has to refuse redirects, and a caller supplying a client that
 /// follows them would otherwise silently lose the `Location` every form write is made for.
+#[cfg(feature = "reqwest")]
 #[tokio::test]
 async fn a_supplied_http_client_still_has_its_redirects_captured() {
     let server = MockServer::start().await;

--- a/rust/hey-sdk/tests/observability.rs
+++ b/rust/hey-sdk/tests/observability.rs
@@ -194,6 +194,7 @@ async fn a_request_that_never_arrives_is_a_retry_with_a_network_error() {
     let recorder = Recorder::new();
     let client = Client::builder(Config::default().with_base_url("http://127.0.0.1:1"))
         .token_provider(StaticTokenProvider::new("t"))
+        .http_client(support::http_client())
         .base_delay(Duration::from_millis(1))
         .max_jitter(Duration::ZERO)
         .max_retries(1)

--- a/rust/hey-sdk/tests/raw.rs
+++ b/rust/hey-sdk/tests/raw.rs
@@ -265,6 +265,7 @@ async fn nothing_is_cached_for_a_request_that_carries_no_credentials() {
 
     let client = Client::builder(Config::default().with_base_url(server.uri()))
         .auth_strategy(Anonymous)
+        .http_client(support::http_client())
         .cache(InMemoryCache::new())
         .build()
         .unwrap();

--- a/rust/hey-sdk/tests/retry_policy.rs
+++ b/rust/hey-sdk/tests/retry_policy.rs
@@ -225,6 +225,7 @@ async fn a_mutation_is_sent_once_whatever_its_policy_says() {
 fn unpaced(server: &MockServer) -> hey_sdk::ClientBuilder {
     Client::builder(Config::default().with_base_url(server.uri()))
         .token_provider(StaticTokenProvider::new("t"))
+        .http_client(support::http_client())
         .max_jitter(Duration::ZERO)
 }
 
@@ -427,6 +428,7 @@ async fn the_longest_wait_holds_the_client_s_own_floor_and_jitter_down() {
     .await;
     let client = Client::builder(Config::default().with_base_url(server.uri()))
         .token_provider(StaticTokenProvider::new("t"))
+        .http_client(support::http_client())
         .base_delay(Duration::from_millis(600))
         .max_jitter(Duration::from_millis(600))
         .max_delay(Duration::from_millis(20))

--- a/rust/hey-sdk/tests/services_attachments.rs
+++ b/rust/hey-sdk/tests/services_attachments.rs
@@ -1,12 +1,15 @@
 mod support;
 
 use hey_sdk::ErrorCode;
+#[cfg(feature = "reqwest")]
 use hey_sdk::http::{HeaderMap, ReqwestClient};
 use serde_json::{Value, json};
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
-use support::{builder, client};
+#[cfg(feature = "reqwest")]
+use support::builder;
+use support::client;
 
 const CONTENTS: &[u8] = b"quarterly report contents";
 
@@ -198,6 +201,7 @@ async fn a_storage_service_that_refuses_the_bytes_reports_its_status() {
 /// The bytes go out on the client's own HTTP client, so whatever the caller configured it
 /// with — a proxy, a certificate, the headers below standing in for both — reaches the
 /// storage service too. Only the HEY credentials are held back.
+#[cfg(feature = "reqwest")]
 #[tokio::test]
 async fn the_bytes_go_out_on_the_clients_own_http_client() {
     let storage = MockServer::start().await;

--- a/rust/hey-sdk/tests/support/mod.rs
+++ b/rust/hey-sdk/tests/support/mod.rs
@@ -3,6 +3,7 @@
 use std::sync::Mutex;
 use std::time::Duration;
 
+use hey_sdk::http::HttpClient;
 use hey_sdk::observability::{Hooks, OperationInfo, OperationState};
 use hey_sdk::{Client, ClientBuilder, Config, Error, StaticTokenProvider};
 use wiremock::MockServer;
@@ -14,9 +15,80 @@ pub const TOKEN: &str = "test-token";
 pub fn builder(server: &MockServer) -> ClientBuilder {
     Client::builder(Config::default().with_base_url(server.uri()))
         .token_provider(StaticTokenProvider::new(TOKEN))
+        .http_client(http_client())
         .base_delay(Duration::from_millis(20))
         .max_delay(Duration::from_millis(20))
         .max_jitter(Duration::ZERO)
+}
+
+/// The transport the tests send on. With the `reqwest` feature it is the client the crate
+/// ships, so the tests see what a caller gets by default. Without it there is none, and the
+/// tests run instead through [`transport::DevTransport`], a transport of the caller's own
+/// over the dev-dependency: the same suite then proves the feature's promise, that nothing
+/// above the [`HttpClient`] seam needs the shipped client.
+#[cfg(feature = "reqwest")]
+pub fn http_client() -> impl HttpClient + 'static {
+    hey_sdk::http::ReqwestClient::default()
+}
+
+#[cfg(not(feature = "reqwest"))]
+pub fn http_client() -> impl HttpClient + 'static {
+    transport::DevTransport::default()
+}
+
+#[cfg(not(feature = "reqwest"))]
+mod transport {
+    use async_trait::async_trait;
+    use bytes::Bytes;
+    use futures_util::stream;
+    use hey_sdk::Error;
+    use hey_sdk::http::{Body, HttpClient, Request, Response};
+    use reqwest::redirect::Policy;
+
+    /// A transport over the `reqwest` dev-dependency alone. It does what the trait asks and
+    /// nothing else: no redirects, which the SDK follows for itself, the body handed over
+    /// as it arrives, and a deadline of its own, since the trait leaves timeouts to the
+    /// transport and a stalled mock would otherwise hang the test.
+    pub struct DevTransport {
+        http: reqwest::Client,
+    }
+
+    impl Default for DevTransport {
+        fn default() -> DevTransport {
+            let http = reqwest::Client::builder()
+                .redirect(Policy::none())
+                .timeout(std::time::Duration::from_secs(30))
+                .build()
+                .expect("reqwest builds a client from its defaults");
+            DevTransport { http }
+        }
+    }
+
+    #[async_trait]
+    impl HttpClient for DevTransport {
+        async fn send(&self, request: Request<Bytes>) -> Result<Response<Body>, Error> {
+            let request = reqwest::Request::try_from(request).map_err(Error::network)?;
+            let answered = self.http.execute(request).await.map_err(Error::network)?;
+
+            let status = answered.status();
+            let version = answered.version();
+            let headers = answered.headers().clone();
+            let content_length = answered.content_length();
+            let chunks = stream::try_unfold(answered, |mut answered| async move {
+                match answered.chunk().await {
+                    Ok(Some(chunk)) => Ok(Some((chunk, answered))),
+                    Ok(None) => Ok(None),
+                    Err(error) => Err(Error::network(error)),
+                }
+            });
+
+            let mut response = Response::new(Body::from_stream(chunks, content_length));
+            *response.status_mut() = status;
+            *response.version_mut() = version;
+            *response.headers_mut() = headers;
+            Ok(response)
+        }
+    }
 }
 
 pub fn client(server: &MockServer) -> Client {


### PR DESCRIPTION
First of three CI-hardening pull requests for the Rust crate (card: [hey-sdk Rust: CI hardening](https://app.basecamp.com/2914079/buckets/46292715/card_tables/cards/10289485364)). This one is the build side; `cargo deny` and the API-compatibility gate follow on top of it.

## What changes

**`test-rust`** installs the toolchain from the new `rust-toolchain.toml` and runs `make rs-check`, which is now fmt, clippy, tests and docs with `--all-features`, then clippy and the tests again with `--no-default-features`. The same target a developer runs locally, in the same order.

**`msrv-rust`** reads `rust-version` out of `rust/Cargo.toml` and builds the library on exactly that toolchain, both feature sets. Only the library: the generator and the conformance runner are tooling and float on the pinned stable. A bump to `rust-version` is what moves this job; the job fails if it can't find the field.

**`docs-rust`** builds the docs on nightly with `RUSTDOCFLAGS="--cfg docsrs -D warnings"`, which is what docs.rs will do with the crate. Not proposed as a required check; nightly is nightly.

**`rust-toolchain.toml`** pins an exact stable (`1.98.1`, what `.mise.toml` resolves `1.98` to) with `clippy` and `rustfmt`. The stable jobs install from it with a bare `rustup toolchain install`; the MSRV and nightly jobs set `RUSTUP_TOOLCHAIN`, which outranks the file. It sits at the repo root rather than under `rust/` because `conformance/runner/rust` is a second workspace outside that directory.

## `--no-default-features`

The crate's one feature is the shipped `reqwest` transport, and without it the test suite had no way to reach wiremock. `tests/support` now builds every client with an explicit `http_client`: the shipped `ReqwestClient` when the feature is on, and otherwise a minimal `DevTransport` over the `reqwest` dev-dependency (no redirects, streamed body). So under `--no-default-features` the whole integration suite runs through a transport of the caller's own, which is the thing the feature exists to allow. Tests that are specifically about the shipped client — `ReqwestClient::from_builder`, the OAuth wire tests that use `OAuthClient::default()`, the messages/entries unit tests that build a default client — are gated on the feature. Doctests are skipped in that configuration; they show the default client on purpose.

Verified locally: `make rs-check` green on this branch; `cargo build -p hey-sdk --locked` green on 1.88.0 with the committed lockfile.

## Not in this PR

- `cargo deny`, Dependabot `cargo`, Trivy over `Cargo.lock` — next PR.
- `cargo semver-checks` and `cargo package` in the gate — third PR.
- `cargo build --examples` — lands with the examples ([docs card](https://app.basecamp.com/2914079/buckets/46292715/card_tables/cards/10289485391)).
- CodeQL for Rust is already on: the repo's default setup analyses `actions`, `go` and `rust`.
- `--all-features` and the default set are the same build today (one feature); when a second feature lands the matrix gains a leg.



## Merge order

This PR is part of a five-PR stack, each rebased on the one below and all five on current `main`, so they merge cleanly in this order and only this order: #155 (build/MSRV/feature matrix) → #157 (cargo deny, Dependabot, Trivy) → #159 (semver-checks, packaging) → #160 (docs, examples, rustfmt) → #162 (crates.io publishing). Every one of them touches `.github/workflows/test.yml` and/or the Makefiles; the stacking is the conflict resolution. Merge each one after the one below has landed; GitHub retargets the next PR to `main` when the merged branch is deleted. #162 can merge before the crates.io bootstrap: it publishes nothing until the crate exists on crates.io (its publish job fails closed with instructions on a tag until then), and nothing in it changes after the bootstrap.
