### PR TITLE
Refuse to generate a response the crate cannot read

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,8 +68,15 @@ method that asks for the page as HEY serves it (no `.json` suffix, `Accept: text
 answers the body as a `String`. Reading anything out of that page is a hand-written
 convenience's job, as `go/pkg/hey` does for the same route.
 
+A 2xx in any other representation — an image, a CSV, two representations on one status, a
+schema that is not a `$ref` — fails generation naming the operation. A method the crate
+cannot call is worse than no method, and one that quietly answered `()` for a page is how
+the gate went red the first time an HTML route arrived.
+
 `rs-check-drift` runs the generator in `--check` mode, so stale generated code fails the
-gate.
+gate. The generator also has fixtures of its own (`rust/generator/src/fixtures.rs`): small
+models put through `Model::build` and the emitters whole, since the drift check only proves
+the checked-in output matches the generator, not that the generator is right.
 
 `rust/hey-sdk/src/services/*.rs` are hand-written, like `go/pkg/hey` — you update them
 yourself. Each one re-exports the generated service it extends and adds conveniences as

--- a/rust/generator/src/fixtures.rs
+++ b/rust/generator/src/fixtures.rs
@@ -69,6 +69,16 @@ fn file<'a>(files: &'a BTreeMap<PathBuf, String>, name: &str) -> &'a str {
     &files[&PathBuf::from(name)]
 }
 
+/// The emitted `Route` static for one operation, so an assertion reads that route's own
+/// fields and not another's.
+fn route<'a>(routes: &'a str, constant: &str) -> &'a str {
+    let start = routes
+        .find(&format!("pub static {constant}: Route = Route {{"))
+        .unwrap_or_else(|| panic!("{constant} is not in routes.rs"));
+    let end = routes[start..].find("};\n").unwrap() + start;
+    &routes[start..end]
+}
+
 fn box_schema() -> Value {
     json!({ "Box": { "type": "object", "properties": { "id": { "type": "integer", "format": "int64" } }, "required": ["id"] } })
 }
@@ -146,6 +156,130 @@ fn an_html_response_has_to_be_a_string_schema() {
 }
 
 #[test]
+fn a_second_success_status_answered_differently_fails_generation() {
+    let mut operation = read("GetBox", "Boxes", &["id"], json_body("Box"));
+    operation["get"]["responses"]["202"] =
+        json!({ "content": { "image/png": { "schema": { "$ref": "#/components/schemas/Box" } } } });
+    let error = build(
+        json!({ "/boxes/{id}": operation }),
+        box_schema(),
+        &["GetBox"],
+    )
+    .err()
+    .unwrap();
+    assert_eq!(
+        error,
+        "GetBox answers 202 as image/png, which the generator has no representation for; it emits application/json and text/html"
+    );
+
+    let mut operation = read("GetBox", "Boxes", &["id"], json_body("Box"));
+    operation["get"]["responses"]["204"] = json!({ "description": "nothing" });
+    let error = build(
+        json!({ "/boxes/{id}": operation }),
+        box_schema(),
+        &["GetBox"],
+    )
+    .err()
+    .unwrap();
+    assert_eq!(
+        error,
+        "GetBox answers 200 and 204 differently (Mailbox as JSON and no body); the generator emits one representation per operation"
+    );
+}
+
+#[test]
+fn a_referenced_response_fails_generation() {
+    let response = json!({ "$ref": "#/components/responses/Stage" });
+    let error = build(
+        json!({ "/stages/{id}": read("GetStage", "Stages", &["id"], response) }),
+        box_schema(),
+        &["GetStage"],
+    )
+    .err()
+    .unwrap();
+
+    assert_eq!(
+        error,
+        "GetStage answers 200 through a $ref response, which the generator does not resolve; write the response inline"
+    );
+}
+
+#[test]
+fn a_reference_outside_the_documents_schemas_fails_generation() {
+    let response = json!({ "content": { "application/json": { "schema": { "$ref": "types.json#/components/schemas/Box" } } } });
+    let error = build(
+        json!({ "/boxes/{id}": read("GetBox", "Boxes", &["id"], response) }),
+        box_schema(),
+        &["GetBox"],
+    )
+    .err()
+    .unwrap();
+    assert_eq!(
+        error,
+        "$ref types.json#/components/schemas/Box does not point into #/components/schemas/; the generator resolves nothing else"
+    );
+
+    let error = build(
+        json!({ "/boxes/{id}": read("GetBox", "Boxes", &["id"], json_body("Crate")) }),
+        box_schema(),
+        &["GetBox"],
+    )
+    .err()
+    .unwrap();
+    assert_eq!(
+        error,
+        "GetBox refers to Crate, which is not in components.schemas"
+    );
+
+    let error = build(
+        json!({}),
+        json!({ "Box": { "type": "object", "properties": { "owner": { "$ref": "#/components/schemas/Owner" } } } }),
+        &[],
+    )
+    .err()
+    .unwrap();
+    assert_eq!(
+        error,
+        "Mailbox refers to Owner, which is not in components.schemas"
+    );
+}
+
+#[test]
+fn an_html_response_may_reach_its_string_through_an_alias() {
+    let response = json!({ "content": { "text/html": { "schema": { "$ref": "#/components/schemas/StagePage" } } } });
+    let files = generate(
+        json!({ "/stages/{id}": read("GetStage", "Stages", &["id"], response) }),
+        json!({
+            "StagePage": { "$ref": "#/components/schemas/PageText" },
+            "PageText": { "type": "string" },
+        }),
+        &["GetStage"],
+    );
+
+    assert!(file(&files, "types.rs").contains("pub type StagePage = PageText;\n"));
+    assert!(file(&files, "services/stages.rs").contains("self.client.send_text(operation).await"));
+}
+
+#[test]
+fn an_operation_the_generator_does_not_emit_fails_generation() {
+    let mut item = read("GetBox", "Boxes", &["id"], json_body("Box"));
+    item["head"] = item["get"].clone();
+    item["head"]["operationId"] = json!("HeadBox");
+    let error = build(
+        json!({ "/boxes/{id}": item }),
+        box_schema(),
+        &["GetBox", "HeadBox"],
+    )
+    .err()
+    .unwrap();
+
+    assert_eq!(
+        error,
+        "/boxes/{id} has a head operation, which the generator does not emit"
+    );
+}
+
+#[test]
 fn an_html_page_is_read_as_text_from_the_path_as_written() {
     let response = json!({ "content": { "text/html": { "schema": { "$ref": "#/components/schemas/StagePage" } } } });
     let files = generate(
@@ -157,7 +291,9 @@ fn an_html_page_is_read_as_text_from_the_path_as_written() {
     let service = file(&files, "services/stages.rs");
     assert!(service.contains("pub async fn get(&self, id: i64) -> Result<StagePage, Error> {"));
     assert!(service.contains("self.client.send_text(operation).await"));
-    assert!(file(&files, "routes.rs").contains("    html: true,\n"));
+    let stage = route(file(&files, "routes.rs"), "GET_STAGE");
+    assert!(stage.contains("    path: \"/stages/{id}\",\n"));
+    assert!(stage.contains("    html: true,\n"));
     assert!(file(&files, "types.rs").contains("pub type StagePage = String;\n"));
 }
 
@@ -179,7 +315,9 @@ fn json_and_empty_responses_take_their_own_send() {
     assert!(service.contains(
         "    pub async fn get_seen(&self, id: i64) -> Result<(), Error> {\n        let mut operation = self.client.operation(&routes::GET_BOX_SEEN, &[&id]);\n        operation.resource_id(id);\n        self.client.send_unit(operation).await\n    }\n"
     ));
-    assert!(file(&files, "routes.rs").contains("    html: false,\n"));
+    let routes = file(&files, "routes.rs");
+    assert!(route(routes, "GET_BOX").contains("    html: false,\n"));
+    assert!(route(routes, "GET_BOX_SEEN").contains("    html: false,\n"));
 }
 
 #[test]
@@ -233,7 +371,7 @@ fn required_and_optional_fields_read_as_the_model_says() {
                 "type": { "type": "string" },
             },
             "required": ["id", "created_at", "box"],
-        } }),
+        }, "Box": box_schema()["Box"] }),
         &[],
     );
 

--- a/rust/generator/src/fixtures.rs
+++ b/rust/generator/src/fixtures.rs
@@ -356,6 +356,16 @@ fn a_method_named_after_a_keyword_fails_generation() {
 }
 
 #[test]
+fn an_override_naming_a_keyword_fails_generation_too() {
+    let naming = Naming::parse("[operation_methods]\nGetBox = \"match\"\n").unwrap();
+
+    assert_eq!(
+        naming.method_for("GetBox", "boxes").unwrap_err(),
+        "GetBox becomes `match` in boxes; add an [operation_methods] override to names.toml"
+    );
+}
+
+#[test]
 fn required_and_optional_fields_read_as_the_model_says() {
     let files = generate(
         json!({}),

--- a/rust/generator/src/fixtures.rs
+++ b/rust/generator/src/fixtures.rs
@@ -1,0 +1,285 @@
+//! Small models put through the generator whole, so a wrong answer is caught here rather
+//! than in the checked-in output. The drift check only proves `src/generated` matches what
+//! the generator emits; these prove the generator emits the right thing.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use serde_json::{Value, json};
+
+use crate::model::{Model, ResourceTypes};
+use crate::naming::Naming;
+
+const NAMES: &str =
+    "[type_names]\nBox = \"Mailbox\"\n\n[resource_types]\nboxes = \"box\"\nstages = \"stage\"\n";
+
+fn behavior(operations: &[&str]) -> Value {
+    let mut entries = serde_json::Map::new();
+    for id in operations {
+        entries.insert(
+            (*id).to_string(),
+            json!({ "readonly": true, "retry": { "max": 3, "base_delay_ms": 1000, "retry_on": [429, 503] } }),
+        );
+    }
+    json!({ "operations": entries })
+}
+
+fn openapi(paths: Value, schemas: Value) -> Value {
+    json!({
+        "openapi": "3.1.0",
+        "info": { "version": "2026-01-01" },
+        "paths": paths,
+        "components": { "schemas": schemas },
+    })
+}
+
+fn read(id: &str, tag: &str, path_params: &[&str], response: Value) -> Value {
+    let parameters: Vec<Value> = path_params
+        .iter()
+        .map(|name| json!({ "name": name, "in": "path", "required": true, "schema": { "type": "integer", "format": "int64" } }))
+        .collect();
+    json!({ "get": {
+        "operationId": id,
+        "tags": [tag],
+        "parameters": parameters,
+        "responses": { "200": response },
+    } })
+}
+
+fn json_body(schema: &str) -> Value {
+    json!({ "content": { "application/json": { "schema": { "$ref": format!("#/components/schemas/{schema}") } } } })
+}
+
+fn build(paths: Value, schemas: Value, operations: &[&str]) -> Result<Model, String> {
+    let naming = Naming::parse(NAMES).unwrap();
+    let resource_types = ResourceTypes::parse(NAMES).unwrap();
+    Model::build(
+        &openapi(paths, schemas),
+        &behavior(operations),
+        &naming,
+        &resource_types,
+    )
+}
+
+fn generate(paths: Value, schemas: Value, operations: &[&str]) -> BTreeMap<PathBuf, String> {
+    crate::render(&build(paths, schemas, operations).unwrap())
+}
+
+fn file<'a>(files: &'a BTreeMap<PathBuf, String>, name: &str) -> &'a str {
+    &files[&PathBuf::from(name)]
+}
+
+fn box_schema() -> Value {
+    json!({ "Box": { "type": "object", "properties": { "id": { "type": "integer", "format": "int64" } }, "required": ["id"] } })
+}
+
+#[test]
+fn an_unsupported_representation_fails_generation() {
+    let response = json!({ "content": { "image/png": { "schema": { "type": "string", "contentEncoding": "byte" } } } });
+    let error = build(
+        json!({ "/boxes/{id}/badge": read("GetBoxBadge", "Boxes", &["id"], response) }),
+        box_schema(),
+        &["GetBoxBadge"],
+    )
+    .err()
+    .unwrap();
+
+    assert_eq!(
+        error,
+        "GetBoxBadge answers 200 as image/png, which the generator has no representation for; it emits application/json and text/html"
+    );
+}
+
+#[test]
+fn more_than_one_representation_fails_generation() {
+    let response = json!({ "content": {
+        "application/json": { "schema": { "$ref": "#/components/schemas/Box" } },
+        "text/html": { "schema": { "$ref": "#/components/schemas/Page" } },
+    } });
+    let error = build(
+        json!({ "/boxes/{id}": read("GetBox", "Boxes", &["id"], response) }),
+        json!({ "Box": box_schema()["Box"], "Page": { "type": "string" } }),
+        &["GetBox"],
+    )
+    .err()
+    .unwrap();
+
+    assert_eq!(
+        error,
+        "GetBox answers 200 in 2 representations (application/json, text/html); the generator emits one"
+    );
+}
+
+#[test]
+fn an_inline_response_schema_fails_generation() {
+    let response = json!({ "content": { "application/json": { "schema": { "type": "object" } } } });
+    let error = build(
+        json!({ "/boxes/{id}": read("GetBox", "Boxes", &["id"], response) }),
+        box_schema(),
+        &["GetBox"],
+    )
+    .err()
+    .unwrap();
+
+    assert_eq!(
+        error,
+        "GetBox answers 200 as application/json with a schema that is not a $ref to components.schemas"
+    );
+}
+
+#[test]
+fn an_html_response_has_to_be_a_string_schema() {
+    let response =
+        json!({ "content": { "text/html": { "schema": { "$ref": "#/components/schemas/Box" } } } });
+    let error = build(
+        json!({ "/boxes/{id}": read("GetBox", "Boxes", &["id"], response) }),
+        box_schema(),
+        &["GetBox"],
+    )
+    .err()
+    .unwrap();
+
+    assert_eq!(
+        error,
+        "GetBox answers text/html as Mailbox, which is not a string schema; an HTML page is handed back as a String"
+    );
+}
+
+#[test]
+fn an_html_page_is_read_as_text_from_the_path_as_written() {
+    let response = json!({ "content": { "text/html": { "schema": { "$ref": "#/components/schemas/StagePage" } } } });
+    let files = generate(
+        json!({ "/stages/{id}": read("GetStage", "Stages", &["id"], response) }),
+        json!({ "StagePage": { "type": "string", "contentEncoding": "byte" } }),
+        &["GetStage"],
+    );
+
+    let service = file(&files, "services/stages.rs");
+    assert!(service.contains("pub async fn get(&self, id: i64) -> Result<StagePage, Error> {"));
+    assert!(service.contains("self.client.send_text(operation).await"));
+    assert!(file(&files, "routes.rs").contains("    html: true,\n"));
+    assert!(file(&files, "types.rs").contains("pub type StagePage = String;\n"));
+}
+
+#[test]
+fn json_and_empty_responses_take_their_own_send() {
+    let files = generate(
+        json!({
+            "/boxes/{id}.json": read("GetBox", "Boxes", &["id"], json_body("Box")),
+            "/boxes/{id}/seen.json": read("GetBoxSeen", "Boxes", &["id"], json!({ "description": "nothing" })),
+        }),
+        box_schema(),
+        &["GetBox", "GetBoxSeen"],
+    );
+
+    let service = file(&files, "services/boxes.rs");
+    assert!(service.contains(
+        "    pub async fn get(&self, id: i64) -> Result<Mailbox, Error> {\n        let mut operation = self.client.operation(&routes::GET_BOX, &[&id]);\n        operation.resource_id(id);\n        self.client.send(operation).await\n    }\n"
+    ));
+    assert!(service.contains(
+        "    pub async fn get_seen(&self, id: i64) -> Result<(), Error> {\n        let mut operation = self.client.operation(&routes::GET_BOX_SEEN, &[&id]);\n        operation.resource_id(id);\n        self.client.send_unit(operation).await\n    }\n"
+    ));
+    assert!(file(&files, "routes.rs").contains("    html: false,\n"));
+}
+
+#[test]
+fn two_operations_collapsing_to_one_method_fail_generation() {
+    let error = build(
+        json!({
+            "/boxes/{id}.json": read("GetBox", "Boxes", &["id"], json_body("Box")),
+            "/boxes/{id}/box.json": read("GetBoxBox", "Boxes", &["id"], json_body("Box")),
+        }),
+        box_schema(),
+        &["GetBox", "GetBoxBox"],
+    )
+    .err()
+    .unwrap();
+
+    assert_eq!(
+        error,
+        "GetBox and GetBoxBox both become boxes::get; add an [operation_methods] override to names.toml"
+    );
+}
+
+#[test]
+fn a_method_named_after_a_keyword_fails_generation() {
+    let error = build(
+        json!({ "/boxes/{id}/match.json": read("MatchBox", "Boxes", &["id"], json_body("Box")) }),
+        box_schema(),
+        &["MatchBox"],
+    )
+    .err()
+    .unwrap();
+
+    assert_eq!(
+        error,
+        "MatchBox becomes `match` in boxes; add an [operation_methods] override to names.toml"
+    );
+}
+
+#[test]
+fn required_and_optional_fields_read_as_the_model_says() {
+    let files = generate(
+        json!({}),
+        json!({ "Sticky": {
+            "type": "object",
+            "description": "A sticky note",
+            "properties": {
+                "id": { "type": "integer", "format": "int64" },
+                "created_at": { "type": "string", "format": "date-time" },
+                "due_on": { "type": "string", "format": "date" },
+                "note": { "type": "string", "description": "What it says" },
+                "box": { "$ref": "#/components/schemas/Box" },
+                "type": { "type": "string" },
+            },
+            "required": ["id", "created_at", "box"],
+        } }),
+        &[],
+    );
+
+    let expected = "/// A sticky note
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct Sticky {
+    #[serde(default, deserialize_with = \"crate::types::null_as_default::deserialize\")]
+    pub id: i64,
+    pub created_at: DateTime,
+    #[serde(default, with = \"crate::types::optional_date\", skip_serializing_if = \"Option::is_none\")]
+    pub due_on: Option<Date>,
+    /// What it says
+    #[serde(default, skip_serializing_if = \"Option::is_none\")]
+    pub note: Option<String>,
+    #[serde(default)]
+    pub r#box: Mailbox,
+    #[serde(default, skip_serializing_if = \"Option::is_none\")]
+    pub r#type: Option<String>,
+}
+
+";
+    assert!(
+        file(&files, "types.rs").contains(expected),
+        "{}",
+        file(&files, "types.rs")
+    );
+}
+
+#[test]
+fn a_shape_that_mentions_itself_is_boxed_and_a_renamed_one_reaches_every_field() {
+    let files = generate(
+        json!({}),
+        json!({
+            "Box": { "type": "object", "properties": { "parent": { "$ref": "#/components/schemas/Box" }, "children": { "type": "array", "items": { "$ref": "#/components/schemas/Box" } } } },
+            "Folder": { "type": "object", "properties": { "box": { "$ref": "#/components/schemas/Box" }, "boxes_by_name": { "type": "object", "additionalProperties": { "$ref": "#/components/schemas/Box" } } } },
+            "Boxes": { "type": "array", "items": { "$ref": "#/components/schemas/Box" } },
+        }),
+        &[],
+    );
+
+    let types = file(&files, "types.rs");
+    assert!(types.contains("pub struct Mailbox {"));
+    assert!(types.contains("    pub parent: Option<::std::boxed::Box<Mailbox>>,"));
+    assert!(types.contains("    pub children: Option<Vec<Mailbox>>,"));
+    assert!(types.contains("    pub r#box: Option<Mailbox>,"));
+    assert!(types.contains("    pub boxes_by_name: Option<BTreeMap<String, Mailbox>>,"));
+    assert!(types.contains("pub type Boxes = Vec<Mailbox>;"));
+    assert!(!types.contains("struct Box "));
+}

--- a/rust/generator/src/main.rs
+++ b/rust/generator/src/main.rs
@@ -5,6 +5,8 @@
 //! the checked-in files differ from what it would generate.
 
 mod emit;
+#[cfg(test)]
+mod fixtures;
 mod model;
 mod naming;
 

--- a/rust/generator/src/model.rs
+++ b/rust/generator/src/model.rs
@@ -171,12 +171,33 @@ impl Model {
             .to_string();
         let schemas = build_schemas(openapi, naming)?;
         let services = build_services(openapi, behavior, naming, resource_types)?;
+        check_html_responses(&schemas, &services)?;
         Ok(Model {
             api_version,
             schemas,
             services,
         })
     }
+}
+
+/// A page is handed back as the `String` it arrived as, so the schema an HTML response
+/// names has to be a string alias; a struct there would be a document the crate had no
+/// parser for.
+fn check_html_responses(schemas: &[Schema], services: &[Service]) -> Result<(), String> {
+    for operation in services.iter().flat_map(|service| &service.operations) {
+        if let Response::Html(name) = &operation.response {
+            let is_string = schemas.iter().any(|schema| {
+                schema.name == *name && matches!(schema.shape, Shape::Alias(FieldType::String))
+            });
+            if !is_string {
+                return Err(format!(
+                    "{} answers text/html as {name}, which is not a string schema; an HTML page is handed back as a String",
+                    operation.id
+                ));
+            }
+        }
+    }
+    Ok(())
 }
 
 fn build_schemas(openapi: &Value, naming: &Naming) -> Result<Vec<Schema>, String> {
@@ -308,7 +329,7 @@ fn build_services(
             let operation = Operation {
                 id: id.to_string(),
                 service: struct_name(&service),
-                method_name: naming.method_for(id, &service),
+                method_name: naming.method_for(id, &service)?,
                 description: description_of(operation),
                 http_method: http_method.to_uppercase(),
                 path: path.clone(),
@@ -407,30 +428,52 @@ fn body_of(operation: &Value, naming: &Naming) -> Option<String> {
         .map(|reference| naming.type_for(&reference_name(reference)))
 }
 
+/// The representations the generator can emit a method for. Anything else fails generation:
+/// a route the model describes and the crate cannot call is worse than no crate at all,
+/// and a method that silently returned `()` for a page HEY serves is how the gate went red
+/// after the first `text/html` route arrived.
+const REPRESENTATIONS: &[&str] = &["application/json", "text/html"];
+
 fn response_of(operation: &Value, naming: &Naming) -> Result<Response, String> {
+    let id = operation["operationId"].as_str().unwrap_or("operation");
     let responses = operation["responses"]
         .as_object()
-        .ok_or("operation has no responses")?;
+        .ok_or(format!("{id} has no responses"))?;
     for (status, response) in responses {
-        if status.starts_with('2') {
-            let content = &response["content"];
-            return Ok(
-                match (
-                    content["application/json"]["schema"]["$ref"].as_str(),
-                    content["text/html"]["schema"]["$ref"].as_str(),
-                ) {
-                    (Some(reference), _) => {
-                        Response::Json(naming.type_for(&reference_name(reference)))
-                    }
-                    (None, Some(reference)) => {
-                        Response::Html(naming.type_for(&reference_name(reference)))
-                    }
-                    (None, None) => Response::Empty,
-                },
-            );
+        if !status.starts_with('2') {
+            continue;
         }
+        let Some(content) = response.get("content").and_then(Value::as_object) else {
+            return Ok(Response::Empty);
+        };
+        let representations: Vec<&str> = content.keys().map(String::as_str).collect();
+        let (media_type, body) = match representations.as_slice() {
+            [] => return Ok(Response::Empty),
+            [one] => (*one, &content[*one]),
+            many => {
+                return Err(format!(
+                    "{id} answers {status} in {} representations ({}); the generator emits one",
+                    many.len(),
+                    many.join(", ")
+                ));
+            }
+        };
+        if !REPRESENTATIONS.contains(&media_type) {
+            return Err(format!(
+                "{id} answers {status} as {media_type}, which the generator has no representation for; it emits {}",
+                REPRESENTATIONS.join(" and ")
+            ));
+        }
+        let reference = body["schema"]["$ref"].as_str().ok_or(format!(
+            "{id} answers {status} as {media_type} with a schema that is not a $ref to components.schemas"
+        ))?;
+        let name = naming.type_for(&reference_name(reference));
+        return Ok(match media_type {
+            "text/html" => Response::Html(name),
+            _ => Response::Json(name),
+        });
     }
-    Err(format!("{} has no 2xx response", operation["operationId"]))
+    Err(format!("{id} has no 2xx response"))
 }
 
 fn idempotent(http_method: &str, operation: &Value) -> bool {

--- a/rust/generator/src/model.rs
+++ b/rust/generator/src/model.rs
@@ -138,11 +138,22 @@ pub enum ParamKind {
     Int64,
 }
 
+#[derive(Debug, Clone, PartialEq)]
 pub enum Response {
     Empty,
     Json(String),
     /// A page HEY serves as HTML, with the name of the `String` alias the schema became.
     Html(String),
+}
+
+impl Response {
+    fn describe(&self) -> String {
+        match self {
+            Response::Empty => "no body".to_string(),
+            Response::Json(name) => format!("{name} as JSON"),
+            Response::Html(name) => format!("{name} as HTML"),
+        }
+    }
 }
 
 #[derive(Clone, Copy, PartialEq)]
@@ -171,6 +182,7 @@ impl Model {
             .to_string();
         let schemas = build_schemas(openapi, naming)?;
         let services = build_services(openapi, behavior, naming, resource_types)?;
+        check_references(&schemas, &services)?;
         check_html_responses(&schemas, &services)?;
         Ok(Model {
             api_version,
@@ -185,19 +197,34 @@ impl Model {
 /// parser for.
 fn check_html_responses(schemas: &[Schema], services: &[Service]) -> Result<(), String> {
     for operation in services.iter().flat_map(|service| &service.operations) {
-        if let Response::Html(name) = &operation.response {
-            let is_string = schemas.iter().any(|schema| {
-                schema.name == *name && matches!(schema.shape, Shape::Alias(FieldType::String))
-            });
-            if !is_string {
-                return Err(format!(
-                    "{} answers text/html as {name}, which is not a string schema; an HTML page is handed back as a String",
-                    operation.id
-                ));
-            }
+        if let Response::Html(name) = &operation.response
+            && !resolves_to_string(schemas, name)
+        {
+            return Err(format!(
+                "{} answers text/html as {name}, which is not a string schema; an HTML page is handed back as a String",
+                operation.id
+            ));
         }
     }
     Ok(())
+}
+
+/// Whether a schema is a string, following an alias of an alias as far as there are schemas
+/// to follow it through.
+fn resolves_to_string(schemas: &[Schema], name: &str) -> bool {
+    let mut current = name.to_string();
+    for _ in 0..=schemas.len() {
+        match schemas
+            .iter()
+            .find(|schema| schema.name == current)
+            .map(|schema| &schema.shape)
+        {
+            Some(Shape::Alias(FieldType::String)) => return true,
+            Some(Shape::Alias(FieldType::Named(next))) => current = next.clone(),
+            _ => return false,
+        }
+    }
+    false
 }
 
 fn build_schemas(openapi: &Value, naming: &Naming) -> Result<Vec<Schema>, String> {
@@ -253,7 +280,7 @@ fn polymorphic_of(schema: &Value) -> Option<Polymorphic> {
 fn field_type(name: &str, property: &Value, naming: &Naming) -> Result<FieldType, String> {
     if let Some(reference) = property.get("$ref").and_then(Value::as_str) {
         return Ok(FieldType::Named(
-            naming.type_for(&reference_name(reference)),
+            naming.type_for(&reference_name(reference)?),
         ));
     }
     let format = property["format"].as_str();
@@ -310,11 +337,14 @@ fn build_services(
         for (http_method, operation) in
             item.as_object().ok_or(format!("{path} is not an object"))?
         {
-            if !matches!(
-                http_method.as_str(),
-                "get" | "post" | "put" | "patch" | "delete"
-            ) {
-                continue;
+            match http_method.as_str() {
+                "get" | "post" | "put" | "patch" | "delete" => {}
+                "head" | "options" | "trace" => {
+                    return Err(format!(
+                        "{path} has a {http_method} operation, which the generator does not emit"
+                    ));
+                }
+                _ => continue,
             }
             let id = operation["operationId"]
                 .as_str()
@@ -337,7 +367,7 @@ fn build_services(
                 resource_type: resource_types.for_operation(id, &service)?,
                 path_params: path_params(operation, path)?,
                 query_params: query_params(operation)?,
-                body: body_of(operation, naming),
+                body: body_of(operation, naming)?,
                 response: response_of(operation, naming)?,
                 idempotent: idempotent(http_method, operation),
                 readonly: readonly(semantics, id)?,
@@ -422,10 +452,11 @@ fn param_kind(parameter: &Value) -> Result<ParamKind, String> {
     }
 }
 
-fn body_of(operation: &Value, naming: &Naming) -> Option<String> {
+fn body_of(operation: &Value, naming: &Naming) -> Result<Option<String>, String> {
     operation["requestBody"]["content"]["application/json"]["schema"]["$ref"]
         .as_str()
-        .map(|reference| naming.type_for(&reference_name(reference)))
+        .map(|reference| Ok(naming.type_for(&reference_name(reference)?)))
+        .transpose()
 }
 
 /// The representations the generator can emit a method for. Anything else fails generation:
@@ -439,41 +470,71 @@ fn response_of(operation: &Value, naming: &Naming) -> Result<Response, String> {
     let responses = operation["responses"]
         .as_object()
         .ok_or(format!("{id} has no responses"))?;
+    let mut agreed: Option<(&str, Response)> = None;
     for (status, response) in responses {
         if !status.starts_with('2') {
             continue;
         }
-        let Some(content) = response.get("content").and_then(Value::as_object) else {
-            return Ok(Response::Empty);
-        };
-        let representations: Vec<&str> = content.keys().map(String::as_str).collect();
-        let (media_type, body) = match representations.as_slice() {
-            [] => return Ok(Response::Empty),
-            [one] => (*one, &content[*one]),
-            many => {
+        let representation = representation_of(id, status, response, naming)?;
+        match &agreed {
+            None => agreed = Some((status, representation)),
+            Some((first, expected)) if *expected != representation => {
                 return Err(format!(
-                    "{id} answers {status} in {} representations ({}); the generator emits one",
-                    many.len(),
-                    many.join(", ")
+                    "{id} answers {first} and {status} differently ({} and {}); the generator emits one representation per operation",
+                    expected.describe(),
+                    representation.describe()
                 ));
             }
-        };
-        if !REPRESENTATIONS.contains(&media_type) {
+            Some(_) => {}
+        }
+    }
+    agreed
+        .map(|(_, representation)| representation)
+        .ok_or(format!("{id} has no 2xx response"))
+}
+
+/// What one success response is answered as. A response object that is itself a `$ref`
+/// is refused rather than read as bodyless: what it points at may well be a page.
+fn representation_of(
+    id: &str,
+    status: &str,
+    response: &Value,
+    naming: &Naming,
+) -> Result<Response, String> {
+    if response.get("$ref").is_some() {
+        return Err(format!(
+            "{id} answers {status} through a $ref response, which the generator does not resolve; write the response inline"
+        ));
+    }
+    let Some(content) = response.get("content").and_then(Value::as_object) else {
+        return Ok(Response::Empty);
+    };
+    let representations: Vec<&str> = content.keys().map(String::as_str).collect();
+    let (media_type, body) = match representations.as_slice() {
+        [] => return Ok(Response::Empty),
+        [one] => (*one, &content[*one]),
+        many => {
             return Err(format!(
-                "{id} answers {status} as {media_type}, which the generator has no representation for; it emits {}",
-                REPRESENTATIONS.join(" and ")
+                "{id} answers {status} in {} representations ({}); the generator emits one",
+                many.len(),
+                many.join(", ")
             ));
         }
-        let reference = body["schema"]["$ref"].as_str().ok_or(format!(
-            "{id} answers {status} as {media_type} with a schema that is not a $ref to components.schemas"
-        ))?;
-        let name = naming.type_for(&reference_name(reference));
-        return Ok(match media_type {
-            "text/html" => Response::Html(name),
-            _ => Response::Json(name),
-        });
+    };
+    if !REPRESENTATIONS.contains(&media_type) {
+        return Err(format!(
+            "{id} answers {status} as {media_type}, which the generator has no representation for; it emits {}",
+            REPRESENTATIONS.join(" and ")
+        ));
     }
-    Err(format!("{id} has no 2xx response"))
+    let reference = body["schema"]["$ref"].as_str().ok_or(format!(
+        "{id} answers {status} as {media_type} with a schema that is not a $ref to components.schemas"
+    ))?;
+    let name = naming.type_for(&reference_name(reference)?);
+    Ok(match media_type {
+        "text/html" => Response::Html(name),
+        _ => Response::Json(name),
+    })
 }
 
 fn idempotent(http_method: &str, operation: &Value) -> bool {
@@ -533,13 +594,70 @@ fn description_of(value: &Value) -> Option<String> {
     value["description"].as_str().map(str::to_string)
 }
 
-fn reference_name(reference: &str) -> String {
+const SCHEMA_REFERENCE: &str = "#/components/schemas/";
+
+/// The schema a `$ref` names. Only a reference into this document's own schemas can
+/// become a type here; anything else would be emitted as a name Rust has never heard of.
+fn reference_name(reference: &str) -> Result<String, String> {
     reference
-        .trim_start_matches("#/components/schemas/")
-        .to_string()
+        .strip_prefix(SCHEMA_REFERENCE)
+        .filter(|name| !name.is_empty() && !name.contains('/'))
+        .map(str::to_string)
+        .ok_or(format!(
+            "$ref {reference} does not point into {SCHEMA_REFERENCE}; the generator resolves nothing else"
+        ))
+}
+
+/// Every schema a field, a body or a response names has to exist, or the emitted type would
+/// refer to something that is nowhere.
+fn check_references(schemas: &[Schema], services: &[Service]) -> Result<(), String> {
+    let known: BTreeSet<&str> = schemas.iter().map(|schema| schema.name.as_str()).collect();
+    for schema in schemas {
+        let mentioned: Vec<&FieldType> = match &schema.shape {
+            Shape::Struct(shape) => shape.fields.iter().map(|field| &field.kind).collect(),
+            Shape::Alias(kind) => vec![kind],
+        };
+        for kind in mentioned {
+            if let Some(name) = kind.named()
+                && !known.contains(name.as_str())
+            {
+                return Err(format!(
+                    "{} refers to {name}, which is not in components.schemas",
+                    schema.name
+                ));
+            }
+        }
+    }
+    for operation in services.iter().flat_map(|service| &service.operations) {
+        let mentioned = [
+            operation.body.as_deref(),
+            match &operation.response {
+                Response::Empty => None,
+                Response::Json(name) | Response::Html(name) => Some(name.as_str()),
+            },
+        ];
+        for name in mentioned.into_iter().flatten() {
+            if !known.contains(name) {
+                return Err(format!(
+                    "{} refers to {name}, which is not in components.schemas",
+                    operation.id
+                ));
+            }
+        }
+    }
+    Ok(())
 }
 
 impl FieldType {
+    /// The schema this type names, if it names one.
+    fn named(&self) -> Option<String> {
+        match self {
+            FieldType::Named(name) => Some(name.clone()),
+            FieldType::List(inner) | FieldType::Map(inner) => inner.named(),
+            _ => None,
+        }
+    }
+
     fn mentions(&self, schema: &str) -> bool {
         match self {
             FieldType::Named(name) => name == schema,

--- a/rust/generator/src/naming.rs
+++ b/rust/generator/src/naming.rs
@@ -39,16 +39,18 @@ impl Naming {
     }
 
     pub fn method_for(&self, operation_id: &str, service: &str) -> Result<String, String> {
-        if let Some(method) = self.operation_methods.get(operation_id) {
-            return Ok(method.clone());
-        }
-        let service_words: Vec<String> = service.split('_').map(singular).collect();
-        let words: Vec<String> = camel_words(operation_id)
-            .into_iter()
-            .map(|word| word.to_lowercase())
-            .filter(|word| !service_words.contains(&singular(word)))
-            .collect();
-        let method = words.join("_");
+        let method = match self.operation_methods.get(operation_id) {
+            Some(method) => method.clone(),
+            None => {
+                let service_words: Vec<String> = service.split('_').map(singular).collect();
+                let words: Vec<String> = camel_words(operation_id)
+                    .into_iter()
+                    .map(|word| word.to_lowercase())
+                    .filter(|word| !service_words.contains(&singular(word)))
+                    .collect();
+                words.join("_")
+            }
+        };
         if method.is_empty() || KEYWORDS.contains(&method.as_str()) {
             Err(format!(
                 "{operation_id} becomes `{method}` in {service}; add an [operation_methods] override to names.toml"

--- a/rust/generator/src/naming.rs
+++ b/rust/generator/src/naming.rs
@@ -38,9 +38,9 @@ impl Naming {
         }
     }
 
-    pub fn method_for(&self, operation_id: &str, service: &str) -> String {
+    pub fn method_for(&self, operation_id: &str, service: &str) -> Result<String, String> {
         if let Some(method) = self.operation_methods.get(operation_id) {
-            return method.clone();
+            return Ok(method.clone());
         }
         let service_words: Vec<String> = service.split('_').map(singular).collect();
         let words: Vec<String> = camel_words(operation_id)
@@ -50,11 +50,12 @@ impl Naming {
             .collect();
         let method = words.join("_");
         if method.is_empty() || KEYWORDS.contains(&method.as_str()) {
-            panic!(
+            Err(format!(
                 "{operation_id} becomes `{method}` in {service}; add an [operation_methods] override to names.toml"
-            );
+            ))
+        } else {
+            Ok(method)
         }
-        method
     }
 
     /// What a schema is called in Rust. A shape whose Smithy name collides with something
@@ -130,30 +131,43 @@ mod tests {
     #[test]
     fn methods_drop_the_service_noun() {
         let naming = Naming::default();
-        assert_eq!(naming.method_for("ListBoxes", "boxes"), "list");
+        assert_eq!(naming.method_for("ListBoxes", "boxes").unwrap(), "list");
         assert_eq!(
-            naming.method_for("GetBoxPostingChanges", "postings"),
+            naming
+                .method_for("GetBoxPostingChanges", "postings")
+                .unwrap(),
             "get_box_changes"
         );
         assert_eq!(
-            naming.method_for("GetTopicEntries", "topics"),
+            naming.method_for("GetTopicEntries", "topics").unwrap(),
             "get_entries"
         );
         assert_eq!(
-            naming.method_for("ListTimeTrackCategories", "time_tracks"),
+            naming
+                .method_for("ListTimeTrackCategories", "time_tracks")
+                .unwrap(),
             "list_categories"
         );
         assert_eq!(
-            naming.method_for("GetOngoingTimeTrack", "time_tracks"),
+            naming
+                .method_for("GetOngoingTimeTrack", "time_tracks")
+                .unwrap(),
             "get_ongoing"
         );
-        assert_eq!(naming.method_for("CreateSticky", "stickies"), "create");
         assert_eq!(
-            naming.method_for("UpdateContactClearance", "contacts"),
+            naming.method_for("CreateSticky", "stickies").unwrap(),
+            "create"
+        );
+        assert_eq!(
+            naming
+                .method_for("UpdateContactClearance", "contacts")
+                .unwrap(),
             "update_clearance"
         );
         assert_eq!(
-            naming.method_for("UpdateMyClearance", "clearances"),
+            naming
+                .method_for("UpdateMyClearance", "clearances")
+                .unwrap(),
             "update_my"
         );
     }

--- a/rust/hey-sdk/tests/routes.rs
+++ b/rust/hey-sdk/tests/routes.rs
@@ -40,6 +40,20 @@ fn the_router_names_the_operation_a_pasted_url_refers_to() {
 fn every_modelled_route_is_listed_once() {
     let ids: HashSet<&str> = ROUTES.iter().map(|route| route.id).collect();
 
-    assert_eq!(ROUTES.len(), 131);
+    assert_eq!(ROUTES.len(), modelled_operations());
     assert_eq!(ids.len(), ROUTES.len());
+}
+
+/// How many operations `openapi.json` models: one per HTTP method under each path.
+fn modelled_operations() -> usize {
+    let path = concat!(env!("CARGO_MANIFEST_DIR"), "/../../openapi.json");
+    let openapi: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(path).unwrap()).unwrap();
+    openapi["paths"]
+        .as_object()
+        .unwrap()
+        .values()
+        .flat_map(|item| item.as_object().unwrap().keys())
+        .filter(|method| matches!(method.as_str(), "get" | "post" | "put" | "patch" | "delete"))
+        .count()
 }


### PR DESCRIPTION
Tracking card: [hey-sdk Rust: restore the gate](https://3.basecamp.com/2914079/buckets/46292715/card_tables/cards/10289494798).

Builds on #153 (now on `main`), which gave the generator `Response::Html`; this is the refusal for the next representation it does not know.

**What was wrong.** `rust/generator/src/model.rs` `response_of` read any 2xx without an `application/json` body as `Response::Empty`. That is the root cause of the red gate after #141: the first `text/html` route was emitted as a method returning `()` and asking for a `.json` path, and nothing objected until the conformance fixture did. #153 teaches the generator HTML; this makes the generator refuse rather than degrade for the next representation it does not know.

**Generator.**
- A 2xx answered in anything but `application/json` or `text/html` fails generation naming the operation, the status and the media type (`GetBoxBadge answers 200 as image/png, which the generator has no representation for; it emits application/json and text/html`). Two representations on one status, and a schema that is not a `$ref` into `components.schemas`, fail the same way.
- An HTML response must name a string schema, since `Client::send_text` hands the page back as a `String`; a struct there would be a document the crate had no parser for.
- A method name that is a Rust keyword is an `Err` from `Naming::method_for` rather than a `panic!`, so it is reported the way every other refusal is.

**Fixtures** (`rust/generator/src/fixtures.rs`, per bar A "generator correctness fixtures"): small models built in memory and put through `Model::build` and the emitters whole. Covered: the three refusals above, HTML-needs-a-string, HTML emitting `send_text` / `html: true` / the string alias, JSON and empty picking `send` and `send_unit`, a name collision, a keyword clash, required-versus-optional field reading (golden struct text: null-as-default on required scalars, no default on a required `DateTime`, the optional-date reader, keyword field escaping), recursive shapes boxed only where `Vec` does not already indirect, and the `Box`→`Mailbox` rename reaching every field and alias.

**Route count.** `rust/hey-sdk/tests/routes.rs` reads the modelled operation count from `openapi.json` (one per HTTP method under each path) instead of carrying a literal every new operation has to bump. The file is read relative to `CARGO_MANIFEST_DIR`, so it is a repository test; a packaged crate does not ship it.

**AGENTS.md** gets a paragraph on the refusal and the fixtures.

**Local gate** on Rust 1.98.1 (what `.mise.toml` pins and CI resolves): `make -C rust check` (fmt, clippy `-D warnings`, test, doc `-D warnings`) exit 0, `make rs-check-drift` exit 0, `make conformance-rs` 190/190, generator tests 14/14.

**Adversarial review** (Codex CLI, gpt-6-astra at xhigh reasoning, read-only, over the first commit). Six findings, all folded into the second commit; none declined:
1. A second 2xx status was never looked at, so `200` JSON followed by `202` PNG passed generation — every success response is read now and they must agree, or generation fails naming both statuses.
2. A response object that is itself a `$ref` read as bodyless, the original silent-empty bug in another spelling — refused.
3. An HTML schema reaching `string` through an alias of an alias was rejected — alias chains are followed, bounded by the schema count.
4. A `$ref` outside `#/components/schemas/` (`types.json#/…`) or to a schema that does not exist was emitted verbatim as a Rust type — both refused, from fields, bodies and responses.
5. The JSON fixture only asserted that *some* route carried `html: false` — fixtures now read each route's own block, and the HTML route's path.
6. `head`/`options`/`trace` were skipped silently, so the route-count oracle and the generator could agree about an operation neither saw — such an operation now fails generation.

Fixtures cover each (19 generator tests). I am babysitting the review loop on this PR to convergence.
