### PR TITLE
Gate the Rust dependency graph with cargo deny, and watch it with Dependabot and Trivy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,32 @@ updates:
       semver-minor-days: 3
       semver-patch-days: 2
       default-days: 7
+  - package-ecosystem: cargo
+    directory: /rust
+    groups:
+      cargo:
+        patterns:
+          - "*"
+    schedule:
+      interval: weekly
+    cooldown:
+      semver-major-days: 7
+      semver-minor-days: 3
+      semver-patch-days: 2
+      default-days: 7
+  - package-ecosystem: cargo
+    directory: /conformance/runner/rust
+    groups:
+      cargo:
+        patterns:
+          - "*"
+    schedule:
+      interval: weekly
+    cooldown:
+      semver-major-days: 7
+      semver-minor-days: 3
+      semver-patch-days: 2
+      default-days: 7
   - package-ecosystem: github-actions
     directory: "/"
     groups:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -42,6 +42,66 @@ jobs:
           sarif_file: 'trivy-go-results.sarif'
           category: 'trivy-go'
 
+  trivy-rust:
+    name: Trivy (Rust SDK)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # Trivy reads each workspace's Cargo.lock: the crate's and the conformance runner's,
+      # which has dependencies of its own (axum). It fails on HIGH/CRITICAL as the Go job
+      # does; on a pull request cargo deny (test-rust, `make rs-deny`) has already said so,
+      # and the weekly run here is what puts the findings on the Security tab.
+      - name: Run Trivy vulnerability scanner (rust)
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          scan-type: 'fs'
+          scan-ref: './rust'
+          severity: 'HIGH,CRITICAL'
+          # In SARIF mode the action drops the severity filter unless told to keep it, and
+          # with exit-code 1 a LOW finding would fail the job.
+          limit-severities-for-sarif: true
+          exit-code: '1'
+          ignore-unfixed: true
+          format: 'sarif'
+          output: 'trivy-rust-results.sarif'
+
+      - name: Upload Trivy scan results to GitHub Security tab (rust)
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+        if: always()
+        continue-on-error: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true }}
+        with:
+          sarif_file: 'trivy-rust-results.sarif'
+          category: 'trivy-rust'
+
+      - name: Run Trivy vulnerability scanner (conformance/runner/rust)
+        if: always()
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          scan-type: 'fs'
+          scan-ref: './conformance/runner/rust'
+          severity: 'HIGH,CRITICAL'
+          limit-severities-for-sarif: true
+          exit-code: '1'
+          ignore-unfixed: true
+          format: 'sarif'
+          output: 'trivy-rust-conformance-results.sarif'
+          skip-setup-trivy: true
+
+      - name: Upload Trivy scan results to GitHub Security tab (conformance/runner/rust)
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+        if: always()
+        continue-on-error: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true }}
+        with:
+          sarif_file: 'trivy-rust-conformance-results.sarif'
+          category: 'trivy-rust-conformance'
+
   govulncheck:
     name: Go Vulnerability Check
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,8 +66,14 @@ jobs:
             rust
             conformance/runner/rust
 
+      - name: Install cargo-deny
+        uses: taiki-e/install-action@c3ec0de9ae7f1019cea21aa96aa0a895b9552063 # v2.87.9
+        with:
+          tool: cargo-deny
+
       # fmt, clippy, tests and docs with all features, then clippy and the tests again
-      # with the shipped HTTP client off. The same target a developer runs.
+      # with the shipped HTTP client off, then cargo deny over both workspaces. The same
+      # target a developer runs.
       - name: Format, lint and test
         run: make rs-check
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,8 @@
 
 - Smithy CLI
 - Go 1.26+
-- Rust 1.88+ (with `rustfmt` and `clippy`)
+- Rust 1.88+ (with `rustfmt` and `clippy`; `rust-toolchain.toml` picks the exact stable for rustup users)
+- [`cargo-deny`](https://github.com/EmbarkStudios/cargo-deny) (`cargo install cargo-deny --locked`), for `make rs-check`
 - Make
 - jq
 

--- a/Makefile
+++ b/Makefile
@@ -203,7 +203,7 @@ go-check-drift:
 # Rust SDK
 #------------------------------------------------------------------------------
 
-.PHONY: rs-generate rs-check-drift rs-test rs-lint rs-check
+.PHONY: rs-generate rs-check-drift rs-test rs-lint rs-deny rs-check
 
 # Types, routes and services are all generated; there is no hand-written wrapper layer
 # to drift, so the drift check is the generator's own --check.
@@ -218,6 +218,9 @@ rs-test:
 
 rs-lint:
 	$(MAKE) -C rust lint
+
+rs-deny:
+	$(MAKE) -C rust deny
 
 rs-check:
 	$(MAKE) -C rust check
@@ -314,7 +317,7 @@ conformance-go:
 	cd conformance/runner/go && go run .
 
 conformance-rs:
-	cd conformance/runner/rust && cargo run -q
+	cd conformance/runner/rust && cargo run -q --locked
 
 conformance-ts:
 	cd conformance/runner/typescript && npm test

--- a/rust/Makefile
+++ b/rust/Makefile
@@ -14,7 +14,7 @@ generate:
 # Fail when the checked-in generated code differs from what the generator emits
 .PHONY: generate-check
 generate-check:
-	$(CARGO) run -q -p hey-sdk-generator -- --check
+	$(CARGO) run -q --locked -p hey-sdk-generator -- --check
 
 .PHONY: fmt
 fmt:
@@ -45,9 +45,18 @@ no-default-features:
 doc:
 	RUSTDOCFLAGS="-D warnings" $(CARGO) doc -p hey-sdk --no-deps --all-features --locked
 
+# RustSec advisories, licences and the shape of the dependency graph, for this workspace and
+# the conformance runner's, against the one deny.toml. Needs cargo-deny installed.
+.PHONY: deny
+deny:
+	@$(CARGO) deny --version >/dev/null 2>&1 || \
+		{ echo "ERROR: cargo-deny is not installed. Run: cargo install cargo-deny --locked"; exit 1; }
+	$(CARGO) deny --locked check
+	cd ../conformance/runner/rust && $(CARGO) deny --locked --config ../../../rust/deny.toml check
+
 # Run all checks: the same steps as CI's test-rust job, in the same order
 .PHONY: check
-check: fmt-check lint test no-default-features doc
+check: fmt-check lint test no-default-features doc deny
 
 .PHONY: clean
 clean:
@@ -65,5 +74,6 @@ help:
 	@echo "  test                 Run all tests"
 	@echo "  no-default-features  Lint and test the crate without the shipped HTTP client"
 	@echo "  doc                  Build the crate docs"
-	@echo "  check                fmt-check + lint + test + no-default-features + doc"
+	@echo "  deny                 cargo deny over both workspaces (advisories, licences, bans)"
+	@echo "  check                fmt-check + lint + test + no-default-features + doc + deny"
 	@echo "  clean                Remove build artifacts"

--- a/rust/deny.toml
+++ b/rust/deny.toml
@@ -1,0 +1,57 @@
+# cargo-deny for both Cargo workspaces: rust/ and conformance/runner/rust. The runner is
+# checked against this same file with `--config`, from `make rs-deny`.
+#
+# One advisory gate for the whole tree: RustSec advisories, licences, and the shape of the
+# dependency graph. Trivy scans the lockfiles too, for the Security tab; a finding fails
+# here first.
+
+[graph]
+all-features = true
+
+[advisories]
+version = 2
+yanked = "deny"
+# Each entry: the advisory id, why it does not apply, and when to look again.
+ignore = []
+
+[licenses]
+version = 2
+# The workspaces' own unpublished crates (the generator, the conformance runner) are the
+# repository's MIT and carry no licence field of their own.
+private = { ignore = true }
+# SPDX identifiers. Everything the tree pulls today is under one of these; a new dependency
+# under anything else fails here and is a decision, not a surprise.
+allow = [
+  "MIT",
+  "Apache-2.0",
+  "Apache-2.0 WITH LLVM-exception",
+  "BSD-2-Clause",
+  "BSD-3-Clause",
+  "ISC",
+  "Unicode-3.0",
+  "Zlib",
+  "MPL-2.0",
+  "CDLA-Permissive-2.0",
+  "OpenSSL",
+]
+confidence-threshold = 0.9
+# The list is the fleet's, not this tree's; an entry nothing uses yet is not a finding.
+unused-allowed-license = "allow"
+
+[bans]
+# Two versions of one crate in the graph is a signal to look at, not a defect; the resolver
+# will not be second-guessed here.
+multiple-versions = "warn"
+wildcards = "deny"
+# The conformance runner depends on the crate by path, with no version to pin.
+allow-wildcard-paths = true
+deny = [
+  # TLS is rustls, and the shipped client is built without OpenSSL; a dependency that links
+  # it would put a second TLS stack in every binary.
+  { crate = "openssl-sys", reason = "rustls only" },
+]
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]


### PR DESCRIPTION
Second of three CI-hardening pull requests for the Rust crate (card: [hey-sdk Rust: CI hardening](https://app.basecamp.com/2914079/buckets/46292715/card_tables/cards/10289485364)). Stacked on #155; the diff here is only the dependency-security layer. Merge #155 first.

## What changes

**`rust/deny.toml`** is one `cargo deny` policy for both Cargo workspaces (`rust/` and `conformance/runner/rust`):

- `advisories`: RustSec, yanked crates denied, no ignores (each future entry carries the id, why it does not apply, and when to look again).
- `licenses`: an allow-list of real SPDX identifiers (`MIT`, `Apache-2.0`, `Apache-2.0 WITH LLVM-exception`, `BSD-2-Clause`, `BSD-3-Clause`, `ISC`, `Unicode-3.0`, `Zlib`, `MPL-2.0`, `CDLA-Permissive-2.0`, `OpenSSL`) — the fleet's list from the cross-repo Rust devex standard, not tuned to this tree, so an entry nothing uses yet is not a finding. The unpublished crates (generator, runner) are the repository's MIT and are skipped.
- `bans`: `multiple-versions = "warn"` — duplicates are a signal, not a defect (today: `base64` 0.22/0.23, `syn` 2/3, `winnow` 0.7/1); `openssl-sys` denied since TLS is rustls; wildcard versions denied except the runner's path dependency.
- `sources`: crates.io only.

**`make rs-deny`** runs it over both workspaces (the runner with `--config ../../../rust/deny.toml`), and **`make rs-check`** now ends with it, so `test-rust` installs `cargo-deny` first ([taiki-e/install-action](https://github.com/taiki-e/install-action), SHA-pinned, checksum-verified binary). CONTRIBUTING lists the tool.

**Dependabot** gets a grouped `cargo` entry for `/rust` and `/conformance/runner/rust`, with the same cooldowns as the Go entries.

**`security.yml`** gets `trivy-rust` beside `trivy-go`: Trivy reads each workspace's `Cargo.lock` (`rust/` and `conformance/runner/rust`, uploaded under separate SARIF categories) and fails on HIGH/CRITICAL as the Go job does. It is the second reader of the same RustSec data on purpose — on a PR `cargo deny` has already failed on the same advisory, and the weekly run here is what puts findings on the Security tab — rather than a third tool: `cargo audit` reads the same database and was left out.

Verified locally: `make rs-deny` green on both workspaces (advisories, bans, licences, sources all ok, three duplicate-version warnings); `make rs-check` green; actionlint and zizmor clean apart from the pre-existing `self-repository` note.

## Merge order

This PR is part of a five-PR stack, each rebased on the one below and all five on current `main`, so they merge cleanly in this order and only this order: #155 (build/MSRV/feature matrix) → #157 (cargo deny, Dependabot, Trivy) → #159 (semver-checks, packaging) → #160 (docs, examples, rustfmt) → #162 (crates.io publishing). Every one of them touches `.github/workflows/test.yml` and/or the Makefiles; the stacking is the conflict resolution. Merge each one after the one below has landed; GitHub retargets the next PR to `main` when the merged branch is deleted. #162 can merge before the crates.io bootstrap: it publishes nothing until the crate exists on crates.io (its publish job fails closed with instructions on a tag until then), and nothing in it changes after the bootstrap.
