### PR TITLE
Check the Rust crate's public API against the pull request's base, and package it in the gate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,8 +72,8 @@ jobs:
           tool: cargo-deny
 
       # fmt, clippy, tests and docs with all features, then clippy and the tests again
-      # with the shipped HTTP client off, then cargo deny over both workspaces. The same
-      # target a developer runs.
+      # with the shipped HTTP client off, cargo deny over both workspaces, and the crate
+      # packaged and built from its tarball. The same target a developer runs.
       - name: Format, lint and test
         run: make rs-check
 
@@ -335,6 +335,37 @@ jobs:
           else
             echo "No breaking API changes detected"
           fi
+
+  api-compat-rust:
+    name: API Compatibility (Rust)
+    if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'breaking')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      # Full history: the baseline is the pull request's base commit, which
+      # cargo-semver-checks checks out from this clone.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Rust
+        run: rustup toolchain install && rustup show
+
+      # The Rust counterpart of api-compat above: the crate's public API on this branch
+      # against the same crate at the base commit, judged by the version in Cargo.toml.
+      # A pull request that does not bump the version may add, not break; one that bumps
+      # it (0.x → 0.y is a major under pre-1.0 semver) may break. The `breaking` label
+      # skips the job, as it does for Go. The baseline moves to the last Rust-bearing
+      # release tag once one exists; v0.29.0 predates rust/.
+      - name: Check API compatibility
+        uses: obi1kenobi/cargo-semver-checks-action@6b69fcf40e9b5fb17adeb57e4b6ecd020649a239 # v2.9
+        with:
+          manifest-path: rust/Cargo.toml
+          package: hey-sdk
+          baseline-rev: ${{ github.event.pull_request.base.sha }}
+          rust-toolchain: manual
 
   rubric-check:
     name: Rubric Check

--- a/Makefile
+++ b/Makefile
@@ -203,7 +203,7 @@ go-check-drift:
 # Rust SDK
 #------------------------------------------------------------------------------
 
-.PHONY: rs-generate rs-check-drift rs-test rs-lint rs-deny rs-check
+.PHONY: rs-generate rs-check-drift rs-test rs-lint rs-deny rs-publish-check rs-check
 
 # Types, routes and services are all generated; there is no hand-written wrapper layer
 # to drift, so the drift check is the generator's own --check.
@@ -221,6 +221,9 @@ rs-lint:
 
 rs-deny:
 	$(MAKE) -C rust deny
+
+rs-publish-check:
+	$(MAKE) -C rust publish-check
 
 rs-check:
 	$(MAKE) -C rust check

--- a/rust/Makefile
+++ b/rust/Makefile
@@ -54,9 +54,16 @@ deny:
 	$(CARGO) deny --locked check
 	cd ../conformance/runner/rust && $(CARGO) deny --locked --config ../../../rust/deny.toml check
 
+# Package the crate as a publish would and build it from the tarball, so a missing file, a
+# path dependency or a metadata slip surfaces on the pull request rather than on the tag.
+# --allow-dirty so it runs before a commit as well as after; CI's checkout is clean anyway.
+.PHONY: publish-check
+publish-check:
+	$(CARGO) package -p hey-sdk --locked --allow-dirty
+
 # Run all checks: the same steps as CI's test-rust job, in the same order
 .PHONY: check
-check: fmt-check lint test no-default-features doc deny
+check: fmt-check lint test no-default-features doc deny publish-check
 
 .PHONY: clean
 clean:
@@ -75,5 +82,6 @@ help:
 	@echo "  no-default-features  Lint and test the crate without the shipped HTTP client"
 	@echo "  doc                  Build the crate docs"
 	@echo "  deny                 cargo deny over both workspaces (advisories, licences, bans)"
-	@echo "  check                fmt-check + lint + test + no-default-features + doc + deny"
+	@echo "  publish-check        Package the crate and build it from the tarball"
+	@echo "  check                fmt-check + lint + test + no-default-features + doc + deny + publish-check"
 	@echo "  clean                Remove build artifacts"


### PR DESCRIPTION
Third of three CI-hardening pull requests for the Rust crate (card: [hey-sdk Rust: CI hardening](https://app.basecamp.com/2914079/buckets/46292715/card_tables/cards/10289485364)). Stacked on #157 (which is on #155); the diff here is only the API-compatibility gate and the packaging check. Merge those first.

## What changes

**`api-compat-rust`** is the Rust counterpart of the Go `api-compat` job: [cargo-semver-checks](https://github.com/obi1kenobi/cargo-semver-checks) over `hey-sdk` on the branch against the same crate at the pull request's base commit, judged by the version in `Cargo.toml`. A PR that leaves the version alone may add but not break; one that bumps it (`0.x → 0.y` is a major under pre-1.0 semver) may break. The `breaking` label skips the job, as it does for Go. Runs on the pinned stable from `rust-toolchain.toml` (`rust-toolchain: manual`).

The baseline is the PR base rather than a release tag because `v0.29.0` predates `rust/`; once a Rust-bearing tag exists (after the publishing PR and the next release) the job gains that second baseline.

**`make rs-publish-check`** runs `cargo package -p hey-sdk --locked`, which builds the crate from its own tarball, and **`make rs-check`** ends with it. A file the package leaves out, a path dependency, a metadata slip: found on the PR, not on the tag. It is `cargo package` and not `cargo publish --dry-run` only because the crate still says `publish = false`; the publishing PR flips both.

Verified locally: `cargo semver-checks check-release -p hey-sdk --baseline-rev origin/main` → 196 checks pass, 58 skip, no semver update required; `make rs-publish-check` green (the tarball currently ships `tests/`, which the publishing PR's `include` allow-list trims); `make rs-check` green; actionlint and zizmor clean apart from the pre-existing `self-repository` note.

## Merge order

This PR is part of a five-PR stack, each rebased on the one below and all five on current `main`, so they merge cleanly in this order and only this order: #155 (build/MSRV/feature matrix) → #157 (cargo deny, Dependabot, Trivy) → #159 (semver-checks, packaging) → #160 (docs, examples, rustfmt) → #162 (crates.io publishing). Every one of them touches `.github/workflows/test.yml` and/or the Makefiles; the stacking is the conflict resolution. Merge each one after the one below has landed; GitHub retargets the next PR to `main` when the merged branch is deleted. #162 can merge before the crates.io bootstrap: it publishes nothing until the crate exists on crates.io (its publish job fails closed with instructions on a tag until then), and nothing in it changes after the bootstrap.
