### PR TITLE
Give the Rust crate examples that compile, a README walkthrough at Go depth, and a formatting pin

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,3 +16,6 @@ indent_style = tab
 
 [*.md]
 trim_trailing_whitespace = false
+
+[*.rs]
+indent_size = 4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,17 @@ gate. The generator also has fixtures of its own (`rust/generator/src/fixtures.r
 models put through `Model::build` and the emitters whole, since the drift check only proves
 the checked-in output matches the generator, not that the generator is right.
 
+`rs-check` is every step CI's `test-rust` job runs before it, in order — fmt, clippy,
+tests and docs with all features, clippy and tests again with `--no-default-features`, the
+examples, `cargo deny` over both workspaces, and `cargo package` — so a green
+`make rs-check rs-check-drift` locally is a green job. CI also builds the library on `rust-version` (`msrv-rust`), the docs on nightly as
+docs.rs would (`docs-rust`), and the public API against the pull request's base
+(`api-compat-rust`, `cargo semver-checks`; the `breaking` label skips it). The toolchain
+everything else runs on is pinned in `rust-toolchain.toml` at the repository root.
+
+`rust/hey-sdk/examples/*.rs` are the crate README's snippets as whole programs; they compile in
+the gate, so a change to the public API that breaks one shows up there.
+
 `rust/hey-sdk/src/services/*.rs` are hand-written, like `go/pkg/hey` — you update them
 yourself. Each one re-exports the generated service it extends and adds conveniences as
 extra `impl` blocks on it: `attachments`, `boxes`, `bulk_replies`, `calendar_changes`,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,9 @@
 - Go 1.26+
 - Rust 1.88+ (with `rustfmt` and `clippy`; `rust-toolchain.toml` picks the exact stable for rustup users)
 - [`cargo-deny`](https://github.com/EmbarkStudios/cargo-deny) (`cargo install cargo-deny --locked`), for `make rs-check`
+- [`cargo-semver-checks`](https://github.com/obi1kenobi/cargo-semver-checks) only if you want the
+  API-compatibility check locally (`cargo semver-checks -p hey-sdk --baseline-rev origin/main`
+  from `rust/`); CI runs it on every pull request
 - Make
 - jq
 

--- a/Makefile
+++ b/Makefile
@@ -203,7 +203,7 @@ go-check-drift:
 # Rust SDK
 #------------------------------------------------------------------------------
 
-.PHONY: rs-generate rs-check-drift rs-test rs-lint rs-deny rs-publish-check rs-check
+.PHONY: rs-generate rs-check-drift rs-test rs-lint rs-examples rs-deny rs-publish-check rs-check
 
 # Types, routes and services are all generated; there is no hand-written wrapper layer
 # to drift, so the drift check is the generator's own --check.
@@ -218,6 +218,9 @@ rs-test:
 
 rs-lint:
 	$(MAKE) -C rust lint
+
+rs-examples:
+	$(MAKE) -C rust examples
 
 rs-deny:
 	$(MAKE) -C rust deny
@@ -382,5 +385,13 @@ help:
 	@echo "  check       Alias for check-mvp"
 	@echo "  smithy-build   Regenerate OpenAPI from Smithy"
 	@echo "  drift-regen    Regenerate route snapshot from haystack"
+	@echo "  go-check       Go build, vet, tests, lint"
+	@echo "  go-generate    Regenerate go/pkg/generated from openapi.json"
+	@echo "  rs-check       What CI runs: fmt, clippy, tests, docs; clippy + tests again with"
+	@echo "                 --no-default-features; examples; cargo deny; cargo package"
+	@echo "  rs-check-drift Fail if rust/hey-sdk/src/generated is stale"
+	@echo "  rs-generate    Regenerate rust/hey-sdk/src/generated from openapi.json"
+	@echo "  rs-test        Rust tests only; rs-lint, rs-examples, rs-deny, rs-publish-check likewise"
+	@echo "  conformance-rs Run the shared conformance fixtures against the Rust crate"
 	@echo "  clean          Remove build artifacts"
 	@echo "  help           Show this help"

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ The SDKs for the [HEY](https://www.hey.com) API, generated from a Smithy model o
 `spec/`, so what an SDK offers is what HEY actually serves.
 
 The repository ships a Go module, `github.com/basecamp/hey-sdk/go`, which is the library behind
-[hey-cli](https://github.com/basecamp/hey-cli), and a Rust crate, `hey-sdk` in `rust/`, which
-is documented in [rust/hey-sdk/README.md](rust/hey-sdk/README.md). The rest of this page is
-about Go.
+[hey-cli](https://github.com/basecamp/hey-cli), and a Rust crate, `hey-sdk` in `rust/`. The
+Go walkthrough is first; [the Rust one](#rust) follows it, and the crate's own
+[README](rust/hey-sdk/README.md) goes further.
 
 TypeScript, Ruby, Swift and Kotlin SDKs will be added in future updates, generated from the
 same Smithy model; the Makefile already reserves targets for them (`ts-`, `rb-`, `swift-`,
@@ -18,13 +18,7 @@ same Smithy model; the Makefile already reserves targets for them (`ts-`, `rb-`,
 go get github.com/basecamp/hey-sdk/go@latest
 ```
 
-Requires Go 1.26 or newer.
-
-The Rust crate is not published; depend on it from the repository:
-
-```toml
-hey-sdk = { git = "https://github.com/basecamp/hey-sdk", version = "0.30" }
-```
+Requires Go 1.26 or newer. The Rust crate's install line is in [its section](#install-1).
 
 ## Authenticate
 
@@ -153,6 +147,121 @@ HTTP status, and — for auth and scope problems — a hint. `hey.AsError(err)` 
 ### Pagination
 
 Paged reads follow HEY's `Link` headers automatically, up to `WithMaxPages`.
+
+## Rust
+
+The crate is `hey-sdk`, at `rust/hey-sdk`, with the same generated surface as the Go module and
+the same hand-written conveniences on top. It is an async client on tokio, sends over rustls
+by default, and lets an application bring its own HTTP stack instead.
+
+### Install
+
+Until the crate is on crates.io, depend on it from the repository at a release tag —
+`v0.30.0` is the first that carries `rust/`:
+
+```toml
+[dependencies]
+hey-sdk = { git = "https://github.com/basecamp/hey-sdk", tag = "v0.30.0" }
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+```
+
+Requires Rust 1.88 or newer (`rust-version` in `rust/Cargo.toml`, built on exactly that in
+CI). The crate's [Versioning](rust/hey-sdk/README.md#versioning) section says when that floor
+moves and what a version bump means.
+
+### Authenticate
+
+A fixed token, for scripts and anything that already holds one:
+
+```rust
+use hey_sdk::{Client, Config, StaticTokenProvider};
+
+let client = Client::new(Config::default(), StaticTokenProvider::new(std::env::var("HEY_TOKEN")?))?;
+```
+
+OAuth 2.0 with PKCE, for user-facing apps: `hey_sdk::oauth` speaks the protocol — the
+authorization URL, the code exchange and refresh, with the `install_id` HEY wants on each.
+The application keeps the tokens and hands the client a `TokenProvider` over them; the
+client asks it to `refresh` once when HEY answers 401. Anything that wants the request
+headers outright implements `AuthStrategy` instead.
+[`examples/oauth_pkce.rs`](rust/hey-sdk/examples/oauth_pkce.rs) is the whole flow.
+
+### Use it
+
+```rust
+use hey_sdk::services::MessageContent;
+
+let boxes = client.boxes().list().await?;                       // Imbox, The Feed, Paper Trail, ...
+let imbox = client.boxes().get_imbox(&Default::default()).await?;
+
+// Sending: recipients are required — HEY saves an unaddressed message as a draft.
+client.messages().send(&MessageContent {
+    subject: "Subject".into(),
+    content: "<div>Body</div>".into(),
+    to: vec!["someone@example.com".into()],
+    ..Default::default()
+}).await?;
+
+// Replying: start from the prefill — the subject, the acting sender, the recipients HEY resolved.
+let prefill = client.entries().new_reply(entry_id).await?;
+
+// Postings are bulk operations, as they are in HEY.
+client.postings().move_to_set_aside(&[posting_id]).await?;
+client.postings().mark_postings_seen(&[a, b]).await?;
+
+// Calendar
+let track = client.time_tracks().start_tracking().await?;
+client.time_tracks().stop(track.id).await?;
+```
+
+Services on the client, one handle per resource: `attachments`, `boxes`, `bulk_replies`,
+`calendar_events`, `calendar_periods`, `calendar_todos`, `calendars`, `clearances`, `clips`,
+`collections`, `contacts`, `designations`, `entries`, `extenzions`, `folders`, `habits`,
+`identity`, `journal`, `messages`, `postings`, `publications`, `search`, `snippets`,
+`stickies`, `time_tracks`, `topics`, `workflows`, `world`. Every method the model describes
+is generated, named for the operation with the service's noun dropped (`ListBoxes` is
+`boxes().list()`); the hand-written ones in `rust/hey-sdk/src/services` take the arguments a
+caller has and cover the parts of HEY the model cannot describe. Every route is data in
+`hey_sdk::routes`, and `hey_sdk::url::router()` names the operation a pasted HEY URL refers to.
+
+### Linked accounts
+
+A root client presents mail from All Accounts. Derive one for a linked account to present that
+account's mail and act as its user and default sender; it adds HEY's `filtered_account_id` to
+every same-origin request, including pagination and retries, and never to signed external URLs:
+
+```rust
+let work = client.for_account(work_account_id).await?;
+let postings = work.boxes().get_imbox(&Default::default()).await?;
+```
+
+### Errors
+
+Every call answers `Result<_, hey_sdk::Error>`: a stable `ErrorCode` (`NotFound`, `Auth`,
+`Forbidden`, `RateLimit`, `Validation`, `Api`, `Usage`, ...), the HTTP status, whether it is
+worth retrying, HEY's `X-Request-Id`, a hint when there was one, and the body HEY answered
+the failure with, for the endpoints that describe a refusal there.
+
+### Pagination
+
+Paged reads answer a `Page<T>`, which derefs to the response and carries the next cursor and
+`X-Total-Count`; `next_page` reads on, `each_page` walks to the client's `max_pages`, and a
+`Link` that points off the HEY origin is refused.
+[`examples/pagination.rs`](rust/hey-sdk/examples/pagination.rs) shows both walks.
+
+### Beyond the Go module
+
+Everything the crate sends goes through one `HttpClient` trait, so a binary that already has
+an HTTP stack — a mobile shell on the platform's own — does not get a second one
+([`examples/custom_http_client.rs`](rust/hey-sdk/examples/custom_http_client.rs) runs on a
+canned transport, without the network and without the `reqwest` feature). Hooks report every
+operation, request and resend ([`examples/hooks.rs`](rust/hey-sdk/examples/hooks.rs)), and
+a gate can refuse an operation before it is sent. Retries, a circuit breaker, a bulkhead, a
+rate limit and an ETag response cache are on the builder. Secrets are `SensitiveString`s that
+print as `[REDACTED]`, response bodies are capped, and HTTPS is enforced off localhost.
+
+The examples under [`rust/hey-sdk/examples`](rust/hey-sdk/examples) compile in CI;
+`HEY_TOKEN=... cargo run --example first_call` from `rust/` is the quickest first call.
 
 ## How the SDK is built
 

--- a/rust/Makefile
+++ b/rust/Makefile
@@ -45,6 +45,12 @@ no-default-features:
 doc:
 	RUSTDOCFLAGS="-D warnings" $(CARGO) doc -p hey-sdk --no-deps --all-features --locked
 
+# The examples under hey-sdk/examples are the README's snippets as whole programs; they
+# have to keep compiling.
+.PHONY: examples
+examples:
+	$(CARGO) build -p hey-sdk --examples --all-features --locked
+
 # RustSec advisories, licences and the shape of the dependency graph, for this workspace and
 # the conformance runner's, against the one deny.toml. Needs cargo-deny installed.
 .PHONY: deny
@@ -63,7 +69,7 @@ publish-check:
 
 # Run all checks: the same steps as CI's test-rust job, in the same order
 .PHONY: check
-check: fmt-check lint test no-default-features doc deny publish-check
+check: fmt-check lint test doc no-default-features examples deny publish-check
 
 .PHONY: clean
 clean:
@@ -81,7 +87,8 @@ help:
 	@echo "  test                 Run all tests"
 	@echo "  no-default-features  Lint and test the crate without the shipped HTTP client"
 	@echo "  doc                  Build the crate docs"
+	@echo "  examples             Build the examples"
 	@echo "  deny                 cargo deny over both workspaces (advisories, licences, bans)"
 	@echo "  publish-check        Package the crate and build it from the tarball"
-	@echo "  check                fmt-check + lint + test + no-default-features + doc + deny + publish-check"
+	@echo "  check                Every step CI's test-rust job runs, in order"
 	@echo "  clean                Remove build artifacts"

--- a/rust/hey-sdk/Cargo.toml
+++ b/rust/hey-sdk/Cargo.toml
@@ -41,6 +41,24 @@ tokio = { version = "1", features = ["io-util", "rt", "time", "sync"] }
 tracing = "0.1"
 url = "2"
 
+# The examples that talk to HEY use the shipped client; without the feature only the one
+# about bringing a transport of your own is built.
+[[example]]
+name = "first_call"
+required-features = ["reqwest"]
+
+[[example]]
+name = "pagination"
+required-features = ["reqwest"]
+
+[[example]]
+name = "hooks"
+required-features = ["reqwest"]
+
+[[example]]
+name = "oauth_pkce"
+required-features = ["reqwest"]
+
 [dev-dependencies]
 # One test configures the shipped client through reqwest's own builder. Default features
 # are off so this resolves to the same build as the dependency above rather than a second

--- a/rust/hey-sdk/README.md
+++ b/rust/hey-sdk/README.md
@@ -4,15 +4,27 @@ The Rust client for the [HEY](https://www.hey.com) API. Types, routes and servic
 generated from the Smithy model in the repository's `spec/` directory, so what the crate offers
 is what HEY serves.
 
-The crate is not on crates.io. Depend on it from the repository:
+The crate is not on crates.io yet. Depend on it from the repository at a release tag — the
+repository's `vX.Y.Z` tags are the crate's releases, `v0.30.0` is the first that carries
+`rust/`, and there is no `rust/vX.Y.Z` tag to look for:
 
 ```toml
 [dependencies]
-hey-sdk = { git = "https://github.com/basecamp/hey-sdk", version = "0.30" }
+hey-sdk = { git = "https://github.com/basecamp/hey-sdk", tag = "v0.30.0" }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 ```
 
-Requires Rust 1.88 or newer.
+Requires Rust 1.88 or newer; see [Versioning](#versioning).
+
+The [examples](examples) are this page's snippets as whole programs, and CI compiles them:
+
+```sh
+HEY_TOKEN=... cargo run --example first_call      # identity and boxes
+HEY_TOKEN=... cargo run --example pagination      # page by page, and to the end
+HEY_TOKEN=... cargo run --example hooks           # every operation, request and resend
+cargo run --example oauth_pkce                    # the whole PKCE login, then a call
+cargo run --example custom_http_client --no-default-features   # a transport of your own, offline
+```
 
 ## Authenticate
 
@@ -349,15 +361,34 @@ of one kind run at once, and the limiter holds the client to a budget of its own
 `Retry-After` HEY sends back. A refused call answers `CircuitOpen`, `BulkheadFull` or
 `RateLimit` without sending anything. Hooks installed before them still hear every operation.
 
+## Versioning
+
+The crate follows [Cargo's reading of semver](https://doc.rust-lang.org/cargo/reference/semver.html)
+before 1.0: a change that breaks the public API moves the minor version (`0.29` → `0.30`), an
+additive one moves the patch. CI runs `cargo semver-checks` on every pull request against the
+base branch, so an accidental break is caught before it is tagged; a deliberate one carries the
+`breaking` label and a version bump. What the API guarantees on the wire is the conformance
+suite's business, not semver's.
+
+`rust-version` is 1.88, and CI builds the library on exactly that toolchain. It moves only when
+a dependency or a feature the crate needs requires it, and a move is a minor release with a
+line in the release notes, never a patch. Development and CI otherwise run on the exact stable
+that `rust-toolchain.toml` at the repository root pins, so rustfmt and clippy agree on every
+machine; a new stable arrives as a bump to that file.
+
 ## Develop
 
 ```bash
-make -C rust check          # fmt, clippy, tests
+make rs-check               # every step CI runs before the drift check, in order: fmt, clippy,
+                            #   tests, docs; clippy + tests again with --no-default-features;
+                            #   examples, cargo deny, cargo package
+make rs-check-drift         # fail if src/generated is stale; with rs-check, the whole CI job
 make rs-generate            # regenerate src/generated from openapi.json
-make rs-check-drift         # fail if src/generated is stale
 make conformance-rs         # run the cross-language conformance fixtures
 ```
 
-Everything under `src/generated/` is written by `rust/generator`; edit the generator or the
-Smithy model, never those files. Method and service names that the generator's rule gets wrong
-are settled in `rust/generator/names.toml`.
+`make -C rust help` lists the steps one by one. `rs-check` needs
+[`cargo-deny`](https://github.com/EmbarkStudios/cargo-deny) installed; the formatter's options
+are in `rust/rustfmt.toml`, stable ones only. Everything under `src/generated/` is written by
+`rust/generator`; edit the generator or the Smithy model, never those files. Method and
+service names that the generator's rule gets wrong are settled in `rust/generator/names.toml`.

--- a/rust/hey-sdk/examples/custom_http_client.rs
+++ b/rust/hey-sdk/examples/custom_http_client.rs
@@ -1,0 +1,50 @@
+//! A transport of the caller's own.
+//!
+//! Everything the SDK sends goes out through one `HttpClient`. This example replaces the
+//! shipped one with a transport that answers from a table, so it runs without the network
+//! and without the `reqwest` feature:
+//!
+//! ```sh
+//! cargo run --example custom_http_client --no-default-features
+//! ```
+//!
+//! A real one hands the request to the platform's own HTTP stack and answers with its
+//! status, headers and body. Two rules: never follow a redirect (the SDK does that itself,
+//! and reads the `Location` a form request was made for), and enforce the timeout, since
+//! the SDK cannot interrupt a transport it does not know.
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use hey_sdk::http::{Body, HttpClient, Request, Response, StatusCode, header};
+use hey_sdk::{Client, Config, Error, StaticTokenProvider};
+
+/// Answers every request with the same page of boxes.
+struct Canned;
+
+#[async_trait]
+impl HttpClient for Canned {
+    async fn send(&self, request: Request<Bytes>) -> Result<Response<Body>, Error> {
+        eprintln!("{} {}", request.method(), request.uri());
+        let body = r#"[{"id": 1, "kind": "imbox", "name": "Imbox"},
+                       {"id": 2, "kind": "feed", "name": "The Feed"}]"#;
+        Response::builder()
+            .status(StatusCode::OK)
+            .header(header::CONTENT_TYPE, "application/json")
+            .header("X-Request-Id", "canned")
+            .body(Body::from(Bytes::from_static(body.as_bytes())))
+            .map_err(Error::network)
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    let client = Client::builder(Config::default())
+        .token_provider(StaticTokenProvider::new("not-a-real-token"))
+        .http_client(Canned)
+        .build()?;
+
+    for mailbox in client.boxes().list().await?.iter() {
+        println!("{:>4}  {:<8} {}", mailbox.id, mailbox.kind, mailbox.name);
+    }
+    Ok(())
+}

--- a/rust/hey-sdk/examples/first_call.rs
+++ b/rust/hey-sdk/examples/first_call.rs
@@ -1,0 +1,26 @@
+//! The first call: a token from the environment, and the boxes in the account.
+//!
+//! ```sh
+//! HEY_TOKEN=... cargo run --example first_call
+//! ```
+
+use hey_sdk::{Client, Config, Error, StaticTokenProvider};
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    let token = std::env::var("HEY_TOKEN")
+        .map_err(|_| Error::usage("set HEY_TOKEN to a HEY access token"))?;
+
+    // `Config::default()` is app.hey.com; `Config::default().with_env()` reads HEY_BASE_URL
+    // and the rest. The client is cheap to clone and safe to share across tasks.
+    let client = Client::new(Config::default(), StaticTokenProvider::new(token))?;
+
+    let me = client.identity().get().await?;
+    println!("{}", me.name.unwrap_or_default());
+
+    // A paged read answers a `Page`, which derefs to the response it wraps.
+    for mailbox in client.boxes().list().await?.iter() {
+        println!("{:>12}  {:<12} {}", mailbox.id, mailbox.kind, mailbox.name);
+    }
+    Ok(())
+}

--- a/rust/hey-sdk/examples/hooks.rs
+++ b/rust/hey-sdk/examples/hooks.rs
@@ -1,0 +1,63 @@
+//! Hearing what the client does: every operation, every request, every resend.
+//!
+//! ```sh
+//! HEY_TOKEN=... cargo run --example hooks
+//! ```
+
+use std::time::Duration;
+
+use hey_sdk::observability::{Hooks, OperationInfo, OperationState, RequestInfo, RequestResult};
+use hey_sdk::{Client, Config, Error, StaticTokenProvider};
+
+/// Prints each step to stderr. Every callback has a do-nothing default, so an
+/// implementation says only what it cares about; several go on as one with `ChainHooks`.
+struct Log;
+
+impl Hooks for Log {
+    fn on_operation_start(&self, op: &OperationInfo) -> OperationState {
+        eprintln!("-> {}.{}", op.service, op.operation);
+        None
+    }
+
+    fn on_operation_end(
+        &self,
+        op: &OperationInfo,
+        _state: OperationState,
+        outcome: Result<(), &Error>,
+        duration: Duration,
+    ) {
+        match outcome {
+            Ok(()) => eprintln!("<- {}.{} ok in {duration:?}", op.service, op.operation),
+            Err(error) => eprintln!("<- {}.{} {error} in {duration:?}", op.service, op.operation),
+        }
+    }
+
+    fn on_request_end(&self, info: &RequestInfo, result: &RequestResult<'_>) {
+        // `info.url` and anything else the hooks see is already redacted.
+        eprintln!(
+            "   {} {} attempt {} -> {:?} in {:?}",
+            info.method, info.url, info.attempt, result.status, result.duration
+        );
+    }
+
+    fn on_retry(&self, info: &RequestInfo, next_attempt: u32, cause: &Error) {
+        eprintln!(
+            "   resending {} {} as attempt {next_attempt}: {cause}",
+            info.method, info.url
+        );
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    let token = std::env::var("HEY_TOKEN")
+        .map_err(|_| Error::usage("set HEY_TOKEN to a HEY access token"))?;
+    let client = Client::builder(Config::default())
+        .token_provider(StaticTokenProvider::new(token))
+        .hooks(Log)
+        .build()?;
+
+    let boxes = client.boxes().list().await?;
+    println!("{} boxes", boxes.len());
+    Ok(())
+}

--- a/rust/hey-sdk/examples/hooks.rs
+++ b/rust/hey-sdk/examples/hooks.rs
@@ -33,17 +33,23 @@ impl Hooks for Log {
     }
 
     fn on_request_end(&self, info: &RequestInfo, result: &RequestResult<'_>) {
-        // `info.url` and anything else the hooks see is already redacted.
+        // The path, not the whole URL: a search's query string carries what was searched
+        // for, and a log is the wrong place for it.
         eprintln!(
             "   {} {} attempt {} -> {:?} in {:?}",
-            info.method, info.url, info.attempt, result.status, result.duration
+            info.method,
+            info.url.path(),
+            info.attempt,
+            result.status,
+            result.duration
         );
     }
 
     fn on_retry(&self, info: &RequestInfo, next_attempt: u32, cause: &Error) {
         eprintln!(
             "   resending {} {} as attempt {next_attempt}: {cause}",
-            info.method, info.url
+            info.method,
+            info.url.path()
         );
     }
 }

--- a/rust/hey-sdk/examples/oauth_pkce.rs
+++ b/rust/hey-sdk/examples/oauth_pkce.rs
@@ -1,0 +1,194 @@
+//! The whole OAuth 2.0 PKCE flow against HEY, then a call with the token it produced, with
+//! refresh wired in for when the token expires.
+//!
+//! ```sh
+//! cargo run --example oauth_pkce
+//! ```
+//!
+//! It opens a listener on the loopback interface for the redirect, prints the URL to
+//! approve the client at, waits for the browser to come back with the code, and trades it
+//! for tokens. HEY wants an `install_id` on the authorization request and on every token
+//! request after it: a stable identifier the application mints once per installation and
+//! keeps beside the tokens. This example keeps it for one run.
+
+use std::sync::Mutex;
+
+use async_trait::async_trait;
+use hey_sdk::oauth::{self, ExchangeRequest, OAuthClient, RefreshRequest, ServerMetadata, Token};
+use hey_sdk::{Client, Config, Error, TokenProvider};
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
+use tokio::net::TcpListener;
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    let config = Config::default().with_env();
+    let oauth = OAuthClient::default();
+    // HEY publishes no well-known document, so its endpoints are known rather than found;
+    // `oauth.discover(..)` is for a server that does publish one.
+    let metadata = ServerMetadata::for_hey(&config.base_url);
+
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .map_err(Error::network)?;
+    let port = listener.local_addr().map_err(Error::network)?.port();
+    let redirect_uri = format!("http://127.0.0.1:{port}/callback");
+
+    let pkce = oauth::generate_pkce();
+    let state = oauth::generate_state();
+    let install_id = oauth::generate_state();
+    let url = oauth::authorization_url(
+        &metadata,
+        &config.oauth_client_id,
+        &redirect_uri,
+        None,
+        &state,
+        &pkce,
+        &install_id,
+    )?;
+    println!("Open this in a browser and approve the client:\n\n  {url}\n");
+
+    let (code, returned_state) = wait_for_redirect(&listener).await?;
+    if returned_state != state {
+        return Err(Error::usage(
+            "the redirect carried a state this run did not send",
+        ));
+    }
+
+    let token = oauth
+        .exchange(&ExchangeRequest {
+            token_endpoint: metadata.token_endpoint.clone(),
+            code: code.into(),
+            redirect_uri,
+            client_id: config.oauth_client_id.clone(),
+            client_secret: None,
+            code_verifier: pkce.verifier,
+            install_id: install_id.clone(),
+        })
+        .await?;
+    println!(
+        "Authorized; the access token expires at {}",
+        token
+            .expires_at
+            .map(|at| at.to_rfc3339())
+            .unwrap_or_else(|| "an unknown time".to_string())
+    );
+
+    // The client asks the provider for a token before each request, and asks it to refresh
+    // once when HEY answers 401; the request is sent again when refresh answers `true`.
+    let provider = Refreshing {
+        oauth,
+        metadata,
+        client_id: config.oauth_client_id.clone(),
+        install_id,
+        token: Mutex::new(token),
+    };
+    let client = Client::new(config, provider)?;
+    let me = client.identity().get().await?;
+    println!("Signed in as {}", me.name.unwrap_or_default());
+    Ok(())
+}
+
+/// Holds the tokens for this run and refreshes them when asked. An application keeps
+/// `Token` (with its `expires_at`) and the `install_id` in its own store instead, and
+/// answers `access_token` from there.
+struct Refreshing {
+    oauth: OAuthClient,
+    metadata: ServerMetadata,
+    client_id: String,
+    install_id: String,
+    token: Mutex<Token>,
+}
+
+#[async_trait]
+impl TokenProvider for Refreshing {
+    async fn access_token(&self) -> Result<String, Error> {
+        Ok(self.lock().access_token.expose().to_string())
+    }
+
+    async fn refresh(&self) -> bool {
+        let Some(refresh_token) = self.lock().refresh_token.clone() else {
+            return false;
+        };
+        let request = RefreshRequest {
+            token_endpoint: self.metadata.token_endpoint.clone(),
+            refresh_token,
+            client_id: self.client_id.clone(),
+            client_secret: None,
+            install_id: self.install_id.clone(),
+        };
+        match self.oauth.refresh(&request).await {
+            Ok(mut renewed) => {
+                // A refresh answer may leave the refresh token out, which means keep using
+                // the one you have; only a new one replaces it.
+                let mut held = self.lock();
+                if renewed.refresh_token.is_none() {
+                    renewed.refresh_token = held.refresh_token.take();
+                }
+                *held = renewed;
+                true
+            }
+            Err(error) => {
+                eprintln!("refresh failed: {error}");
+                false
+            }
+        }
+    }
+}
+
+impl Refreshing {
+    fn lock(&self) -> std::sync::MutexGuard<'_, Token> {
+        self.token
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+}
+
+/// Takes one HTTP request on the listener, answers it with a page to close, and picks the
+/// `code` and `state` out of its query string.
+async fn wait_for_redirect(listener: &TcpListener) -> Result<(String, String), Error> {
+    let (mut socket, _) = listener.accept().await.map_err(Error::network)?;
+
+    // The request line, then the headers up to the blank line, however TCP splits them;
+    // 16 KiB is more than a redirect needs.
+    let mut reader = BufReader::new((&mut socket).take(16 * 1024));
+    let mut request_line = String::new();
+    reader
+        .read_line(&mut request_line)
+        .await
+        .map_err(Error::network)?;
+    let mut header = String::new();
+    loop {
+        header.clear();
+        let read = reader
+            .read_line(&mut header)
+            .await
+            .map_err(Error::network)?;
+        if read == 0 || header == "\r\n" || header == "\n" {
+            break;
+        }
+    }
+    let target = request_line
+        .split_whitespace()
+        .nth(1)
+        .ok_or_else(|| Error::usage("the redirect was not an HTTP request"))?;
+    let url = url::Url::parse(&format!("http://127.0.0.1{target}"))?;
+    let mut code = None;
+    let mut state = None;
+    for (key, value) in url.query_pairs() {
+        match key.as_ref() {
+            "code" => code = Some(value.into_owned()),
+            "state" => state = Some(value.into_owned()),
+            _ => {}
+        }
+    }
+    let page = "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nConnection: close\r\n\r\n\
+                Authorized. You can close this tab.\n";
+    socket
+        .write_all(page.as_bytes())
+        .await
+        .map_err(Error::network)?;
+    match (code, state) {
+        (Some(code), Some(state)) => Ok((code, state)),
+        _ => Err(Error::usage("the redirect carried no code and state")),
+    }
+}

--- a/rust/hey-sdk/examples/oauth_pkce.rs
+++ b/rust/hey-sdk/examples/oauth_pkce.rs
@@ -81,6 +81,7 @@ async fn main() -> Result<(), Error> {
         client_id: config.oauth_client_id.clone(),
         install_id,
         token: Mutex::new(token),
+        refreshing: tokio::sync::Mutex::new(()),
     };
     let client = Client::new(config, provider)?;
     let me = client.identity().get().await?;
@@ -91,12 +92,18 @@ async fn main() -> Result<(), Error> {
 /// Holds the tokens for this run and refreshes them when asked. An application keeps
 /// `Token` (with its `expires_at`) and the `install_id` in its own store instead, and
 /// answers `access_token` from there.
+///
+/// One refresh at a time: a client shared across tasks can meet several 401s at once, and
+/// HEY rotates refresh tokens, so the second refresh in flight would spend a token the
+/// first one already replaced. The task that arrives late finds fresh credentials and
+/// reports them as its own refresh.
 struct Refreshing {
     oauth: OAuthClient,
     metadata: ServerMetadata,
     client_id: String,
     install_id: String,
     token: Mutex<Token>,
+    refreshing: tokio::sync::Mutex<()>,
 }
 
 #[async_trait]
@@ -106,6 +113,11 @@ impl TokenProvider for Refreshing {
     }
 
     async fn refresh(&self) -> bool {
+        let stale = self.lock().access_token.clone();
+        let _one_at_a_time = self.refreshing.lock().await;
+        if self.lock().access_token != stale {
+            return true;
+        }
         let Some(refresh_token) = self.lock().refresh_token.clone() else {
             return false;
         };

--- a/rust/hey-sdk/examples/pagination.rs
+++ b/rust/hey-sdk/examples/pagination.rs
@@ -1,0 +1,51 @@
+//! Walking a paginated read: page by page, and to the end.
+//!
+//! ```sh
+//! HEY_TOKEN=... cargo run --example pagination
+//! ```
+
+use hey_sdk::services::contacts::ListContactsParams;
+use hey_sdk::{Client, Config, Error, StaticTokenProvider};
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    let token = std::env::var("HEY_TOKEN")
+        .map_err(|_| Error::usage("set HEY_TOKEN to a HEY access token"))?;
+    let client = Client::builder(Config::default())
+        .token_provider(StaticTokenProvider::new(token))
+        // `each_page` and `get_all` stop here; `next_page` is the caller's to stop.
+        .max_pages(50)
+        .build()?;
+
+    // A page carries the cursor HEY answered with and, where HEY sends it, the total.
+    let mut page = client
+        .contacts()
+        .list(&ListContactsParams::default())
+        .await?;
+    if let Some(total) = page.total_count() {
+        println!("{total} contacts");
+    }
+
+    // One page at a time, with the loop in the caller's hands.
+    let mut seen = page.len();
+    while let Some(next) = client.next_page(&page).await? {
+        seen += next.len();
+        page = next;
+    }
+    println!("{seen} contacts across the pages read one by one");
+
+    // The same walk, with the client driving. The visitor answers whether to go on.
+    let first = client
+        .contacts()
+        .list(&ListContactsParams::default())
+        .await?;
+    let mut names = Vec::new();
+    client
+        .each_page(first, |page| {
+            names.extend(page.iter().filter_map(|contact| contact.name.clone()));
+            true
+        })
+        .await?;
+    println!("{} named contacts", names.len());
+    Ok(())
+}

--- a/rust/hey-sdk/src/client.rs
+++ b/rust/hey-sdk/src/client.rs
@@ -301,6 +301,7 @@ impl Client {
     /// ships. Without the `reqwest` feature there is no such client, and a
     /// [`ClientBuilder`] with an [`HttpClient`] of the application's own is the way in.
     #[cfg(feature = "reqwest")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "reqwest")))]
     pub fn new(config: Config, provider: impl TokenProvider + 'static) -> Result<Client, Error> {
         Client::builder(config).token_provider(provider).build()
     }

--- a/rust/hey-sdk/src/http/mod.rs
+++ b/rust/hey-sdk/src/http/mod.rs
@@ -22,6 +22,7 @@ pub use ::http::{Method, Request, Response, StatusCode, Version};
 #[cfg(feature = "reqwest")]
 mod reqwest;
 #[cfg(feature = "reqwest")]
+#[cfg_attr(docsrs, doc(cfg(feature = "reqwest")))]
 pub use self::reqwest::ReqwestClient;
 
 /// Sends one HTTP request and answers with the response, its body still unread.

--- a/rust/hey-sdk/src/lib.rs
+++ b/rust/hey-sdk/src/lib.rs
@@ -18,6 +18,10 @@
 //! # }
 //! ```
 
+// docs.rs builds with `--cfg docsrs` on nightly, where `doc_cfg` badges the items that
+// exist only with a feature on.
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 mod account_scope;
 pub mod auth;
 pub mod cache;

--- a/rust/hey-sdk/src/oauth.rs
+++ b/rust/hey-sdk/src/oauth.rs
@@ -293,6 +293,7 @@ impl fmt::Debug for OAuthClient {
 }
 
 #[cfg(feature = "reqwest")]
+#[cfg_attr(docsrs, doc(cfg(feature = "reqwest")))]
 impl Default for OAuthClient {
     fn default() -> OAuthClient {
         OAuthClient::new(crate::http::ReqwestClient::default())

--- a/rust/rustfmt.toml
+++ b/rust/rustfmt.toml
@@ -1,0 +1,8 @@
+# Stable rustfmt options only, so `cargo fmt` on the pinned toolchain and rustfmt on any
+# other stable agree. The unstable ones (imports_granularity, group_imports) stay out: they
+# need nightly, and a formatter the gate cannot run is not a formatter.
+edition = "2024"
+style_edition = "2024"
+max_width = 100
+use_field_init_shorthand = true
+use_try_shorthand = true


### PR DESCRIPTION
Docs, examples and the local-equals-CI devex for the Rust crate (card: [hey-sdk Rust: docs, examples, changelog](https://app.basecamp.com/2914079/buckets/46292715/card_tables/cards/10289485391)). Stacked on #159 → #157 → #155; merge those first.

## Examples that compile

`rust/hey-sdk/examples/` holds five whole programs, each the README's snippet grown into something runnable, and `make rs-check` now builds them (`make rs-examples`), so a public-API change that breaks a snippet fails the gate:

- `first_call.rs` — identity and boxes from `HEY_TOKEN`.
- `pagination.rs` — a paginated read walked page by page with `next_page`, then to the end with `each_page`, with the total count.
- `hooks.rs` — a `Hooks` impl hearing every operation, request and resend.
- `oauth_pkce.rs` — the whole PKCE login: loopback listener for the redirect, `authorization_url` with `install_id`, state check, code exchange, then a call through a `TokenProvider` that refreshes on 401.
- `custom_http_client.rs` — a transport of the caller's own that answers from a table; runs offline and with `--no-default-features`, which is what the `HttpClient` seam exists for.

The four that talk to HEY are `required-features = ["reqwest"]`, so `--no-default-features` builds only the one that should.

## Docs

- Root `README.md` gets a Rust section with the same headings as the Go walkthrough — install, authenticate, use it, linked accounts, errors, pagination — plus what the crate has that the module does not. Install stays the git form at a release tag until the crate is on crates.io; the publishing PR switches it.
- Crate `README.md` links the examples, gains a **Versioning** section (pre-1.0 semver as Cargo reads it and as `api-compat-rust` checks it; MSRV 1.88, when it moves and what that costs; the pinned stable), and describes `make rs-check` as it now is. The API-governance card may extend that section with the request-construction policy; this is the floor.
- `AGENTS.md` and `CONTRIBUTING.md` describe the gate and the tools.
- `#![cfg_attr(docsrs, feature(doc_cfg))]` and `doc(cfg(feature = "reqwest"))` on `ReqwestClient`, `Client::new` and `OAuthClient::default`, so docs.rs badges them. Verified on nightly locally with `--cfg docsrs -D warnings`: the badge renders.

## Devex

- `rust/rustfmt.toml`: stable options only (`edition`/`style_edition` 2024, `max_width = 100`, the two shorthands); it changes nothing in the tree today. `imports_granularity`/`group_imports` stay out: they need nightly.
- `make -C rust help` and `make help` list every `rs-*` target; `rs-check` is documented as the exact CI step list.
- `.editorconfig` gets `[*.rs] indent_size = 4`.
- `rust-toolchain.toml` landed with #155.

## Not in this PR

- `CHANGELOG.md` / `MIGRATING.md`: GitHub Releases with `.github/release.yml` categories are this repo's changelog, and there is no real migration to write yet (the governance card's `#[non_exhaustive]` change will be the first). No placeholder.
- crates.io / docs.rs install lines and links — the publishing PR.

Verified locally: `make rs-check rs-check-drift` green (the whole step list, including the examples); `cargo run --example custom_http_client --no-default-features` prints the canned boxes.

## Merge order

This PR is part of a five-PR stack, each rebased on the one below and all five on current `main`, so they merge cleanly in this order and only this order: #155 (build/MSRV/feature matrix) → #157 (cargo deny, Dependabot, Trivy) → #159 (semver-checks, packaging) → #160 (docs, examples, rustfmt) → #162 (crates.io publishing). Every one of them touches `.github/workflows/test.yml` and/or the Makefiles; the stacking is the conflict resolution. Merge each one after the one below has landed; GitHub retargets the next PR to `main` when the merged branch is deleted. #162 can merge before the crates.io bootstrap: it publishes nothing until the crate exists on crates.io (its publish job fails closed with instructions on a tag until then), and nothing in it changes after the bootstrap.
