### PR TITLE
Publish the Rust crate to crates.io on the release tag, with trusted publishing

### DIFF
--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -25,4 +25,4 @@ jobs:
         with:
           version: ${{ github.event.inputs.tag || github.ref_name }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          languages: go
+          languages: go,rust

--- a/.github/workflows/release-rust.yml
+++ b/.github/workflows/release-rust.yml
@@ -1,0 +1,277 @@
+name: Release Rust SDK
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:  # Manual trigger is always dry-run (rehearsal mode)
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  CRATE: hey-sdk
+
+jobs:
+  smithy:
+    permissions:
+      contents: read
+    uses: ./.github/workflows/smithy-verify.yml
+
+  test:
+    name: Test before release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Verify tag is on main
+        if: github.event_name == 'push'
+        run: |
+          git fetch origin main
+          git merge-base --is-ancestor "$GITHUB_SHA" origin/main
+
+      - name: Set up Rust
+        run: rustup toolchain install && rustup show
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2 # zizmor: ignore[cache-poisoning] -- cache is branch-isolated; fork PRs cannot write to this cache
+        with:
+          workspaces: |
+            rust
+            conformance/runner/rust
+
+      - name: Install cargo-deny
+        uses: taiki-e/install-action@c3ec0de9ae7f1019cea21aa96aa0a895b9552063 # v2.87.9
+        with:
+          tool: cargo-deny
+
+      # The same gate a pull request passes: fmt, clippy, tests, docs, both feature sets,
+      # the examples, cargo deny, the dry-run publish, the generated code, the conformance
+      # fixtures. A tag is not the place to find out.
+      - name: Run the Rust gate
+        run: make rs-check rs-check-drift conformance-rs
+
+  # Packaging is separate from publishing on purpose: this job carries no `environment:`
+  # and no credentials, so a workflow_dispatch rehearsal runs it from any ref, and what it
+  # packages is what the publish job checks itself against.
+  package:
+    name: Package crate
+    needs: [smithy, test]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      sha256: ${{ steps.package.outputs.sha256 }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Rust
+        run: rustup toolchain install && rustup show
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2 # zizmor: ignore[cache-poisoning] -- cache is branch-isolated; fork PRs cannot write to this cache
+        with:
+          workspaces: rust
+
+      # The version Cargo reads, not a grep over TOML; on a tag it has to be the tag's.
+      - name: Read the crate version
+        id: version
+        working-directory: rust
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          version=$(cargo metadata --no-deps --format-version 1 --locked \
+            | jq -r --arg crate "$CRATE" '.packages[] | select(.name == $crate) | .version')
+          if [ -z "$version" ]; then
+            echo "::error::no package named $CRATE in the workspace"
+            exit 1
+          fi
+          if [ "$EVENT_NAME" = "push" ]; then
+            tag="${GITHUB_REF#refs/tags/v}"
+            if [ "$version" != "$tag" ]; then
+              echo "::error::$CRATE is $version in Cargo.toml but the tag is v$tag; run make bump VERSION=$tag, merge it, then tag"
+              exit 1
+            fi
+            echo "Releasing $CRATE $version"
+          else
+            echo "Rehearsal for $CRATE $version"
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      # `cargo package` is what `cargo publish` uploads, built once more from the tarball to
+      # prove it stands on its own. The tarball is reproducible from the same commit and
+      # toolchain, which is what lets the publish job compare against it. The VCS stamp
+      # inside it is the crate's only provenance on crates.io, so it has to name this commit.
+      - name: Package the crate
+        id: package
+        working-directory: rust
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          cargo package -p "$CRATE" --locked
+          crate="target/package/$CRATE-$VERSION.crate"
+          stamp=$(tar xzOf "$crate" "$CRATE-$VERSION/.cargo_vcs_info.json")
+          echo "$stamp"
+          sha1=$(echo "$stamp" | jq -r '.git.sha1')
+          path=$(echo "$stamp" | jq -r '.path_in_vcs')
+          if [ "$sha1" != "$GITHUB_SHA" ] || [ "$path" != "rust/$CRATE" ]; then
+            echo "::error::.cargo_vcs_info.json names $sha1 at $path, expected $GITHUB_SHA at rust/$CRATE"
+            exit 1
+          fi
+          sha256=$(sha256sum "$crate" | cut -d' ' -f1)
+          echo "sha256=$sha256" >> "$GITHUB_OUTPUT"
+          echo "$crate $sha256"
+
+      - name: Dry-run publish
+        if: github.event_name == 'workflow_dispatch'
+        working-directory: rust
+        run: |
+          cargo publish -p "$CRATE" --dry-run --locked
+          echo "::notice::Dry run mode - not actually publishing"
+
+      - name: Upload the crate
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: rust-crate
+          path: rust/target/package/*.crate
+          if-no-files-found: error
+          retention-days: 7
+
+  publish:
+    name: Publish to crates.io
+    needs: package
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    # Restricted to `v*` tags; the trusted-publisher configuration on crates.io names this
+    # environment, so a token cannot be minted from anywhere else. No required reviewers:
+    # release-github.yml polls this workflow for thirty minutes and a wait for approval
+    # would time it out, and the tag is already a deliberate `make release` from a green
+    # gate — the same footing basecamp-sdk's release-pypi environment stands on.
+    environment: release-crates
+    env:
+      VERSION: ${{ needs.package.outputs.version }}
+      PACKAGED_SHA256: ${{ needs.package.outputs.sha256 }}
+      USER_AGENT: hey-sdk release workflow (https://github.com/basecamp/hey-sdk)
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # Publishes only on a clean 404 for this version. A 200 means it is already there —
+      # a re-run after a partial failure — and the job succeeds without publishing again,
+      # provided the bytes crates.io holds are the ones the package job built; a version
+      # published from anything else, or yanked, fails. Anything but 200 or 404 (a 5xx, a
+      # rate limit, a body that does not parse) is not a reason to try an upload; fail and
+      # re-run later. A 404 for the crate itself means the one-time first publish has not
+      # happened yet — crates.io's trusted publishing is configured on an existing crate —
+      # so there is nothing to mint a token against: fail, pointing at the steps in
+      # CONTRIBUTING.md, and re-run this workflow once they are done.
+      - name: Check crates.io for this version
+        id: check
+        run: |
+          crate_status=$(curl -sS -o /dev/null -w '%{http_code}' -A "$USER_AGENT" \
+            "https://crates.io/api/v1/crates/$CRATE")
+          case "$crate_status" in
+            200) ;;
+            404)
+              echo "::error::$CRATE is not on crates.io yet. The first publish is manual: CONTRIBUTING.md, 'The first publish, once'. Do that, then re-run this workflow to publish $VERSION."
+              exit 1
+              ;;
+            *)
+              echo "::error::crates.io answered $crate_status for $CRATE; not publishing on a guess"
+              exit 1
+              ;;
+          esac
+          body=$(mktemp)
+          status=$(curl -sS -o "$body" -w '%{http_code}' -A "$USER_AGENT" \
+            "https://crates.io/api/v1/crates/$CRATE/$VERSION")
+          case "$status" in
+            200)
+              yanked=$(jq -er '.version.yanked' "$body") || { echo "::error::crates.io's answer for $CRATE $VERSION did not parse"; exit 1; }
+              checksum=$(jq -er '.version.checksum' "$body") || { echo "::error::crates.io's answer for $CRATE $VERSION carries no checksum"; exit 1; }
+              if [ "$yanked" = "true" ]; then
+                echo "::error::$CRATE $VERSION is on crates.io but yanked; release the next version"
+                exit 1
+              fi
+              if [ "$checksum" != "$PACKAGED_SHA256" ]; then
+                echo "::error::$CRATE $VERSION is on crates.io as $checksum, but this commit packages as $PACKAGED_SHA256; it was published from something else"
+                exit 1
+              fi
+              echo "::notice::$CRATE $VERSION is already on crates.io, with the checksum this commit packages to"
+              echo "publish=false" >> "$GITHUB_OUTPUT"
+              ;;
+            404)
+              echo "publish=true" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "::error::crates.io answered $status for $CRATE $VERSION; not publishing on a guess"
+              exit 1
+              ;;
+          esac
+
+      - name: Set up Rust
+        if: steps.check.outputs.publish == 'true'
+        run: rustup toolchain install && rustup show
+
+      # Cargo publishes from source, not from a tarball, so the artifact from the package
+      # job is evidence rather than input: package again here and refuse to go on unless
+      # the bytes are the same ones that job built and verified.
+      - name: Package again and compare
+        if: steps.check.outputs.publish == 'true'
+        working-directory: rust
+        run: |
+          cargo package -p "$CRATE" --locked --no-verify
+          sha256=$(sha256sum "target/package/$CRATE-$VERSION.crate" | cut -d' ' -f1)
+          if [ "$sha256" != "$PACKAGED_SHA256" ]; then
+            echo "::error::packaged $sha256 here, but the package job built $PACKAGED_SHA256"
+            exit 1
+          fi
+
+      # A short-lived token in exchange for this job's OIDC identity; the action revokes it
+      # when the job ends. Nothing long-lived exists to leak.
+      - name: Authenticate with crates.io
+        if: steps.check.outputs.publish == 'true'
+        id: auth
+        uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
+
+      - name: Publish
+        if: steps.check.outputs.publish == 'true'
+        working-directory: rust
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+        run: cargo publish -p "$CRATE" --locked --no-verify
+
+      # What crates.io holds is what was packaged here. An upload that times out waiting on
+      # the index still stands, so a re-run lands on the 200 above rather than here.
+      - name: Verify the published checksum
+        if: steps.check.outputs.publish == 'true'
+        run: |
+          # The upload is done, so a failed request here is a reason to ask again, not to
+          # stop: the shell runs with -e, and the `|| true` keeps a curl or jq failure from
+          # ending the loop on the first try.
+          checksum=""
+          for _ in 1 2 3 4 5 6; do
+            checksum=$(curl -sS -A "$USER_AGENT" "https://crates.io/api/v1/crates/$CRATE/$VERSION" \
+              | jq -r '.version.checksum // empty' || true)
+            [ -n "$checksum" ] && break
+            sleep 10
+          done
+          if [ "$checksum" != "$PACKAGED_SHA256" ]; then
+            echo "::error::crates.io holds $checksum for $CRATE $VERSION, but $PACKAGED_SHA256 was packaged"
+            exit 1
+          fi
+          echo "Published $CRATE $VERSION ($checksum)"

--- a/.github/workflows/release-rust.yml
+++ b/.github/workflows/release-rust.yml
@@ -201,8 +201,18 @@ jobs:
             "https://crates.io/api/v1/crates/$CRATE/$VERSION")
           case "$status" in
             200)
-              yanked=$(jq -er '.version.yanked' "$body") || { echo "::error::crates.io's answer for $CRATE $VERSION did not parse"; exit 1; }
-              checksum=$(jq -er '.version.checksum' "$body") || { echo "::error::crates.io's answer for $CRATE $VERSION carries no checksum"; exit 1; }
+              # Not `jq -e`: it reports a `false` result as exit status 1, and unyanked is
+              # the answer this path exists for.
+              yanked=$(jq -r '.version.yanked | tostring' "$body" 2>/dev/null) || yanked=""
+              checksum=$(jq -r '.version.checksum // empty' "$body" 2>/dev/null) || checksum=""
+              case "$yanked" in
+                true|false) ;;
+                *) echo "::error::crates.io's answer for $CRATE $VERSION did not parse"; exit 1 ;;
+              esac
+              if [ -z "$checksum" ]; then
+                echo "::error::crates.io's answer for $CRATE $VERSION carries no checksum"
+                exit 1
+              fi
               if [ "$yanked" = "true" ]; then
                 echo "::error::$CRATE $VERSION is on crates.io but yanked; release the next version"
                 exit 1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,22 +41,74 @@ The full step-by-step, including how the drift gates work, is in [AGENTS.md](AGE
 Two steps, in this order.
 
 ```bash
-make bump VERSION=x.y.z     # rewrites go/pkg/hey/version.go and rust/hey-sdk/Cargo.toml
+make bump VERSION=x.y.z     # rewrites go/pkg/hey/version.go, rust/hey-sdk/Cargo.toml and both Cargo.lock files
 # commit that, open a PR, merge it
 make release VERSION=x.y.z  # runs the gate, then tags vx.y.z and go/vx.y.z
 ```
 
-The bump has to land on main *before* the tag, because the release workflow checks that
-`version.go` matches the tag it was pushed for and refuses to publish otherwise. The Rust
-crate is not published to crates.io; consumers depend on it by git tag, so the same
-`vx.y.z` tag is what they pin.
-`make release` checks the same thing up front, so a forgotten bump fails locally in a
-second rather than on GitHub after the tags are already pushed.
+The bump has to land on main *before* the tag, because the release workflows check that
+`version.go` and `Cargo.toml` match the tag they were pushed for and refuse to publish
+otherwise. `make release` checks the same thing up front, so a forgotten bump fails
+locally in a second rather than on GitHub after the tags are already pushed; its gate
+includes `cargo publish --dry-run`, so a crate that would not package fails there too.
 
-Both tags matter: the plain one triggers the release, and the `go/` one is what
-`go get github.com/basecamp/hey-sdk/go` resolves, since the module lives in a
-subdirectory.
+The `vx.y.z` tag runs three workflows: `release-go.yml` tags the module, `release-rust.yml`
+publishes the crate to crates.io, and `release-github.yml` waits for both and then creates
+the GitHub release. Both git tags matter: the plain one triggers the release and is what a
+git-dependency on the crate pins (there is no `rust/vx.y.z` tag; Cargo does not resolve tags
+by path), and the `go/` one is what `go get github.com/basecamp/hey-sdk/go` resolves, since
+the module lives in a subdirectory.
 
 `Version` is not decorative — it goes out on every request as part of the User-Agent,
 alongside `APIVersion`, which is how HEY sees which SDK and which contract a client is
 working from.
+
+### Publishing the crate
+
+`release-rust.yml` publishes with [crates.io trusted
+publishing](https://crates.io/docs/trusted-publishing): the `publish` job trades its GitHub
+OIDC identity for a short-lived token through
+[`rust-lang/crates-io-auth-action`](https://github.com/rust-lang/crates-io-auth-action), runs
+`cargo publish`, and the token is revoked when the job ends. There is no long-lived token in
+the repository's secrets. The job runs only for a pushed `v*` tag, inside the `release-crates`
+environment, which is restricted to `v*` tags (no required reviewers: `release-github.yml`
+polls the run for thirty minutes, and the tag is already a deliberate `make release` from a
+green gate); a `workflow_dispatch` run is a rehearsal that packages and dry-runs but never
+publishes and never exercises the token exchange.
+
+The job is safe to re-run. It publishes only when crates.io answers 404 for the version; a 200
+means the version is there (an earlier run that failed after the upload, say) and the job
+succeeds without publishing again, provided the checksum crates.io holds is the one this
+commit packages to; a version published from anything else, or yanked, fails; any other
+answer fails without trying. After a partial release, re-run the failed run
+(`gh run rerun <run-id> --failed`, or the Re-run button); do not delete or move the tag.
+
+Before publishing it packages the crate a second time and refuses unless the bytes match what
+the `package` job built and verified from the same commit, and afterwards it compares the
+checksum crates.io holds with what it packaged. `.cargo_vcs_info.json` inside the crate names
+the commit and `rust/hey-sdk` as the path, which is the crate's provenance on crates.io.
+
+#### The first publish, once
+
+Trusted publishing is configured on an existing crate's settings page, so the first version
+of `hey-sdk` on crates.io is published by hand, by a crates.io user who will own the crate,
+and everything after it by the workflow. Until then `https://crates.io/api/v1/crates/hey-sdk`
+answers 404 and the `publish` job fails pointing here, which holds the GitHub release for
+that tag; finish these steps and re-run the failed run.
+
+1. Create the `release-crates` environment on the repository (Settings → Environments) with
+   deployment branches and tags restricted to the tag pattern `v*`, and no required
+   reviewers. Do this before the first tag: a job that references an environment that does
+   not exist creates one with no protection.
+2. On a clean checkout of `main` at the commit about to be tagged, with `make check` green:
+   mint a crates.io API token scoped to `publish-new` and `change-owners`, crate-name
+   pattern `hey-sdk`, with a one-day expiry.
+3. `cd rust && cargo publish -p hey-sdk --locked` with that token (`CARGO_REGISTRY_TOKEN`).
+4. `cargo owner --add github:basecamp:cli hey-sdk`, so ownership is the GitHub team and not
+   the person.
+5. On the crate's settings page on crates.io, add a trusted publisher: repository owner
+   `basecamp`, repository `hey-sdk`, workflow filename `release-rust.yml` (the exact
+   basename; renaming the file breaks the exchange), environment `release-crates`.
+6. Revoke the token.
+7. `make release VERSION=x.y.z` from that same commit. The tag's `release-rust.yml` run finds
+   the version already on crates.io and succeeds; the next tag is the first real exchange.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 37signals, LLC
+Copyright (c) 37signals LLC
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Basecamp
+Copyright (c) 37signals, LLC
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -156,18 +156,18 @@ by default, and lets an application bring its own HTTP stack instead.
 
 ### Install
 
-Until the crate is on crates.io, depend on it from the repository at a release tag —
-`v0.30.0` is the first that carries `rust/`:
-
 ```toml
 [dependencies]
-hey-sdk = { git = "https://github.com/basecamp/hey-sdk", tag = "v0.30.0" }
+hey-sdk = "0.30"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 ```
 
-Requires Rust 1.88 or newer (`rust-version` in `rust/Cargo.toml`, built on exactly that in
-CI). The crate's [Versioning](rust/hey-sdk/README.md#versioning) section says when that floor
-moves and what a version bump means.
+The crate is [`hey-sdk` on crates.io](https://crates.io/crates/hey-sdk), documented on
+[docs.rs](https://docs.rs/hey-sdk). To track the repository instead, depend on it at a release
+tag: `hey-sdk = { git = "https://github.com/basecamp/hey-sdk", tag = "v0.30.0" }`. Requires
+Rust 1.88 or newer (`rust-version` in `rust/Cargo.toml`, built on exactly that in CI); the
+crate's [Versioning](rust/hey-sdk/README.md#versioning) section says when that floor moves
+and what a version bump means.
 
 ### Authenticate
 

--- a/rust/Makefile
+++ b/rust/Makefile
@@ -60,12 +60,13 @@ deny:
 	$(CARGO) deny --locked check
 	cd ../conformance/runner/rust && $(CARGO) deny --locked --config ../../../rust/deny.toml check
 
-# Package the crate as a publish would and build it from the tarball, so a missing file, a
-# path dependency or a metadata slip surfaces on the pull request rather than on the tag.
-# --allow-dirty so it runs before a commit as well as after; CI's checkout is clean anyway.
+# Everything `cargo publish` does short of the upload: package the crate, build it from the
+# tarball, check the metadata, so a missing file, a path dependency or a metadata slip
+# surfaces on the pull request rather than on the tag. --allow-dirty so it runs before a
+# commit as well as after; CI's checkout is clean anyway.
 .PHONY: publish-check
 publish-check:
-	$(CARGO) package -p hey-sdk --locked --allow-dirty
+	$(CARGO) publish -p hey-sdk --dry-run --locked --allow-dirty
 
 # Run all checks: the same steps as CI's test-rust job, in the same order
 .PHONY: check
@@ -89,6 +90,6 @@ help:
 	@echo "  doc                  Build the crate docs"
 	@echo "  examples             Build the examples"
 	@echo "  deny                 cargo deny over both workspaces (advisories, licences, bans)"
-	@echo "  publish-check        Package the crate and build it from the tarball"
+	@echo "  publish-check        cargo publish --dry-run: package, build from the tarball, check metadata"
 	@echo "  check                Every step CI's test-rust job runs, in order"
 	@echo "  clean                Remove build artifacts"

--- a/rust/hey-sdk/Cargo.toml
+++ b/rust/hey-sdk/Cargo.toml
@@ -2,12 +2,24 @@
 name = "hey-sdk"
 version = "0.30.0"
 description = "Rust client for the HEY API, generated from the Smithy model in spec/"
-readme = "README.md"
-publish = false
+homepage = "https://github.com/basecamp/hey-sdk"
+documentation = "https://docs.rs/hey-sdk"
+keywords = ["hey", "email", "37signals", "api", "sdk"]
+categories = ["api-bindings", "web-programming::http-client"]
+# What the published crate carries; Cargo.toml, Cargo.lock and the VCS stamp always go
+# along. The integration tests and their fixtures stay here. LICENSE is a copy of the
+# repository's: `license` names it by SPDX id, and the text has to travel with the crate.
+include = ["src/**", "examples/**", "README.md", "LICENSE"]
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
+
+# docs.rs builds with every feature on and `--cfg docsrs`, which is what badges the
+# feature-gated items (see lib.rs).
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
 
 [lib]
 name = "hey_sdk"

--- a/rust/hey-sdk/Cargo.toml
+++ b/rust/hey-sdk/Cargo.toml
@@ -1,15 +1,17 @@
 [package]
 name = "hey-sdk"
 version = "0.30.0"
-description = "Rust client for the HEY API, generated from the Smithy model in spec/"
+description = "Rust client for the HEY API, generated from a Smithy model of the API"
 homepage = "https://github.com/basecamp/hey-sdk"
 documentation = "https://docs.rs/hey-sdk"
 keywords = ["hey", "email", "37signals", "api", "sdk"]
 categories = ["api-bindings", "web-programming::http-client"]
 # What the published crate carries; Cargo.toml, Cargo.lock and the VCS stamp always go
-# along. The integration tests and their fixtures stay here. LICENSE is a copy of the
-# repository's: `license` names it by SPDX id, and the text has to travel with the crate.
-include = ["src/**", "examples/**", "README.md", "LICENSE"]
+# along. LICENSE is a copy of the repository's: `license` names it by SPDX id, and the text
+# has to travel with the crate. The tests travel too, since they carry their own fake HEY
+# and so run from the tarball -- and a test target left out of it is a warning on every
+# package, one per file.
+include = ["src/**", "examples/**", "tests/**", "README.md", "LICENSE"]
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/rust/hey-sdk/LICENSE
+++ b/rust/hey-sdk/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Basecamp
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/rust/hey-sdk/LICENSE
+++ b/rust/hey-sdk/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 37signals, LLC
+Copyright (c) 37signals LLC
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/rust/hey-sdk/LICENSE
+++ b/rust/hey-sdk/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Basecamp
+Copyright (c) 37signals, LLC
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/rust/hey-sdk/README.md
+++ b/rust/hey-sdk/README.md
@@ -4,14 +4,19 @@ The Rust client for the [HEY](https://www.hey.com) API. Types, routes and servic
 generated from the Smithy model in the repository's `spec/` directory, so what the crate offers
 is what HEY serves.
 
-The crate is not on crates.io yet. Depend on it from the repository at a release tag — the
-repository's `vX.Y.Z` tags are the crate's releases, `v0.30.0` is the first that carries
-`rust/`, and there is no `rust/vX.Y.Z` tag to look for:
-
 ```toml
 [dependencies]
-hey-sdk = { git = "https://github.com/basecamp/hey-sdk", tag = "v0.30.0" }
+hey-sdk = "0.30"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+```
+
+The crate is on [crates.io](https://crates.io/crates/hey-sdk) and documented on
+[docs.rs](https://docs.rs/hey-sdk). To track the repository instead, depend on it at a release
+tag — the repository's `vX.Y.Z` tags are the crate's releases, and there is no `rust/vX.Y.Z`
+tag to look for:
+
+```toml
+hey-sdk = { git = "https://github.com/basecamp/hey-sdk", tag = "v0.30.0" }
 ```
 
 Requires Rust 1.88 or newer; see [Versioning](#versioning).

--- a/rust/hey-sdk/tests/routes.rs
+++ b/rust/hey-sdk/tests/routes.rs
@@ -40,20 +40,29 @@ fn the_router_names_the_operation_a_pasted_url_refers_to() {
 fn every_modelled_route_is_listed_once() {
     let ids: HashSet<&str> = ROUTES.iter().map(|route| route.id).collect();
 
-    assert_eq!(ROUTES.len(), modelled_operations());
     assert_eq!(ids.len(), ROUTES.len());
+    match modelled_operations() {
+        Some(modelled) => assert_eq!(ROUTES.len(), modelled),
+        None => eprintln!(
+            "openapi.json is not in the package; the route count is checked in the repository"
+        ),
+    }
 }
 
-/// How many operations `openapi.json` models: one per HTTP method under each path.
-fn modelled_operations() -> usize {
+/// How many operations `openapi.json` models: one per HTTP method under each path. `None`
+/// from the published crate, which carries the tests but not the model they were generated
+/// from; in the repository the file is always there.
+fn modelled_operations() -> Option<usize> {
     let path = concat!(env!("CARGO_MANIFEST_DIR"), "/../../openapi.json");
     let openapi: serde_json::Value =
-        serde_json::from_str(&std::fs::read_to_string(path).unwrap()).unwrap();
-    openapi["paths"]
-        .as_object()
-        .unwrap()
-        .values()
-        .flat_map(|item| item.as_object().unwrap().keys())
-        .filter(|method| matches!(method.as_str(), "get" | "post" | "put" | "patch" | "delete"))
-        .count()
+        serde_json::from_str(&std::fs::read_to_string(path).ok()?).unwrap();
+    Some(
+        openapi["paths"]
+            .as_object()
+            .unwrap()
+            .values()
+            .flat_map(|item| item.as_object().unwrap().keys())
+            .filter(|method| matches!(method.as_str(), "get" | "post" | "put" | "patch" | "delete"))
+            .count(),
+    )
 }


### PR DESCRIPTION
Publishes `hey-sdk` to crates.io on every `vX.Y.Z` tag (card: [hey-sdk Rust: crates.io publishing + release automation](https://app.basecamp.com/2914079/buckets/46292715/card_tables/cards/10289485344)). Stacked on #160 → #159 → #157 → #155; merge those first.

**This PR does not publish anything, and merging it does not publish anything.** The first version on crates.io is a one-time manual publish by a human (steps below and in CONTRIBUTING). Until that is done `crates.io/api/v1/crates/hey-sdk` answers 404 and the publish job fails closed, pointing at those steps, which holds the GitHub release for that tag until the bootstrap is done and the run re-run — so merge this after `v0.30.0` is cut (it is a new workflow and does not fire retroactively) and do the bootstrap before the next tag. The first automated publish is also gated on the API-governance card landing its `#[non_exhaustive]` decision first, so the first crates.io version is not immediately followed by a breaking one. Both are said again at the bottom.

## What changes

**`rust/hey-sdk/Cargo.toml`** — `publish = false` goes; `homepage`, `documentation` (docs.rs), `keywords`, `categories`, an `include` allow-list (`src/**`, `examples/**`, `tests/**`, `README.md`, `LICENSE` — the licence is a copy of the repository's, since the SPDX id alone does not put the text in the tarball; the tests ship because a test target on disk but out of the tarball is a cargo warning per file, and they run from the tarball on their own fake HEY — Stanko's commit on this branch), `[package.metadata.docs.rs]` with `all-features` and `--cfg docsrs`. `license`, `repository` and `rust-version` were already there through the workspace; `readme` is inferred (the explicit key is what nightly cargo now warns about).

**`make rs-publish-check`** becomes `cargo publish --dry-run --locked` — everything a publish does short of the upload — and stays in `make rs-check`.

**`.github/workflows/release-rust.yml`**, shaped like basecamp-sdk's `release-python.yml`:
- `smithy` → `test` (tag on `main`; the same `make rs-check rs-check-drift conformance-rs` a PR passes) → `package` (version read with `cargo metadata`, must equal the tag; `cargo package --locked`; `.cargo_vcs_info.json` must name `$GITHUB_SHA` at `rust/hey-sdk`; sha256 as an output; `.crate` artifact; on `workflow_dispatch` a dry-run publish and a notice, never more) → `publish`.
- `publish` runs only on a pushed tag, in the `release-crates` environment (restricted to `v*` tags; no required reviewers, see the bootstrap), with `id-token: write` and nothing else. It publishes only on a clean 404 for the version: a 200 means already there and the job succeeds without publishing, provided the checksum crates.io holds equals what this commit packages to (re-run after a partial failure is idempotent; a `cargo publish` that timed out waiting on the index still stands; a version published from other bytes fails); a yanked 200 fails with "release the next one"; a body that does not parse, or any other status, fails closed. It packages again and refuses unless the sha256 equals the `package` job's; mints a short-lived token with [`rust-lang/crates-io-auth-action`](https://github.com/rust-lang/crates-io-auth-action) (revoked at job end; no long-lived secret exists); `cargo publish --locked`; then compares the checksum crates.io holds with what was packaged.
- `cargo package` output is byte-reproducible from the same commit and toolchain (verified locally: identical sha256 across runs, with and without `SOURCE_DATE_EPOCH`; cargo fixes the tarball mtimes itself), which is what makes the cross-job comparison meaningful.

**`release-github.yml`** — `languages: go,rust`, so the GitHub release waits on the crate.

**`make bump`** already stamps `Cargo.toml` and both `Cargo.lock` files (verified: `scripts/bump-version.sh 0.99.0` rewrote all four version files, then reverted). No change needed.

**Docs** — CONTRIBUTING's release section describes the three tag-triggered workflows, the re-run semantics, and the one-time bootstrap; both READMEs switch the install line to crates.io with the git-tag form as the alternative.

Verified locally: `make rs-check rs-check-drift` green (including the dry-run publish); actionlint and zizmor clean apart from the pre-existing `self-repository` note, which is the repo's convention.

## Human bootstrap (one-time, not automatable)

1. Create the `release-crates` environment (Settings → Environments), deployment tags restricted to `v*`, no required reviewers (release-github's orchestrator polls for 30 minutes; an approval wait would time it out, and the tag is already a deliberate `make release` — same footing as basecamp-sdk's release environments). Before the first tag: a job that references a missing environment creates an unprotected one.
2. On a clean `main` at the commit about to be tagged, `make check` green: mint a crates.io token scoped `publish-new` + `change-owners`, crate-name pattern `hey-sdk`, one-day expiry.
3. `cd rust && CARGO_REGISTRY_TOKEN=… cargo publish -p hey-sdk --locked`
4. `cargo owner --add github:basecamp:cli hey-sdk`
5. crates.io → hey-sdk → Settings → Trusted Publishing: owner `basecamp`, repository `hey-sdk`, workflow `release-rust.yml`, environment `release-crates`.
6. Revoke the token.
7. `make release VERSION=x.y.z` from the same commit. That tag's run finds the version already there and succeeds; the next tag is the first real OIDC exchange.

## After the bootstrap: no flip

Nothing in this workflow changes once the trusted publisher exists. There is no dry-run flag to remove and no step to enable: on a pushed `v*` tag the `publish` job already runs for real, and the only thing standing between it and an upload today is crates.io answering 404 for the crate, which the manual first publish turns into a 200. `workflow_dispatch` stays a rehearsal forever; the pushed tag is the real thing. The first tag after the bootstrap is the first OIDC exchange, and its run is the proof.

## Merge order

Top of a five-PR stack, each rebased on the one below and all five on current `main`: #155 (build/MSRV/feature matrix) → #157 (cargo deny, Dependabot, Trivy) → #159 (semver-checks, packaging) → #160 (docs, examples, rustfmt) → #162 (this). Every one touches `.github/workflows/test.yml` and/or the Makefiles; the stacking is the conflict resolution. Merge each after the one below has landed; GitHub retargets this PR to `main` when its base branch is deleted. Merging this one on its own would land it on `rust-docs-examples`.

This PR can merge before the crates.io bootstrap: it publishes nothing until the crate exists on crates.io — on a tag, its publish job fails closed with the bootstrap instructions and the GitHub release waits for a re-run — and nothing in it changes after the bootstrap (see "no flip" above).

## Blocked on

- The bootstrap above (human).
- The API-governance card's `#[non_exhaustive]` / request-construction decision landing before the first automated publish.

Until both, a tag's `release-rust.yml` run fails at the publish step with the bootstrap instructions and the GitHub release waits; the fix is the bootstrap, then a re-run.

## Adversarial review

An external review (Codex, gpt-6-astra) over the whole stack raised ten findings; the ones for this PR: the already-published path skipped byte verification and accepted a body that did not parse (folded: checksum must equal the package job's, `jq -e` on both fields); an unpublished crate produced a green release (folded: fail closed, as above); the tarball carried no licence text (folded: `LICENSE` copied in and included). The rest landed on #155, #157 and #160 and are noted there.
