### PR TITLE
Hold the Go client's retry settings as a ceiling over each operation's policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,10 +119,22 @@ workMail, _ := workIdentity.ForAccount(ctx, workAccountID)
 
 Every call reports itself to the client's `Hooks` (`hey.WithHooks`) as a named operation —
 `Postings.MovePostings`, `TimeTracks.StopTimeTrack` — and a `GatingHooks` implementation
-can refuse an operation before it runs. Retries, circuit breaking, bulkheads and rate limits
-are configured with `WithResilience`, `WithCircuitBreaker`, `WithBulkhead` and
-`WithRateLimit`; HTTP caching with `WithCache`. Response caching is active for requests with
-an `Authorization` header, which gives each authenticated identity a stable cache partition.
+can refuse an operation before it runs. Circuit breaking, bulkheads and rate limits are
+configured with `WithResilience`, `WithCircuitBreaker`, `WithBulkhead` and `WithRateLimit`;
+HTTP caching with `WithCache`. Response caching is active for requests with an
+`Authorization` header, which gives each authenticated identity a stable cache partition.
+
+Every modelled operation carries its retry policy from the API contract: how many sends it
+gets in all, which statuses earn another, and the wait before the first resend. The client
+honours that policy on the first request and on every page read after it, and its own
+settings only ever make it gentler: `WithMaxRetries` caps the sends (an operation modelled
+with two sends gets two whatever the cap, and a cap of one resend holds an operation
+modelled with three to two), `WithBaseDelay` is the least the client waits before the first
+resend, and a status the policy does not name is the operation's answer. An operation that
+is not idempotent is sent once, and so is one the contract gives no policy. Whatever the
+count, a 401 that a credential refresh answered earns one more send. A GET on a path
+the caller wrote (`Get`, `GetAll`) has no policy to bring and runs on the client's settings
+alone, resent on 429, 502, 503 and 504.
 
 JSON and HTML answers are capped in the transport at `WithMaxResponseBodyBytes` (16 MiB of
 decompressed body by default; the cap can be raised but not removed), success and error

--- a/conformance/runner/go/main.go
+++ b/conformance/runner/go/main.go
@@ -249,7 +249,13 @@ func runTest(tc TestCase) TestResult {
 	var sdkErr error
 	var heyResult interface{}
 	if layer, _ := tc.ConfigOverrides["clientLayer"].(string); layer == "hey" {
-		options := []hey.ClientOption{hey.WithMaxRetries(0)}
+		// The HEY client's own retry settings are a ceiling over each operation's policy,
+		// and a case that exercises the ceiling says where it sits (configOverrides
+		// maxRetries, baseDelayMs); any other case runs with no resends.
+		options := []hey.ClientOption{hey.WithMaxRetries(int(getInt64Param(tc.ConfigOverrides, "maxRetries")))}
+		if _, set := tc.ConfigOverrides["baseDelayMs"]; set {
+			options = append(options, hey.WithBaseDelay(time.Duration(getInt64Param(tc.ConfigOverrides, "baseDelayMs"))*time.Millisecond))
+		}
 		if enabled, _ := tc.ConfigOverrides["cacheEnabled"].(bool); enabled {
 			cacheDir, tmpErr := os.MkdirTemp("", "hey-conformance-cache")
 			if tmpErr != nil {

--- a/conformance/runner/rust/src/fixtures.rs
+++ b/conformance/runner/rust/src/fixtures.rs
@@ -37,6 +37,8 @@ pub struct ConfigOverrides {
     pub cache_enabled: bool,
     pub refreshable_credentials: bool,
     pub account_id: Option<i64>,
+    pub max_retries: Option<u32>,
+    pub base_delay_ms: Option<u64>,
 }
 
 #[derive(Debug, Default, Clone, Deserialize)]

--- a/conformance/runner/rust/src/operations.rs
+++ b/conformance/runner/rust/src/operations.rs
@@ -76,9 +76,15 @@ async fn client_for(case: &TestCase, base_url: &str) -> Result<Client, Error> {
     let config = Config::default().with_base_url(base_url);
     let credentials = ConformanceCredentials::new(case.config_overrides.refreshable_credentials);
     if case.is_hey_layer() {
+        // The client's own retry settings are a ceiling over each operation's policy, and a
+        // case that exercises the ceiling says where it sits; any other case runs with no
+        // resends.
         let mut builder = Client::builder(config)
             .token_provider(credentials)
-            .max_retries(0);
+            .max_retries(case.config_overrides.max_retries.unwrap_or(0));
+        if let Some(base_delay_ms) = case.config_overrides.base_delay_ms {
+            builder = builder.base_delay(Duration::from_millis(base_delay_ms));
+        }
         if case.config_overrides.cache_enabled {
             builder = builder.cache(InMemoryCache::new());
         }

--- a/conformance/tests/retry-policy.json
+++ b/conformance/tests/retry-policy.json
@@ -5,18 +5,200 @@
     "operation": "DeleteBoxDesignation",
     "method": "DELETE",
     "path": "/boxes/{boxId}/designations/{designationId}",
-    "pathParams": {"boxId": 12345, "designationId": 67890},
+    "pathParams": {
+      "boxId": 12345,
+      "designationId": 67890
+    },
     "mockResponses": [
-      {"status": 500},
-      {"status": 503},
-      {"status": 503},
-      {"status": 200}
+      {
+        "status": 500
+      },
+      {
+        "status": 503
+      },
+      {
+        "status": 503
+      },
+      {
+        "status": 200
+      }
     ],
     "repeatOperation": 2,
     "assertions": [
-      {"type": "requestCount", "expected": 3},
-      {"type": "statusCode", "expected": 503}
+      {
+        "type": "requestCount",
+        "expected": 3
+      },
+      {
+        "type": "statusCode",
+        "expected": 503
+      }
     ],
-    "tags": ["retry", "operation-policy", "retry-on", "max-attempts"]
+    "tags": [
+      "retry",
+      "operation-policy",
+      "retry-on",
+      "max-attempts"
+    ]
+  },
+  {
+    "name": "Client retry ceiling below the operation policy wins",
+    "description": "ListBoxes is modelled with three sends; a HEY client allowing one resend sends it twice and stops on the second 503",
+    "operation": "ListBoxes",
+    "method": "GET",
+    "path": "/boxes",
+    "configOverrides": {
+      "clientLayer": "hey",
+      "maxRetries": 1
+    },
+    "mockResponses": [
+      {
+        "status": 503
+      },
+      {
+        "status": 503
+      },
+      {
+        "status": 200,
+        "body": []
+      }
+    ],
+    "assertions": [
+      {
+        "type": "requestCount",
+        "expected": 2
+      },
+      {
+        "type": "statusCode",
+        "expected": 503
+      }
+    ],
+    "tags": [
+      "retry",
+      "operation-policy",
+      "max-attempts",
+      "client-ceiling"
+    ]
+  },
+  {
+    "name": "Client retry ceiling never raises the operation policy",
+    "description": "DeleteExtenzion is modelled with two sends; a HEY client allowing five resends still sends it twice and stops on the second 503",
+    "operation": "DeleteExtenzion",
+    "method": "DELETE",
+    "path": "/accounts/{accountId}/domains/extenzions/{extenzionId}.json",
+    "pathParams": {
+      "accountId": 12345,
+      "extenzionId": 67890
+    },
+    "configOverrides": {
+      "clientLayer": "hey",
+      "maxRetries": 5
+    },
+    "mockResponses": [
+      {
+        "status": 503
+      },
+      {
+        "status": 503
+      },
+      {
+        "status": 503
+      },
+      {
+        "status": 200
+      }
+    ],
+    "assertions": [
+      {
+        "type": "requestCount",
+        "expected": 2
+      },
+      {
+        "type": "statusCode",
+        "expected": 503
+      }
+    ],
+    "tags": [
+      "retry",
+      "operation-policy",
+      "max-attempts",
+      "client-ceiling"
+    ]
+  },
+  {
+    "name": "Operation policy decides which statuses are resent under a client allowing retries",
+    "description": "ListBoxes is modelled to resend on 429 and 503 only; a 502 is the answer even though the HEY client allows three resends and would resend a 502 on a path of its own",
+    "operation": "ListBoxes",
+    "method": "GET",
+    "path": "/boxes",
+    "configOverrides": {
+      "clientLayer": "hey",
+      "maxRetries": 3
+    },
+    "mockResponses": [
+      {
+        "status": 502
+      },
+      {
+        "status": 200,
+        "body": []
+      }
+    ],
+    "assertions": [
+      {
+        "type": "requestCount",
+        "expected": 1
+      },
+      {
+        "type": "statusCode",
+        "expected": 502
+      }
+    ],
+    "tags": [
+      "retry",
+      "operation-policy",
+      "retry-on",
+      "client-ceiling"
+    ]
+  },
+  {
+    "name": "Operation policy base delay holds under a client asking for less",
+    "description": "ListBoxes is modelled to wait a second before its first resend; a HEY client whose own base delay is a millisecond still waits the policy's second",
+    "operation": "ListBoxes",
+    "method": "GET",
+    "path": "/boxes",
+    "configOverrides": {
+      "clientLayer": "hey",
+      "maxRetries": 3,
+      "baseDelayMs": 1
+    },
+    "mockResponses": [
+      {
+        "status": 503
+      },
+      {
+        "status": 200,
+        "body": []
+      }
+    ],
+    "assertions": [
+      {
+        "type": "requestCount",
+        "expected": 2
+      },
+      {
+        "type": "delayBetweenRequests",
+        "min": 1000
+      },
+      {
+        "type": "noError"
+      }
+    ],
+    "tags": [
+      "retry",
+      "operation-policy",
+      "base-delay",
+      "client-ceiling"
+    ]
   }
 ]

--- a/go/pkg/generated/client.gen.go
+++ b/go/pkg/generated/client.gen.go
@@ -14,6 +14,7 @@ import (
 	"math/rand"
 	"net/http"
 	"net/url"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -2094,14 +2095,22 @@ type HttpRequestDoer interface {
 	Do(req *http.Request) (*http.Response, error)
 }
 
-// RetryConfig configures client-level retry overrides and delays for idempotent operations.
-// Retryable status codes always come from each operation's API contract.
+// RetryConfig is the client's own say over resends. Every operation brings its retry policy
+// from the API contract — how many sends it gets in all, which statuses earn another, and
+// the wait before the first resend — and these settings only ever make that gentler: they
+// lower the count and lengthen the waits, never the reverse. See [Client.RetryPolicy].
 type RetryConfig struct {
-	// MaxRetries overrides an operation's maximum attempts when WithRetryConfig is used.
+	// MaxRetries caps the resends of any operation: an operation is sent at most
+	// MaxRetries+1 times, or as many times as its own policy allows when that is fewer.
+	// It never grants an operation more sends than its policy does. The one resend after
+	// a 401 the AuthRefresher answered is granted on top when the sends are already spent.
 	MaxRetries int
-	// BaseDelay is the initial delay between retries (default: 1s)
+	// BaseDelay is the least the client waits before the first resend (default: 1s). An
+	// operation whose policy names a longer wait starts from that instead.
 	BaseDelay time.Duration
-	// MaxDelay is the maximum delay between retries (default: 30s)
+	// MaxDelay is the most the backoff waits between any two attempts (default: 30s),
+	// whatever the policy asks for. The wait a Retry-After names is honoured as given, and
+	// up to 100ms of jitter is added to every wait.
 	MaxDelay time.Duration
 	// Multiplier is the exponential backoff multiplier (default: 2.0)
 	Multiplier float64
@@ -2117,138 +2126,148 @@ func DefaultRetryConfig() RetryConfig {
 	}
 }
 
-type retryPolicy struct {
-	MaxAttempts       int
+// RetryPolicy is what one operation may spend on being resent: the sends it gets in all,
+// the statuses that earn another, and the wait before the first resend.
+type RetryPolicy struct {
+	// MaxAttempts is the sends in all, the first one included.
+	MaxAttempts int
+	// RetryableStatuses are the response statuses that earn a resend. Any other status is
+	// the operation's answer.
 	RetryableStatuses []int
+	// BaseDelay is the wait before the first resend; each wait after it is longer by the
+	// backoff multiplier.
+	BaseDelay time.Duration
 }
 
-var operationRetryPolicies = map[string]retryPolicy{
-	"DeleteExtenzion":               {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
-	"AdvancedSearch":                {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
-	"GetAdvancedSearchFilters":      {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
-	"ListBoxes":                     {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
-	"GetBox":                        {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
-	"CreateBoxDesignation":          {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
-	"DeleteBoxDesignation":          {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
-	"ListBoxGroups":                 {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
-	"CreateBoxGroup":                {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
-	"DeleteBoxGroup":                {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
-	"GetBoxGroup":                   {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
-	"MarkBoxSeen":                   {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
-	"GetBoxPostingChanges":          {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
-	"GetBubblebox":                  {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
-	"NewBulkReply":                  {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
-	"ListCalendarDays":              {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
-	"GetCalendarDay":                {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
-	"UncompleteHabit":               {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
-	"CompleteHabit":                 {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
-	"GetJournalEntry":               {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
-	"UpdateJournalEntry":            {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
-	"DeleteCalendarEvent":           {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
-	"DeleteCalendarEventOccurrence": {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
-	"CreateHabit":                   {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
-	"DeleteHabit":                   {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
-	"UpdateHabit":                   {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
-	"ResumeHabit":                   {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
-	"StopHabit":                     {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
-	"UpdateFirstWeekDay":            {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
-	"ListJournalEntries":            {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
-	"GetOngoingTimeTrack":           {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
-	"StartTimeTrack":                {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
-	"ListTimeTracks":                {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
-	"CreateTimeTrack":               {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
-	"ListTimeTrackCategories":       {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
-	"DeleteTimeTrack":               {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
-	"UpdateTimeTrack":               {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
-	"CreateCalendarTodo":            {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
-	"DeleteCalendarTodo":            {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
-	"UpdateCalendarTodo":            {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
-	"UncompleteCalendarTodo":        {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
-	"CompleteCalendarTodo":          {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
-	"ListCalendarWeeks":             {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
-	"GetCalendarWeek":               {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
-	"GetCalendarYear":               {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
-	"ListCalendars":                 {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
-	"GetCalendarRecordings":         {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
-	"ToggleCalendar":                {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
-	"GetClearances":                 {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
-	"BulkUpdateClearances":          {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
-	"PuntClearances":                {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
-	"UpdateClearance":               {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
-	"ListClips":                     {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
-	"ListCollections":               {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
-	"GetCollection":                 {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
-	"UpdateCollection":              {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
-	"ListContacts":                  {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
-	"CreateContact":                 {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
-	"HideContact":                   {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
-	"GetContact":                    {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
-	"UpdateContact":                 {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
-	"UnbundleContact":               {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
-	"BundleContact":                 {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
-	"UpdateContactClearance":        {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
-	"DeleteContactNote":             {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
-	"GetContactNote":                {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
-	"UpdateContactNote":             {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
-	"RevealContact":                 {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
-	"ListDrafts":                    {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
-	"DeleteDraft":                   {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
-	"NewEntryForward":               {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
-	"CreateReply":                   {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
-	"NewEntryReply":                 {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
-	"MarkEntrySpam":                 {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
-	"GetFeedbox":                    {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
-	"GetFolder":                     {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
-	"GetIdentity":                   {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
-	"UpdateTimeFormat":              {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
-	"GetImbox":                      {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
-	"GetImboxSeen":                  {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
-	"CreateMessage":                 {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
-	"GetMessage":                    {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
-	"UpdateMessage":                 {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
-	"GetMessageEdit":                {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
-	"GetMyClearances":               {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
-	"UpdateMyClearance":             {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
-	"GetNavigation":                 {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
-	"GetTrailbox":                   {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
-	"RemovePostingsFromBoxGroup":    {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
-	"AddPostingsToBoxGroup":         {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
-	"CancelPostingsBubbleUp":        {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
-	"SchedulePostingsBubbleUp":      {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
-	"BubbleUpPostingsNow":           {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
-	"UnfilePostings":                {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
-	"FilePostings":                  {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
-	"CreateFolderForPostings":       {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
-	"MovePostings":                  {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
-	"UnmutePostings":                {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
-	"MutePostings":                  {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
-	"MarkPostingsSeen":              {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
-	"MarkPostingsSpam":              {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
-	"TrashPostings":                 {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
-	"MarkPostingsUnseen":            {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
-	"GetBundleUnseenPostings":       {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
-	"GetLaterbox":                   {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
-	"GetAsidebox":                   {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
-	"ListSnippets":                  {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
-	"ListStickies":                  {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
-	"CreateSticky":                  {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
-	"MoveSticky":                    {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
-	"DeleteSticky":                  {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
-	"UpdateSticky":                  {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
-	"GetEverythingTopics":           {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
-	"GetSentTopics":                 {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
-	"GetSpamTopics":                 {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
-	"EmptySpam":                     {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
-	"GetTrashTopics":                {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
-	"EmptyTrash":                    {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
-	"GetTopic":                      {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
-	"GetTopicEntries":               {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
-	"MoveTopic":                     {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
-	"GetTopicPublication":           {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
-	"RestoreTopic":                  {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
-	"MarkTopicHam":                  {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
-	"TrashTopic":                    {MaxAttempts: 2, RetryableStatuses: []int{429, 503}},
-	"GetWorkflow":                   {MaxAttempts: 3, RetryableStatuses: []int{429, 503}},
+// operationRetryPolicies is each operation's policy as the API contract declares it,
+// before the client's RetryConfig has its say.
+var operationRetryPolicies = map[string]RetryPolicy{
+	"DeleteExtenzion":               {MaxAttempts: 2, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"AdvancedSearch":                {MaxAttempts: 3, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"GetAdvancedSearchFilters":      {MaxAttempts: 3, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"ListBoxes":                     {MaxAttempts: 3, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"GetBox":                        {MaxAttempts: 3, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"CreateBoxDesignation":          {MaxAttempts: 2, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"DeleteBoxDesignation":          {MaxAttempts: 2, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"ListBoxGroups":                 {MaxAttempts: 3, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"CreateBoxGroup":                {MaxAttempts: 2, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"DeleteBoxGroup":                {MaxAttempts: 2, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"GetBoxGroup":                   {MaxAttempts: 3, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"MarkBoxSeen":                   {MaxAttempts: 2, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"GetBoxPostingChanges":          {MaxAttempts: 3, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"GetBubblebox":                  {MaxAttempts: 3, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"NewBulkReply":                  {MaxAttempts: 3, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"ListCalendarDays":              {MaxAttempts: 3, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"GetCalendarDay":                {MaxAttempts: 3, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"UncompleteHabit":               {MaxAttempts: 3, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"CompleteHabit":                 {MaxAttempts: 3, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"GetJournalEntry":               {MaxAttempts: 3, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"UpdateJournalEntry":            {MaxAttempts: 2, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"DeleteCalendarEvent":           {MaxAttempts: 3, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"DeleteCalendarEventOccurrence": {MaxAttempts: 3, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"CreateHabit":                   {MaxAttempts: 2, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"DeleteHabit":                   {MaxAttempts: 2, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"UpdateHabit":                   {MaxAttempts: 2, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"ResumeHabit":                   {MaxAttempts: 2, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"StopHabit":                     {MaxAttempts: 2, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"UpdateFirstWeekDay":            {MaxAttempts: 3, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"ListJournalEntries":            {MaxAttempts: 3, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"GetOngoingTimeTrack":           {MaxAttempts: 3, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"StartTimeTrack":                {MaxAttempts: 2, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"ListTimeTracks":                {MaxAttempts: 3, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"CreateTimeTrack":               {MaxAttempts: 2, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"ListTimeTrackCategories":       {MaxAttempts: 3, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"DeleteTimeTrack":               {MaxAttempts: 2, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"UpdateTimeTrack":               {MaxAttempts: 3, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"CreateCalendarTodo":            {MaxAttempts: 2, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"DeleteCalendarTodo":            {MaxAttempts: 3, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"UpdateCalendarTodo":            {MaxAttempts: 2, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"UncompleteCalendarTodo":        {MaxAttempts: 3, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"CompleteCalendarTodo":          {MaxAttempts: 3, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"ListCalendarWeeks":             {MaxAttempts: 3, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"GetCalendarWeek":               {MaxAttempts: 3, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"GetCalendarYear":               {MaxAttempts: 3, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"ListCalendars":                 {MaxAttempts: 3, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"GetCalendarRecordings":         {MaxAttempts: 3, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"ToggleCalendar":                {MaxAttempts: 2, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"GetClearances":                 {MaxAttempts: 3, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"BulkUpdateClearances":          {MaxAttempts: 2, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"PuntClearances":                {MaxAttempts: 2, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"UpdateClearance":               {MaxAttempts: 2, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"ListClips":                     {MaxAttempts: 3, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"ListCollections":               {MaxAttempts: 3, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"GetCollection":                 {MaxAttempts: 3, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"UpdateCollection":              {MaxAttempts: 2, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"ListContacts":                  {MaxAttempts: 3, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"CreateContact":                 {MaxAttempts: 2, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"HideContact":                   {MaxAttempts: 2, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"GetContact":                    {MaxAttempts: 3, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"UpdateContact":                 {MaxAttempts: 2, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"UnbundleContact":               {MaxAttempts: 2, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"BundleContact":                 {MaxAttempts: 2, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"UpdateContactClearance":        {MaxAttempts: 2, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"DeleteContactNote":             {MaxAttempts: 2, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"GetContactNote":                {MaxAttempts: 3, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"UpdateContactNote":             {MaxAttempts: 2, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"RevealContact":                 {MaxAttempts: 2, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"ListDrafts":                    {MaxAttempts: 3, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"DeleteDraft":                   {MaxAttempts: 2, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"NewEntryForward":               {MaxAttempts: 3, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"CreateReply":                   {MaxAttempts: 2, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"NewEntryReply":                 {MaxAttempts: 3, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"MarkEntrySpam":                 {MaxAttempts: 2, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"GetFeedbox":                    {MaxAttempts: 3, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"GetFolder":                     {MaxAttempts: 3, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"GetIdentity":                   {MaxAttempts: 3, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"UpdateTimeFormat":              {MaxAttempts: 3, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"GetImbox":                      {MaxAttempts: 3, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"GetImboxSeen":                  {MaxAttempts: 3, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"CreateMessage":                 {MaxAttempts: 2, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"GetMessage":                    {MaxAttempts: 3, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"UpdateMessage":                 {MaxAttempts: 2, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"GetMessageEdit":                {MaxAttempts: 3, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"GetMyClearances":               {MaxAttempts: 3, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"UpdateMyClearance":             {MaxAttempts: 2, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"GetNavigation":                 {MaxAttempts: 3, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"GetTrailbox":                   {MaxAttempts: 3, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"RemovePostingsFromBoxGroup":    {MaxAttempts: 2, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"AddPostingsToBoxGroup":         {MaxAttempts: 2, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"CancelPostingsBubbleUp":        {MaxAttempts: 2, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"SchedulePostingsBubbleUp":      {MaxAttempts: 2, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"BubbleUpPostingsNow":           {MaxAttempts: 2, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"UnfilePostings":                {MaxAttempts: 2, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"FilePostings":                  {MaxAttempts: 2, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"CreateFolderForPostings":       {MaxAttempts: 2, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"MovePostings":                  {MaxAttempts: 2, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"UnmutePostings":                {MaxAttempts: 2, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"MutePostings":                  {MaxAttempts: 2, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"MarkPostingsSeen":              {MaxAttempts: 2, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"MarkPostingsSpam":              {MaxAttempts: 2, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"TrashPostings":                 {MaxAttempts: 2, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"MarkPostingsUnseen":            {MaxAttempts: 2, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"GetBundleUnseenPostings":       {MaxAttempts: 3, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"GetLaterbox":                   {MaxAttempts: 3, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"GetAsidebox":                   {MaxAttempts: 3, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"ListSnippets":                  {MaxAttempts: 3, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"ListStickies":                  {MaxAttempts: 3, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"CreateSticky":                  {MaxAttempts: 2, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"MoveSticky":                    {MaxAttempts: 2, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"DeleteSticky":                  {MaxAttempts: 2, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"UpdateSticky":                  {MaxAttempts: 2, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"GetEverythingTopics":           {MaxAttempts: 3, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"GetSentTopics":                 {MaxAttempts: 3, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"GetSpamTopics":                 {MaxAttempts: 3, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"EmptySpam":                     {MaxAttempts: 2, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"GetTrashTopics":                {MaxAttempts: 3, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"EmptyTrash":                    {MaxAttempts: 2, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"GetTopic":                      {MaxAttempts: 3, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"GetTopicEntries":               {MaxAttempts: 3, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"MoveTopic":                     {MaxAttempts: 2, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"GetTopicPublication":           {MaxAttempts: 3, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"RestoreTopic":                  {MaxAttempts: 2, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"MarkTopicHam":                  {MaxAttempts: 2, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"TrashTopic":                    {MaxAttempts: 2, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"GetWorkflow":                   {MaxAttempts: 3, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
 }
 
 // Client which conforms to the OpenAPI3 specification for this service.
@@ -2267,9 +2286,8 @@ type Client struct {
 	// the network.
 	RequestEditors []RequestEditorFn
 
-	// RetryConfig for idempotent operations
-	RetryConfig           RetryConfig
-	retryAttemptsOverride bool
+	// RetryConfig is the client's ceiling over every operation's retry policy.
+	RetryConfig RetryConfig
 
 	// AuthRefresher is asked once when a response is 401. It renews whatever the request
 	// editors authenticate with and reports whether it could; when it could, the request
@@ -2348,11 +2366,13 @@ func WithRequestEditorFn(fn RequestEditorFn) ClientOption {
 	}
 }
 
-// WithRetryConfig allows setting custom retry configuration for idempotent operations.
+// WithRetryConfig sets the client's ceiling over every operation's retry policy: the
+// operation is sent at most cfg.MaxRetries+1 times and never more than its policy allows,
+// its first wait is at least cfg.BaseDelay, and no backoff wait is longer than
+// cfg.MaxDelay.
 func WithRetryConfig(cfg RetryConfig) ClientOption {
 	return func(c *Client) error {
 		c.RetryConfig = cfg
-		c.retryAttemptsOverride = true
 		return nil
 	}
 }
@@ -2382,7 +2402,9 @@ func WithLogger(logger *slog.Logger) ClientOption {
 	}
 }
 
-func (p retryPolicy) retriesStatus(statusCode int) bool {
+// RetriesStatus reports whether a response with the given status earns a resend under
+// the policy.
+func (p RetryPolicy) RetriesStatus(statusCode int) bool {
 	for _, retryableStatus := range p.RetryableStatuses {
 		if statusCode == retryableStatus {
 			return true
@@ -2391,17 +2413,20 @@ func (p retryPolicy) retriesStatus(statusCode int) bool {
 	return false
 }
 
-// retryPolicy returns the operation's declared policy. WithRetryConfig can override its
-// attempt count, while retryable statuses remain operation-defined.
-func (c *Client) retryPolicy(operationId string) retryPolicy {
+// RetryPolicy is what the client will spend on the operation: the policy the API contract
+// declares for it, held under the client's RetryConfig. The sends are the policy's
+// MaxAttempts or MaxRetries+1, whichever is fewer; the statuses are the policy's own; the
+// first wait is the policy's BaseDelay or the config's, whichever is longer, and no longer
+// than MaxDelay. An operation the contract gives no policy is sent once. Idempotency is
+// judged separately: an operation that is not idempotent is sent once whatever its policy.
+func (c *Client) RetryPolicy(operationId string) RetryPolicy {
 	policy, ok := operationRetryPolicies[operationId]
 	if !ok {
-		policy = retryPolicy{MaxAttempts: 1}
+		return RetryPolicy{MaxAttempts: 1, BaseDelay: c.RetryConfig.BaseDelay}
 	}
-	if c.retryAttemptsOverride {
-		policy.MaxAttempts = max(c.RetryConfig.MaxRetries, 0) + 1
-	}
-	policy.MaxAttempts = max(policy.MaxAttempts, 1)
+	policy.MaxAttempts = max(min(policy.MaxAttempts-1, c.RetryConfig.MaxRetries), 0) + 1
+	policy.BaseDelay = min(max(policy.BaseDelay, c.RetryConfig.BaseDelay), c.RetryConfig.MaxDelay)
+	policy.RetryableStatuses = slices.Clone(policy.RetryableStatuses)
 	return policy
 }
 
@@ -2410,7 +2435,7 @@ func (c *Client) retryPolicy(operationId string) retryPolicy {
 // whatever retry budget the operation has left rather than starting a fresh one, and is
 // always granted at least the one attempt.
 func (c *Client) doWithRetry(ctx context.Context, buildRequest func() (*http.Request, error), isIdempotent bool, operationId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	policy := c.retryPolicy(operationId)
+	policy := c.RetryPolicy(operationId)
 	maxAttempts := 1
 	if isIdempotent {
 		maxAttempts = policy.MaxAttempts
@@ -2448,6 +2473,22 @@ func AttemptFromContext(ctx context.Context) int {
 }
 
 type attemptKey struct{}
+
+// ContextWithOperation marks the context a request is sent with as belonging to the named
+// operation, so that whatever handles the response — a walk on to the next page, say —
+// can carry on under that operation's retry policy.
+func ContextWithOperation(ctx context.Context, operationId string) context.Context {
+	return context.WithValue(ctx, operationKey{}, operationId)
+}
+
+// OperationFromContext reports which operation a request was sent for, or "" when the
+// context does not say.
+func OperationFromContext(ctx context.Context) string {
+	operationId, _ := ctx.Value(operationKey{}).(string)
+	return operationId
+}
+
+type operationKey struct{}
 
 // resendableBody makes a request body good for more than one send, since every attempt
 // builds its request afresh from the same reader: a seekable body is rewound to where it
@@ -2495,19 +2536,19 @@ type readOnly struct{ io.Reader }
 // transient failures with backoff between them. Along with the last response it returns
 // the request that response answered, as the editors left it: a transport is free to
 // leave Response.Request unset, so the loop does not rely on it.
-func (c *Client) doAttempts(ctx context.Context, buildRequest func() (*http.Request, error), first, last int, policy retryPolicy, operationId string, reqEditors ...RequestEditorFn) (*http.Response, *http.Request, error) {
+func (c *Client) doAttempts(ctx context.Context, buildRequest func() (*http.Request, error), first, last int, policy RetryPolicy, operationId string, reqEditors ...RequestEditorFn) (*http.Response, *http.Request, error) {
 
 	var lastResp *http.Response
 	var lastReq *http.Request
 	var lastErr error
-	delay := c.RetryConfig.BaseDelay
+	delay := policy.BaseDelay
 
 	for attempt := first; attempt <= last; attempt++ {
 		req, err := buildRequest()
 		if err != nil {
 			return nil, nil, err
 		}
-		req = req.WithContext(ContextWithAttempt(ctx, attempt))
+		req = req.WithContext(ContextWithOperation(ContextWithAttempt(ctx, attempt), operationId))
 		if err := c.applyEditors(ctx, req, reqEditors); err != nil {
 			return nil, nil, err
 		}
@@ -2535,7 +2576,7 @@ func (c *Client) doAttempts(ctx context.Context, buildRequest func() (*http.Requ
 		}
 
 		// Success or non-retryable status
-		if !policy.retriesStatus(resp.StatusCode) {
+		if !policy.RetriesStatus(resp.StatusCode) {
 			return resp, req, nil
 		}
 

--- a/go/pkg/generated/client.gen.go
+++ b/go/pkg/generated/client.gen.go
@@ -2268,6 +2268,7 @@ var operationRetryPolicies = map[string]RetryPolicy{
 	"MarkTopicHam":                  {MaxAttempts: 2, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
 	"TrashTopic":                    {MaxAttempts: 2, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
 	"GetWorkflow":                   {MaxAttempts: 3, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
+	"GetWorkflowStage":              {MaxAttempts: 3, RetryableStatuses: []int{429, 503}, BaseDelay: 1000 * time.Millisecond},
 }
 
 // Client which conforms to the OpenAPI3 specification for this service.

--- a/go/pkg/hey/client.go
+++ b/go/pkg/hey/client.go
@@ -8,9 +8,11 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"math"
 	"math/rand"
 	"net/http"
 	"net/url"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -264,12 +266,13 @@ func (c *Client) initGeneratedClient() {
 			req.Header.Set("Accept", "application/json")
 			return nil
 		}
-		// The generated client runs its own retry loop, so it has to be told what
-		// WithMaxRetries and WithBaseDelay configured or it runs on its own defaults.
-		// Idempotency still gates it: a non-idempotent operation gets one attempt no
-		// matter the count. The generated MaxDelay ceiling is lifted to the configured
-		// BaseDelay when that is higher, since the hand-written paths sleep BaseDelay
-		// verbatim and the generated loop must not sleep less than asked.
+		// The generated client runs its own retry loop on each operation's policy, and
+		// what WithMaxRetries and WithBaseDelay configured is its ceiling: the count can
+		// only come down and the first wait only go up. Idempotency still gates it: a
+		// non-idempotent operation gets one attempt no matter the count. The generated
+		// MaxDelay ceiling is lifted to the configured BaseDelay when that is higher,
+		// since the hand-written paths sleep BaseDelay verbatim and the generated loop
+		// must not sleep less than asked.
 		retryCfg := generated.DefaultRetryConfig()
 		retryCfg.MaxRetries = max(c.httpOpts.MaxRetries, 0)
 		retryCfg.BaseDelay = max(c.httpOpts.BaseDelay, 0)
@@ -647,6 +650,47 @@ func (c *Client) doRequest(ctx context.Context, method, path string, body any) (
 }
 
 func (c *Client) doRequestURL(ctx context.Context, method, url string, body any) (*Response, error) {
+	return c.doRequestURLWithBudget(ctx, method, url, body, c.clientBudget())
+}
+
+// retryBudget is what one hand-written request may spend on being resent: the sends it
+// gets in all, the wait before the first resend, and the statuses that earn another. A
+// request on a path the caller wrote has no policy behind it, and its budget is the
+// client's own settings over every failure the SDK classes as transient; a walk on from
+// a modelled operation's first page runs on that operation's policy.
+type retryBudget struct {
+	attempts  int
+	baseDelay time.Duration
+	statuses  []int
+	declared  bool
+}
+
+func (c *Client) clientBudget() retryBudget {
+	return retryBudget{attempts: min(c.httpOpts.MaxRetries, math.MaxInt-1) + 1, baseDelay: c.httpOpts.BaseDelay}
+}
+
+// operationBudget is the policy the generated client holds for the operation, already
+// under the client's settings.
+func (c *Client) operationBudget(operationID string) retryBudget {
+	c.initGeneratedClient()
+	policy := c.gen.ClientInterface.(*generated.Client).RetryPolicy(operationID)
+	return retryBudget{
+		attempts:  policy.MaxAttempts,
+		baseDelay: policy.BaseDelay,
+		statuses:  policy.RetryableStatuses,
+		declared:  true,
+	}
+}
+
+// resends reports whether a failure the SDK classes as transient earns another send. One
+// with no status behind it — a transport failure, a refreshed 401 — always does, as it
+// does in the generated loop; a status does when the budget names it, or, with no policy
+// behind the budget, always.
+func (b retryBudget) resends(status int) bool {
+	return !b.declared || status == 0 || slices.Contains(b.statuses, status)
+}
+
+func (c *Client) doRequestURLWithBudget(ctx context.Context, method, url string, body any, budget retryBudget) (*Response, error) {
 	requestURL, err := c.accountScopedURL(url)
 	if err != nil {
 		return nil, err
@@ -673,7 +717,7 @@ func (c *Client) doRequestURL(ctx context.Context, method, url string, body any)
 	var attempt int
 	var lastErr error
 
-	for attempt = 1; attempt <= c.httpOpts.MaxRetries+1; attempt++ {
+	for attempt = 1; attempt <= budget.attempts; attempt++ {
 		resp, err := c.singleRequest(ctx, method, url, body, attempt)
 		if err == nil {
 			return resp, nil
@@ -681,26 +725,32 @@ func (c *Client) doRequestURL(ctx context.Context, method, url string, body any)
 
 		var delay time.Duration
 		if re, ok := err.(*retryableError); ok {
+			if !budget.resends(http.StatusTooManyRequests) {
+				return nil, re.err
+			}
 			lastErr = re.err
 			if re.retryAfter > 0 {
 				delay = re.retryAfter
 			} else {
-				delay = c.backoffDelay(attempt)
+				delay = c.backoffDelay(budget.baseDelay, attempt)
 			}
 		} else if apiErr, ok := err.(*Error); ok {
-			if !apiErr.Retryable {
+			if !apiErr.Retryable || !budget.resends(apiErr.HTTPStatus) {
 				return nil, err
 			}
 			lastErr = err
-			delay = c.backoffDelay(attempt)
+			delay = c.backoffDelay(budget.baseDelay, attempt)
 		} else {
 			return nil, err
+		}
+		if attempt >= budget.attempts {
+			break
 		}
 
 		c.logger.Debug(
 			"retrying request",
 			"attempt", attempt,
-			"maxRetries", c.httpOpts.MaxRetries,
+			"maxRetries", budget.attempts-1,
 			"delay", delay,
 			"errorCode", errorCodeForLog(lastErr),
 		)
@@ -716,7 +766,7 @@ func (c *Client) doRequestURL(ctx context.Context, method, url string, body any)
 		}
 	}
 
-	return nil, fmt.Errorf("request failed after %d retries: %w", c.httpOpts.MaxRetries, lastErr)
+	return nil, fmt.Errorf("request failed after %d retries: %w", budget.attempts-1, lastErr)
 }
 
 func errorCodeForLog(err error) string {
@@ -923,8 +973,8 @@ func extractHost(rawURL string) string {
 	return u.Host
 }
 
-func (c *Client) backoffDelay(attempt int) time.Duration {
-	delay := c.httpOpts.BaseDelay * time.Duration(1<<(attempt-1))
+func (c *Client) backoffDelay(base time.Duration, attempt int) time.Duration {
+	delay := base * time.Duration(1<<(attempt-1))
 	jitter := time.Duration(rand.Int63n(int64(c.httpOpts.MaxJitter))) // #nosec G404 -- jitter doesn't need cryptographic randomness
 	return delay + jitter
 }

--- a/go/pkg/hey/generated_client_test.go
+++ b/go/pkg/hey/generated_client_test.go
@@ -16,16 +16,19 @@ import (
 	"github.com/basecamp/hey-sdk/go/pkg/generated"
 )
 
-// Generated operations run the generated client's own retry loop, so what WithMaxRetries
-// configured has to reach it: a caller who lowered the cap to fail fast gets that, not the
-// generated default of three.
+// Generated operations run the generated client's own retry loop on each operation's
+// policy, and what WithMaxRetries configured is the ceiling over it: a caller who lowered
+// the cap to fail fast gets that, and one who raised it gets no more than the policy's
+// three sends for ListBoxes.
 func TestGeneratedOperationsHonorMaxRetries(t *testing.T) {
 	for _, tc := range []struct {
 		maxRetries int
 		requests   int32
 	}{
 		{maxRetries: 0, requests: 1},
+		{maxRetries: 1, requests: 2},
 		{maxRetries: 2, requests: 3},
+		{maxRetries: 5, requests: 3},
 	} {
 		var requests atomic.Int32
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -252,7 +255,8 @@ func TestGeneratedRefreshResendSharesTheRetryBudget(t *testing.T) {
 		statuses   []int
 		succeeds   bool
 	}{
-		{name: "the budget remaining after the 401 carries the resend's transient failures", maxRetries: 3, statuses: []int{401, 503, 503, 200}, succeeds: true},
+		{name: "the budget remaining after the 401 carries the resend's transient failures", maxRetries: 3, statuses: []int{401, 503, 200}, succeeds: true},
+		{name: "the budget is the operation's policy, not the client's count", maxRetries: 3, statuses: []int{401, 503, 503, 200}, succeeds: false},
 		{name: "a budget spent before the 401 still grants the one resend", maxRetries: 1, statuses: []int{503, 401, 200}, succeeds: true},
 		{name: "the resend does not get a budget of its own", maxRetries: 1, statuses: []int{401, 503, 200}, succeeds: false},
 	} {

--- a/go/pkg/hey/http.go
+++ b/go/pkg/hey/http.go
@@ -28,10 +28,14 @@ type HTTPOptions struct {
 	// Timeout is the request timeout (default: 30s).
 	Timeout time.Duration
 
-	// MaxRetries is the maximum retry attempts for GET requests (default: 3).
+	// MaxRetries is the most times any request is resent (default: 3). A modelled
+	// operation is resent as many times as its own retry policy allows and no more; this
+	// only lowers that. A GET on a path the caller wrote, which no policy covers, is
+	// resent this many times.
 	MaxRetries int
 
-	// BaseDelay is the initial backoff delay (default: 1s).
+	// BaseDelay is the least the client waits before the first resend (default: 1s). A
+	// modelled operation whose policy names a longer wait starts from that instead.
 	BaseDelay time.Duration
 
 	// MaxJitter is the maximum random jitter to add to delays (default: 100ms).
@@ -87,14 +91,25 @@ func WithTimeout(d time.Duration) ClientOption {
 	}
 }
 
-// WithMaxRetries sets the maximum number of retry attempts for GET requests.
+// WithMaxRetries caps the resends of any request. Every modelled operation carries its
+// own retry policy from the API contract — how many sends it gets in all, which statuses
+// earn another, and the wait before the first resend — and the client's settings only
+// ever make that gentler: an operation is sent at most n+1 times, or as many times as its
+// policy allows when that is fewer, and never more than its policy allows; the one resend
+// after a 401 that a credential refresh answered is granted on top when those sends are
+// already spent. The policy holds on the first request and on every page read after it,
+// through the service methods' page parameters and FollowPagination. A GET on a path the caller wrote
+// (Get, GetAll) has no policy to bring and is resent n times on the SDK's own list of
+// transient failures.
 func WithMaxRetries(n int) ClientOption {
 	return func(c *Client) {
 		c.httpOpts.MaxRetries = n
 	}
 }
 
-// WithBaseDelay sets the initial backoff delay.
+// WithBaseDelay sets the least the client waits before the first resend. A modelled
+// operation whose policy names a longer wait starts from that instead; each wait after the
+// first is longer by the backoff multiplier.
 func WithBaseDelay(d time.Duration) ClientOption {
 	return func(c *Client) {
 		c.httpOpts.BaseDelay = d

--- a/go/pkg/hey/pagination.go
+++ b/go/pkg/hey/pagination.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+
+	"github.com/basecamp/hey-sdk/go/pkg/generated"
 )
 
 func gearedPageFromLink(header string) string {
@@ -70,7 +72,10 @@ func gearedLinkIsNext(params string) bool {
 // FollowPagination fetches additional pages following Link headers from an HTTP response.
 // firstPageCount is the number of items already collected from the first page.
 // limit is the maximum total items to return (0 = unlimited).
-// Returns raw JSON items from subsequent pages only.
+// Returns raw JSON items from subsequent pages only. A response the generated client
+// answered says which operation it came from, and every page after it is read under that
+// operation's retry policy; a response from anywhere else is walked on the client's own
+// retry settings.
 func (c *Client) FollowPagination(ctx context.Context, httpResp *http.Response, firstPageCount, limit int) ([]json.RawMessage, error) {
 	if httpResp == nil {
 		return nil, nil
@@ -101,6 +106,11 @@ func (c *Client) FollowPagination(ctx context.Context, httpResp *http.Response, 
 		return nil, fmt.Errorf("pagination Link header points to different origin: %s", nextURL)
 	}
 
+	budget := c.clientBudget()
+	if operationID := generated.OperationFromContext(httpResp.Request.Context()); operationID != "" { //nolint:contextcheck // the first page's context is read for the operation it named, not carried on.
+		budget = c.operationBudget(operationID)
+	}
+
 	var allResults []json.RawMessage
 	currentCount := firstPageCount
 	var page int
@@ -108,7 +118,7 @@ func (c *Client) FollowPagination(ctx context.Context, httpResp *http.Response, 
 	for page = 2; page <= c.httpOpts.MaxPages && nextURL != ""; page++ {
 		currentPageURL := nextURL
 
-		resp, err := c.doRequestURL(ctx, "GET", nextURL, nil)
+		resp, err := c.doRequestURLWithBudget(ctx, "GET", nextURL, nil, budget)
 		if err != nil {
 			return nil, err
 		}

--- a/go/pkg/hey/retry_policy_test.go
+++ b/go/pkg/hey/retry_policy_test.go
@@ -66,17 +66,33 @@ func TestOperationPolicyDecidesWhichStatusesAreResent(t *testing.T) {
 	}
 }
 
-// An operation the contract gives no policy is sent once, whatever the client allows.
-func TestOperationWithoutPolicyIsSentOnce(t *testing.T) {
-	server, requests := policyTestServer(t, `[]`, 503, 503, 503)
+// The workflow stage read is served as HTML, and its policy holds all the same: three
+// sends, whatever the client allows beyond them.
+func TestOperationPolicyHoldsOnTheHTMLRoute(t *testing.T) {
+	server, requests := policyTestServer(t, `[]`, 503, 503, 503, 503)
 	root := NewClient(&Config{BaseURL: server.URL}, &StaticTokenProvider{Token: "token"},
-		WithMaxRetries(3), WithBaseDelay(time.Millisecond))
+		WithMaxRetries(5), WithBaseDelay(time.Millisecond))
 
 	if _, err := root.Workflows().GetStage(context.Background(), 1, 2); err == nil {
-		t.Fatal("expected the 503 to surface")
+		t.Fatal("expected the 503 to surface once the policy's sends were spent")
 	}
-	if got := requests.Load(); got != 1 {
-		t.Errorf("requests = %d, want 1", got)
+	if got := requests.Load(); got != 3 {
+		t.Errorf("requests = %d, want the policy's 3", got)
+	}
+}
+
+// An operation the contract gives no policy is sent once, whatever the client allows.
+func TestOperationWithoutPolicyIsSentOnce(t *testing.T) {
+	root := NewClient(&Config{BaseURL: "https://example.test"}, &StaticTokenProvider{Token: "token"},
+		WithMaxRetries(5))
+	root.initGeneratedClient()
+
+	policy := root.gen.ClientInterface.(*generated.Client).RetryPolicy("CreateBulkReply")
+	if policy.MaxAttempts != 1 {
+		t.Errorf("MaxAttempts = %d, want 1", policy.MaxAttempts)
+	}
+	if policy.RetriesStatus(http.StatusServiceUnavailable) {
+		t.Error("expected no status to earn a resend without a policy")
 	}
 }
 

--- a/go/pkg/hey/retry_policy_test.go
+++ b/go/pkg/hey/retry_policy_test.go
@@ -1,0 +1,223 @@
+package hey
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/basecamp/hey-sdk/go/pkg/generated"
+)
+
+// policyTestServer answers each request with the next status in turn, a 200 carrying the
+// given body, and counts what it was sent.
+func policyTestServer(t *testing.T, body string, statuses ...int) (*httptest.Server, *atomic.Int32) {
+	t.Helper()
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		n := int(requests.Add(1))
+		status := http.StatusOK
+		if n <= len(statuses) {
+			status = statuses[n-1]
+		}
+		if status != http.StatusOK {
+			http.Error(w, http.StatusText(status), status)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, body)
+	}))
+	t.Cleanup(server.Close)
+	return server, &requests
+}
+
+// DeleteExtenzion is modelled with two sends in all. A client allowing five resends gets
+// the policy's two sends, not six: the client's count is a ceiling, never a grant.
+func TestOperationPolicyBoundsTheClientRetries(t *testing.T) {
+	server, requests := policyTestServer(t, `{}`, 503, 503, 503, 503, 503)
+	root := NewClient(&Config{BaseURL: server.URL}, &StaticTokenProvider{Token: "token"},
+		WithMaxRetries(5), WithBaseDelay(time.Millisecond))
+
+	if err := root.Extenzions().Delete(context.Background(), 1, 2); err == nil {
+		t.Fatal("expected the 503 to surface once the policy's sends were spent")
+	}
+	if got := requests.Load(); got != 2 {
+		t.Errorf("requests = %d, want the policy's 2", got)
+	}
+}
+
+// A 502 is on the SDK's own list of transient failures, and the client's count would
+// allow a resend, but ListBoxes is modelled to resend on 429 and 503 only: the 502 is
+// the answer.
+func TestOperationPolicyDecidesWhichStatusesAreResent(t *testing.T) {
+	server, requests := policyTestServer(t, `[]`, 502, 200)
+	root := NewClient(&Config{BaseURL: server.URL}, &StaticTokenProvider{Token: "token"},
+		WithMaxRetries(3), WithBaseDelay(time.Millisecond))
+	client := scopedTestClient(root, 42)
+
+	if _, err := client.Boxes().List(context.Background()); err == nil {
+		t.Fatal("expected the 502 to surface")
+	}
+	if got := requests.Load(); got != 1 {
+		t.Errorf("requests = %d, want 1", got)
+	}
+}
+
+// An operation the contract gives no policy is sent once, whatever the client allows.
+func TestOperationWithoutPolicyIsSentOnce(t *testing.T) {
+	server, requests := policyTestServer(t, `[]`, 503, 503, 503)
+	root := NewClient(&Config{BaseURL: server.URL}, &StaticTokenProvider{Token: "token"},
+		WithMaxRetries(3), WithBaseDelay(time.Millisecond))
+
+	if _, err := root.Workflows().GetStage(context.Background(), 1, 2); err == nil {
+		t.Fatal("expected the 503 to surface")
+	}
+	if got := requests.Load(); got != 1 {
+		t.Errorf("requests = %d, want 1", got)
+	}
+}
+
+// The first wait is the operation's own base delay when the client's is shorter, and the
+// client's when that is longer; the client's MaxDelay bounds both.
+func TestOperationPolicyDelayIsFlooredByTheClient(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		baseDelay time.Duration
+		want      time.Duration
+	}{
+		{name: "a shorter client delay leaves the policy's second", baseDelay: time.Millisecond, want: time.Second},
+		{name: "a longer client delay is the floor", baseDelay: 2 * time.Second, want: 2 * time.Second},
+		{name: "a client delay above the default ceiling lifts the ceiling with it", baseDelay: 45 * time.Second, want: 45 * time.Second},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := NewClient(&Config{BaseURL: "https://example.test"}, &StaticTokenProvider{Token: "token"},
+				WithBaseDelay(tc.baseDelay))
+			root.initGeneratedClient()
+
+			policy := root.gen.ClientInterface.(*generated.Client).RetryPolicy("ListBoxes")
+			if policy.BaseDelay != tc.want {
+				t.Errorf("BaseDelay = %v, want %v", policy.BaseDelay, tc.want)
+			}
+			if policy.MaxAttempts != 3 {
+				t.Errorf("MaxAttempts = %d, want the policy's 3", policy.MaxAttempts)
+			}
+		})
+	}
+}
+
+// On the wire, ListBoxes waits its modelled second before the resend even when the client
+// asked for a millisecond.
+func TestOperationPolicyDelayHoldsOnTheWire(t *testing.T) {
+	server, requests := policyTestServer(t, `[]`, 503, 200)
+	root := NewClient(&Config{BaseURL: server.URL}, &StaticTokenProvider{Token: "token"},
+		WithMaxRetries(3), WithBaseDelay(time.Millisecond))
+	client := scopedTestClient(root, 42)
+
+	start := time.Now()
+	if _, err := client.Boxes().List(context.Background()); err != nil {
+		t.Fatalf("expected the resend to succeed: %v", err)
+	}
+	if got := requests.Load(); got != 2 {
+		t.Errorf("requests = %d, want 2", got)
+	}
+	if elapsed := time.Since(start); elapsed < time.Second {
+		t.Errorf("resend came after %v, want the policy's second", elapsed)
+	}
+}
+
+// A walk on from a generated operation's first page reads every later page under the same
+// policy: a 502 on page two is the answer, and page two's 503s are resent up to the
+// policy's three sends and no further, whatever the client's count allows.
+func TestFollowPaginationReadsLaterPagesUnderTheOperationPolicy(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		pageTwo      []int
+		pageRequests int32
+	}{
+		{name: "a status outside the policy is the answer", pageTwo: []int{502, 200}, pageRequests: 1},
+		{name: "the policy's sends bound the resends", pageTwo: []int{503, 503, 503, 200}, pageRequests: 3},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var pageTwoRequests atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Query().Get("page") != "2" {
+					w.Header().Set("Content-Type", "application/json")
+					w.Header().Set("Link", `</boxes.json?page=2>; rel="next"`)
+					_, _ = fmt.Fprint(w, `[{"id": 1}]`)
+					return
+				}
+				n := int(pageTwoRequests.Add(1))
+				status := http.StatusOK
+				if n <= len(tc.pageTwo) {
+					status = tc.pageTwo[n-1]
+				}
+				if status != http.StatusOK {
+					http.Error(w, http.StatusText(status), status)
+					return
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = fmt.Fprint(w, `[{"id": 2}]`)
+			}))
+			t.Cleanup(server.Close)
+
+			root := NewClient(&Config{BaseURL: server.URL}, &StaticTokenProvider{Token: "token"},
+				WithMaxRetries(5), WithBaseDelay(time.Millisecond))
+			first, err := root.genClient().ListBoxesWithResponse(context.Background())
+			if err != nil {
+				t.Fatalf("first page: %v", err)
+			}
+
+			if _, err := root.FollowPagination(context.Background(), first.HTTPResponse, 1, 0); err == nil {
+				t.Fatal("expected page two's failure to surface")
+			}
+			if got := pageTwoRequests.Load(); got != tc.pageRequests {
+				t.Errorf("page two requests = %d, want %d", got, tc.pageRequests)
+			}
+		})
+	}
+}
+
+// A walk on from a response the generated client did not answer has no operation to bring
+// a policy, and runs on the client's own settings as before.
+func TestFollowPaginationWithoutAnOperationRunsOnTheClientSettings(t *testing.T) {
+	var pageTwoRequests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("page") != "2" {
+			w.Header().Set("Link", `</items.json?page=2>; rel="next"`)
+			_, _ = fmt.Fprint(w, `[{"id": 1}]`)
+			return
+		}
+		if pageTwoRequests.Add(1) <= 2 {
+			http.Error(w, "bad gateway", http.StatusBadGateway)
+			return
+		}
+		_, _ = fmt.Fprint(w, `[{"id": 2}]`)
+	}))
+	t.Cleanup(server.Close)
+
+	root := NewClient(&Config{BaseURL: server.URL}, &StaticTokenProvider{Token: "token"},
+		WithMaxRetries(3), WithBaseDelay(time.Millisecond))
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, server.URL+"/items.json", nil)
+	if err != nil {
+		t.Fatalf("first page request: %v", err)
+	}
+	first, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("first page: %v", err)
+	}
+	defer func() { _ = first.Body.Close() }()
+
+	items, err := root.FollowPagination(context.Background(), first, 1, 0)
+	if err != nil {
+		t.Fatalf("expected the 502s to be resent on the client's settings: %v", err)
+	}
+	if len(items) != 1 {
+		t.Errorf("items = %d, want 1", len(items))
+	}
+	if got := pageTwoRequests.Load(); got != 3 {
+		t.Errorf("page two requests = %d, want 3", got)
+	}
+}

--- a/go/templates/client.tmpl
+++ b/go/templates/client.tmpl
@@ -10,14 +10,22 @@ type HttpRequestDoer interface {
 
 {{$clientTypeName := opts.OutputOptions.ClientTypeName -}}
 
-// RetryConfig configures client-level retry overrides and delays for idempotent operations.
-// Retryable status codes always come from each operation's API contract.
+// RetryConfig is the client's own say over resends. Every operation brings its retry policy
+// from the API contract — how many sends it gets in all, which statuses earn another, and
+// the wait before the first resend — and these settings only ever make that gentler: they
+// lower the count and lengthen the waits, never the reverse. See [Client.RetryPolicy].
 type RetryConfig struct {
-	// MaxRetries overrides an operation's maximum attempts when WithRetryConfig is used.
+	// MaxRetries caps the resends of any operation: an operation is sent at most
+	// MaxRetries+1 times, or as many times as its own policy allows when that is fewer.
+	// It never grants an operation more sends than its policy does. The one resend after
+	// a 401 the AuthRefresher answered is granted on top when the sends are already spent.
 	MaxRetries int
-	// BaseDelay is the initial delay between retries (default: 1s)
+	// BaseDelay is the least the client waits before the first resend (default: 1s). An
+	// operation whose policy names a longer wait starts from that instead.
 	BaseDelay time.Duration
-	// MaxDelay is the maximum delay between retries (default: 30s)
+	// MaxDelay is the most the backoff waits between any two attempts (default: 30s),
+	// whatever the policy asks for. The wait a Retry-After names is honoured as given, and
+	// up to 100ms of jitter is added to every wait.
 	MaxDelay time.Duration
 	// Multiplier is the exponential backoff multiplier (default: 2.0)
 	Multiplier float64
@@ -33,13 +41,23 @@ func DefaultRetryConfig() RetryConfig {
 	}
 }
 
-type retryPolicy struct {
-	MaxAttempts       int
+// RetryPolicy is what one operation may spend on being resent: the sends it gets in all,
+// the statuses that earn another, and the wait before the first resend.
+type RetryPolicy struct {
+	// MaxAttempts is the sends in all, the first one included.
+	MaxAttempts int
+	// RetryableStatuses are the response statuses that earn a resend. Any other status is
+	// the operation's answer.
 	RetryableStatuses []int
+	// BaseDelay is the wait before the first resend; each wait after it is longer by the
+	// backoff multiplier.
+	BaseDelay time.Duration
 }
 
-var operationRetryPolicies = map[string]retryPolicy{
-{{range .}}{{$opid := .OperationId}}{{if .Spec}}{{if .Spec.Extensions}}{{$retry := index .Spec.Extensions "x-hey-retry"}}{{if $retry}}	"{{$opid}}": {MaxAttempts: {{index $retry "maxAttempts"}}, RetryableStatuses: []int{ {{range index $retry "retryOn"}}{{.}}, {{end}} }},
+// operationRetryPolicies is each operation's policy as the API contract declares it,
+// before the client's RetryConfig has its say.
+var operationRetryPolicies = map[string]RetryPolicy{
+{{range .}}{{$opid := .OperationId}}{{if .Spec}}{{if .Spec.Extensions}}{{$retry := index .Spec.Extensions "x-hey-retry"}}{{if $retry}}	"{{$opid}}": {MaxAttempts: {{index $retry "maxAttempts"}}, RetryableStatuses: []int{ {{range index $retry "retryOn"}}{{.}}, {{end}} }, BaseDelay: {{index $retry "baseDelayMs"}} * time.Millisecond},
 {{end}}{{end}}{{end}}{{end}}}
 
 // {{ $clientTypeName }} which conforms to the OpenAPI3 specification for this service.
@@ -58,9 +76,8 @@ type {{ $clientTypeName }} struct {
 	// the network.
 	RequestEditors []RequestEditorFn
 
-	// RetryConfig for idempotent operations
+	// RetryConfig is the client's ceiling over every operation's retry policy.
 	RetryConfig RetryConfig
-	retryAttemptsOverride bool
 
 	// AuthRefresher is asked once when a response is 401. It renews whatever the request
 	// editors authenticate with and reports whether it could; when it could, the request
@@ -139,11 +156,13 @@ func WithRequestEditorFn(fn RequestEditorFn) ClientOption {
 	}
 }
 
-// WithRetryConfig allows setting custom retry configuration for idempotent operations.
+// WithRetryConfig sets the client's ceiling over every operation's retry policy: the
+// operation is sent at most cfg.MaxRetries+1 times and never more than its policy allows,
+// its first wait is at least cfg.BaseDelay, and no backoff wait is longer than
+// cfg.MaxDelay.
 func WithRetryConfig(cfg RetryConfig) ClientOption {
 	return func(c *{{ $clientTypeName }}) error {
 		c.RetryConfig = cfg
-		c.retryAttemptsOverride = true
 		return nil
 	}
 }
@@ -173,7 +192,9 @@ func WithLogger(logger *slog.Logger) ClientOption {
 	}
 }
 
-func (p retryPolicy) retriesStatus(statusCode int) bool {
+// RetriesStatus reports whether a response with the given status earns a resend under
+// the policy.
+func (p RetryPolicy) RetriesStatus(statusCode int) bool {
 	for _, retryableStatus := range p.RetryableStatuses {
 		if statusCode == retryableStatus {
 			return true
@@ -182,17 +203,20 @@ func (p retryPolicy) retriesStatus(statusCode int) bool {
 	return false
 }
 
-// retryPolicy returns the operation's declared policy. WithRetryConfig can override its
-// attempt count, while retryable statuses remain operation-defined.
-func (c *{{ $clientTypeName }}) retryPolicy(operationId string) retryPolicy {
+// RetryPolicy is what the client will spend on the operation: the policy the API contract
+// declares for it, held under the client's RetryConfig. The sends are the policy's
+// MaxAttempts or MaxRetries+1, whichever is fewer; the statuses are the policy's own; the
+// first wait is the policy's BaseDelay or the config's, whichever is longer, and no longer
+// than MaxDelay. An operation the contract gives no policy is sent once. Idempotency is
+// judged separately: an operation that is not idempotent is sent once whatever its policy.
+func (c *{{ $clientTypeName }}) RetryPolicy(operationId string) RetryPolicy {
 	policy, ok := operationRetryPolicies[operationId]
 	if !ok {
-		policy = retryPolicy{MaxAttempts: 1}
+		return RetryPolicy{MaxAttempts: 1, BaseDelay: c.RetryConfig.BaseDelay}
 	}
-	if c.retryAttemptsOverride {
-		policy.MaxAttempts = max(c.RetryConfig.MaxRetries, 0) + 1
-	}
-	policy.MaxAttempts = max(policy.MaxAttempts, 1)
+	policy.MaxAttempts = max(min(policy.MaxAttempts-1, c.RetryConfig.MaxRetries), 0) + 1
+	policy.BaseDelay = min(max(policy.BaseDelay, c.RetryConfig.BaseDelay), c.RetryConfig.MaxDelay)
+	policy.RetryableStatuses = slices.Clone(policy.RetryableStatuses)
 	return policy
 }
 
@@ -201,7 +225,7 @@ func (c *{{ $clientTypeName }}) retryPolicy(operationId string) retryPolicy {
 // whatever retry budget the operation has left rather than starting a fresh one, and is
 // always granted at least the one attempt.
 func (c *{{ $clientTypeName }}) doWithRetry(ctx context.Context, buildRequest func() (*http.Request, error), isIdempotent bool, operationId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	policy := c.retryPolicy(operationId)
+	policy := c.RetryPolicy(operationId)
 	maxAttempts := 1
 	if isIdempotent {
 		maxAttempts = policy.MaxAttempts
@@ -239,6 +263,22 @@ func AttemptFromContext(ctx context.Context) int {
 }
 
 type attemptKey struct{}
+
+// ContextWithOperation marks the context a request is sent with as belonging to the named
+// operation, so that whatever handles the response — a walk on to the next page, say —
+// can carry on under that operation's retry policy.
+func ContextWithOperation(ctx context.Context, operationId string) context.Context {
+	return context.WithValue(ctx, operationKey{}, operationId)
+}
+
+// OperationFromContext reports which operation a request was sent for, or "" when the
+// context does not say.
+func OperationFromContext(ctx context.Context) string {
+	operationId, _ := ctx.Value(operationKey{}).(string)
+	return operationId
+}
+
+type operationKey struct{}
 
 // resendableBody makes a request body good for more than one send, since every attempt
 // builds its request afresh from the same reader: a seekable body is rewound to where it
@@ -286,19 +326,19 @@ type readOnly struct{ io.Reader }
 // transient failures with backoff between them. Along with the last response it returns
 // the request that response answered, as the editors left it: a transport is free to
 // leave Response.Request unset, so the loop does not rely on it.
-func (c *{{ $clientTypeName }}) doAttempts(ctx context.Context, buildRequest func() (*http.Request, error), first, last int, policy retryPolicy, operationId string, reqEditors ...RequestEditorFn) (*http.Response, *http.Request, error) {
+func (c *{{ $clientTypeName }}) doAttempts(ctx context.Context, buildRequest func() (*http.Request, error), first, last int, policy RetryPolicy, operationId string, reqEditors ...RequestEditorFn) (*http.Response, *http.Request, error) {
 
 	var lastResp *http.Response
 	var lastReq *http.Request
 	var lastErr error
-	delay := c.RetryConfig.BaseDelay
+	delay := policy.BaseDelay
 
 	for attempt := first; attempt <= last; attempt++ {
 		req, err := buildRequest()
 		if err != nil {
 			return nil, nil, err
 		}
-		req = req.WithContext(ContextWithAttempt(ctx, attempt))
+		req = req.WithContext(ContextWithOperation(ContextWithAttempt(ctx, attempt), operationId))
 		if err := c.applyEditors(ctx, req, reqEditors); err != nil {
 			return nil, nil, err
 		}
@@ -326,7 +366,7 @@ func (c *{{ $clientTypeName }}) doAttempts(ctx context.Context, buildRequest fun
 		}
 
 		// Success or non-retryable status
-		if !policy.retriesStatus(resp.StatusCode) {
+		if !policy.RetriesStatus(resp.StatusCode) {
 			return resp, req, nil
 		}
 

--- a/go/templates/imports.tmpl
+++ b/go/templates/imports.tmpl
@@ -15,6 +15,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"slices"
 	"strings"
 	"sync"
 

--- a/openapi.json
+++ b/openapi.json
@@ -10554,7 +10554,16 @@
         },
         "tags": [
           "Workflows"
-        ]
+        ],
+        "x-hey-retry": {
+          "maxAttempts": 3,
+          "baseDelayMs": 1000,
+          "backoff": "exponential",
+          "retryOn": [
+            429,
+            503
+          ]
+        }
       }
     }
   },

--- a/spec/hey.smithy
+++ b/spec/hey.smithy
@@ -4517,6 +4517,7 @@ operation GetWorkflow {
 @readonly
 @http(method: "GET", uri: "/workflows/{workflowId}/stages/{stageId}")
 @tags(["Workflows"])
+@heyRetry(maxAttempts: 3, baseDelayMs: 1000, backoff: "exponential", retryOn: [429, 503])
 operation GetWorkflowStage {
     input: GetWorkflowStageInput
     output: GetWorkflowStageOutput


### PR DESCRIPTION
Refs: [hey-sdk Rust: honor per-operation retry policy](https://app.basecamp.com/2914079/buckets/46292715/card_tables/cards/10289485327) — the Go half of the card's bar, split off from #154 (Rust). Targets the release after 0.30.0: this is a behavioral change for every `hey.Client` user and should not ride the tag being cut from `main` now. Rebased onto #154, which gives Rust the same reading.

## What changes

The generated client has honored each operation's `x-hey-retry` policy since #94, but `hey.Client.initGeneratedClient` passed `WithRetryConfig`, which **replaced** every operation's attempt count with `MaxRetries+1`, and the policy's `baseDelayMs` was never emitted. Through the public Go SDK a route modelled with two sends got four, and so did an operation the contract gives no policy (on transport failures). The conformance case passed only because the runner drives the raw generated client, which never saw the override.

Now the policy is what an operation may spend, and the client's settings are a ceiling that only makes it gentler — the reading the card's bar names, and the one #154 gives Rust:

| | policy says | client setting | result |
|---|---|---|---|
| sends in all | `maxAttempts` (Smithy: the sends, first included) | `WithMaxRetries(n)` | `min(maxAttempts, n+1)`; never more than the policy |
| statuses resent | `retryOn` | — | the policy's list; any other status is the answer |
| first wait | `baseDelayMs` | `WithBaseDelay(d)` | `max(baseDelayMs, d)`, capped by `MaxDelay` |
| no policy | — | any | sent once |
| not idempotent | any | any | sent once (unchanged) |
| path the caller wrote (`Get`, `GetAll`) | — | client settings | unchanged: `n` resends on 429/502/503/504 and transport failures |

- `client.tmpl`: `RetryPolicy` is exported with `BaseDelay` from `baseDelayMs`; `Client.RetryPolicy(operationId)` is the effective policy under the config; `WithRetryConfig` no longer flips an override flag — the ceiling is always on (the default `MaxRetries: 3` sits above every policy's 3, so a raw generated client behaves as before). The operation id rides on the request context (`ContextWithOperation` / `OperationFromContext`, beside the attempt).
- `FollowPagination` reads the operation off the first page's request and walks every later page under that policy through the hand-written loop, which now takes a budget; a response the generated client did not answer walks on the client's settings as before. Service-level paging (`Page:` params on the same operation) already went through the generated loop and is covered by the ceiling.
- Doc comments on `WithMaxRetries`, `WithBaseDelay`, `HTTPOptions`, `RetryConfig`; README paragraph.
- Second commit: `GetWorkflowStage` gets an explicit `@heyRetry` in the spec. The behavior model gives every `@readonly` operation a default policy, so the Rust route table had one for it while OpenAPI (and Go's table) did not; without this the two clients would send the HTML route 3× and 1×. Regenerated `openapi.json` and `client.gen.go`; `behavior-model.json` is unchanged.

## Public behavior change for existing callers

Behavioral, no signature change — `apidiff` on `go/pkg/hey` reports nothing, compatible or incompatible. Release-notes line:

> The Go client's `WithMaxRetries`/`WithBaseDelay` are now a ceiling over each operation's modelled retry policy rather than a replacement for it. An operation modelled with two sends (`DeleteExtenzion`, `DeleteBoxDesignation` and 60 others) is sent twice however high `WithMaxRetries` is set (four before, at the default); a `WithMaxRetries` below the policy still wins; a status the policy does not name (a 502 on `ListBoxes`) is no longer resent; a resend after a refreshed 401 draws on the policy's count (a `ListBoxes` that meets 401, 503, 503 now fails after three sends where it used to succeed on the fourth); the first wait is at least the policy's `baseDelayMs` (1s across the model) even when `WithBaseDelay` asks for less. `FollowPagination` on a generated response now applies the same policy to later pages. `Get`/`GetAll` on caller-written paths are unaffected. Affects hey-cli and hey-mcp-server as `hey.Client` users.

## Shared fixture

#154 moved `conformance/tests/go/retry-policy.json` into the shared set. Four hey-layer cases are added to it here, and both runners read `configOverrides.maxRetries` / `baseDelayMs` for the ceiling: ceiling below the policy (`ListBoxes`, 1 resend → 2 sends), ceiling above the policy (`DeleteExtenzion`, 5 resends → 2 sends), a 502 outside the policy under a client allowing retries, and the policy's base delay holding over a 1 ms client delay. Two of the four fail against `main`'s Go SDK (the ceiling above the policy, and the base delay); the other two pin behavior both clients must keep.

## Gate

- `make go-check` (fmt, vet, golangci-lint, test): green; `make go-check-drift`: green
- `apidiff -incompatible` against `origin/main`'s `go/pkg/hey`: empty
- `make smithy-check behavior-model-check drift-check-mvp url-routes-check`: green; `make rs-check-drift`: green (Rust generated code unchanged)
- `make conformance-go`: 195/195; `make conformance-rs`: 195/195
- The conformance runner's Rust changes (`fixtures.rs`, `operations.rs`) are `cargo fmt`/`clippy -D warnings` clean.

The hand-written loop no longer waits out a backoff (and announces a resend to `OnRetry`) after its last send, which the policy's one-second base delay would otherwise have added to a failed page read under `WithMaxRetries(0)`. `RetryPolicy` hands back a clone of the status list; the `MaxRetries+1` in both loops saturates at `math.MaxInt`; the docs say that the one resend after a refreshed 401 is granted on top of the count.

New Go tests in `go/pkg/hey/retry_policy_test.go`: policy below client count, client count below policy (extends `TestGeneratedOperationsHonorMaxRetries` with 1 → 2 and 5 → 3), a 502 outside the policy, the base delay floor (unit and on the wire), the HTML route's policy, an operation without a policy, `FollowPagination` under the operation's policy (502 is the answer on page two; 503s bounded at three sends) and without one. `TestGeneratedRefreshResendSharesTheRetryBudget` is corrected from four sends to the model's three, with a case that pins the bound.
