### PR TITLE
Put a tracing span on every operation and every attempt, behind a feature

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -472,6 +472,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+ "tracing-subscriber",
  "url",
  "wiremock",
 ]
@@ -1325,6 +1326,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1440,6 +1450,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.4",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -1630,6 +1649,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "sharded-slab",
+ "thread_local",
+ "tracing-core",
 ]
 
 [[package]]

--- a/rust/hey-sdk/Cargo.toml
+++ b/rust/hey-sdk/Cargo.toml
@@ -14,9 +14,12 @@ name = "hey_sdk"
 path = "src/lib.rs"
 
 [features]
-default = ["reqwest"]
+default = ["reqwest", "tracing"]
 # The HTTP client the SDK ships. Off, an application supplies its own `http::HttpClient`.
 reqwest = ["dep:reqwest"]
+# One `tracing` span per operation and per attempt, and the debug lines the retry loop
+# writes. Off, the SDK emits nothing and depends on nothing for it.
+tracing = ["dep:tracing"]
 
 [dependencies]
 async-trait = "0.1"
@@ -38,7 +41,7 @@ thiserror = "2"
 # `rt` for the blocking pool the response cache's file reads go to; reqwest used to bring it
 # along, and without the feature nothing else does.
 tokio = { version = "1", features = ["io-util", "rt", "time", "sync"] }
-tracing = "0.1"
+tracing = { version = "0.1", optional = true }
 url = "2"
 
 [dev-dependencies]
@@ -47,4 +50,6 @@ url = "2"
 # one.
 reqwest = { version = "0.13", default-features = false }
 tokio = { version = "1", features = ["macros", "net", "rt-multi-thread", "time", "sync"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", default-features = false, features = ["registry"] }
 wiremock = "0.6"

--- a/rust/hey-sdk/README.md
+++ b/rust/hey-sdk/README.md
@@ -280,7 +280,8 @@ with `operation`, `service`, and once HEY has answered `http.status` and `reques
 `hey.attempt` child span per send, numbered the way the hooks number attempts, with the status
 each one got. Spans are put on the futures with `Instrument`, so concurrent calls keep their
 own, and a call the caller drops closes its span with no status. Nothing the caller passed is
-recorded: no path, no query, no body. A quiet send — a read-back inside another operation —
+recorded: no path, no query, no body — a request for a path the caller wrote is named by its
+method alone, and the hooks are where its URL goes. A quiet send — a read-back inside another operation —
 opens no span of its own and runs in whichever span its caller is in. Any `tracing-subscriber`
 sees them; with `default-features = false` (plus `reqwest` if wanted) the crate depends on
 `tracing` for nothing and emits nothing. The hooks stay the place for a policy or a metric:

--- a/rust/hey-sdk/README.md
+++ b/rust/hey-sdk/README.md
@@ -275,6 +275,17 @@ impl Hooks for Log {
 let client = Client::builder(Config::default()).token_provider(provider).hooks(Log).build()?;
 ```
 
+The `tracing` feature, on by default, opens one `tracing` span per operation — `hey.operation`,
+with `operation`, `service`, and once HEY has answered `http.status` and `request_id` — and a
+`hey.attempt` child span per send, numbered the way the hooks number attempts, with the status
+each one got. Spans are put on the futures with `Instrument`, so concurrent calls keep their
+own, and a call the caller drops closes its span with no status. Nothing the caller passed is
+recorded: no path, no query, no body. A quiet send — a read-back inside another operation —
+opens no span of its own and runs in whichever span its caller is in. Any `tracing-subscriber`
+sees them; with `default-features = false` (plus `reqwest` if wanted) the crate depends on
+`tracing` for nothing and emits nothing. The hooks stay the place for a policy or a metric:
+they carry the whole `RequestResult`, and they run whether or not `tracing` is on.
+
 `on_operation_gate` is the one callback that can refuse a call before it is sent, and the only
 one that may wait — which is how the bulkhead below holds a call back rather than turning it
 away.

--- a/rust/hey-sdk/src/client.rs
+++ b/rust/hey-sdk/src/client.rs
@@ -26,7 +26,7 @@ use crate::pagination::Page;
 use crate::route::Route;
 use crate::security::{is_same_origin, require_secure_endpoint};
 use crate::services::boxes::BoxKinds;
-use crate::trace::{AttemptSpan, OperationSpan};
+use crate::trace::{AttemptSpan, OperationSpan, label};
 use crate::version::default_user_agent;
 
 pub const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
@@ -600,14 +600,18 @@ impl Client {
             };
             hooks.on_request_start(&info);
             let started = Instant::now();
-            let span = AttemptSpan::new(attempt);
-            let sent = span
-                .wrap(self.transmit(operation, url.clone(), request))
-                .await;
+            // The attempt span closes here, before any refresh or backoff: it is the send.
+            let sent = {
+                let span = AttemptSpan::new(attempt);
+                let sent = span
+                    .wrap(self.transmit(operation, url.clone(), request))
+                    .await;
+                if let Ok((_, response)) = &sent {
+                    span.answered(response.status());
+                }
+                sent
+            };
             let duration = started.elapsed();
-            if let Ok((_, response)) = &sent {
-                span.answered(response.status());
-            }
 
             match sent {
                 Err(error) => {
@@ -623,7 +627,7 @@ impl Client {
                         },
                     );
                     if attempt < attempts {
-                        crate::trace::debug!(operation = %operation.id, attempt, %error, "request failed, retrying");
+                        crate::trace::debug!(operation = label(operation), attempt, error = %error.code(), "request failed, retrying");
                         hooks.on_retry(&info, attempt + 1, &error);
                         self.wait(delay).await;
                         delay = self.next_delay(delay);
@@ -652,7 +656,10 @@ impl Client {
                                 retry_after,
                             },
                         );
-                        crate::trace::debug!(operation = %operation.id, "credentials refreshed, resending");
+                        crate::trace::debug!(
+                            operation = label(operation),
+                            "credentials refreshed, resending"
+                        );
                         hooks.on_retry(&info, attempt + 1, &cause);
                         refreshed = true;
                         attempt += 1;
@@ -675,7 +682,7 @@ impl Client {
                                 retry_after,
                             },
                         );
-                        crate::trace::debug!(operation = %operation.id, attempt, %status, "retryable status, retrying");
+                        crate::trace::debug!(operation = label(operation), attempt, %status, "retryable status, retrying");
                         hooks.on_retry(&info, attempt + 1, &cause);
                         match retry_after {
                             Some(seconds)
@@ -1164,7 +1171,7 @@ fn span_for(operation: &Operation) -> OperationSpan {
     if operation.quiet {
         OperationSpan::none()
     } else {
-        OperationSpan::new(&operation.info)
+        OperationSpan::new(operation)
     }
 }
 

--- a/rust/hey-sdk/src/client.rs
+++ b/rust/hey-sdk/src/client.rs
@@ -26,6 +26,7 @@ use crate::pagination::Page;
 use crate::route::Route;
 use crate::security::{is_same_origin, require_secure_endpoint};
 use crate::services::boxes::BoxKinds;
+use crate::trace::{AttemptSpan, OperationSpan};
 use crate::version::default_user_agent;
 
 pub const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
@@ -432,7 +433,9 @@ impl Client {
     /// resends once after a refreshed 401, and answers a cached body on 304. Non-2xx
     /// statuses become errors unless the operation treats them as empty.
     pub async fn execute(&self, operation: Operation) -> Result<Response, Error> {
-        self.instrument(&operation, self.dispatch(&operation)).await
+        let span = span_for(&operation);
+        span.wrap(self.instrument(&operation, self.dispatch(&operation, &span)))
+            .await
     }
 
     /// Sends an operation and hands back the answer with its body unread, for a caller
@@ -441,11 +444,15 @@ impl Client {
     /// retries, the resend after a refreshed 401 — and nothing is resent once the answer
     /// is in hand, since its bytes may already be on their way out.
     pub(crate) async fn stream(&self, operation: Operation) -> Result<HttpResponse<Body>, Error> {
-        self.instrument(&operation, self.streamed(&operation)).await
+        let span = span_for(&operation);
+        span.wrap(self.instrument(&operation, self.streamed(&operation, &span)))
+            .await
     }
 
     /// Runs one operation inside the hook lifecycle every call shares. A quiet operation is
     /// one request inside another and skips that lifecycle — see [`Operation::quiet`].
+    /// The `tracing` span around all of this is the caller's to put on, so that the gate and
+    /// the end hook are inside it too.
     ///
     /// The end is reported from a drop guard rather than after the await, because the await
     /// may never return: a caller's `tokio::time::timeout` or `select!` can drop the future
@@ -477,10 +484,15 @@ impl Client {
 
     /// Reads the answer the retry loop settled on, and tells the hooks how it turned out
     /// once its body has been dealt with.
-    async fn dispatch(&self, operation: &Operation) -> Result<Response, Error> {
+    async fn dispatch(
+        &self,
+        operation: &Operation,
+        span: &OperationSpan,
+    ) -> Result<Response, Error> {
         let url = self.url_for(operation)?;
         let answered = self.attempt(operation, &url).await?;
         let status = answered.response.status();
+        span.answered(status, request_id(answered.response.headers()));
         let finished = self
             .finish(
                 operation,
@@ -505,10 +517,15 @@ impl Client {
     }
 
     /// Hands the answer over unread, once its status says there is a body worth reading.
-    async fn streamed(&self, operation: &Operation) -> Result<HttpResponse<Body>, Error> {
+    async fn streamed(
+        &self,
+        operation: &Operation,
+        span: &OperationSpan,
+    ) -> Result<HttpResponse<Body>, Error> {
         let url = self.url_for(operation)?;
         let answered = self.attempt(operation, &url).await?;
         let status = answered.response.status();
+        span.answered(status, request_id(answered.response.headers()));
         let failure = (!status.is_success()).then(|| {
             Error::from_response(status, &operation.method, answered.response.headers(), &[])
         });
@@ -583,8 +600,14 @@ impl Client {
             };
             hooks.on_request_start(&info);
             let started = Instant::now();
-            let sent = self.transmit(operation, url.clone(), request).await;
+            let span = AttemptSpan::new(attempt);
+            let sent = span
+                .wrap(self.transmit(operation, url.clone(), request))
+                .await;
             let duration = started.elapsed();
+            if let Ok((_, response)) = &sent {
+                span.answered(response.status());
+            }
 
             match sent {
                 Err(error) => {
@@ -600,7 +623,7 @@ impl Client {
                         },
                     );
                     if attempt < attempts {
-                        tracing::debug!(operation = %operation.id, attempt, %error, "request failed, retrying");
+                        crate::trace::debug!(operation = %operation.id, attempt, %error, "request failed, retrying");
                         hooks.on_retry(&info, attempt + 1, &error);
                         self.wait(delay).await;
                         delay = self.next_delay(delay);
@@ -629,7 +652,7 @@ impl Client {
                                 retry_after,
                             },
                         );
-                        tracing::debug!(operation = %operation.id, "credentials refreshed, resending");
+                        crate::trace::debug!(operation = %operation.id, "credentials refreshed, resending");
                         hooks.on_retry(&info, attempt + 1, &cause);
                         refreshed = true;
                         attempt += 1;
@@ -652,7 +675,7 @@ impl Client {
                                 retry_after,
                             },
                         );
-                        tracing::debug!(operation = %operation.id, attempt, %status, "retryable status, retrying");
+                        crate::trace::debug!(operation = %operation.id, attempt, %status, "retryable status, retrying");
                         hooks.on_retry(&info, attempt + 1, &cause);
                         match retry_after {
                             Some(seconds)
@@ -1133,6 +1156,23 @@ pub(crate) fn with_json_extension(path: &str) -> String {
     } else {
         format!("{path}.json")
     }
+}
+
+/// The span an operation runs in: one of its own, or none for a quiet send, which is one
+/// request inside another operation and runs in that operation's span.
+fn span_for(operation: &Operation) -> OperationSpan {
+    if operation.quiet {
+        OperationSpan::none()
+    } else {
+        OperationSpan::new(&operation.info)
+    }
+}
+
+/// HEY's own id for the request, when the answer names one.
+fn request_id(headers: &HeaderMap) -> Option<&str> {
+    headers
+        .get("x-request-id")
+        .and_then(|value| value.to_str().ok())
 }
 
 /// The wait HEY asked for, on the two statuses that carry one.

--- a/rust/hey-sdk/src/lib.rs
+++ b/rust/hey-sdk/src/lib.rs
@@ -36,6 +36,7 @@ pub mod resilience;
 pub mod route;
 pub mod security;
 pub mod services;
+mod trace;
 pub mod types;
 pub mod url;
 pub mod version;

--- a/rust/hey-sdk/src/pagination.rs
+++ b/rust/hey-sdk/src/pagination.rs
@@ -148,7 +148,7 @@ impl Client {
                     operation = Operation::at(Method::GET, next);
                 }
                 Some(_) => {
-                    tracing::warn!(max_pages = self.max_pages(), "pagination capped");
+                    crate::trace::warning!(max_pages = self.max_pages(), "pagination capped");
                     break;
                 }
                 None => break,
@@ -194,7 +194,7 @@ impl Client {
             next = match self.next_page_url(&response, &started_at)? {
                 Some(url) if pages < self.max_pages() => Some(url),
                 Some(_) => {
-                    tracing::warn!(max_pages = self.max_pages(), "pagination capped");
+                    crate::trace::warning!(max_pages = self.max_pages(), "pagination capped");
                     None
                 }
                 None => None,

--- a/rust/hey-sdk/src/services/calendar_changes.rs
+++ b/rust/hey-sdk/src/services/calendar_changes.rs
@@ -161,7 +161,7 @@ impl<'a> Calendars<'a> {
             }
         }
 
-        tracing::warn!(
+        crate::trace::warning!(
             max_pages = self.client().max_pages(),
             "calendar changes pagination capped"
         );
@@ -224,7 +224,7 @@ impl<'a> Calendars<'a> {
             }
         }
 
-        tracing::warn!(
+        crate::trace::warning!(
             max_pages = self.client().max_pages(),
             "recording changes pagination capped"
         );

--- a/rust/hey-sdk/src/services/postings.rs
+++ b/rust/hey-sdk/src/services/postings.rs
@@ -324,7 +324,7 @@ impl<'a> Postings<'a> {
                 None => return Ok(all),
             }
         }
-        tracing::warn!(
+        crate::trace::warning!(
             max_pages = self.client().max_pages(),
             "posting changes pagination capped"
         );

--- a/rust/hey-sdk/src/trace.rs
+++ b/rust/hey-sdk/src/trace.rs
@@ -5,10 +5,13 @@
 //! A span is put on a future with `Instrument` and never entered across an `.await`: an
 //! entered span is a thread-local, and a task that yields would leave it on whatever the
 //! executor runs next. Nothing a caller passed to an operation is recorded — the span names
-//! the operation, the attempt, the status and HEY's request id, and that is all.
+//! the operation, the attempt, the status and HEY's request id, and that is all. A request
+//! for a path the caller wrote is named by its method alone, since the path and whatever
+//! query it carries are the caller's; the hooks are where the URL goes.
 
 use crate::http::StatusCode;
 use crate::observability::OperationInfo;
+use crate::operation::Operation;
 
 #[cfg(feature = "tracing")]
 macro_rules! debug {
@@ -41,15 +44,15 @@ pub(crate) struct OperationSpan {
 }
 
 impl OperationSpan {
-    pub(crate) fn new(info: &OperationInfo) -> OperationSpan {
+    pub(crate) fn new(operation: &Operation) -> OperationSpan {
         #[cfg(not(feature = "tracing"))]
-        let _ = info;
+        let _ = operation;
         OperationSpan {
             #[cfg(feature = "tracing")]
             span: tracing::info_span!(
                 "hey.operation",
-                operation = %info.operation,
-                service = %info.service,
+                operation = label(operation),
+                service = %operation.info.service,
                 http.status = tracing::field::Empty,
                 request_id = tracing::field::Empty,
             ),
@@ -88,6 +91,20 @@ impl OperationSpan {
             let _ = (status, request_id);
         }
     }
+}
+
+/// What a span or an event calls the operation: the name the model or a wrapper gave it,
+/// or the method alone for a path the caller wrote, whose path is the caller's own.
+pub(crate) fn label(operation: &Operation) -> &str {
+    if is_raw(&operation.info) {
+        operation.method.as_str()
+    } else {
+        &operation.info.operation
+    }
+}
+
+fn is_raw(info: &OperationInfo) -> bool {
+    info.service == "Raw"
 }
 
 /// The span one send runs inside, a child of the operation's. Numbered the way the hooks

--- a/rust/hey-sdk/src/trace.rs
+++ b/rust/hey-sdk/src/trace.rs
@@ -1,0 +1,127 @@
+//! The `tracing` the SDK emits, behind the `tracing` feature: one span per operation, a
+//! child span per attempt, and the debug lines the retry loop and pagination write. Without
+//! the feature every one of these is nothing, so the call sites read the same either way.
+//!
+//! A span is put on a future with `Instrument` and never entered across an `.await`: an
+//! entered span is a thread-local, and a task that yields would leave it on whatever the
+//! executor runs next. Nothing a caller passed to an operation is recorded — the span names
+//! the operation, the attempt, the status and HEY's request id, and that is all.
+
+use crate::http::StatusCode;
+use crate::observability::OperationInfo;
+
+#[cfg(feature = "tracing")]
+macro_rules! debug {
+    ($($arg:tt)*) => { tracing::debug!($($arg)*) };
+}
+
+#[cfg(not(feature = "tracing"))]
+macro_rules! debug {
+    ($($arg:tt)*) => {{}};
+}
+
+#[cfg(feature = "tracing")]
+macro_rules! warning {
+    ($($arg:tt)*) => { tracing::warn!($($arg)*) };
+}
+
+#[cfg(not(feature = "tracing"))]
+macro_rules! warning {
+    ($($arg:tt)*) => {{}};
+}
+
+pub(crate) use {debug, warning};
+
+/// The span one operation runs inside, from the gate to the end hook. Its `http.status`
+/// and `request_id` are empty until the answer the retry loop settled on is in hand.
+#[derive(Clone)]
+pub(crate) struct OperationSpan {
+    #[cfg(feature = "tracing")]
+    span: tracing::Span,
+}
+
+impl OperationSpan {
+    pub(crate) fn new(info: &OperationInfo) -> OperationSpan {
+        #[cfg(not(feature = "tracing"))]
+        let _ = info;
+        OperationSpan {
+            #[cfg(feature = "tracing")]
+            span: tracing::info_span!(
+                "hey.operation",
+                operation = %info.operation,
+                service = %info.service,
+                http.status = tracing::field::Empty,
+                request_id = tracing::field::Empty,
+            ),
+        }
+    }
+
+    /// The span nothing is announced in: a quiet send, which is one request inside another
+    /// operation, runs in that operation's span rather than one of its own.
+    pub(crate) fn none() -> OperationSpan {
+        OperationSpan {
+            #[cfg(feature = "tracing")]
+            span: tracing::Span::none(),
+        }
+    }
+
+    #[cfg(feature = "tracing")]
+    pub(crate) fn wrap<F: Future>(&self, work: F) -> tracing::instrument::Instrumented<F> {
+        tracing::Instrument::instrument(work, self.span.clone())
+    }
+
+    #[cfg(not(feature = "tracing"))]
+    pub(crate) fn wrap<F: Future>(&self, work: F) -> F {
+        work
+    }
+
+    pub(crate) fn answered(&self, status: StatusCode, request_id: Option<&str>) {
+        #[cfg(feature = "tracing")]
+        {
+            self.span.record("http.status", status.as_u16());
+            if let Some(request_id) = request_id {
+                self.span.record("request_id", request_id);
+            }
+        }
+        #[cfg(not(feature = "tracing"))]
+        {
+            let _ = (status, request_id);
+        }
+    }
+}
+
+/// The span one send runs inside, a child of the operation's. Numbered the way the hooks
+/// number attempts: from 1 across the whole operation, the resend after a credential
+/// refresh included.
+pub(crate) struct AttemptSpan {
+    #[cfg(feature = "tracing")]
+    span: tracing::Span,
+}
+
+impl AttemptSpan {
+    pub(crate) fn new(attempt: u32) -> AttemptSpan {
+        #[cfg(not(feature = "tracing"))]
+        let _ = attempt;
+        AttemptSpan {
+            #[cfg(feature = "tracing")]
+            span: tracing::debug_span!("hey.attempt", attempt, http.status = tracing::field::Empty),
+        }
+    }
+
+    #[cfg(feature = "tracing")]
+    pub(crate) fn wrap<F: Future>(&self, work: F) -> tracing::instrument::Instrumented<F> {
+        tracing::Instrument::instrument(work, self.span.clone())
+    }
+
+    #[cfg(not(feature = "tracing"))]
+    pub(crate) fn wrap<F: Future>(&self, work: F) -> F {
+        work
+    }
+
+    pub(crate) fn answered(&self, status: StatusCode) {
+        #[cfg(feature = "tracing")]
+        self.span.record("http.status", status.as_u16());
+        #[cfg(not(feature = "tracing"))]
+        let _ = status;
+    }
+}

--- a/rust/hey-sdk/tests/tracing.rs
+++ b/rust/hey-sdk/tests/tracing.rs
@@ -30,6 +30,7 @@ struct Span {
 #[derive(Clone, Default)]
 struct Capture {
     spans: Arc<Mutex<BTreeMap<u64, Span>>>,
+    events: Arc<Mutex<Vec<BTreeMap<String, String>>>>,
 }
 
 impl Capture {
@@ -47,12 +48,41 @@ impl Capture {
             .collect()
     }
 
+    /// Every value any span or event carried.
+    fn values(&self) -> Vec<String> {
+        let mut values: Vec<String> = self
+            .spans
+            .lock()
+            .unwrap()
+            .values()
+            .flat_map(|span| span.fields.values().cloned())
+            .collect();
+        values.extend(
+            self.events
+                .lock()
+                .unwrap()
+                .iter()
+                .flat_map(|fields| fields.values().cloned()),
+        );
+        values
+    }
+
     fn operations(&self) -> Vec<Span> {
         self.named("hey.operation")
     }
 
     fn attempts(&self) -> Vec<Span> {
         self.named("hey.attempt")
+    }
+
+    fn operations_with_ids(&self) -> Vec<(u64, Span)> {
+        self.spans
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|(_, span)| span.name == "hey.operation")
+            .map(|(id, span)| (*id, span.clone()))
+            .collect()
     }
 
     fn id_of_named(&self, name: &str) -> u64 {
@@ -122,6 +152,12 @@ impl<S: Subscriber + for<'a> LookupSpan<'a>> Layer<S> for Capture {
         if let Some(span) = self.spans.lock().unwrap().get_mut(&id.into_u64()) {
             values.record(&mut Fields(&mut span.fields));
         }
+    }
+
+    fn on_event(&self, event: &tracing::Event<'_>, _ctx: Context<'_, S>) {
+        let mut fields = BTreeMap::new();
+        event.record(&mut Fields(&mut fields));
+        self.events.lock().unwrap().push(fields);
     }
 
     fn on_close(&self, id: Id, _ctx: Context<'_, S>) {
@@ -256,8 +292,8 @@ async fn a_failure_records_the_status_it_failed_with() {
     assert!(operation.closed);
 }
 
-/// Two operations in flight at once each keep their own span: the status one answered
-/// never lands on the other.
+/// Two operations in flight at once each keep their own span: each hangs off the span its
+/// caller was in, carries the status its own call got, and parents only its own attempts.
 #[tokio::test]
 async fn concurrent_operations_keep_their_own_spans() {
     let server = MockServer::start().await;
@@ -281,31 +317,37 @@ async fn concurrent_operations_keep_their_own_spans() {
 
     let params = Default::default();
     let boxes = client.boxes();
-    let (first, second) = tokio::join!(boxes.get(1, &params), boxes.get(2, &params));
+    let (first, second) = tokio::join!(
+        tracing::Instrument::instrument(boxes.get(1, &params), tracing::info_span!("first")),
+        tracing::Instrument::instrument(boxes.get(2, &params), tracing::info_span!("second"))
+    );
     first.unwrap();
     second.unwrap_err();
 
-    let operations = capture.operations();
+    let first = capture.id_of_named("first");
+    let second = capture.id_of_named("second");
+    let operations = capture.operations_with_ids();
     assert_eq!(operations.len(), 2);
-    let mut statuses: Vec<(&str, &str)> = operations
-        .iter()
-        .map(|span| {
-            (
-                span.fields["operation"].as_str(),
-                span.fields["http.status"].as_str(),
-            )
-        })
-        .collect();
-    statuses.sort();
-    assert_eq!(statuses, [("GetBox", "200"), ("GetBox", "404")]);
+    let under = |caller: u64| -> (u64, &Span) {
+        operations
+            .iter()
+            .find(|(_, span)| span.parent == Some(caller))
+            .map(|(id, span)| (*id, span))
+            .unwrap()
+    };
+    let (first_op, first_span) = under(first);
+    let (second_op, second_span) = under(second);
+    assert_eq!(first_span.fields["http.status"], "200");
+    assert_eq!(second_span.fields["http.status"], "404");
     let mut parents: Vec<u64> = capture
         .attempts()
         .iter()
         .map(|span| span.parent.unwrap())
         .collect();
     parents.sort_unstable();
-    parents.dedup();
-    assert_eq!(parents.len(), 2, "each attempt hangs off its own operation");
+    let mut expected = vec![first_op, second_op];
+    expected.sort_unstable();
+    assert_eq!(parents, expected);
 }
 
 /// A caller that drops the call mid-flight drops the span with it: it closes, with no
@@ -375,10 +417,18 @@ async fn a_quiet_send_runs_in_the_span_its_caller_is_in() {
     assert_eq!(parents, [Some(operation), Some(caller)]);
 }
 
-/// Nothing the caller passed in is recorded: no URL, no query, no body.
+/// Nothing the caller passed in reaches a span or an event: a request for a path the
+/// caller wrote is named by its method alone, and a resend is logged by the operation's
+/// name and the failure's code, not by anything that could carry the URL.
 #[tokio::test]
-async fn the_span_names_the_operation_and_nothing_the_caller_passed() {
+async fn nothing_the_caller_passed_reaches_a_span_or_an_event() {
     let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/topics/search.json"))
+        .respond_with(ResponseTemplate::new(503))
+        .up_to_n_times(1)
+        .mount(&server)
+        .await;
     Mock::given(method("GET"))
         .and(path("/topics/search.json"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!([])))
@@ -386,16 +436,36 @@ async fn the_span_names_the_operation_and_nothing_the_caller_passed() {
         .await;
     let capture = Capture::default();
     let _guard = capture.install();
+    let client = client(&server);
 
-    let _ = client(&server).get("/topics/search?q=secret%20plans").await;
+    let mut operation = client.request(hey_sdk::http::Method::GET, "/topics/search");
+    operation.query("q", "secret plans");
+    client.send_unit(operation).await.unwrap();
 
     let operations = capture.operations();
-    let names: Vec<&str> = operations[0].fields.keys().map(String::as_str).collect();
-    assert_eq!(names, ["http.status", "operation", "service"]);
-    for span in capture.attempts() {
-        assert_eq!(
-            span.fields.keys().map(String::as_str).collect::<Vec<_>>(),
-            ["attempt", "http.status"]
-        );
-    }
+    assert_eq!(operations.len(), 1);
+    assert_eq!(
+        fields(&operations[0]),
+        [
+            ("http.status", "200"),
+            ("operation", "GET"),
+            ("service", "Raw")
+        ]
+    );
+    assert_eq!(capture.attempts().len(), 2);
+    let leaked: Vec<String> = capture
+        .values()
+        .into_iter()
+        .filter(|value| value.contains("secret") || value.contains("topics"))
+        .collect();
+    assert!(leaked.is_empty(), "leaked {leaked:?}");
+    assert!(
+        capture
+            .events
+            .lock()
+            .unwrap()
+            .iter()
+            .any(|fields| fields.get("operation").is_some_and(|op| op == "GET")),
+        "the resend was logged"
+    );
 }

--- a/rust/hey-sdk/tests/tracing.rs
+++ b/rust/hey-sdk/tests/tracing.rs
@@ -1,0 +1,401 @@
+#![cfg(feature = "tracing")]
+
+mod support;
+
+use std::collections::BTreeMap;
+use std::fmt::Debug;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use serde_json::json;
+use tracing::Subscriber;
+use tracing::field::{Field, Visit};
+use tracing::span::{Attributes, Id, Record};
+use tracing_subscriber::layer::{Context, Layer, SubscriberExt};
+use tracing_subscriber::registry::LookupSpan;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+use support::client;
+
+#[derive(Debug, Clone, Default)]
+struct Span {
+    name: String,
+    parent: Option<u64>,
+    fields: BTreeMap<String, String>,
+    closed: bool,
+}
+
+/// Every span the SDK opened, with the fields it recorded, in the order they were opened.
+#[derive(Clone, Default)]
+struct Capture {
+    spans: Arc<Mutex<BTreeMap<u64, Span>>>,
+}
+
+impl Capture {
+    fn install(&self) -> tracing::subscriber::DefaultGuard {
+        tracing::subscriber::set_default(tracing_subscriber::registry().with(self.clone()))
+    }
+
+    fn named(&self, name: &str) -> Vec<Span> {
+        self.spans
+            .lock()
+            .unwrap()
+            .values()
+            .filter(|span| span.name == name)
+            .cloned()
+            .collect()
+    }
+
+    fn operations(&self) -> Vec<Span> {
+        self.named("hey.operation")
+    }
+
+    fn attempts(&self) -> Vec<Span> {
+        self.named("hey.attempt")
+    }
+
+    fn id_of_named(&self, name: &str) -> u64 {
+        *self
+            .spans
+            .lock()
+            .unwrap()
+            .iter()
+            .find(|(_, span)| span.name == name)
+            .map(|(id, _)| id)
+            .unwrap()
+    }
+
+    fn id_of(&self, name: &str, operation: &str) -> u64 {
+        *self
+            .spans
+            .lock()
+            .unwrap()
+            .iter()
+            .find(|(_, span)| {
+                span.name == name
+                    && span
+                        .fields
+                        .get("operation")
+                        .is_some_and(|op| op == operation)
+            })
+            .map(|(id, _)| id)
+            .unwrap()
+    }
+}
+
+struct Fields<'a>(&'a mut BTreeMap<String, String>);
+
+impl Visit for Fields<'_> {
+    fn record_debug(&mut self, field: &Field, value: &dyn Debug) {
+        self.0
+            .insert(field.name().to_string(), format!("{value:?}"));
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        self.0.insert(field.name().to_string(), value.to_string());
+    }
+
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        self.0.insert(field.name().to_string(), value.to_string());
+    }
+
+    fn record_i64(&mut self, field: &Field, value: i64) {
+        self.0.insert(field.name().to_string(), value.to_string());
+    }
+}
+
+impl<S: Subscriber + for<'a> LookupSpan<'a>> Layer<S> for Capture {
+    fn on_new_span(&self, attrs: &Attributes<'_>, id: &Id, ctx: Context<'_, S>) {
+        let mut span = Span {
+            name: attrs.metadata().name().to_string(),
+            parent: ctx
+                .span(id)
+                .and_then(|span| span.parent().map(|parent| parent.id().into_u64())),
+            ..Span::default()
+        };
+        attrs.record(&mut Fields(&mut span.fields));
+        self.spans.lock().unwrap().insert(id.into_u64(), span);
+    }
+
+    fn on_record(&self, id: &Id, values: &Record<'_>, _ctx: Context<'_, S>) {
+        if let Some(span) = self.spans.lock().unwrap().get_mut(&id.into_u64()) {
+            values.record(&mut Fields(&mut span.fields));
+        }
+    }
+
+    fn on_close(&self, id: Id, _ctx: Context<'_, S>) {
+        if let Some(span) = self.spans.lock().unwrap().get_mut(&id.into_u64()) {
+            span.closed = true;
+        }
+    }
+}
+
+/// An attempt span as a test reads it: its parent and its fields.
+type Attempt<'a> = (Option<u64>, Vec<(&'a str, &'a str)>);
+
+fn fields(span: &Span) -> Vec<(&str, &str)> {
+    span.fields
+        .iter()
+        .map(|(name, value)| (name.as_str(), value.as_str()))
+        .collect()
+}
+
+#[tokio::test]
+async fn one_span_per_operation_names_it_and_records_what_hey_answered() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/boxes/123.json"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("x-request-id", "req-4242")
+                .set_body_json(json!({ "id": 123, "kind": "imbox", "name": "Imbox" })),
+        )
+        .mount(&server)
+        .await;
+    let capture = Capture::default();
+    let _guard = capture.install();
+
+    client(&server)
+        .boxes()
+        .get(123, &Default::default())
+        .await
+        .unwrap();
+
+    let operations = capture.operations();
+    assert_eq!(operations.len(), 1);
+    assert_eq!(
+        fields(&operations[0]),
+        [
+            ("http.status", "200"),
+            ("operation", "GetBox"),
+            ("request_id", "req-4242"),
+            ("service", "Boxes"),
+        ]
+    );
+    assert_eq!(operations[0].parent, None);
+    assert!(operations[0].closed);
+    let attempts = capture.attempts();
+    assert_eq!(attempts.len(), 1);
+    assert_eq!(
+        fields(&attempts[0]),
+        [("attempt", "1"), ("http.status", "200")]
+    );
+    assert_eq!(
+        attempts[0].parent,
+        Some(capture.id_of("hey.operation", "GetBox"))
+    );
+}
+
+#[tokio::test]
+async fn every_attempt_is_a_child_span_numbered_in_order() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/boxes.json"))
+        .respond_with(ResponseTemplate::new(503))
+        .up_to_n_times(2)
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/boxes.json"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([])))
+        .mount(&server)
+        .await;
+    let capture = Capture::default();
+    let _guard = capture.install();
+
+    client(&server).boxes().list().await.unwrap();
+
+    let operation = capture.id_of("hey.operation", "ListBoxes");
+    let attempts = capture.attempts();
+    let numbered: Vec<Attempt<'_>> = attempts
+        .iter()
+        .map(|span| (span.parent, fields(span)))
+        .collect();
+    assert_eq!(
+        numbered,
+        [
+            (
+                Some(operation),
+                vec![("attempt", "1"), ("http.status", "503")]
+            ),
+            (
+                Some(operation),
+                vec![("attempt", "2"), ("http.status", "503")]
+            ),
+            (
+                Some(operation),
+                vec![("attempt", "3"), ("http.status", "200")]
+            ),
+        ]
+    );
+    assert!(attempts.iter().all(|span| span.closed));
+    assert_eq!(capture.operations()[0].fields["http.status"], "200");
+}
+
+#[tokio::test]
+async fn a_failure_records_the_status_it_failed_with() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/boxes/9.json"))
+        .respond_with(ResponseTemplate::new(404).insert_header("x-request-id", "req-404"))
+        .mount(&server)
+        .await;
+    let capture = Capture::default();
+    let _guard = capture.install();
+
+    client(&server)
+        .boxes()
+        .get(9, &Default::default())
+        .await
+        .unwrap_err();
+
+    let operation = &capture.operations()[0];
+    assert_eq!(operation.fields["http.status"], "404");
+    assert_eq!(operation.fields["request_id"], "req-404");
+    assert!(operation.closed);
+}
+
+/// Two operations in flight at once each keep their own span: the status one answered
+/// never lands on the other.
+#[tokio::test]
+async fn concurrent_operations_keep_their_own_spans() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/boxes/1.json"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_delay(Duration::from_millis(50))
+                .set_body_json(json!({ "id": 1, "kind": "imbox", "name": "Imbox" })),
+        )
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/boxes/2.json"))
+        .respond_with(ResponseTemplate::new(404))
+        .mount(&server)
+        .await;
+    let capture = Capture::default();
+    let _guard = capture.install();
+    let client = client(&server);
+
+    let params = Default::default();
+    let boxes = client.boxes();
+    let (first, second) = tokio::join!(boxes.get(1, &params), boxes.get(2, &params));
+    first.unwrap();
+    second.unwrap_err();
+
+    let operations = capture.operations();
+    assert_eq!(operations.len(), 2);
+    let mut statuses: Vec<(&str, &str)> = operations
+        .iter()
+        .map(|span| {
+            (
+                span.fields["operation"].as_str(),
+                span.fields["http.status"].as_str(),
+            )
+        })
+        .collect();
+    statuses.sort();
+    assert_eq!(statuses, [("GetBox", "200"), ("GetBox", "404")]);
+    let mut parents: Vec<u64> = capture
+        .attempts()
+        .iter()
+        .map(|span| span.parent.unwrap())
+        .collect();
+    parents.sort_unstable();
+    parents.dedup();
+    assert_eq!(parents.len(), 2, "each attempt hangs off its own operation");
+}
+
+/// A caller that drops the call mid-flight drops the span with it: it closes, with no
+/// status, rather than staying open for the life of the subscriber.
+#[tokio::test]
+async fn a_cancelled_operation_closes_its_span_without_an_answer() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/boxes.json"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_delay(Duration::from_secs(5))
+                .set_body_json(json!([])),
+        )
+        .mount(&server)
+        .await;
+    let capture = Capture::default();
+    let _guard = capture.install();
+    let client = client(&server);
+
+    let abandoned = tokio::time::timeout(Duration::from_millis(50), client.boxes().list()).await;
+    assert!(abandoned.is_err());
+
+    let operation = &capture.operations()[0];
+    assert!(operation.closed);
+    assert!(!operation.fields.contains_key("http.status"));
+    let attempt = &capture.attempts()[0];
+    assert!(attempt.closed);
+    assert!(!attempt.fields.contains_key("http.status"));
+}
+
+/// A quiet send is one request inside another operation and opens no operation span of
+/// its own: its attempt hangs off whatever span its caller is in, the way the hooks hear of
+/// one operation rather than two.
+#[tokio::test]
+async fn a_quiet_send_runs_in_the_span_its_caller_is_in() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/topics/5/publication"))
+        .respond_with(ResponseTemplate::new(302).insert_header("Location", "/topics/5"))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/topics/5/publication.json"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(json!({ "published": true, "url": "https://public.hey.com/p/abc" })),
+        )
+        .mount(&server)
+        .await;
+    let capture = Capture::default();
+    let _guard = capture.install();
+    let client = client(&server);
+
+    let caller = tracing::info_span!("caller");
+    tracing::Instrument::instrument(client.publications().publish(5), caller)
+        .await
+        .unwrap();
+
+    let caller = capture.id_of_named("caller");
+    let operations = capture.operations();
+    assert_eq!(operations.len(), 1);
+    assert_eq!(operations[0].fields["operation"], "CreateTopicPublication");
+    assert_eq!(operations[0].parent, Some(caller));
+    let operation = capture.id_of("hey.operation", "CreateTopicPublication");
+    let parents: Vec<Option<u64>> = capture.attempts().iter().map(|span| span.parent).collect();
+    assert_eq!(parents, [Some(operation), Some(caller)]);
+}
+
+/// Nothing the caller passed in is recorded: no URL, no query, no body.
+#[tokio::test]
+async fn the_span_names_the_operation_and_nothing_the_caller_passed() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/topics/search.json"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([])))
+        .mount(&server)
+        .await;
+    let capture = Capture::default();
+    let _guard = capture.install();
+
+    let _ = client(&server).get("/topics/search?q=secret%20plans").await;
+
+    let operations = capture.operations();
+    let names: Vec<&str> = operations[0].fields.keys().map(String::as_str).collect();
+    assert_eq!(names, ["http.status", "operation", "service"]);
+    for span in capture.attempts() {
+        assert_eq!(
+            span.fields.keys().map(String::as_str).collect::<Vec<_>>(),
+            ["attempt", "http.status"]
+        );
+    }
+}


### PR DESCRIPTION
Card: [hey-sdk Rust: tracing feature with per-operation spans](https://app.basecamp.com/2914079/buckets/46292715/card_tables/cards/10289485443)

## What changes

`tracing` was an unconditional dependency used for eight `debug!`/`warn!` lines and no spans, so a subscriber saw resends but could not tie an operation to its attempts, its status and HEY's request id.

- New `src/trace.rs`, the one place the crate touches `tracing`. `OperationSpan` is a `hey.operation` span with `operation`, `service`, and `http.status` + `request_id` recorded once the retry loop settles on an answer (the id from `x-request-id` on that answer). `AttemptSpan` is a `hey.attempt` child span per send with `attempt` (numbered as the hooks number them, the refresh resend included) and the `http.status` that send got.
- Spans go on the futures with `tracing::Instrument` — `execute`/`stream` wrap the whole hook lifecycle (gate, start, work, end) in the operation span; each `transmit` is wrapped in its attempt span — and nothing is `enter()`ed across an `.await`, so concurrent calls keep their own spans and a call the caller drops closes its span with no status.
- A quiet send (`Operation::quiet`, the read-back inside `Publications::publish` / `Workflows::stage_topic`) opens no operation span and runs in whichever span its caller is in, the way the hooks hear of one operation rather than two.
- Nothing the caller passed is recorded: no URL, query, body or header reaches a span or event. The existing `debug!`/`warn!` lines move to `crate::trace::{debug, warning}` macros that expand to nothing without the feature.
- `Cargo.toml`: `tracing` is optional behind a `tracing` feature, on by default (`default = ["reqwest", "tracing"]`), so existing consumers see no change; `--no-default-features` compiles without it and emits nothing. `tracing-subscriber` (registry only) is a dev-dependency for the capturing test layer.
- `Hooks` are untouched and stay the place for policy and metrics; the README's Hooks section documents both.

## Gate

On the branch as pushed (rebased onto `main` after #156):

- `make rs-check`: green
- `make rs-check-drift`: green
- `make conformance-rs`: 190/190 (191 once #154 lands)
- `cargo test -p hey-sdk --no-default-features --features reqwest` (tracing off): green; `cargo check -p hey-sdk --no-default-features`: green
- Pre-existing and untouched: `cargo test --no-default-features --lib` and `cargo doc --no-default-features` fail on `main` today (`OAuthClient::default()` in tests and intra-doc links to `ReqwestClient` in `http/mod.rs` are `reqwest`-gated) — the feature-matrix CI job on the CI-hardening card is where those get fixed.

New tests in `rust/hey-sdk/tests/tracing.rs` (gated on the feature, capturing `tracing-subscriber` layer): one span per operation with the four fields and its attempt child; three attempts as ordered child spans with their statuses; a failure's status and request id; two concurrent operations each keeping their own span and attempts; a cancelled operation closing its spans without a status; a quiet send hanging off the caller's span with one operation span for the whole convenience; span field names holding nothing the caller passed.

## Adversarial review

Reviewed by Codex CLI (`gpt-6-astra`, reasoning `xhigh`) before opening; findings and dispositions are in a comment below.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Addresses [hey-sdk Rust: tracing feature with per-operation spans](https://app.basecamp.com/2914079/buckets/46292715/card_tables/cards/10289485443).

Adds one `tracing` span per operation and per attempt, behind a new `tracing` feature that's on by default. Previously `tracing` was an unconditional dependency used only for debug/warn lines, so a subscriber saw resends but couldn't tie an operation to its attempts, its status, or HEY's request id.

**New Features**
- Every operation runs in a `hey.operation` span carrying operation, service, http.status, and request_id (from the answer's `x-request-id`); raw requests the caller wrote are named by method alone.
- Every send runs in a `hey.attempt` child span carrying the attempt number and the status that send got; the span closes when the send does, before any refresh or backoff.
- Spans are put on futures with `tracing::Instrument`, so concurrent calls keep their own and a dropped call closes its span with no status.
- Quiet sends open no span of their own and run in whichever span their caller is in.
- Nothing the caller passed — no URL, query, body, or header — is recorded.

**Dependencies**
- `tracing` is now optional behind the `tracing` feature, on by default, so existing consumers see no change.
- With `--no-default-features`, the crate emits nothing and depends on nothing for tracing.

<sup>Written for commit f05c915746dad2d8ee2f4e46143de9ac97188de9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-sdk/pull/165?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

