### PR TITLE
Apply the type-evolution policy: non_exhaustive on what HEY answers

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -1,0 +1,61 @@
+# Migrating
+
+Breaking changes to the SDKs' public surface, by release, with what to change. Wire behavior
+is not versioned here; the conformance fixtures under `conformance/tests/` hold that.
+
+## Rust: the first release after 0.30.0
+
+### Response-side types and open enums are `#[non_exhaustive]`
+
+Every type the crate decodes and hands back, and every enum whose set of values is HEY's to
+grow, is now `#[non_exhaustive]`. The policy — which side a type is on and what a change to
+it costs — is in [rust/hey-sdk/README.md](rust/hey-sdk/README.md#versioning); this is what
+it changes for code outside the crate.
+
+**Building one literally no longer compiles**, `..Default::default()` included. This reaches
+tests and fixtures more than applications:
+
+```rust
+// before
+let mailbox = Mailbox { name: "Imbox".into(), ..Default::default() };
+
+// after: the types keep `Default`, so build one and set what the test needs
+let mut mailbox = Mailbox::default();
+mailbox.name = "Imbox".into();
+```
+
+**A `match` over an open enum needs a wildcard arm**, and a struct pattern needs `..`:
+
+```rust
+match error.code() {
+    ErrorCode::NotFound => …,
+    ErrorCode::RateLimit => …,
+    _ => …,
+}
+```
+
+Reading fields, calling methods, `Clone`, `PartialEq` and serde are untouched.
+
+The types affected:
+
+- Generated: every schema the model reads back and nothing the model sends. Request bodies
+  (`*RequestContent`) and everything they mention (`MessagePayload`, `ContactPayload`,
+  `StickyPayload`, …) stay literal; the generator decides by reachability from the request
+  bodies, not by name.
+- Hand-written results: `WorkflowSummary`, `CalendarChanges`, `RecordingChanges`,
+  `DeletedRecording`, `DeletedCalendar`, `PostingChanges`, `SearchResults`,
+  `ContactConflict`, `ListedCalendar`, `CalendarList`, `services::extenzions::Extenzion`,
+  `url::Match`.
+- Runtime: `client::Response`, `FormResponse`, `oauth::Token`, and what the hooks see —
+  `RequestInfo` and `RequestResult`. `OperationInfo` stays literal: `Operation::info` takes
+  one from a caller describing its own form-backed call. `Route`, `RouteParam` and `Retry`
+  stay literal too: a caller may write a route for a path the model lacks and hand it to
+  `Client::operation`.
+- Open enums: `ErrorCode`, `route::Pagination`, `route::ParamKind`, `BoxKind`, `StickySize`,
+  `BubbleUpSlot`, `RepeatFrequency`, `CountdownUnit`, `TimeFormat`.
+
+Not affected, on purpose: `Config`, the resilience configs, `ExchangeRequest`,
+`RefreshRequest`, `ServerMetadata`, `Pkce`, `CachedResponse`, `OperationInfo`, `Route`,
+`RouteParam`, `Retry`, the `*Params` structs, the `*Cursor` structs, and the closed enums
+`ClearanceStatus`, `OccurrenceScope`, `RepeatUntil` and `ParamRole`. A field added to one of
+those is a `0.MINOR` release.

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -13,16 +13,23 @@ it costs — is in [rust/hey-sdk/README.md](rust/hey-sdk/README.md#versioning); 
 it changes for code outside the crate.
 
 **Building one literally no longer compiles**, `..Default::default()` included. This reaches
-tests and fixtures more than applications:
+tests and fixtures more than applications. The generated types and most hand-written results
+keep `Default`, so build one and set what the test needs:
 
 ```rust
 // before
 let mailbox = Mailbox { name: "Imbox".into(), ..Default::default() };
 
-// after: the types keep `Default`, so build one and set what the test needs
+// after
 let mut mailbox = Mailbox::default();
 mailbox.name = "Imbox".into();
 ```
+
+A few carry no `Default`, and a fixture for one of those comes from where the crate itself
+gets it: `Token`, `DeletedCalendar` and `DeletedRecording` deserialize from JSON;
+`client::Response`, `FormResponse`, `RequestInfo` and `RequestResult` come out of a call
+against a mock server (the crate's own tests use wiremock for this); `url::Match` comes from
+`Router::recognize`.
 
 **A `match` over an open enum needs a wildcard arm**, and a struct pattern needs `..`:
 

--- a/rust/generator/src/emit/types.rs
+++ b/rust/generator/src/emit/types.rs
@@ -29,6 +29,12 @@ fn render_schema(out: &mut String, schema: &Schema) {
         }
         Shape::Struct(shape) => {
             out.push_str("#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]\n");
+            // What HEY answers is read, never built: a field the model adds to it is then
+            // an addition rather than a break for every caller. What a caller sends stays
+            // literal, `..Default::default()` included.
+            if !schema.request_side {
+                out.push_str("#[non_exhaustive]\n");
+            }
             writeln!(out, "pub struct {} {{", schema.name).unwrap();
             for field in &shape.fields {
                 out.push_str(&doc_comment(field.description.as_deref(), "    "));
@@ -124,5 +130,43 @@ pub(crate) fn rust_type(kind: &FieldType, recursive: bool) -> String {
         FieldType::Named(name) => name.clone(),
         FieldType::List(inner) => format!("Vec<{}>", rust_type(inner, false)),
         FieldType::Map(inner) => format!("BTreeMap<String, {}>", rust_type(inner, false)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::{Field, FieldType, Struct};
+
+    fn schema(name: &str, request_side: bool) -> Schema {
+        Schema {
+            name: name.to_string(),
+            description: None,
+            request_side,
+            shape: Shape::Struct(Struct {
+                fields: vec![Field {
+                    wire_name: "id".to_string(),
+                    description: None,
+                    kind: FieldType::Int64,
+                    required: true,
+                    recursive: false,
+                }],
+                polymorphic: None,
+            }),
+        }
+    }
+
+    #[test]
+    fn what_hey_answers_is_non_exhaustive_and_what_a_caller_sends_is_not() {
+        let mut out = String::new();
+        render_schema(&mut out, &schema("Box", false));
+        render_schema(&mut out, &schema("CreateBoxRequestContent", true));
+
+        assert!(out.contains(
+            "#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]\n#[non_exhaustive]\npub struct Box {"
+        ));
+        assert!(out.contains(
+            "#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]\npub struct CreateBoxRequestContent {"
+        ));
     }
 }

--- a/rust/generator/src/fixtures.rs
+++ b/rust/generator/src/fixtures.rs
@@ -389,6 +389,7 @@ fn required_and_optional_fields_read_as_the_model_says() {
 
     let expected = "/// A sticky note
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct Sticky {
     #[serde(default, deserialize_with = \"crate::types::null_as_default::deserialize\")]
     pub id: i64,
@@ -410,6 +411,28 @@ pub struct Sticky {
         "{}",
         file(&files, "types.rs")
     );
+}
+
+#[test]
+fn what_a_caller_sends_stays_literal_and_what_hey_answers_does_not() {
+    let mut create = read("CreateBox", "Boxes", &[], &json_body("Box"));
+    create["get"]["requestBody"] = json!({ "content": { "application/json": { "schema": { "$ref": "#/components/schemas/CreateBoxRequestContent" } } } });
+    let files = generate(
+        json!({ "/boxes.json": create }),
+        json!({
+            "CreateBoxRequestContent": { "type": "object", "properties": { "box": { "$ref": "#/components/schemas/BoxPayload" } } },
+            "BoxPayload": { "type": "object", "properties": { "name": { "type": "string" } } },
+            "Box": { "type": "object", "properties": { "id": { "type": "integer", "format": "int64" }, "owner": { "$ref": "#/components/schemas/Owner" } } },
+            "Owner": { "type": "object", "properties": { "name": { "type": "string" } } },
+        }),
+        &["CreateBox"],
+    );
+
+    let types = file(&files, "types.rs");
+    assert!(types.contains("#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]\npub struct CreateBoxRequestContent {"));
+    assert!(types.contains("#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]\npub struct BoxPayload {"));
+    assert!(types.contains("#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]\n#[non_exhaustive]\npub struct Mailbox {"));
+    assert!(types.contains("#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]\n#[non_exhaustive]\npub struct Owner {"));
 }
 
 #[test]

--- a/rust/generator/src/model.rs
+++ b/rust/generator/src/model.rs
@@ -45,6 +45,10 @@ pub(crate) struct Schema {
     pub name: String,
     pub description: Option<String>,
     pub shape: Shape,
+    /// The schema is a request body, or something a request body mentions however deep, so
+    /// a caller builds it literally and it can never be `#[non_exhaustive]`. Everything
+    /// else is read back from HEY and only ever read.
+    pub request_side: bool,
 }
 
 pub(crate) enum Shape {
@@ -181,10 +185,11 @@ impl Model {
             .as_str()
             .ok_or("openapi.json has no info.version")?
             .to_string();
-        let schemas = build_schemas(openapi, naming)?;
+        let mut schemas = build_schemas(openapi, naming)?;
         let services = build_services(openapi, behavior, naming, resource_types)?;
         check_references(&schemas, &services)?;
         check_html_responses(&schemas, &services)?;
+        mark_request_side(&mut schemas, &services);
         Ok(Model {
             api_version,
             schemas,
@@ -265,9 +270,36 @@ fn build_schemas(openapi: &Value, naming: &Naming) -> Result<Vec<Schema>, String
             name,
             description: description_of(schema),
             shape,
+            request_side: false,
         });
     }
     Ok(schemas)
+}
+
+/// Walks out from every request body to what it mentions, however deep, and marks those
+/// schemas as the caller's to build. A schema reached from a body and from a response is
+/// request-side: it has to stay constructible.
+fn mark_request_side(schemas: &mut [Schema], services: &[Service]) {
+    let mut pending: Vec<String> = services
+        .iter()
+        .flat_map(|service| &service.operations)
+        .filter_map(|operation| operation.body.clone())
+        .collect();
+    let mut seen = BTreeSet::new();
+    while let Some(name) = pending.pop() {
+        if !seen.insert(name.clone()) {
+            continue;
+        }
+        if let Some(schema) = schemas.iter_mut().find(|schema| schema.name == name) {
+            schema.request_side = true;
+            match &schema.shape {
+                Shape::Struct(shape) => {
+                    pending.extend(shape.fields.iter().filter_map(|field| field.kind.named()));
+                }
+                Shape::Alias(kind) => pending.extend(kind.named()),
+            }
+        }
+    }
 }
 
 fn polymorphic_of(schema: &Value) -> Option<Polymorphic> {
@@ -659,5 +691,79 @@ impl FieldType {
             FieldType::List(inner) | FieldType::Map(inner) => inner.mentions(schema),
             _ => false,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn model(paths: &Value, schemas: &Value) -> Model {
+        let names = "[resource_types]\nboxes = \"box\"\n";
+        let openapi = json!({
+            "openapi": "3.1.0",
+            "info": { "version": "2026-01-01" },
+            "paths": paths,
+            "components": { "schemas": schemas },
+        });
+        let mut operations = serde_json::Map::new();
+        for item in openapi["paths"].as_object().unwrap().values() {
+            for operation in item.as_object().unwrap().values() {
+                operations.insert(
+                    operation["operationId"].as_str().unwrap().to_string(),
+                    json!({ "readonly": false }),
+                );
+            }
+        }
+        let behavior = json!({ "operations": operations });
+        Model::build(
+            &openapi,
+            &behavior,
+            &Naming::parse(names).unwrap(),
+            &ResourceTypes::parse(names).unwrap(),
+        )
+        .unwrap()
+    }
+
+    fn request_side(model: &Model, name: &str) -> bool {
+        model
+            .schemas
+            .iter()
+            .find(|schema| schema.name == name)
+            .unwrap_or_else(|| panic!("{name} is not in the model"))
+            .request_side
+    }
+
+    #[test]
+    fn a_body_and_everything_it_mentions_is_request_side_and_the_rest_is_not() {
+        let model = model(
+            &json!({ "/boxes.json": { "post": {
+                "operationId": "CreateBox",
+                "tags": ["Boxes"],
+                "requestBody": { "content": { "application/json": { "schema": { "$ref": "#/components/schemas/CreateBoxRequestContent" } } } },
+                "responses": { "201": { "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Box" } } } } },
+            } } }),
+            &json!({
+                "CreateBoxRequestContent": { "type": "object", "properties": { "box": { "$ref": "#/components/schemas/BoxPayload" } } },
+                "BoxPayload": { "type": "object", "properties": { "labels": { "type": "array", "items": { "$ref": "#/components/schemas/Label" } }, "shared": { "$ref": "#/components/schemas/Owner" } } },
+                "Label": { "type": "object", "properties": { "name": { "type": "string" } } },
+                "Owner": { "type": "object", "properties": { "name": { "type": "string" } } },
+                "Box": { "type": "object", "properties": { "owner": { "$ref": "#/components/schemas/Owner" }, "postings": { "$ref": "#/components/schemas/Postings" } } },
+                "Postings": { "type": "array", "items": { "$ref": "#/components/schemas/Posting" } },
+                "Posting": { "type": "object", "properties": { "id": { "type": "integer", "format": "int64" } } },
+            }),
+        );
+
+        assert!(request_side(&model, "CreateBoxRequestContent"));
+        assert!(request_side(&model, "BoxPayload"));
+        assert!(request_side(&model, "Label"));
+        assert!(
+            request_side(&model, "Owner"),
+            "a shape on both sides has to stay constructible"
+        );
+        assert!(!request_side(&model, "Box"));
+        assert!(!request_side(&model, "Postings"));
+        assert!(!request_side(&model, "Posting"));
     }
 }

--- a/rust/hey-sdk/src/client.rs
+++ b/rust/hey-sdk/src/client.rs
@@ -105,6 +105,7 @@ pub(crate) struct ScopeState {
 
 /// What came back from HEY, before it is decoded.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct Response {
     /// What HEY answered.
     pub status: StatusCode,

--- a/rust/hey-sdk/src/error.rs
+++ b/rust/hey-sdk/src/error.rs
@@ -37,6 +37,7 @@ pub const MAX_ERROR_MESSAGE_BYTES: usize = 500;
 
 /// Machine-readable error categories, shared with the other HEY SDKs.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
 pub enum ErrorCode {
     /// The call was asked for wrongly: a bad argument, a URL that will not parse.
     Usage,

--- a/rust/hey-sdk/src/form.rs
+++ b/rust/hey-sdk/src/form.rs
@@ -54,6 +54,7 @@ impl Client {
 /// so a 302 or 303 arrives here with its `Location` intact; an endpoint reached on a
 /// `.json` path answers the record itself, which lands in `body` instead.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct FormResponse {
     /// Where the redirect pointed, exactly as HEY wrote it — often a path rather than a
     /// whole URL.

--- a/rust/hey-sdk/src/generated/types.rs
+++ b/rust/hey-sdk/src/generated/types.rs
@@ -10,6 +10,7 @@ use crate::types::{Date, DateTime, SensitiveString};
 
 /// Account — a HEY account
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct Account {
     #[serde(
         default,
@@ -59,6 +60,7 @@ pub struct AddPostingsToBoxGroupRequestContent {
 
 /// Addressed recipients
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct Addressed {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub directly: Option<Vec<Contact>>,
@@ -70,6 +72,7 @@ pub struct Addressed {
 
 /// AddressedSender — sender context
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct AddressedSender {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub directly: Option<Vec<Contact>>,
@@ -77,6 +80,7 @@ pub struct AddressedSender {
 
 /// AdvancedSearchFilters — the options the advanced search refine form offers
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct AdvancedSearchFilters {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub refine_in: Option<Vec<SearchFilterItem>>,
@@ -91,6 +95,7 @@ pub struct AdvancedSearchFilters {
 pub type AdvancedSearchResponseContent = AdvancedSearchResult;
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct AdvancedSearchResult {
     #[serde(
         default,
@@ -101,6 +106,7 @@ pub struct AdvancedSearchResult {
 
 /// AttachedEntry — entry reference on a calendar event
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct AttachedEntry {
     #[serde(
         default,
@@ -117,6 +123,7 @@ pub struct AttachedEntry {
 
 /// Attendance — calendar event attendee
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct Attendance {
     #[serde(
         default,
@@ -132,6 +139,7 @@ pub struct Attendance {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct BadRequestErrorResponseContent {
     #[serde(
         default,
@@ -142,6 +150,7 @@ pub struct BadRequestErrorResponseContent {
 
 /// Box — a HEY mailbox
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct Mailbox {
     #[serde(
         default,
@@ -172,6 +181,7 @@ pub struct Mailbox {
 
 /// BoxGroup — a Set Aside group. The API only ever returns the id.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct BoxGroup {
     #[serde(
         default,
@@ -182,6 +192,7 @@ pub struct BoxGroup {
 
 /// BoxGroupWithPostings — a Set Aside group with one page of the postings in it
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct BoxGroupWithPostings {
     #[serde(
         default,
@@ -196,6 +207,7 @@ pub struct BoxGroupWithPostings {
 
 /// BoxGroupsResponse — the wrapper the groups index answers with
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct BoxGroupsResponse {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub box_groups: Option<Vec<BoxGroup>>,
@@ -205,6 +217,7 @@ pub struct BoxGroupsResponse {
 /// The API can return fields at root level or nested under a `box` key.
 /// SDK response decoders normalize the nested variant to flat before decoding.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct BoxShowResponse {
     #[serde(
         default,
@@ -241,6 +254,7 @@ pub struct BoxShowResponse {
 
 /// BubbleUpSchedule
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct BubbleUpSchedule {
     /// ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -250,6 +264,7 @@ pub struct BubbleUpSchedule {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct BulkReplyDelivery {
     #[serde(
         default,
@@ -274,6 +289,7 @@ pub struct BulkReplyDelivery {
 
 /// The reply as HEY would send it: the prefilled content and the entries it goes to.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct BulkReplyDraft {
     /// The prefilled body — the name tag when every thread is on the same account.
     #[serde(
@@ -290,6 +306,7 @@ pub struct BulkReplyDraft {
 
 /// One thread a bulk reply answers, with the recipients that thread's reply goes to.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct BulkReplyEntry {
     #[serde(
         default,
@@ -351,6 +368,7 @@ pub type BulkUpdateClearancesResponseContent = ClearanceListResponse;
 
 /// Calendar
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct Calendar {
     #[serde(
         default,
@@ -386,6 +404,7 @@ pub struct Calendar {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct CalendarDayListPayload {
     #[serde(
         default,
@@ -396,6 +415,7 @@ pub struct CalendarDayListPayload {
 
 /// CalendarListPayload
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct CalendarListPayload {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub calendars: Option<Vec<CalendarWithRecordingChangesUrl>>,
@@ -412,6 +432,7 @@ pub struct CalendarListPayload {
 /// Recurring events arrive expanded into the occurrences that fall inside the window,
 /// which is what makes this a different answer than the recordings a calendar lists.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct CalendarPeriod {
     /// ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
     pub starts_at: DateTime,
@@ -432,6 +453,7 @@ pub type CalendarRecordingsResponse = BTreeMap<String, Vec<Recording>>;
 
 /// CalendarSelection — the calendars a toggle left switched on
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct CalendarSelection {
     #[serde(
         default,
@@ -465,6 +487,7 @@ pub struct CalendarTodoPayload {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct CalendarWeekListPayload {
     #[serde(
         default,
@@ -475,6 +498,7 @@ pub struct CalendarWeekListPayload {
 
 /// CalendarWithRecordingChangesUrl — wraps calendar with sync URL
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct CalendarWithRecordingChangesUrl {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub calendar: Option<Calendar>,
@@ -486,6 +510,7 @@ pub struct CalendarWithRecordingChangesUrl {
 /// events that span more than one, not every recording it holds: a year's worth of
 /// expanded occurrences is not something a client asks for by opening a year.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct CalendarYear {
     /// ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
     pub starts_at: DateTime,
@@ -517,6 +542,7 @@ pub struct CalendarYear {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct CalendarYearDay {
     /// ISO 8601 date-time timestamp (overrides restJson1 epoch-seconds default)
     pub starts_at: DateTime,
@@ -532,6 +558,7 @@ pub struct CalendarYearDay {
 /// petitioner and most_recent_entry are only filled in by the Screener reads. The
 /// contact reads answer a clearance with nothing but its id and status.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct Clearance {
     #[serde(
         default,
@@ -554,6 +581,7 @@ pub struct Clearance {
 
 /// ClearanceListResponse — wire format: {clearances: [...]}
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct ClearanceListResponse {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub clearances: Option<Vec<Clearance>>,
@@ -564,6 +592,7 @@ pub struct ClearanceListResponse {
 /// clearances is only present when the read passes include_clearances. Without it HEY
 /// answers the count alone, which is what its own apps sync.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct ClearanceSummary {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pending_clearances_count: Option<i32>,
@@ -574,6 +603,7 @@ pub struct ClearanceSummary {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct Clip {
     #[serde(
         default,
@@ -596,6 +626,7 @@ pub struct Clip {
 
 /// The topic a clip was taken from
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct ClipTopic {
     #[serde(
         default,
@@ -610,6 +641,7 @@ pub struct ClipTopic {
 
 /// Collection — email collection/label
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct Collection {
     #[serde(
         default,
@@ -638,6 +670,7 @@ pub struct CollectionPayload {
 
 /// CollectionWithPostings — collection detail with its threads as posting objects
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct CollectionWithPostings {
     #[serde(
         default,
@@ -666,6 +699,7 @@ pub type CompleteHabitResponseContent = Recording;
 /// already ongoing. Time tracks answer {"error": "..."}; contact writes answer the
 /// {"errors": [...]} list every other error path uses.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct ConflictErrorResponseContent {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
@@ -682,6 +716,7 @@ pub struct ConflictErrorResponseContent {
 
 /// Contact — the identity of someone in HEY
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct Contact {
     #[serde(
         default,
@@ -711,6 +746,7 @@ pub struct Contact {
 
 /// ContactDetail — extended contact with additional show fields
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct ContactDetail {
     #[serde(
         default,
@@ -754,6 +790,7 @@ pub struct ContactDetail {
 
 /// A contact's private note. Empty strings when there is no note.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct ContactNote {
     #[serde(
         default,
@@ -912,6 +949,7 @@ pub type CreateTimeTrackResponseContent = Recording;
 
 /// DeletedPosting — the stub the changes feed answers with for a posting that is gone
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct DeletedPosting {
     #[serde(
         default,
@@ -926,6 +964,7 @@ pub struct DeletedPosting {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct DirectUpload {
     #[serde(
         default,
@@ -968,6 +1007,7 @@ pub struct DirectUploadBlob {
 pub type DirectUploadHeaders = BTreeMap<String, String>;
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct DirectUploadTarget {
     #[serde(
         default,
@@ -980,6 +1020,7 @@ pub struct DirectUploadTarget {
 
 /// Domain — email domain
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct Domain {
     #[serde(
         default,
@@ -996,6 +1037,7 @@ pub struct Domain {
 
 /// DraftMessage — a draft entry
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct DraftMessage {
     #[serde(
         default,
@@ -1028,6 +1070,7 @@ pub struct DraftMessage {
 
 /// Entry — a message entry within a topic
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct Entry {
     #[serde(
         default,
@@ -1058,6 +1101,7 @@ pub struct Entry {
 
 /// Extenzion — external account extension
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct Extenzion {
     #[serde(
         default,
@@ -1071,6 +1115,7 @@ pub struct Extenzion {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct ExternalAccount {
     #[serde(
         default,
@@ -1106,6 +1151,7 @@ pub struct FirstWeekDayParams {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct FirstWeekDayPreference {
     /// 0 is Sunday through 6 Saturday, as GetIdentity serves it.
     #[serde(
@@ -1117,6 +1163,7 @@ pub struct FirstWeekDayPreference {
 
 /// Folder — email folder
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct Folder {
     #[serde(
         default,
@@ -1148,6 +1195,7 @@ pub struct FolderPayload {
 
 /// FolderWithPostings — folder detail with the postings filed in it
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct FolderWithPostings {
     #[serde(
         default,
@@ -1169,6 +1217,7 @@ pub struct FolderWithPostings {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct ForbiddenErrorResponseContent {
     #[serde(
         default,
@@ -1184,6 +1233,7 @@ pub type GetAsideboxResponseContent = BoxShowResponse;
 pub type GetBoxGroupResponseContent = BoxGroupWithPostings;
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct GetBoxPostingChangesResponseContent {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub added: Option<Vec<Posting>>,
@@ -1198,6 +1248,7 @@ pub type GetBoxResponseContent = BoxShowResponse;
 pub type GetBubbleboxResponseContent = BoxShowResponse;
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct GetBundleUnseenPostingsResponseContent {
     #[serde(default)]
     pub contact: Contact,
@@ -1289,6 +1340,7 @@ pub struct HabitRequestContent {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct Identity {
     #[serde(
         default,
@@ -1324,6 +1376,7 @@ pub struct Identity {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct InternalServerErrorResponseContent {
     #[serde(
         default,
@@ -1334,6 +1387,7 @@ pub struct InternalServerErrorResponseContent {
 
 /// JoinLink — video/meeting join link
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct JoinLink {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
@@ -1389,6 +1443,7 @@ pub struct MarkPostingsRequestContent {
 
 /// Message — full message detail
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct Message {
     #[serde(
         default,
@@ -1441,6 +1496,7 @@ pub struct MessageAddressed {
 
 /// MessageDraft — a prefilled compose payload (forward, reply). Unsent, so it has no id.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct MessageDraft {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
@@ -1467,6 +1523,7 @@ pub struct MessageDraft {
 /// MessageEditState — a saved draft as the editor sees it. The same compose fields as
 /// MessageDraft, plus the identity and scheduling a saved entry carries.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct MessageEditState {
     #[serde(
         default,
@@ -1543,6 +1600,7 @@ pub struct MessagePayload {
 
 /// MessagePostingContext — posting context for a message
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct MessagePostingContext {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub r#box: Option<String>,
@@ -1594,6 +1652,7 @@ pub struct MoveWorkflowStagingRequestContent {
 
 /// NavigationIcon
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct NavigationIcon {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
@@ -1605,6 +1664,7 @@ pub struct NavigationIcon {
 
 /// NavigationItem
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct NavigationItem {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
@@ -1624,6 +1684,7 @@ pub struct NavigationItem {
 
 /// NavigationResponse
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct NavigationResponse {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub items: Option<Vec<NavigationItem>>,
@@ -1638,6 +1699,7 @@ pub type NewEntryForwardResponseContent = MessageDraft;
 pub type NewEntryReplyResponseContent = MessageDraft;
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct NotFoundErrorResponseContent {
     #[serde(
         default,
@@ -1648,6 +1710,7 @@ pub struct NotFoundErrorResponseContent {
 
 /// Organizer — calendar event organizer
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct Organizer {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub email_address: Option<String>,
@@ -1657,6 +1720,7 @@ pub struct Organizer {
 
 /// Posting — polymorphic by `kind` (topic, bundle, entry)
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct Posting {
     #[serde(
         default,
@@ -1755,6 +1819,7 @@ impl Posting {
 
 /// Note — a posting note
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct PostingNote {
     #[serde(
         default,
@@ -1767,6 +1832,7 @@ pub struct PostingNote {
 
 /// Recording — polymorphic by `type` (Calendar::Event, Calendar::Todo, etc.)
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct Recording {
     #[serde(
         default,
@@ -1909,6 +1975,7 @@ impl Recording {
 
 /// RecurrenceSchedule
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct RecurrenceSchedule {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub kind: Option<String>,
@@ -1920,6 +1987,7 @@ pub struct RecurrenceSchedule {
 
 /// Reminder
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct Reminder {
     #[serde(
         default,
@@ -1985,6 +2053,7 @@ pub struct SchedulePostingsBubbleUpRequestContent {
 
 /// SearchFilterItem — one option offered by the advanced search refine form
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct SearchFilterItem {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
@@ -1994,6 +2063,7 @@ pub struct SearchFilterItem {
 
 /// One matching topic: the topic, your posting of it (if any), and the entries that matched.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct SearchMatch {
     #[serde(default)]
     pub topic: Topic,
@@ -2005,6 +2075,7 @@ pub struct SearchMatch {
 
 /// Sender — a contact with default flag
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct Sender {
     #[serde(
         default,
@@ -2032,6 +2103,7 @@ pub struct Sender {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct ServiceUnavailableErrorResponseContent {
     #[serde(
         default,
@@ -2041,6 +2113,7 @@ pub struct ServiceUnavailableErrorResponseContent {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct Snippet {
     #[serde(
         default,
@@ -2067,6 +2140,7 @@ pub type StartTimeTrackResponseContent = Recording;
 
 /// Sticky — a note on the stickies board
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct Sticky {
     #[serde(
         default,
@@ -2101,6 +2175,7 @@ pub struct StickyRequestContent {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct TimeFormatPreference {
     /// "twelve_hour" or "twenty_four_hour", as GetIdentity serves it.
     #[serde(
@@ -2111,6 +2186,7 @@ pub struct TimeFormatPreference {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct TimeTrackCategory {
     #[serde(
         default,
@@ -2141,6 +2217,7 @@ pub type ToggleCalendarResponseContent = CalendarSelection;
 
 /// Topic detail
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct Topic {
     #[serde(
         default,
@@ -2184,6 +2261,7 @@ pub struct Topic {
 
 /// TopicListResponse — wrapped topic list (sent, spam, trash, everything)
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct TopicListResponse {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
@@ -2194,6 +2272,7 @@ pub struct TopicListResponse {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct TopicPublication {
     #[serde(
         default,
@@ -2208,6 +2287,7 @@ pub struct TopicPublication {
 /// The tracked-time index: a page of completed tracks, and every category they can be
 /// filed under.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct TrackedTime {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub time_tracks: Option<Vec<Recording>>,
@@ -2229,6 +2309,7 @@ pub struct TrashPostingsRequestContent {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct UnauthorizedErrorResponseContent {
     #[serde(
         default,
@@ -2244,6 +2325,7 @@ pub type UncompleteHabitResponseContent = Recording;
 /// The server rejected what was sent. HEY answers {"errors": ["..."]} — the messages
 /// the model itself produced — so a client can show them as they are.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct UnprocessableEntityErrorResponseContent {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub errors: Option<Vec<String>>,
@@ -2380,6 +2462,7 @@ pub type UpdateTimeTrackResponseContent = Recording;
 
 /// UpdatesChannel — streaming channel for a box
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct UpdatesChannel {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub signed_stream_name: Option<String>,
@@ -2387,6 +2470,7 @@ pub struct UpdatesChannel {
 
 /// User — a user within an account
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct User {
     #[serde(
         default,
@@ -2407,6 +2491,7 @@ pub struct User {
 
 /// Workflow — email workflow/label
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct Workflow {
     #[serde(
         default,
@@ -2429,6 +2514,7 @@ pub struct Workflow {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct WorkflowStage {
     #[serde(
         default,

--- a/rust/hey-sdk/src/oauth.rs
+++ b/rust/hey-sdk/src/oauth.rs
@@ -64,6 +64,7 @@ impl ServerMetadata {
 /// The two tokens are [`SensitiveString`]s: serde-transparent, so the wire is what the
 /// server sent, but `[REDACTED]` under `{:?}`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct Token {
     /// What goes in `Authorization` on every request.
     pub access_token: SensitiveString,

--- a/rust/hey-sdk/src/observability.rs
+++ b/rust/hey-sdk/src/observability.rs
@@ -35,6 +35,7 @@ pub struct OperationInfo {
 /// One HTTP request the SDK is about to make, or has just made. `attempt` counts from 1
 /// across the whole operation, the resend after a credential refresh included.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct RequestInfo {
     /// The HTTP method the request goes out with.
     pub method: Method,
@@ -46,6 +47,7 @@ pub struct RequestInfo {
 
 /// How one HTTP request turned out.
 #[derive(Debug)]
+#[non_exhaustive]
 pub struct RequestResult<'a> {
     /// What HEY answered, or `None` when nothing came back at all.
     pub status: Option<StatusCode>,

--- a/rust/hey-sdk/src/route.rs
+++ b/rust/hey-sdk/src/route.rs
@@ -64,6 +64,7 @@ pub enum ParamRole {
 
 /// The type the model gives a path parameter's value.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum ParamKind {
     /// Any text, such as a slug or a token.
     String,
@@ -77,6 +78,7 @@ pub enum ParamKind {
 
 /// How a route pages its answer.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum Pagination {
     /// The whole answer comes at once.
     None,

--- a/rust/hey-sdk/src/services/boxes.rs
+++ b/rust/hey-sdk/src/services/boxes.rs
@@ -17,6 +17,7 @@ pub use crate::generated::services::boxes::*;
 
 /// The kinds of box a HEY account has, as [`Boxes::list`] reports them.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
 pub enum BoxKind {
     /// The Imbox, where screened-in mail lands.
     Imbox,

--- a/rust/hey-sdk/src/services/calendar_changes.rs
+++ b/rust/hey-sdk/src/services/calendar_changes.rs
@@ -82,6 +82,7 @@ impl CalendarChangesCursor {
 
 /// A calendar the changes feed reports gone.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct DeletedCalendar {
     /// The id the calendar had.
     #[serde(default)]
@@ -99,6 +100,7 @@ pub struct DeletedCalendar {
 /// changed, in which case the cursor that produced this page still stands. Unlike the
 /// recording feed, this one never falls too far behind, so there is no full sync to ask for.
 #[derive(Debug, Clone, Default, PartialEq)]
+#[non_exhaustive]
 pub struct CalendarChanges {
     /// The calendars that appeared, each with what a live follower needs.
     pub added: Vec<ListedCalendar>,
@@ -115,6 +117,7 @@ pub struct CalendarChanges {
 /// A recording the changes feed reports gone. `type` is the recordable type key the
 /// recording was grouped under while it existed.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct DeletedRecording {
     /// The id the recording had.
     #[serde(default)]
@@ -143,6 +146,7 @@ pub struct DeletedRecording {
 /// the difference — or speaks a version the feed no longer does — and the calendar has to be
 /// read in full instead.
 #[derive(Debug, Clone, Default, PartialEq)]
+#[non_exhaustive]
 pub struct RecordingChanges {
     /// The recordings that appeared, grouped by recordable type key.
     pub added: BTreeMap<String, Vec<Recording>>,

--- a/rust/hey-sdk/src/services/calendar_events.rs
+++ b/rust/hey-sdk/src/services/calendar_events.rs
@@ -62,6 +62,7 @@ pub struct EventContent {
 /// A countdown's unit, written as the number of seconds HEY's own form submits and the only
 /// form it reads.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum CountdownUnit {
     /// A day: 86,400 seconds.
     #[default]
@@ -91,6 +92,7 @@ pub struct Countdown {
 /// [`RepeatFrequency::EveryWeekday`] — a hardcoded Monday to Friday — is the only weekday
 /// set that can be expressed.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum RepeatFrequency {
     /// Every day.
     EveryDay,

--- a/rust/hey-sdk/src/services/calendars.rs
+++ b/rust/hey-sdk/src/services/calendars.rs
@@ -18,6 +18,7 @@ pub use crate::generated::services::calendars::*;
 /// feed's added bucket carries this same shape, so a calendar learned of either way arrives
 /// subscribable.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct ListedCalendar {
     /// The calendar itself, as [`Calendars::list`] serves it.
     #[serde(default)]
@@ -33,6 +34,7 @@ pub struct ListedCalendar {
 /// The full calendars index: every calendar with its changes URL and signed stream name,
 /// the calendar-level changes feed's own URL, and the calendars the reader has switched on.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct CalendarList {
     /// Every calendar the identity sees, each with what a live follower needs.
     #[serde(default)]

--- a/rust/hey-sdk/src/services/contacts.rs
+++ b/rust/hey-sdk/src/services/contacts.rs
@@ -44,6 +44,7 @@ pub struct ContactParams {
 /// It travels as the source of an [`Error`] with [`crate::ErrorCode::Conflict`], so a
 /// caller who only cares that the write was refused can ignore it.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct ContactConflict {
     /// The contact the write was for — on a create, the one it made.
     pub contact_id: i64,

--- a/rust/hey-sdk/src/services/extenzions.rs
+++ b/rust/hey-sdk/src/services/extenzions.rs
@@ -30,6 +30,7 @@ const CONTACT_PATH: &str = "/contacts/";
 /// its `app_url` carries. The id a JSON write answers with belongs to the Extenzion record
 /// instead, which no endpoint takes.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct Extenzion {
     /// The extenzion's contact id.
     pub id: i64,

--- a/rust/hey-sdk/src/services/identity.rs
+++ b/rust/hey-sdk/src/services/identity.rs
@@ -13,6 +13,7 @@ pub use crate::generated::services::identity::*;
 
 /// The clock HEY renders times on.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum TimeFormat {
     /// A 12-hour clock, HEY's `twelve_hour`.
     TwelveHour,

--- a/rust/hey-sdk/src/services/postings.rs
+++ b/rust/hey-sdk/src/services/postings.rs
@@ -34,6 +34,7 @@ const TOO_FAR_BEHIND: u16 = 409;
 /// [`BubbleUpSlot::LaterToday`] at its evening hour of the current day instead — and reads
 /// both hours in UTC, like every hour it takes out of a JSON request.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum BubbleUpSlot {
     /// This evening. HEY's `today`.
     LaterToday,
@@ -117,6 +118,7 @@ impl PostingChangesCursor {
 /// set when the cursor is too far behind for an increment to carry the difference, and the
 /// box has to be read in full instead.
 #[derive(Debug, Clone, Default, PartialEq)]
+#[non_exhaustive]
 pub struct PostingChanges {
     /// The postings that appeared in the box.
     pub added: Vec<Posting>,

--- a/rust/hey-sdk/src/services/search.rs
+++ b/rust/hey-sdk/src/services/search.rs
@@ -48,6 +48,7 @@ pub struct SearchParams {
 /// the `Link` header while there is more to read, which is how a caller walking the results
 /// is told to stop asking rather than having to ask for a page that turns out empty.
 #[derive(Debug, Clone, Default, PartialEq)]
+#[non_exhaustive]
 pub struct SearchResults {
     /// The matches, grouped by topic.
     pub result: AdvancedSearchResult,

--- a/rust/hey-sdk/src/services/stickies.rs
+++ b/rust/hey-sdk/src/services/stickies.rs
@@ -20,6 +20,7 @@ pub const MAX_STICKY_POSITION: i64 = i32::MAX as i64;
 
 /// How much room a sticky takes on the board.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum StickySize {
     /// The smallest.
     Small,

--- a/rust/hey-sdk/src/services/workflows.rs
+++ b/rust/hey-sdk/src/services/workflows.rs
@@ -16,6 +16,7 @@ pub use crate::generated::services::workflows::*;
 
 /// A workflow as the autocomplete endpoint names it.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct WorkflowSummary {
     /// The workflow's id.
     pub id: i64,

--- a/rust/hey-sdk/src/url.rs
+++ b/rust/hey-sdk/src/url.rs
@@ -20,6 +20,7 @@ struct Pattern {
 
 /// What a recognized path refers to.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct Match {
     /// The path template the path matched: `/boxes/{boxId}/groups/{groupId}`.
     pub pattern: &'static str,

--- a/rust/hey-sdk/tests/form.rs
+++ b/rust/hey-sdk/tests/form.rs
@@ -177,40 +177,47 @@ async fn a_form_request_that_fails_keeps_what_hey_answered_and_is_not_resent() {
     assert_eq!(server.received_requests().await.unwrap().len(), 2);
 }
 
-#[test]
-fn the_id_is_the_rightmost_numeric_segment_of_the_redirect() {
+#[tokio::test]
+async fn the_id_is_the_rightmost_numeric_segment_of_the_redirect() {
     assert_eq!(
-        redirected_to("/calendar/events/42").extract_id().unwrap(),
+        redirected_to(Some("/calendar/events/42"))
+            .await
+            .extract_id()
+            .unwrap(),
         42
     );
     assert_eq!(
-        redirected_to("https://app.hey.com/calendar/events/99")
+        redirected_to(Some("https://app.hey.com/calendar/events/99"))
+            .await
             .extract_id()
             .unwrap(),
         99
     );
     assert_eq!(
-        redirected_to("/calendar/events/7/").extract_id().unwrap(),
+        redirected_to(Some("/calendar/events/7/"))
+            .await
+            .extract_id()
+            .unwrap(),
         7
     );
     assert_eq!(
-        redirected_to("/calendar/events/13?edit=1")
+        redirected_to(Some("/calendar/events/13?edit=1"))
+            .await
             .extract_id()
             .unwrap(),
         13
     );
 
-    let nameless = redirected_to("/calendar").extract_id().unwrap_err();
+    let nameless = redirected_to(Some("/calendar"))
+        .await
+        .extract_id()
+        .unwrap_err();
     assert_eq!(
         nameless.message(),
         "no numeric ID found in location: /calendar"
     );
 
-    let nowhere = FormResponse {
-        location: None,
-        status: StatusCode::FOUND,
-        body: String::new(),
-    };
+    let nowhere = redirected_to(None).await;
     assert_eq!(
         nowhere.extract_id().unwrap_err().message(),
         "no location header in response"
@@ -249,12 +256,20 @@ async fn a_supplied_http_client_still_has_its_redirects_captured() {
     assert_eq!(server.received_requests().await.unwrap().len(), 1);
 }
 
-fn redirected_to(location: &str) -> FormResponse {
-    FormResponse {
-        location: Some(location.to_string()),
-        status: StatusCode::FOUND,
-        body: String::new(),
+/// What a form post answered with when HEY redirected to `location`, or answered a bare
+/// 302 when there is none.
+async fn redirected_to(location: Option<&str>) -> FormResponse {
+    let server = MockServer::start().await;
+    let mut response = ResponseTemplate::new(302);
+    if let Some(location) = location {
+        response = response.insert_header("Location", location);
     }
+    Mock::given(method("POST"))
+        .and(path("/redirect"))
+        .respond_with(response)
+        .mount(&server)
+        .await;
+    client(&server).post_form("/redirect", &[]).await.unwrap()
 }
 
 /// A provider whose credentials can be renewed: the first 401 swaps the stale token for a

--- a/rust/hey-sdk/tests/recordings.rs
+++ b/rust/hey-sdk/tests/recordings.rs
@@ -31,8 +31,7 @@ fn every_recording_variant_has_a_helper_that_answers_to_its_wire_type() {
 }
 
 fn recording(wire_type: &str) -> Recording {
-    Recording {
-        r#type: wire_type.to_string(),
-        ..Default::default()
-    }
+    let mut recording = Recording::default();
+    recording.r#type = wire_type.to_string();
+    recording
 }

--- a/rust/hey-sdk/tests/services_extenzions.rs
+++ b/rust/hey-sdk/tests/services_extenzions.rs
@@ -4,7 +4,7 @@ mod support;
 
 use std::sync::Arc;
 
-use hey_sdk::services::{CreateExtenzionParams, Extenzion, UpdateExtenzionParams};
+use hey_sdk::services::{CreateExtenzionParams, UpdateExtenzionParams};
 use serde_json::json;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -33,19 +33,21 @@ async fn listing_reads_the_extensions_group_out_of_navigation() {
 
     let extenzions = client(&server).extenzions().list().await.unwrap();
 
+    let listed: Vec<(i64, &str, &str)> = extenzions
+        .iter()
+        .map(|extenzion| {
+            (
+                extenzion.id,
+                extenzion.name.as_str(),
+                extenzion.app_url.as_str(),
+            )
+        })
+        .collect();
     assert_eq!(
-        extenzions,
+        listed,
         [
-            Extenzion {
-                id: 10,
-                name: "sales".to_string(),
-                app_url: "https://app.hey.com/contacts/10".to_string(),
-            },
-            Extenzion {
-                id: 20,
-                name: "support".to_string(),
-                app_url: "https://app.hey.com/contacts/20".to_string(),
-            },
+            (10, "sales", "https://app.hey.com/contacts/10"),
+            (20, "support", "https://app.hey.com/contacts/20"),
         ]
     );
 }
@@ -75,14 +77,10 @@ async fn creating_answers_the_extenzion_under_its_contact_id() {
         .await
         .unwrap();
 
-    assert_eq!(
-        created,
-        Some(Extenzion {
-            id: 10,
-            name: "sales".to_string(),
-            app_url: "https://app.hey.com/contacts/10".to_string(),
-        })
-    );
+    let created = created.unwrap();
+    assert_eq!(created.id, 10);
+    assert_eq!(created.name, "sales");
+    assert_eq!(created.app_url, "https://app.hey.com/contacts/10");
     assert_eq!(
         sent_form(&server).await,
         [

--- a/rust/hey-sdk/tests/services_workflows.rs
+++ b/rust/hey-sdk/tests/services_workflows.rs
@@ -4,7 +4,6 @@ mod support;
 
 use std::sync::Arc;
 
-use hey_sdk::services::WorkflowSummary;
 use serde_json::json;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -30,20 +29,19 @@ async fn the_workflow_list_reads_the_rows_the_autocomplete_endpoint_answers() {
 
     let workflows = client(&server).workflows().list(77).await.unwrap();
 
+    let listed: Vec<(i64, &str, &str)> = workflows
+        .iter()
+        .map(|workflow| {
+            (
+                workflow.id,
+                workflow.name.as_str(),
+                workflow.account_name.as_str(),
+            )
+        })
+        .collect();
     assert_eq!(
-        workflows,
-        [
-            WorkflowSummary {
-                id: 8801,
-                name: "Hiring".to_string(),
-                account_name: "Example Co".to_string(),
-            },
-            WorkflowSummary {
-                id: 8802,
-                name: "Sales pipeline".to_string(),
-                account_name: String::new(),
-            },
-        ]
+        listed,
+        [(8801, "Hiring", "Example Co"), (8802, "Sales pipeline", "")]
     );
     let requests = server.received_requests().await.unwrap();
     assert_eq!(


### PR DESCRIPTION
Tracking card: [hey-sdk Rust: public API governance](https://3.basecamp.com/2914079/buckets/46292715/card_tables/cards/10289485376). Second of two, stacked on #163 (base is its branch; GitHub retargets to `main` when it merges). **Merge order: #163, then this PR.** It depends on #163 for the lint table the tests now satisfy and the policy text it applies; both are kept rebased on `main` and converged together. This is the decision that has to land before the first crates.io publish: adding `#[non_exhaustive]` later is itself a breaking change.

**What is `#[non_exhaustive]` now, and why.** The rule from #163, applied: what the crate decodes and hands back is read, never built; what a caller sends stays literal.

- **Generated** (`rust/generator/src/model.rs` `mark_request_side`, `emit/types.rs`): the generator walks out from every request body to everything it mentions, however deep, and marks those schemas request-side; every other struct schema is emitted `#[non_exhaustive]`. On today's model that is 51 request-side structs (every `*RequestContent` and the payloads they carry — `MessagePayload`, `ContactPayload`, `StickyPayload`, …) and 86 response-side ones (`Mailbox`, `Posting`, `Topic`, `Contact`, `Calendar`, the `*ResponseContent` envelopes, the error bodies, …); no schema is on both sides. The `*Params` structs are untouched. Tests: `model.rs` (a body, what it mentions through a list, and a shape shared with a response all stay request-side; the rest do not), `emit/types.rs` (the attribute is emitted for one and not the other), and a generator fixture running the whole thing end to end.
- **Hand-written results**: `WorkflowSummary`, `CalendarChanges`, `RecordingChanges`, `DeletedRecording`, `DeletedCalendar`, `PostingChanges`, `SearchResults`, `ContactConflict`, `ListedCalendar`, `CalendarList`, `services::extenzions::Extenzion`, `url::Match`.
- **Runtime**: `client::Response`, `FormResponse`, `oauth::Token`, and what the hooks hand back — `RequestInfo`, `RequestResult`.
- **Open enums** (their variant sets are HEY's to grow): `ErrorCode`, `route::Pagination`, `route::ParamKind`, `BoxKind`, `StickySize`, `BubbleUpSlot`, `RepeatFrequency`, `CountdownUnit`, `TimeFormat`.

**Left constructible, on purpose**: `OperationInfo` (`Operation::info` takes one from a caller describing its own form-backed call); `Route`, `RouteParam`, `Retry` (a caller may write a route for a path the model lacks and hand it to `Client::operation` — #154's `tests/retry_policy.rs` does exactly that, which is how this line got drawn); `Config`, the resilience configs, `ExchangeRequest`, `RefreshRequest`, `ServerMetadata`, `Pkce`, `CachedResponse`, the `*Cursor` structs; and the closed enums `ClearanceStatus`, `OccurrenceScope`, `RepeatUntil`, `ParamRole`. A field added to any of those is a `0.MINOR`.

**What is and isn't breaking afterward.** A field added to a response-side type or a variant added to an open enum is a `0.x.PATCH`, provided what HEY already sends still decodes (a required field with no decoding default is not additive). A field added to a request-side type is a `0.MINOR`. `cargo semver-checks` against #163's head reports exactly the two checks this change is: `struct_marked_non_exhaustive` and `enum_marked_non_exhaustive`, nothing else.

**Migration** (`MIGRATING.md`, new at the repo root, Rust section for the first release after 0.30.0): literal construction of a response-side type stops compiling, `..Default::default()` included — build with `T::default()` and set fields; a `match` over an open enum needs a `_` arm; reading, methods, `Clone`, `PartialEq`, serde are untouched. The crate's own tests show the shape: `tests/recordings.rs` builds a `Recording` through `default()`; `tests/form.rs` reads a `FormResponse` back from a mock instead of building one; `tests/services_extenzions.rs` and `tests/services_workflows.rs` compare fields.

**Enums from the model.** None today (`openapi.json` declares no `enum`), so the generator invents none; the `Unknown(String)` shape is policy in #163 and lands as emit the day the model declares one.

**The `breaking` label, and why it is the instrument.** `api-compat-rust` runs `cargo semver-checks` against the base commit and fails on any major-class change; its `if:` skips the job when the pull request carries the `breaking` label, the same escape hatch the Go job has, and the crate's own policy text names for a pre-1.0 break (README, *Versioning*). The label is on. The alternative the job's comment offers — bumping `Cargo.toml` to `0.31.0` in the PR so the checker judges it a permitted major — is wrong here: the Go module and the Rust crate share one version and one tag, and the version moves when a release is cut, not inside a feature PR. The break itself is intended and is the whole point: pre-1.0, `0.30 → 0.31` is the major, and `#[non_exhaustive]` has to be on the response types before the first crates.io publish, because adding it afterward is itself the same break against a public baseline. `cargo semver-checks --baseline-rev <#163 head>` on the current head reports exactly `struct_marked_non_exhaustive` and `enum_marked_non_exhaustive`, nothing else, so the label excuses only what this PR sets out to do. `main` is not branch-protected, so a skipped job holds nothing up.

**Local gate** on Rust 1.98.1, at the current head (rebased with #163 onto `main` after #165 and #170): `make -C rust check` (fmt, clippy `--all-targets -D warnings`, test — 48 suites, doc `-D warnings`, `--no-default-features`, examples, deny, publish dry run) exit 0, `rs-check-drift` exit 0, `conformance-rs` 195/195; `cargo check -p hey-sdk` on 1.88.0 with `--all-features` and `--no-default-features` both build; `cargo semver-checks` as above.

**Review.** Adversarial Codex CLI pass done (gpt-6-astra at xhigh, read-only) over the hand-written diff: one finding, folded in (the fixture test says where a result without `Default` comes from). Copilot recommended approval; no inline threads. Babysitting to convergence.

