### PR TITLE
Make the runtime keep the contracts the tests now hold it to

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -203,7 +203,7 @@ go-check-drift:
 # Rust SDK
 #------------------------------------------------------------------------------
 
-.PHONY: rs-generate rs-check-drift rs-test rs-lint rs-examples rs-deny rs-publish-check rs-check
+.PHONY: rs-generate rs-check-drift rs-test rs-lint rs-examples rs-deny rs-publish-check rs-check rs-consumer-check
 
 # Types, routes and services are all generated; there is no hand-written wrapper layer
 # to drift, so the drift check is the generator's own --check.
@@ -230,6 +230,11 @@ rs-publish-check:
 
 rs-check:
 	$(MAKE) -C rust check
+
+# Build the packaged crate from a throwaway consumer, with fresh resolution and no
+# dev-dependencies, for the default features and with none
+rs-consumer-check:
+	./scripts/rs-consumer-check
 
 #------------------------------------------------------------------------------
 # TypeScript SDK

--- a/rust/hey-sdk/README.md
+++ b/rust/hey-sdk/README.md
@@ -235,8 +235,12 @@ while let Some(next) = client.next_page(&page).await? {
 }
 ```
 
-`next_page` refuses a `Link` header that points off the HEY origin. `each_page` walks pages
-up to the client's `max_pages`.
+`next_page` refuses a `Link` header that points off the HEY origin. `each_page`, `get_all`
+and `follow_pagination` walk up to the client's `max_pages`, and a walk that reaches it with
+pages still to read ends as a `Usage` error saying so rather than as a shorter list that
+looks complete. `each_page` has handed every page it read to the visitor by then; `get_all`
+and `follow_pagination` answer only the error, since a list cut short is the thing they exist
+not to hand back. Raise `max_pages`, or read with a limit.
 
 ### Linked accounts
 
@@ -323,9 +327,21 @@ gives no policy is sent once, and so is any operation that is not idempotent, wh
 policy says. A path the caller wrote has no policy to bring, so an idempotent one runs on the
 client's settings alone and is resent on 429, 500, 502, 503 and 504; `get_all` and
 `follow_pagination` read every page that way. Any operation is resent once after a 401 that
-the token provider's `refresh` could answer, even with its sends spent. With a `ResponseCache` (`InMemoryCache`, `FileCache`, or
+the token provider's `refresh` could answer, even with its sends spent — and once for all the
+calls a stale credential earned a 401 on: refreshes go one at a time, and a call signed before
+the last refresh is resent on the new credentials rather than refreshing again, so a rotating
+refresh token is spent once. With a `ResponseCache` (`InMemoryCache`, `FileCache`, or
 `config.cache_enabled`), JSON reads revalidate with `If-None-Match` and a 304 is answered from
 the cache. Response bodies are capped at `max_response_body_bytes` (16 MiB by default).
+
+`timeout` on the builder is the HTTP client's: how long one request on the wire may take.
+`operation_timeout` is the operation's: how long the whole call may take, from waiting at the
+gate through credentials, every attempt, every wait between attempts, the resend after a
+refresh, and reading the body — everything the client waits for. Past it the call ends as a
+retryable network error and whatever it was doing is dropped — a bulkhead permit it held goes
+back and the hooks hear it end. Decoding the answer into your type comes after, on your own
+thread, and is not part of the wait. Neither bounds the other: without `operation_timeout` a
+call may take as long as its attempts and waits add up to.
 
 ### Bring your own HTTP client
 

--- a/rust/hey-sdk/src/auth.rs
+++ b/rust/hey-sdk/src/auth.rs
@@ -47,6 +47,19 @@ impl TokenProvider for StaticTokenProvider {
     }
 }
 
+/// A provider behind an `Arc` is a provider, so one can be shared with the client and
+/// kept by the application — to watch its refreshes, say.
+#[async_trait]
+impl<P: TokenProvider + ?Sized> TokenProvider for std::sync::Arc<P> {
+    async fn access_token(&self) -> Result<String, Error> {
+        (**self).access_token().await
+    }
+
+    async fn refresh(&self) -> bool {
+        (**self).refresh().await
+    }
+}
+
 /// Puts credentials on a request. The default, [`BearerAuth`], sets an `Authorization`
 /// header from a [`TokenProvider`]; anything else can plug in here.
 #[async_trait]

--- a/rust/hey-sdk/src/client.rs
+++ b/rust/hey-sdk/src/client.rs
@@ -1,5 +1,6 @@
 use std::fmt::Display;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
 use bytes::Bytes;
@@ -66,6 +67,13 @@ const ACCOUNT_FILTER_PARAMETER: &str = "filtered_account_id";
 /// is what reqwest allowed when it was the one following them.
 const MAX_REDIRECTS: usize = 10;
 
+tokio::task_local! {
+    /// The deadline the operation in progress on this task is held to, so that every
+    /// request a convenience or a walk makes inside it is held to the same one rather
+    /// than each starting a limit of its own.
+    static DEADLINE: Option<Instant>;
+}
+
 /// A HEY client: one authenticated identity, presenting mail from All Accounts unless
 /// derived for one linked account with [`Client::for_account`].
 ///
@@ -91,6 +99,17 @@ pub(crate) struct Shared {
     pub(crate) max_response_body_bytes: usize,
     pub(crate) cache: Option<Arc<dyn ResponseCache>>,
     pub(crate) hooks: Arc<dyn Hooks>,
+    pub(crate) operation_timeout: Option<Duration>,
+    /// How many times the credentials have been refreshed. A request remembers the count it
+    /// was signed under, so a 401 answered after someone else refreshed is resent on the
+    /// new credentials rather than refreshing again.
+    pub(crate) refreshes: AtomicU64,
+    /// One refresh at a time, and none while a request is being signed: the 401s a stale
+    /// credential earns all arrive together, and only the first of them should cost a
+    /// round trip to the token endpoint. Signing takes this for reading, so requests sign
+    /// concurrently; a refresh takes it for writing, so the count a request is signed
+    /// under is the count of the credentials it carries.
+    pub(crate) refreshing: tokio::sync::RwLock<()>,
 }
 
 /// What a client works out about the identity it presents and keeps for as long as it
@@ -124,12 +143,19 @@ pub struct Response {
 }
 
 impl Response {
-    /// The body decoded as `T`. An empty body is refused rather than decoded as nothing.
+    /// Decodes the body as JSON. A body that will not decode is an error that still says
+    /// what HEY answered: the status, and the request id when the answer named one.
     pub fn json<T: DeserializeOwned>(&self) -> Result<T, Error> {
         if self.body.is_empty() {
-            Err(Error::api(self.status.as_u16(), "empty response body"))
+            let error = Error::api(self.status.as_u16(), "empty response body");
+            Err(match self.header("x-request-id") {
+                Some(request_id) => error.with_request_id(request_id),
+                None => error,
+            })
         } else {
-            Ok(serde_json::from_slice(&self.body)?)
+            serde_json::from_slice(&self.body).map_err(|error| {
+                Error::decoding(self.status.as_u16(), self.header("x-request-id"), error)
+            })
         }
     }
 
@@ -155,6 +181,7 @@ pub struct ClientBuilder {
     max_response_body_bytes: usize,
     cache: Option<Arc<dyn ResponseCache>>,
     pub(crate) hooks: Arc<dyn Hooks>,
+    operation_timeout: Option<Duration>,
 }
 
 impl ClientBuilder {
@@ -174,6 +201,7 @@ impl ClientBuilder {
             max_response_body_bytes: DEFAULT_MAX_RESPONSE_BODY_BYTES,
             cache: None,
             hooks: Arc::new(NoopHooks),
+            operation_timeout: None,
         }
     }
 
@@ -208,10 +236,25 @@ impl ClientBuilder {
     }
 
     /// How long the HTTP client the SDK ships gives an answer to arrive. It has no effect on
-    /// one supplied with [`ClientBuilder::http_client`].
+    /// one supplied with [`ClientBuilder::http_client`]. This bounds one request on the
+    /// wire; the whole of an operation is bounded by [`ClientBuilder::operation_timeout`].
     #[must_use]
     pub fn timeout(mut self, timeout: Duration) -> ClientBuilder {
         self.timeout = timeout;
+        self
+    }
+
+    /// The most an operation may take from the call to its answer, everything the client
+    /// waits for included: waiting at the gate, fetching credentials, every attempt, every
+    /// wait between them, the resend after a refresh, and reading the body. Past it the
+    /// operation ends as a retryable network error, and whatever it was doing is dropped —
+    /// a permit it held goes back, and the hooks hear it end. Decoding the answer into the
+    /// caller's type comes after, on the caller's own thread, and is not waited for. None
+    /// by default: an operation may then take as long as its attempts and waits add up to,
+    /// each attempt bounded only by the HTTP client's own [`ClientBuilder::timeout`].
+    #[must_use]
+    pub fn operation_timeout(mut self, limit: Duration) -> ClientBuilder {
+        self.operation_timeout = Some(limit);
         self
     }
 
@@ -298,6 +341,17 @@ impl ClientBuilder {
         if self.max_pages == 0 {
             return Err(Error::usage("max pages must be greater than zero"));
         }
+        if self.operation_timeout.is_some_and(|limit| limit.is_zero()) {
+            return Err(Error::usage("operation timeout must be greater than zero"));
+        }
+        if self
+            .operation_timeout
+            .is_some_and(|limit| Instant::now().checked_add(limit).is_none())
+        {
+            return Err(Error::usage(
+                "operation timeout is too long to keep time by",
+            ));
+        }
         let http = match self.http {
             Some(http) => http,
             None => shipped_http_client(self.timeout)?,
@@ -327,6 +381,9 @@ impl ClientBuilder {
             max_response_body_bytes,
             cache,
             hooks: self.hooks,
+            operation_timeout: self.operation_timeout,
+            refreshes: AtomicU64::new(0),
+            refreshing: tokio::sync::RwLock::new(()),
         };
         Ok(Client {
             shared: Arc::new(shared),
@@ -395,7 +452,11 @@ impl Client {
 
     /// Sends an operation and decodes its JSON body.
     pub async fn send<T: DeserializeOwned>(&self, operation: Operation) -> Result<T, Error> {
-        self.execute(operation).await?.json()
+        let label = operation.label().to_string();
+        self.execute(operation)
+            .await?
+            .json()
+            .map_err(|error| error.about(&label))
     }
 
     /// Sends an operation whose answer carries no body worth reading.
@@ -415,11 +476,15 @@ impl Client {
         &self,
         operation: Operation,
     ) -> Result<Option<T>, Error> {
+        let label = operation.label().to_string();
         let response = self.execute(operation).await?;
         if response.empty {
             Ok(None)
         } else {
-            response.json().map(Some)
+            response
+                .json()
+                .map(Some)
+                .map_err(|error| error.about(&label))
         }
     }
 
@@ -428,10 +493,12 @@ impl Client {
         &self,
         operation: Operation,
     ) -> Result<Page<T>, Error> {
+        let label = operation.label().to_string();
         let info = operation.info.clone();
         let route = operation.route;
         let response = self.execute(operation).await?;
-        Ok(Page::new(response.json()?, &response, info, route))
+        let value = response.json().map_err(|error| error.about(&label))?;
+        Ok(Page::new(value, &response, info, route))
     }
 
     /// Reads the page after the given one, or `None` when HEY named no next page. A
@@ -457,23 +524,34 @@ impl Client {
         }
     }
 
-    /// Reads every page after the first, up to the client's page limit, calling `visit`
-    /// with each one. Stops early when `visit` answers `false`.
+    /// Reads every page after the first, calling `visit` with each one. Stops early when
+    /// `visit` answers `false`. A walk that reaches the client's page limit with pages
+    /// still to read stops there and says so, as [`Error::pagination_capped`]: the pages
+    /// visited stand, and the caller knows they were not all of them.
     pub async fn each_page<T: DeserializeOwned>(
         &self,
         first: Page<T>,
         mut visit: impl FnMut(&Page<T>) -> bool,
     ) -> Result<(), Error> {
-        let mut page = first;
-        let mut count = 1;
-        while visit(&page) && count < self.shared.max_pages {
-            match self.next_page(&page).await? {
-                Some(next) => page = next,
-                None => break,
+        self.within_limit(Box::pin(async move {
+            let mut page = first;
+            let mut count = 1;
+            while visit(&page) {
+                if !page.has_next() {
+                    break;
+                }
+                if count >= self.shared.max_pages {
+                    return Err(Error::pagination_capped(self.shared.max_pages));
+                }
+                match self.next_page(&page).await? {
+                    Some(next) => page = next,
+                    None => break,
+                }
+                count += 1;
             }
-            count += 1;
-        }
-        Ok(())
+            Ok(())
+        }))
+        .await
     }
 
     /// Sends an operation: asks the hooks whether it may run, applies credentials and
@@ -481,8 +559,9 @@ impl Client {
     /// resends once after a refreshed 401, and answers a cached body on 304. Non-2xx
     /// statuses become errors unless the operation treats them as empty.
     pub async fn execute(&self, operation: Operation) -> Result<Response, Error> {
+        let deadline = self.deadline();
         let span = span_for(&operation);
-        span.wrap(self.instrument(&operation, self.dispatch(&operation, &span)))
+        span.wrap(self.instrument(&operation, deadline, self.dispatch(&operation, &span)))
             .await
     }
 
@@ -490,11 +569,62 @@ impl Client {
     /// that writes it somewhere rather than holding it. Everything up to the answer is
     /// [`Client::execute`]'s doing — the gate, the credentials, the account scope, the
     /// retries, the resend after a refreshed 401 — and nothing is resent once the answer
-    /// is in hand, since its bytes may already be on their way out.
-    pub(crate) async fn stream(&self, operation: Operation) -> Result<HttpResponse<Body>, Error> {
+    /// is in hand, since its bytes may already be on their way out. The deadline is the
+    /// caller's to hold, so the bytes it goes on to read can be held to the same one.
+    pub(crate) async fn stream(
+        &self,
+        operation: Operation,
+        deadline: Option<Instant>,
+    ) -> Result<HttpResponse<Body>, Error> {
         let span = span_for(&operation);
-        span.wrap(self.instrument(&operation, self.streamed(&operation, &span)))
+        span.wrap(self.instrument(&operation, deadline, self.streamed(&operation, &span)))
             .await
+    }
+
+    /// When the operation in progress has to be over: the deadline of the operation this
+    /// task is already inside, when it is inside one, or else
+    /// [`ClientBuilder::operation_timeout`] from now; `None` when there is no limit.
+    pub(crate) fn deadline(&self) -> Option<Instant> {
+        match DEADLINE.try_with(|deadline| *deadline) {
+            Ok(inherited) => inherited,
+            Err(_) => self
+                .shared
+                .operation_timeout
+                .and_then(|limit| Instant::now().checked_add(limit)),
+        }
+    }
+
+    /// Holds some work to [`ClientBuilder::operation_timeout`] as one operation: every
+    /// request made inside it — a convenience's follow-up, a walk's later pages — shares
+    /// the one deadline rather than starting a limit of its own.
+    pub(crate) async fn within_limit<T>(
+        &self,
+        work: impl Future<Output = Result<T, Error>>,
+    ) -> Result<T, Error> {
+        let deadline = self.deadline();
+        DEADLINE
+            .scope(deadline, self.within_deadline(deadline, work))
+            .await
+    }
+
+    /// Holds some work to a deadline. Past it the work is dropped where it stands — which
+    /// is what makes the guards report the ends they owe, and the resilience layer give
+    /// back what the operation held — and the caller gets a network error naming the
+    /// limit.
+    pub(crate) async fn within_deadline<T>(
+        &self,
+        deadline: Option<Instant>,
+        work: impl Future<Output = Result<T, Error>>,
+    ) -> Result<T, Error> {
+        match (deadline, self.shared.operation_timeout) {
+            (Some(deadline), Some(limit)) => {
+                match tokio::time::timeout_at(deadline.into(), work).await {
+                    Ok(outcome) => outcome,
+                    Err(_) => Err(Error::timed_out(limit)),
+                }
+            }
+            _ => work.await,
+        }
     }
 
     /// Runs one operation inside the hook lifecycle every call shares. A quiet operation is
@@ -502,21 +632,25 @@ impl Client {
     /// The `tracing` span around all of this is the caller's to put on, so that the gate and
     /// the end hook are inside it too.
     ///
-    /// The end is reported from a drop guard rather than after the await, because the await
-    /// may never return: a caller's `tokio::time::timeout` or `select!` can drop the future
-    /// mid-flight, and a start with no end leaves the bulkhead a permit short and the
-    /// circuit breaker a call short for the life of the client. Dropped that way, the
-    /// operation ends as [`Error::cancelled`].
+    /// The deadline is applied in here, to the gate and to the work, so that the hooks hear
+    /// an operation that ran out of time end with the same [`Error::timed_out`] the caller
+    /// gets. The end is reported from a drop guard rather than after the await all the
+    /// same, because the await may never return: a caller's own `tokio::time::timeout` or
+    /// `select!` can drop the future mid-flight, and a start with no end leaves the
+    /// bulkhead a permit short and the circuit breaker a call short for the life of the
+    /// client. Dropped that way, the operation ends as [`Error::cancelled`].
     async fn instrument<T>(
         &self,
         operation: &Operation,
+        deadline: Option<Instant>,
         work: impl Future<Output = Result<T, Error>>,
     ) -> Result<T, Error> {
         if operation.quiet {
-            work.await
+            self.within_deadline(deadline, work).await
         } else {
             let hooks = &self.shared.hooks;
-            hooks.on_operation_gate(&operation.info).await?;
+            self.within_deadline(deadline, hooks.on_operation_gate(&operation.info))
+                .await?;
 
             let mut running = Running {
                 hooks,
@@ -524,7 +658,7 @@ impl Client {
                 state: Some(hooks.on_operation_start(&operation.info)),
                 started: Instant::now(),
             };
-            let outcome = work.await;
+            let outcome = self.within_deadline(deadline, work).await;
             running.finished(outcome.as_ref().map(|_| ()));
             outcome
         }
@@ -538,7 +672,7 @@ impl Client {
         span: &OperationSpan,
     ) -> Result<Response, Error> {
         let url = self.url_for(operation)?;
-        let answered = self.attempt(operation, &url).await?;
+        let mut answered = self.attempt(operation, &url).await?;
         let status = answered.response.status();
         span.answered(status, request_id(answered.response.headers()));
         let finished = self
@@ -550,17 +684,14 @@ impl Client {
                 answered.cached,
             )
             .await;
-        self.shared.hooks.on_request_end(
-            &answered.info,
-            &RequestResult {
-                status: Some(status),
-                duration: answered.duration,
-                error: finished.as_ref().err(),
-                from_cache: finished.as_ref().is_ok_and(|response| response.from_cache),
-                retryable: answered.retryable,
-                retry_after: answered.retry_after,
-            },
-        );
+        answered.sending.end(&RequestResult {
+            status: Some(status),
+            duration: answered.duration,
+            error: finished.as_ref().err(),
+            from_cache: finished.as_ref().is_ok_and(|response| response.from_cache),
+            retryable: answered.retryable,
+            retry_after: answered.retry_after,
+        });
         finished
     }
 
@@ -571,23 +702,20 @@ impl Client {
         span: &OperationSpan,
     ) -> Result<HttpResponse<Body>, Error> {
         let url = self.url_for(operation)?;
-        let answered = self.attempt(operation, &url).await?;
+        let mut answered = self.attempt(operation, &url).await?;
         let status = answered.response.status();
         span.answered(status, request_id(answered.response.headers()));
         let failure = (!status.is_success()).then(|| {
             Error::from_response(status, &operation.method, answered.response.headers(), &[])
         });
-        self.shared.hooks.on_request_end(
-            &answered.info,
-            &RequestResult {
-                status: Some(status),
-                duration: answered.duration,
-                error: failure.as_ref(),
-                from_cache: false,
-                retryable: answered.retryable,
-                retry_after: answered.retry_after,
-            },
-        );
+        answered.sending.end(&RequestResult {
+            status: Some(status),
+            duration: answered.duration,
+            error: failure.as_ref(),
+            from_cache: false,
+            retryable: answered.retryable,
+            retry_after: answered.retry_after,
+        });
         match failure {
             Some(error) => Err(error),
             None => Ok(answered.response),
@@ -641,13 +769,21 @@ impl Client {
         let mut cached = None;
 
         loop {
-            let request = self.prepare(operation, url, &mut cached).await?;
-            let info = RequestInfo {
-                method: operation.method.clone(),
-                url: url.clone(),
-                attempt,
+            // Signed and counted under the read half of the refresh lock, so no refresh
+            // lands between the two: the count says exactly which credentials went out.
+            let (request, signed_under) = {
+                let _signing = self.shared.refreshing.read().await;
+                let request = self.prepare(operation, url, &mut cached).await?;
+                (request, self.shared.refreshes.load(Ordering::Acquire))
             };
-            hooks.on_request_start(&info);
+            let mut sending = Sending::start(
+                hooks.clone(),
+                RequestInfo {
+                    method: operation.method.clone(),
+                    url: url.clone(),
+                    attempt,
+                },
+            );
             let started = Instant::now();
             // The attempt span closes here, before any refresh or backoff: it is the send.
             let sent = {
@@ -664,20 +800,17 @@ impl Client {
 
             match sent {
                 Err(error) => {
-                    hooks.on_request_end(
-                        &info,
-                        &RequestResult {
-                            status: None,
-                            duration,
-                            error: Some(&error),
-                            from_cache: false,
-                            retryable: true,
-                            retry_after: None,
-                        },
-                    );
+                    sending.end(&RequestResult {
+                        status: None,
+                        duration,
+                        error: Some(&error),
+                        from_cache: false,
+                        retryable: true,
+                        retry_after: None,
+                    });
                     if attempt < attempts {
                         crate::trace::debug!(operation = label(operation), attempt, error = %error.code(), "request failed, retrying");
-                        hooks.on_retry(&info, attempt + 1, &error);
+                        hooks.on_retry(&sending.info, attempt + 1, &error);
                         self.wait(delay).await;
                         delay = self.next_delay(delay);
                         attempt += 1;
@@ -691,25 +824,22 @@ impl Client {
                     let retry_after = retry_after_asked(status, response.headers());
                     if status == StatusCode::UNAUTHORIZED
                         && !refreshed
-                        && self.shared.auth.refresh().await
+                        && self.refresh_credentials(signed_under).await
                     {
                         let cause = Error::auth("Token refreshed").retryable();
-                        hooks.on_request_end(
-                            &info,
-                            &RequestResult {
-                                status: Some(status),
-                                duration,
-                                error: Some(&cause),
-                                from_cache: false,
-                                retryable,
-                                retry_after,
-                            },
-                        );
+                        sending.end(&RequestResult {
+                            status: Some(status),
+                            duration,
+                            error: Some(&cause),
+                            from_cache: false,
+                            retryable,
+                            retry_after,
+                        });
                         crate::trace::debug!(
                             operation = label(operation),
                             "credentials refreshed, resending"
                         );
-                        hooks.on_retry(&info, attempt + 1, &cause);
+                        hooks.on_retry(&sending.info, attempt + 1, &cause);
                         refreshed = true;
                         attempt += 1;
                         attempts = attempts.max(attempt);
@@ -720,19 +850,16 @@ impl Client {
                             response.headers(),
                             &[],
                         );
-                        hooks.on_request_end(
-                            &info,
-                            &RequestResult {
-                                status: Some(status),
-                                duration,
-                                error: Some(&cause),
-                                from_cache: false,
-                                retryable,
-                                retry_after,
-                            },
-                        );
+                        sending.end(&RequestResult {
+                            status: Some(status),
+                            duration,
+                            error: Some(&cause),
+                            from_cache: false,
+                            retryable,
+                            retry_after,
+                        });
                         crate::trace::debug!(operation = label(operation), attempt, %status, "retryable status, retrying");
-                        hooks.on_retry(&info, attempt + 1, &cause);
+                        hooks.on_retry(&sending.info, attempt + 1, &cause);
                         match retry_after {
                             Some(seconds)
                                 if status == StatusCode::TOO_MANY_REQUESTS && seconds > 0 =>
@@ -748,7 +875,7 @@ impl Client {
                             url: final_url,
                             response,
                             cached: cached.take(),
-                            info,
+                            sending,
                             duration,
                             retryable,
                             retry_after,
@@ -757,6 +884,43 @@ impl Client {
                 }
             }
         }
+    }
+
+    /// Answers a 401 with fresh credentials, once for all the requests the stale ones
+    /// earned it on. Refreshes go one at a time, and a request that was signed before the
+    /// last refresh is simply resent: the credentials it will pick up are already the new
+    /// ones, and asking the token endpoint again would only spend a round trip — or, with
+    /// a rotating refresh token, burn the one just issued. A refresh that fails leaves the
+    /// count where it was, so the next 401 asks again rather than trusting a failure.
+    ///
+    /// The refresh runs on a task of its own, which holds the turn, so a caller that gives
+    /// up waiting — its [`ClientBuilder::operation_timeout`] running out, say — does not
+    /// abandon a refresh the token endpoint may already have honoured: the provider still
+    /// gets to keep what it was handed, the count still moves, and the next caller waits
+    /// its turn rather than refreshing again over the top of it.
+    /// A caller gone before its refresh got the turn does not have one started on its
+    /// behalf: a queue of stale requests whose limits ran out while an earlier refresh
+    /// held the turn would otherwise each refresh in turn, for nobody.
+    async fn refresh_credentials(&self, signed_under: u64) -> bool {
+        let shared = self.shared.clone();
+        let interest = Interest::new();
+        let wanted = interest.wanted.clone();
+        let refresh = tokio::spawn(async move {
+            let _turn = shared.refreshing.write().await;
+            if shared.refreshes.load(Ordering::Acquire) != signed_under {
+                true
+            } else if !wanted.load(Ordering::Acquire) {
+                false
+            } else if shared.auth.refresh().await {
+                shared.refreshes.fetch_add(1, Ordering::AcqRel);
+                true
+            } else {
+                false
+            }
+        });
+        let refreshed = refresh.await.unwrap_or(false);
+        drop(interest);
+        refreshed
     }
 
     pub(crate) fn url_for(&self, operation: &Operation) -> Result<Url, Error> {
@@ -917,7 +1081,7 @@ impl Client {
                         ErrorCode::Network,
                         format!(
                             "{} redirected more than {MAX_REDIRECTS} times",
-                            operation.id
+                            operation.label()
                         ),
                     )
                     .retryable());
@@ -1094,6 +1258,71 @@ struct Budget {
     delay: Duration,
 }
 
+/// Whether the caller that asked for a refresh is still there to want it. Dropped when
+/// that caller's future is — its limit running out, a `select!` taking another branch —
+/// so a refresh that has not yet had its turn can stand down.
+struct Interest {
+    wanted: Arc<AtomicBool>,
+}
+
+impl Interest {
+    fn new() -> Interest {
+        Interest {
+            wanted: Arc::new(AtomicBool::new(true)),
+        }
+    }
+}
+
+impl Drop for Interest {
+    fn drop(&mut self) {
+        self.wanted.store(false, Ordering::Release);
+    }
+}
+
+/// A request the hooks have been told the start of and are still owed the end of, the
+/// way [`Running`] is for an operation. It reports the end from [`Sending::end`] with how
+/// the request turned out, or from the drop that comes instead when the future is
+/// abandoned mid-request — an operation limit running out, a caller's `select!` — so a
+/// hook counting requests in flight is never left one short.
+struct Sending {
+    hooks: Arc<dyn Hooks>,
+    info: RequestInfo,
+    started: Instant,
+    owed: bool,
+}
+
+impl Sending {
+    fn start(hooks: Arc<dyn Hooks>, info: RequestInfo) -> Sending {
+        hooks.on_request_start(&info);
+        Sending {
+            hooks,
+            info,
+            started: Instant::now(),
+            owed: true,
+        }
+    }
+
+    fn end(&mut self, result: &RequestResult<'_>) {
+        self.owed = false;
+        self.hooks.on_request_end(&self.info, result);
+    }
+}
+
+impl Drop for Sending {
+    fn drop(&mut self) {
+        if self.owed {
+            self.end(&RequestResult {
+                status: None,
+                duration: self.started.elapsed(),
+                error: Some(&Error::cancelled()),
+                from_cache: false,
+                retryable: false,
+                retry_after: None,
+            });
+        }
+    }
+}
+
 /// One answer from HEY with its body unread: what the retry loop settled on, the URL it
 /// came from once any redirects were followed, and what the hooks still have to be told
 /// about it once the body has been dealt with.
@@ -1101,7 +1330,7 @@ struct Answered {
     url: Url,
     response: HttpResponse<Body>,
     cached: Option<(String, CachedResponse)>,
-    info: RequestInfo,
+    sending: Sending,
     duration: Duration,
     retryable: bool,
     retry_after: Option<u64>,

--- a/rust/hey-sdk/src/error.rs
+++ b/rust/hey-sdk/src/error.rs
@@ -488,6 +488,52 @@ impl From<serde_json::Error> for Error {
     }
 }
 
+impl Error {
+    /// An answer that would not decode, with what is known about the answer kept: an
+    /// operation that got a 200 it cannot read is a different problem from one that got
+    /// nothing, and the request id is what HEY needs to find it.
+    pub(crate) fn decoding(
+        status: u16,
+        request_id: Option<&str>,
+        error: serde_json::Error,
+    ) -> Error {
+        let error = Error::new(ErrorCode::Api, "unexpected JSON in the response")
+            .with_status(status)
+            .with_hint(error.to_string())
+            .with_source(error);
+        match request_id {
+            Some(request_id) => error.with_request_id(request_id),
+            None => error,
+        }
+    }
+
+    /// Names the operation an error belongs to, in front of its message.
+    pub(crate) fn about(mut self, operation: &str) -> Error {
+        self.message = format!("{operation}: {}", self.message);
+        self
+    }
+
+    /// The operation ran past [`crate::ClientBuilder::operation_timeout`] and was dropped
+    /// where it stood. Retryable: nothing says the next call would take as long.
+    pub fn timed_out(limit: std::time::Duration) -> Error {
+        Error::new(
+            ErrorCode::Network,
+            format!("operation timed out after {limit:?}"),
+        )
+        .retryable()
+    }
+
+    /// A walk reached the client's page limit with pages still to read. What was read
+    /// stands with the caller; this says it was not all of it. Raise
+    /// [`crate::ClientBuilder::max_pages`], or read with a limit.
+    pub fn pagination_capped(max_pages: usize) -> Error {
+        Error::usage(format!(
+            "pagination stopped at the page limit of {max_pages} with more pages to read"
+        ))
+        .with_hint("raise max_pages on the client, or read with a limit")
+    }
+}
+
 impl From<url::ParseError> for Error {
     fn from(error: url::ParseError) -> Error {
         Error::usage(format!("invalid URL: {error}")).with_source(error)

--- a/rust/hey-sdk/src/http/reqwest.rs
+++ b/rust/hey-sdk/src/http/reqwest.rs
@@ -54,8 +54,8 @@ impl Default for ReqwestClient {
 #[async_trait]
 impl HttpClient for ReqwestClient {
     async fn send(&self, request: Request<Bytes>) -> Result<Response<Body>, Error> {
-        let request = reqwest::Request::try_from(request).map_err(Error::network)?;
-        let answered = self.http.execute(request).await.map_err(Error::network)?;
+        let request = reqwest::Request::try_from(request).map_err(network)?;
+        let answered = self.http.execute(request).await.map_err(network)?;
 
         let status = answered.status();
         let version = answered.version();
@@ -77,7 +77,13 @@ fn chunks(response: reqwest::Response) -> impl stream::Stream<Item = Result<Byte
         match response.chunk().await {
             Ok(Some(chunk)) => Ok(Some((chunk, response))),
             Ok(None) => Ok(None),
-            Err(error) => Err(Error::network(error)),
+            Err(error) => Err(network(error)),
         }
     })
+}
+
+/// A transport failure as the SDK's network error, less the URL reqwest writes into its
+/// own message: the failure ends up in logs and hints, and the URL carries the query.
+fn network(error: reqwest::Error) -> Error {
+    Error::network(error.without_url())
 }

--- a/rust/hey-sdk/src/operation.rs
+++ b/rust/hey-sdk/src/operation.rs
@@ -12,7 +12,7 @@ use crate::route::Route;
 
 /// A request the client has not sent yet. Generated service methods build one from a
 /// [`Route`]; [`crate::Client::request`] builds one for anything the model does not cover.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 #[allow(clippy::struct_excessive_bools)] // each flag is one independent choice about the send
 pub struct Operation {
     pub(crate) id: Cow<'static, str>,
@@ -38,10 +38,42 @@ pub struct Operation {
     pub(crate) quiet: bool,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub(crate) struct Body {
     pub(crate) content_type: String,
     pub(crate) bytes: Bytes,
+}
+
+/// An operation prints what it is and where it goes, not what it carries: the path
+/// without any query the caller wrote into it, the query's names without their values, the
+/// body's shape without its bytes. A `{:?}` is the kind of thing that lands in a log, and
+/// the values are the caller's data.
+impl std::fmt::Debug for Operation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let query: Vec<&str> = self.query.iter().map(|(name, _)| name.as_str()).collect();
+        let without_query =
+            |value: &str| -> String { value.split('?').next().unwrap_or_default().to_string() };
+        f.debug_struct("Operation")
+            .field("id", &without_query(&self.id))
+            .field("method", &self.method)
+            .field("path", &without_query(&self.path))
+            .field("query", &query)
+            .field("body", &self.body)
+            .field("idempotent", &self.idempotent)
+            .field("quiet", &self.quiet)
+            .finish_non_exhaustive()
+    }
+}
+
+/// A body prints as its type and its size, never its bytes: a `{:?}` of an operation is
+/// the kind of thing that lands in a log, and the body is the caller's data.
+impl std::fmt::Debug for Body {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Body")
+            .field("content_type", &self.content_type)
+            .field("len", &self.bytes.len())
+            .finish()
+    }
 }
 
 /// The two redirects HEY's form-backed endpoints answer with, which
@@ -120,6 +152,17 @@ impl Operation {
     /// The operation as the model names it, or `METHOD /path` for one built by hand.
     pub fn id(&self) -> &str {
         &self.id
+    }
+
+    /// What an error or a log calls the operation: the name the model or a wrapper gave
+    /// it, or the method alone for a path the caller wrote, since that path — and whatever
+    /// query it carries — is the caller's.
+    pub(crate) fn label(&self) -> &str {
+        if self.info.service == "Raw" {
+            self.method.as_str()
+        } else {
+            &self.info.operation
+        }
     }
 
     /// The HTTP method the operation is sent with.

--- a/rust/hey-sdk/src/pagination.rs
+++ b/rust/hey-sdk/src/pagination.rs
@@ -126,7 +126,9 @@ impl Client {
     /// Reads a paginated path to its end and hands back the items of every page as one
     /// list. Each page has to decode as a JSON array. Use this for the paths the model
     /// does not cover; a modelled read walks with [`Client::each_page`], which keeps the
-    /// records typed.
+    /// records typed. A walk that reaches the client's page limit with pages still to
+    /// read is an error, [`Error::pagination_capped`], rather than a shorter list that
+    /// looks complete.
     pub async fn get_all(&self, path: &str) -> Result<Vec<Value>, Error> {
         self.get_all_with_limit(path, 0).await
     }
@@ -134,32 +136,32 @@ impl Client {
     /// Reads a paginated path until `limit` items are in hand, or to its end when `limit`
     /// is zero. The last page is trimmed to land on exactly `limit`.
     pub async fn get_all_with_limit(&self, path: &str, limit: usize) -> Result<Vec<Value>, Error> {
-        let mut operation = self.raw(Method::GET, path)?;
-        let started_at = self.url_for(&operation)?;
-        let mut collected: Vec<Value> = Vec::new();
-        let mut pages = 0;
+        self.within_limit(Box::pin(async move {
+            let mut operation = self.raw(Method::GET, path)?;
+            let started_at = self.url_for(&operation)?;
+            let mut collected: Vec<Value> = Vec::new();
+            let mut pages = 0;
 
-        loop {
-            let response = self.execute(operation).await?;
-            collected.extend(response.json::<Vec<Value>>()?);
-            pages += 1;
+            loop {
+                let response = self.execute(operation).await?;
+                collected.extend(response.json::<Vec<Value>>()?);
+                pages += 1;
 
-            if limit > 0 && collected.len() >= limit {
-                collected.truncate(limit);
-                break;
-            }
-            match next_page_url(&response, &started_at)? {
-                Some(next) if pages < self.max_pages() => {
-                    operation = Operation::at(Method::GET, next);
-                }
-                Some(_) => {
-                    crate::trace::warning!(max_pages = self.max_pages(), "pagination capped");
+                if limit > 0 && collected.len() >= limit {
+                    collected.truncate(limit);
                     break;
                 }
-                None => break,
+                match next_page_url(&response, &started_at)? {
+                    Some(next) if pages < self.max_pages() => {
+                        operation = Operation::at(Method::GET, next);
+                    }
+                    Some(_) => return Err(Error::pagination_capped(self.max_pages())),
+                    None => break,
+                }
             }
-        }
-        Ok(collected)
+            Ok(collected)
+        }))
+        .await
     }
 
     /// Reads the pages after one already in hand, and hands back their items. Say how many
@@ -175,37 +177,36 @@ impl Client {
         first_page_count: usize,
         limit: usize,
     ) -> Result<Vec<Value>, Error> {
-        if limit > 0 && first_page_count >= limit {
-            return Ok(Vec::new());
-        }
-
-        let started_at = first.url.clone();
-        let mut next = next_page_url(first, &started_at)?;
-        let mut collected: Vec<Value> = Vec::new();
-        let mut count = first_page_count;
-        let mut pages = 1;
-
-        while let Some(url) = next {
-            let response = self.execute(Operation::at(Method::GET, url)).await?;
-            let items: Vec<Value> = response.json()?;
-            count += items.len();
-            collected.extend(items);
-            pages += 1;
-
-            if limit > 0 && count >= limit {
-                collected.truncate(collected.len().saturating_sub(count - limit));
-                break;
+        self.within_limit(Box::pin(async move {
+            if limit > 0 && first_page_count >= limit {
+                return Ok(Vec::new());
             }
-            next = match next_page_url(&response, &started_at)? {
-                Some(url) if pages < self.max_pages() => Some(url),
-                Some(_) => {
-                    crate::trace::warning!(max_pages = self.max_pages(), "pagination capped");
-                    None
+
+            let started_at = first.url.clone();
+            let mut next = next_page_url(first, &started_at)?;
+            let mut collected: Vec<Value> = Vec::new();
+            let mut count = first_page_count;
+            let mut pages = 1;
+
+            while let Some(url) = next {
+                if pages >= self.max_pages() {
+                    return Err(Error::pagination_capped(self.max_pages()));
                 }
-                None => None,
-            };
-        }
-        Ok(collected)
+                let response = self.execute(Operation::at(Method::GET, url)).await?;
+                let items: Vec<Value> = response.json()?;
+                count += items.len();
+                collected.extend(items);
+                pages += 1;
+
+                if limit > 0 && count >= limit {
+                    collected.truncate(collected.len().saturating_sub(count - limit));
+                    break;
+                }
+                next = next_page_url(&response, &started_at)?;
+            }
+            Ok(collected)
+        }))
+        .await
     }
 }
 

--- a/rust/hey-sdk/src/raw.rs
+++ b/rust/hey-sdk/src/raw.rs
@@ -61,17 +61,25 @@ impl Client {
         path: &str,
         destination: &mut (impl AsyncWrite + Unpin),
     ) -> Result<(u64, HeaderMap), Error> {
-        let response = self.stream(self.blob(path)?).await?;
+        let deadline = self.deadline();
+        let response = self.stream(self.blob(path)?, deadline).await?;
         let headers = response.headers().clone();
         let mut body = response.into_body();
-        let mut written = 0;
-        while let Some(chunk) = body.chunk().await? {
-            destination
-                .write_all(&chunk)
-                .await
-                .map_err(Error::from_std)?;
-            written += chunk.len() as u64;
-        }
+        // The hooks heard the operation end when the answer arrived; the operation's one
+        // deadline still holds over the bytes that follow it.
+        let written = self
+            .within_deadline(deadline, async {
+                let mut written = 0;
+                while let Some(chunk) = body.chunk().await? {
+                    destination
+                        .write_all(&chunk)
+                        .await
+                        .map_err(Error::from_std)?;
+                    written += chunk.len() as u64;
+                }
+                Ok(written)
+            })
+            .await?;
         Ok((written, headers))
     }
 

--- a/rust/hey-sdk/src/services/attachments.rs
+++ b/rust/hey-sdk/src/services/attachments.rs
@@ -48,9 +48,14 @@ impl Attachments<'_> {
                 content_type: content_type.unwrap_or(DEFAULT_CONTENT_TYPE).to_string(),
             },
         };
-        let upload = reserved(self.create_direct_upload(&body).await?)?;
-        store(self.client(), &upload.direct_upload, content).await?;
-        Ok(upload)
+        // Two requests, one operation: one limit over the reservation and the bytes.
+        self.client()
+            .within_limit(Box::pin(async move {
+                let upload = reserved(self.create_direct_upload(&body).await?)?;
+                store(self.client(), &upload.direct_upload, content).await?;
+                Ok(upload)
+            }))
+            .await
     }
 }
 
@@ -95,17 +100,22 @@ async fn store(client: &Client, target: &DirectUploadTarget, content: Bytes) -> 
         .body(content)
         .map_err(Error::from_std)?;
     *request.headers_mut() = storage_headers(target)?;
-    let answered = client.http().send(request).await?;
-
-    let status = answered.status();
-    let headers = answered.headers().clone();
-    let body = read_body(
-        answered.into_body(),
-        MAX_RESPONSE_BODY_BYTES,
-        &Method::PUT,
-        &path,
-    )
-    .await?;
+    // The storage service's answer is held to the operation's deadline like HEY's own.
+    let (status, headers, body) = client
+        .within_deadline(client.deadline(), async {
+            let answered = client.http().send(request).await?;
+            let status = answered.status();
+            let headers = answered.headers().clone();
+            let body = read_body(
+                answered.into_body(),
+                MAX_RESPONSE_BODY_BYTES,
+                &Method::PUT,
+                &path,
+            )
+            .await?;
+            Ok((status, headers, body))
+        })
+        .await?;
     if status.is_success() {
         Ok(())
     } else {

--- a/rust/hey-sdk/src/services/publications.rs
+++ b/rust/hey-sdk/src/services/publications.rs
@@ -32,13 +32,17 @@ impl Publications<'_> {
             Some(topic_id),
         ));
         operation.form(&[]);
-        self.client().send_unit(operation).await?;
-
-        let mut read = self
-            .client()
-            .operation(&routes::GET_TOPIC_PUBLICATION, &[&topic_id]);
-        read.quiet();
-        self.client().send(read).await
+        // Two requests, one operation: one limit over both.
+        self.client()
+            .within_limit(Box::pin(async {
+                self.client().send_unit(operation).await?;
+                let mut read = self
+                    .client()
+                    .operation(&routes::GET_TOPIC_PUBLICATION, &[&topic_id]);
+                read.quiet();
+                self.client().send(read).await
+            }))
+            .await
     }
 
     /// Unpublishes a thread, breaking its public link.

--- a/rust/hey-sdk/src/services/workflows.rs
+++ b/rust/hey-sdk/src/services/workflows.rs
@@ -179,9 +179,13 @@ impl Workflows<'_> {
                 Some(topic_id),
             ))
             .form_representation();
-        self.client().send_unit(operation).await?;
-
-        self.move_to_stage(topic_id, workflow_id, stage_id, None)
+        // Two requests, one operation: one limit over both.
+        self.client()
+            .within_limit(Box::pin(async {
+                self.client().send_unit(operation).await?;
+                self.move_to_stage(topic_id, workflow_id, stage_id, None)
+                    .await
+            }))
             .await
     }
 

--- a/rust/hey-sdk/tests/credential_refresh.rs
+++ b/rust/hey-sdk/tests/credential_refresh.rs
@@ -1,0 +1,244 @@
+//! What a 401 costs when many calls earn one at once. The transport here is the test's
+//! own: reqwest's pool holds later requests to a new host until the first connection has
+//! settled its protocol, which would sign them after the refresh and prove nothing.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use hey_sdk::http::{Body, HttpClient, Request, Response, StatusCode};
+use hey_sdk::{Client, Config, Error, ErrorCode, TokenProvider};
+
+/// A provider whose refresh takes a moment and hands out a new token each time, counting
+/// how often it was asked. `refreshable` off makes every refresh fail.
+struct Rotating {
+    token: Mutex<String>,
+    refreshes: AtomicUsize,
+    refreshable: bool,
+}
+
+impl Rotating {
+    fn new(refreshable: bool) -> Arc<Rotating> {
+        Arc::new(Rotating {
+            token: Mutex::new("token-0".to_string()),
+            refreshes: AtomicUsize::new(0),
+            refreshable,
+        })
+    }
+
+    fn refreshes(&self) -> usize {
+        self.refreshes.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl TokenProvider for Rotating {
+    async fn access_token(&self) -> Result<String, Error> {
+        Ok(self.token.lock().unwrap().clone())
+    }
+
+    async fn refresh(&self) -> bool {
+        let count = self.refreshes.fetch_add(1, Ordering::SeqCst) + 1;
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        if self.refreshable {
+            *self.token.lock().unwrap() = format!("token-{count}");
+        }
+        self.refreshable
+    }
+}
+
+/// A server that answers `token-0` with a 401 and anything else with an empty list. It
+/// holds every stale request at a barrier sized for the case, so the 401s come back
+/// together whatever the scheduler did with the tasks.
+struct Stale {
+    tokens: Mutex<Vec<String>>,
+    arrived: tokio::sync::Barrier,
+}
+
+impl Stale {
+    fn new(expected: usize) -> Arc<Stale> {
+        Arc::new(Stale {
+            tokens: Mutex::new(Vec::new()),
+            arrived: tokio::sync::Barrier::new(expected),
+        })
+    }
+
+    fn tokens(&self) -> Vec<String> {
+        self.tokens.lock().unwrap().clone()
+    }
+}
+
+/// The transport handle the client takes; the test keeps the [`Stale`] behind it.
+#[derive(Clone)]
+struct Transport(Arc<Stale>);
+
+#[async_trait]
+impl HttpClient for Transport {
+    async fn send(&self, request: Request<Bytes>) -> Result<Response<Body>, Error> {
+        let token = request.headers()["authorization"]
+            .to_str()
+            .unwrap()
+            .trim_start_matches("Bearer ")
+            .to_string();
+        self.0.tokens.lock().unwrap().push(token.clone());
+        let mut response = Response::new(Body::from("[]"));
+        if token == "token-0" {
+            self.0.arrived.wait().await;
+            *response.status_mut() = StatusCode::UNAUTHORIZED;
+        }
+        Ok(response)
+    }
+}
+
+fn client(server: Arc<Stale>, provider: Arc<Rotating>) -> Client {
+    Client::builder(Config::default().with_base_url("https://hey.test"))
+        .token_provider(provider)
+        .http_client(Transport(server))
+        .max_jitter(Duration::ZERO)
+        .build()
+        .unwrap()
+}
+
+/// Ten calls sent on the same stale token are all in flight when the 401s come back; the
+/// credentials are refreshed once, and every call is resent on the refreshed ones.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn concurrent_401s_share_one_refresh() {
+    let server = Stale::new(10);
+    let provider = Rotating::new(true);
+    let client = client(server.clone(), provider.clone());
+
+    let calls: Vec<_> = (0..10)
+        .map(|_| {
+            let client = client.clone();
+            tokio::spawn(async move { client.boxes().list().await })
+        })
+        .collect();
+    for call in calls {
+        call.await.unwrap().unwrap();
+    }
+
+    assert_eq!(provider.refreshes(), 1);
+    let tokens = server.tokens();
+    assert_eq!(tokens.len(), 20, "{tokens:?}");
+    assert_eq!(
+        tokens.iter().filter(|token| *token == "token-0").count(),
+        10
+    );
+    assert_eq!(
+        tokens.iter().filter(|token| *token == "token-1").count(),
+        10
+    );
+}
+
+/// A rotating refresh token is only good once: a call whose 401 comes back after another
+/// call's refresh has already completed is resent on the new credentials rather than
+/// refreshing again, which would burn the token the first refresh just issued.
+#[tokio::test]
+async fn a_401_that_arrives_after_the_refresh_does_not_refresh_again() {
+    let server = Stale::new(2);
+    let provider = Rotating::new(true);
+    let client = client(server.clone(), provider.clone());
+
+    let boxes = client.boxes();
+    let (first, second) = tokio::join!(boxes.list(), async {
+        // Signed on token-0 alongside the first call, answered with it, then held past
+        // the first call's refresh before its own 401 is acted on.
+        let late = boxes.list();
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        late.await
+    });
+    first.unwrap();
+    second.unwrap();
+
+    assert_eq!(provider.refreshes(), 1);
+    assert_eq!(server.tokens().len(), 4);
+}
+
+/// A caller whose limit runs out during the refresh leaves the refresh to finish: the
+/// provider keeps the token it was handed, and the next call is resent on it rather than
+/// refreshing over the top of a refresh the token endpoint already honoured.
+#[tokio::test]
+async fn a_caller_cut_off_during_the_refresh_does_not_abandon_it() {
+    let server = Stale::new(1);
+    let provider = Rotating::new(true);
+    let client = Client::builder(Config::default().with_base_url("https://hey.test"))
+        .token_provider(provider.clone())
+        .http_client(Transport(server.clone()))
+        .max_jitter(Duration::ZERO)
+        .operation_timeout(Duration::from_millis(20))
+        .build()
+        .unwrap();
+
+    let error = client.boxes().list().await.unwrap_err();
+    assert!(error.message().contains("timed out"), "{error}");
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    assert_eq!(provider.refreshes(), 1);
+    assert_eq!(
+        provider.access_token().await.unwrap(),
+        "token-1",
+        "the refresh finished without the caller"
+    );
+
+    let unhurried = Client::builder(Config::default().with_base_url("https://hey.test"))
+        .token_provider(provider.clone())
+        .http_client(Transport(server.clone()))
+        .build()
+        .unwrap();
+    unhurried.boxes().list().await.unwrap();
+    assert_eq!(provider.refreshes(), 1);
+}
+
+/// A refresh that fails leaves the 401 standing for every caller, as the authentication
+/// error it is, and the next 401 asks again rather than trusting the failure.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_failed_refresh_leaves_every_caller_with_the_401() {
+    let server = Stale::new(4);
+    let provider = Rotating::new(false);
+    let client = client(server.clone(), provider.clone());
+
+    let calls: Vec<_> = (0..4)
+        .map(|_| {
+            let client = client.clone();
+            tokio::spawn(async move { client.boxes().list().await })
+        })
+        .collect();
+    for call in calls {
+        let error = call.await.unwrap().unwrap_err();
+        assert_eq!(error.code(), ErrorCode::Auth);
+        assert_eq!(error.http_status(), Some(401));
+    }
+
+    assert_eq!(provider.refreshes(), 4);
+    assert_eq!(server.tokens().len(), 4);
+}
+
+/// Callers whose limits run out while an earlier refresh holds the turn do not each have
+/// a refresh started for them once it fails: a waiter whose caller is gone stands down.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_waiter_whose_caller_is_gone_does_not_refresh_for_nobody() {
+    let server = Stale::new(3);
+    let provider = Rotating::new(false);
+    let client = Client::builder(Config::default().with_base_url("https://hey.test"))
+        .token_provider(provider.clone())
+        .http_client(Transport(server.clone()))
+        .max_jitter(Duration::ZERO)
+        .operation_timeout(Duration::from_millis(20))
+        .build()
+        .unwrap();
+
+    let calls: Vec<_> = (0..3)
+        .map(|_| {
+            let client = client.clone();
+            tokio::spawn(async move { client.boxes().list().await })
+        })
+        .collect();
+    for call in calls {
+        call.await.unwrap().unwrap_err();
+    }
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    assert_eq!(provider.refreshes(), 1);
+}

--- a/rust/hey-sdk/tests/deadline.rs
+++ b/rust/hey-sdk/tests/deadline.rs
@@ -1,0 +1,394 @@
+//! The operation limit: one deadline over the whole call, distinct from the transport's
+//! timeout, and what a call cut off at it leaves behind.
+
+mod support;
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use async_trait::async_trait;
+use hey_sdk::resilience::{BulkheadConfig, ResilienceConfig};
+use hey_sdk::{Client, Config, Error, ErrorCode, StaticTokenProvider, TokenProvider};
+use serde_json::json;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+use std::sync::Mutex;
+
+use hey_sdk::observability::{Hooks, RequestInfo, RequestResult};
+
+use support::{Outcomes, builder};
+
+/// The operation limit is not the transport timeout: the transport would have waited the
+/// full thirty seconds for this answer, and the operation stops at its own limit.
+#[tokio::test]
+async fn an_operation_ends_at_its_limit_while_the_transport_would_still_wait() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/boxes.json"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_delay(Duration::from_secs(5))
+                .set_body_json(json!([])),
+        )
+        .mount(&server)
+        .await;
+    let client = builder(&server)
+        .timeout(Duration::from_secs(30))
+        .operation_timeout(Duration::from_millis(100))
+        .build()
+        .unwrap();
+
+    let started = Instant::now();
+    let error = client.boxes().list().await.unwrap_err();
+
+    assert_eq!(error.code(), ErrorCode::Network);
+    assert!(error.is_retryable());
+    assert!(error.message().contains("timed out"), "{error}");
+    assert!(started.elapsed() < Duration::from_secs(2));
+}
+
+/// The limit covers the waits between attempts, not only the attempts.
+#[tokio::test]
+async fn the_limit_covers_the_backoff_between_attempts() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/boxes.json"))
+        .respond_with(ResponseTemplate::new(503))
+        .mount(&server)
+        .await;
+    let client = Client::builder(Config::default().with_base_url(server.uri()))
+        .token_provider(StaticTokenProvider::new("t"))
+        .http_client(support::http_client())
+        .base_delay(Duration::from_secs(5))
+        .max_jitter(Duration::ZERO)
+        .operation_timeout(Duration::from_millis(200))
+        .build()
+        .unwrap();
+
+    let started = Instant::now();
+    let error = client.boxes().list().await.unwrap_err();
+
+    assert!(error.message().contains("timed out"), "{error}");
+    assert!(started.elapsed() < Duration::from_secs(2));
+    assert_eq!(server.received_requests().await.unwrap().len(), 1);
+}
+
+/// The limit covers fetching the credentials, before anything is sent.
+#[tokio::test]
+async fn the_limit_covers_fetching_the_credentials() {
+    struct Slow;
+
+    #[async_trait]
+    impl TokenProvider for Slow {
+        async fn access_token(&self) -> Result<String, Error> {
+            tokio::time::sleep(Duration::from_secs(5)).await;
+            Ok("late".to_string())
+        }
+    }
+
+    let server = MockServer::start().await;
+    let client = Client::builder(Config::default().with_base_url(server.uri()))
+        .token_provider(Slow)
+        .http_client(support::http_client())
+        .operation_timeout(Duration::from_millis(100))
+        .build()
+        .unwrap();
+
+    let started = Instant::now();
+    let error = client.boxes().list().await.unwrap_err();
+
+    assert!(error.message().contains("timed out"), "{error}");
+    assert!(started.elapsed() < Duration::from_secs(2));
+    assert!(server.received_requests().await.unwrap().is_empty());
+}
+
+/// An operation cut off at its limit still ends for the hooks, and gives back what it
+/// held: the next call into the same scope gets the bulkhead's one permit.
+#[tokio::test]
+async fn an_operation_cut_off_at_its_limit_ends_and_gives_back_its_permit() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/boxes.json"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_delay(Duration::from_secs(5))
+                .set_body_json(json!([])),
+        )
+        .up_to_n_times(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/boxes.json"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([])))
+        .mount(&server)
+        .await;
+    let outcomes = Arc::new(Outcomes::default());
+    let client = builder(&server)
+        .hooks(outcomes.clone())
+        .resilience(ResilienceConfig {
+            bulkhead: Some(BulkheadConfig {
+                max_concurrent: 1,
+                max_wait: Duration::ZERO,
+            }),
+            ..ResilienceConfig::default()
+        })
+        .operation_timeout(Duration::from_millis(100))
+        .build()
+        .unwrap();
+
+    let error = client.boxes().list().await.unwrap_err();
+    client.boxes().list().await.unwrap();
+
+    assert!(error.message().contains("timed out"), "{error}");
+    assert_eq!(outcomes.statuses().len(), 2);
+}
+
+/// The limit holds over the bytes of a download too, though the hooks hear the operation
+/// end when the answer arrives.
+#[tokio::test]
+async fn the_limit_covers_the_body_of_a_download() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/blobs/1"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_delay(Duration::from_secs(5))
+                .set_body_bytes(vec![0u8; 16]),
+        )
+        .mount(&server)
+        .await;
+    let client = builder(&server)
+        .operation_timeout(Duration::from_millis(100))
+        .build()
+        .unwrap();
+
+    let started = Instant::now();
+    let mut sink = Vec::new();
+    let error = client
+        .download_blob("/blobs/1", &mut sink)
+        .await
+        .unwrap_err();
+
+    assert!(error.message().contains("timed out"), "{error}");
+    assert!(started.elapsed() < Duration::from_secs(2));
+}
+
+#[test]
+fn a_limit_too_long_to_keep_time_by_is_refused() {
+    let error = Client::builder(Config::default().with_base_url("https://hey.test"))
+        .token_provider(StaticTokenProvider::new("t"))
+        .operation_timeout(Duration::MAX)
+        .build()
+        .err()
+        .expect("a limit past the end of time is a usage error");
+
+    assert_eq!(error.code(), ErrorCode::Usage);
+}
+
+#[test]
+fn a_zero_limit_is_refused() {
+    let error = Client::builder(Config::default().with_base_url("https://hey.test"))
+        .token_provider(StaticTokenProvider::new("t"))
+        .operation_timeout(Duration::ZERO)
+        .build()
+        .err()
+        .expect("a zero limit is a usage error");
+
+    assert_eq!(error.code(), ErrorCode::Usage);
+}
+
+/// Every request the hooks were told the start of, and how it ended.
+#[derive(Default)]
+struct Requests {
+    started: Mutex<u32>,
+    ended: Mutex<Vec<String>>,
+}
+
+impl Hooks for Requests {
+    fn on_request_start(&self, _info: &RequestInfo) {
+        *self.started.lock().unwrap() += 1;
+    }
+
+    fn on_request_end(&self, _info: &RequestInfo, result: &RequestResult<'_>) {
+        self.ended
+            .lock()
+            .unwrap()
+            .push(match (result.status, result.error) {
+                (Some(status), _) => status.as_u16().to_string(),
+                (None, Some(error)) => error.message().to_string(),
+                (None, None) => "nothing".to_string(),
+            });
+    }
+}
+
+/// A request the limit cuts off mid-flight still ends for the hooks, as cancelled, so a
+/// hook counting requests in flight is never left one short.
+#[tokio::test]
+async fn a_request_cut_off_by_the_limit_ends_for_the_hooks() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/boxes.json"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_delay(Duration::from_secs(5))
+                .set_body_json(json!([])),
+        )
+        .mount(&server)
+        .await;
+    let requests = Arc::new(Requests::default());
+    let client = builder(&server)
+        .hooks(requests.clone())
+        .operation_timeout(Duration::from_millis(100))
+        .build()
+        .unwrap();
+
+    client.boxes().list().await.unwrap_err();
+
+    assert_eq!(*requests.started.lock().unwrap(), 1);
+    assert_eq!(*requests.ended.lock().unwrap(), ["operation cancelled"]);
+}
+
+/// The hooks hear an operation that ran out of time end with the timeout the caller
+/// gets, not as a cancellation: a policy that reads the outcome sees what happened.
+#[tokio::test]
+async fn the_hooks_hear_the_timeout_the_caller_gets() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/boxes.json"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_delay(Duration::from_secs(5))
+                .set_body_json(json!([])),
+        )
+        .mount(&server)
+        .await;
+    let endings = Arc::new(Endings::default());
+    let client = builder(&server)
+        .hooks(endings.clone())
+        .operation_timeout(Duration::from_millis(100))
+        .build()
+        .unwrap();
+
+    let error = client.boxes().list().await.unwrap_err();
+
+    assert_eq!(
+        *endings.messages.lock().unwrap(),
+        [error.message().to_string()]
+    );
+    assert!(error.message().contains("timed out"), "{error}");
+}
+
+/// A convenience that sends two requests is one operation to its caller, and gets one
+/// limit over both — not one each.
+#[tokio::test]
+async fn a_convenience_of_two_requests_gets_one_limit() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/topics/5/publication"))
+        .respond_with(
+            ResponseTemplate::new(302)
+                .set_delay(Duration::from_millis(70))
+                .insert_header("Location", "/topics/5"),
+        )
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/topics/5/publication.json"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_delay(Duration::from_millis(70))
+                .set_body_json(json!({ "published": true, "url": "https://public.hey.com/p/a" })),
+        )
+        .mount(&server)
+        .await;
+    let client = builder(&server)
+        .operation_timeout(Duration::from_millis(100))
+        .build()
+        .unwrap();
+
+    let started = Instant::now();
+    let error = client.publications().publish(5).await.unwrap_err();
+
+    assert!(error.message().contains("timed out"), "{error}");
+    assert!(started.elapsed() < Duration::from_millis(500));
+}
+
+/// The hooks hear the operation inside a two-request convenience end with the timeout,
+/// not as a cancellation: the inner send runs against the same deadline as the whole.
+#[tokio::test]
+async fn the_hooks_hear_the_timeout_inside_a_two_request_convenience() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/topics/5/publication"))
+        .respond_with(
+            ResponseTemplate::new(302)
+                .set_delay(Duration::from_secs(5))
+                .insert_header("Location", "/topics/5"),
+        )
+        .mount(&server)
+        .await;
+    let endings = Arc::new(Endings::default());
+    let client = builder(&server)
+        .hooks(endings.clone())
+        .operation_timeout(Duration::from_millis(100))
+        .build()
+        .unwrap();
+
+    let error = client.publications().publish(5).await.unwrap_err();
+
+    assert!(error.message().contains("timed out"), "{error}");
+    assert_eq!(
+        *endings.messages.lock().unwrap(),
+        [error.message().to_string()]
+    );
+}
+
+/// A walk over many pages is one operation with one limit, not a limit per page.
+#[tokio::test]
+async fn a_walk_over_many_pages_gets_one_limit() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/items"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_delay(Duration::from_millis(60))
+                .insert_header("Link", r#"</items?page=next>; rel="next""#)
+                .set_body_json(json!([{ "id": 1 }])),
+        )
+        .mount(&server)
+        .await;
+    let client = builder(&server)
+        .operation_timeout(Duration::from_millis(150))
+        .build()
+        .unwrap();
+
+    let started = Instant::now();
+    let error = client.get_all("/items").await.unwrap_err();
+
+    assert!(error.message().contains("timed out"), "{error}");
+    assert!(started.elapsed() < Duration::from_millis(600));
+    assert!(server.received_requests().await.unwrap().len() <= 3);
+}
+
+#[derive(Default)]
+struct Endings {
+    messages: Mutex<Vec<String>>,
+}
+
+impl Hooks for Endings {
+    fn on_operation_end(
+        &self,
+        _op: &hey_sdk::observability::OperationInfo,
+        _state: hey_sdk::observability::OperationState,
+        outcome: Result<(), &Error>,
+        _duration: Duration,
+    ) {
+        if let Err(error) = outcome {
+            self.messages
+                .lock()
+                .unwrap()
+                .push(error.message().to_string());
+        }
+    }
+}

--- a/rust/hey-sdk/tests/errors.rs
+++ b/rust/hey-sdk/tests/errors.rs
@@ -1,5 +1,7 @@
 //! `Error` and `ErrorCode`: the status mapping, the exit codes and what an error keeps of the failure.
 
+mod support;
+
 use hey_sdk::error::{
     EXIT_AMBIGUOUS, EXIT_API, EXIT_AUTH, EXIT_FORBIDDEN, EXIT_NETWORK, EXIT_NOT_FOUND,
     EXIT_RATE_LIMIT, EXIT_USAGE, EXIT_VALIDATION, MAX_ERROR_BODY_BYTES, MAX_ERROR_MESSAGE_BYTES,
@@ -366,4 +368,34 @@ fn respond(status: u16, method: &Method, headers: &[(&str, &str)], body: &[u8]) 
         );
     }
     Error::from_response(StatusCode::from_u16(status).unwrap(), method, &map, body)
+}
+
+/// An answer that will not decode is still an answer: the error keeps the status, the
+/// request id and the operation, which is what tells "HEY sent something unreadable" from
+/// "nothing came back".
+#[tokio::test]
+async fn an_answer_that_will_not_decode_keeps_the_operation_the_status_and_the_request_id() {
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/boxes.json"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("x-request-id", "req-garbled")
+                .insert_header("content-type", "application/json")
+                .set_body_string("<html>not json</html>"),
+        )
+        .mount(&server)
+        .await;
+
+    let error = support::client(&server).boxes().list().await.unwrap_err();
+
+    assert_eq!(error.code(), ErrorCode::Api);
+    assert_eq!(error.http_status(), Some(200));
+    assert_eq!(error.request_id(), Some("req-garbled"));
+    assert!(error.message().starts_with("ListBoxes: "), "{error}");
+    assert!(error.hint().is_some(), "{error}");
+    assert!(!error.is_retryable());
 }

--- a/rust/hey-sdk/tests/get_all.rs
+++ b/rust/hey-sdk/tests/get_all.rs
@@ -87,8 +87,10 @@ async fn a_next_link_off_the_origin_is_refused_rather_than_followed() {
     assert_eq!(server.received_requests().await.unwrap().len(), 1);
 }
 
+/// A walk that runs into the page limit with pages still to read is not a shorter list
+/// that looks complete: it says so.
 #[tokio::test]
-async fn the_walk_stops_at_the_page_limit_with_what_it_has() {
+async fn the_walk_stops_at_the_page_limit_and_says_so() {
     let server = MockServer::start().await;
     Mock::given(method("GET"))
         .and(path("/items"))
@@ -100,16 +102,139 @@ async fn the_walk_stops_at_the_page_limit_with_what_it_has() {
         .mount(&server)
         .await;
 
-    let items = builder(&server)
+    let error = builder(&server)
         .max_pages(3)
         .build()
         .unwrap()
         .get_all("/items")
         .await
-        .unwrap();
+        .unwrap_err();
 
-    assert_eq!(items.len(), 3);
+    assert_eq!(error.code(), ErrorCode::Usage);
+    assert!(error.message().contains("page limit of 3"), "{error}");
     assert_eq!(server.received_requests().await.unwrap().len(), 3);
+}
+
+/// A limit met before the page limit is a complete answer; a last page with no next link
+/// is the end of the walk, page limit or not.
+#[tokio::test]
+async fn a_walk_that_ends_inside_the_page_limit_is_complete() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/items"))
+        .and(query_param_is_missing("page"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("Link", r#"</items?page=2>; rel="next""#)
+                .set_body_json(json!([{ "id": 1 }])),
+        )
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/items"))
+        .and(query_param("page", "2"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([{ "id": 2 }])))
+        .mount(&server)
+        .await;
+    let client = builder(&server).max_pages(2).build().unwrap();
+
+    let items = client.get_all("/items").await.unwrap();
+    assert_eq!(items.len(), 2);
+
+    let limited = client.get_all_with_limit("/items", 1).await.unwrap();
+    assert_eq!(limited.len(), 1);
+}
+
+/// A page with nothing on it and a cursor is not the end: the walk goes on.
+#[tokio::test]
+async fn an_empty_page_with_a_cursor_is_followed() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/items"))
+        .and(query_param_is_missing("page"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("Link", r#"</items?page=2>; rel="next""#)
+                .set_body_json(json!([])),
+        )
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/items"))
+        .and(query_param("page", "2"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([{ "id": 2 }])))
+        .mount(&server)
+        .await;
+
+    let items = client(&server).get_all("/items").await.unwrap();
+
+    assert_eq!(items.len(), 1);
+    assert_eq!(server.received_requests().await.unwrap().len(), 2);
+}
+
+/// A server that keeps naming the same next page would have the walk go on forever; the
+/// page limit is what ends it, and it ends as the truncation it is.
+#[tokio::test]
+async fn a_cursor_that_repeats_ends_at_the_page_limit() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/items"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("Link", r#"</items?page=same>; rel="next""#)
+                .set_body_json(json!([{ "id": 1 }])),
+        )
+        .mount(&server)
+        .await;
+
+    let error = builder(&server)
+        .max_pages(4)
+        .build()
+        .unwrap()
+        .get_all("/items")
+        .await
+        .unwrap_err();
+
+    assert_eq!(error.code(), ErrorCode::Usage);
+    assert_eq!(server.received_requests().await.unwrap().len(), 4);
+}
+
+/// A page that fails ends the walk with that failure, and nothing after it is read.
+#[tokio::test]
+async fn a_page_that_fails_ends_the_walk_with_its_failure() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/items"))
+        .and(query_param_is_missing("page"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("Link", r#"</items?page=2>; rel="next""#)
+                .set_body_json(json!([{ "id": 1 }])),
+        )
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/items"))
+        .and(query_param("page", "2"))
+        .respond_with(
+            ResponseTemplate::new(500)
+                .insert_header("x-request-id", "req-500")
+                .insert_header("Link", r#"</items?page=3>; rel="next""#),
+        )
+        .mount(&server)
+        .await;
+
+    let error = builder(&server)
+        .max_retries(0)
+        .build()
+        .unwrap()
+        .get_all("/items")
+        .await
+        .unwrap_err();
+
+    assert_eq!(error.http_status(), Some(500));
+    assert_eq!(error.request_id(), Some("req-500"));
+    assert_eq!(server.received_requests().await.unwrap().len(), 2);
 }
 
 /// Following on from a page already in hand reads only what comes after it, and counts the
@@ -228,4 +353,20 @@ async fn page(
     .respond_with(answer)
     .mount(server)
     .await;
+}
+
+/// Following on from a page that is itself the whole page budget reads nothing more, and
+/// says why.
+#[tokio::test]
+async fn following_on_past_a_page_budget_of_one_is_cut_off_before_it_reads() {
+    let server = MockServer::start().await;
+    page(&server, None, json!([{ "id": 1 }]), Some("/items?page=2")).await;
+    page(&server, Some("2"), json!([{ "id": 2 }]), None).await;
+    let client = builder(&server).max_pages(1).build().unwrap();
+    let first = client.get("/items").await.unwrap();
+
+    let error = client.follow_pagination(&first, 1, 0).await.unwrap_err();
+
+    assert_eq!(error.code(), ErrorCode::Usage);
+    assert_eq!(server.received_requests().await.unwrap().len(), 1);
 }

--- a/rust/hey-sdk/tests/guarantees.rs
+++ b/rust/hey-sdk/tests/guarantees.rs
@@ -1,0 +1,47 @@
+//! What the types promise at compile time: a client can be shared across tasks and
+//! threads, an error can cross them, and the futures the client hands back can be spawned.
+//! The future checks are never run — they only have to compile.
+
+use hey_sdk::http::Method;
+use hey_sdk::models::CreateMessageRequestContent;
+use hey_sdk::observability::Hooks;
+use hey_sdk::services::boxes::GetBoxParams;
+use hey_sdk::{
+    AuthStrategy, Client, ClientBuilder, Error, HttpClient, Page, Response, TokenProvider,
+};
+use serde_json::Value;
+
+fn is_send_sync<T: Send + Sync>() {}
+fn is_clone<T: Clone>() {}
+fn is_send_future<F: Future + Send>(_: F) {}
+
+#[test]
+fn the_client_and_its_error_can_be_shared_and_sent() {
+    is_send_sync::<Client>();
+    is_clone::<Client>();
+    is_send_sync::<ClientBuilder>();
+    is_send_sync::<Error>();
+    is_send_sync::<Response>();
+    is_send_sync::<Page<Vec<Value>>>();
+    is_send_sync::<Box<dyn Hooks>>();
+    is_send_sync::<Box<dyn TokenProvider>>();
+    is_send_sync::<Box<dyn AuthStrategy>>();
+    is_send_sync::<Box<dyn HttpClient>>();
+}
+
+#[allow(dead_code)]
+fn every_kind_of_call_is_a_future_that_can_be_spawned(client: &Client, page: Page<Vec<Value>>) {
+    is_send_future(client.boxes().list());
+    is_send_future(client.boxes().get(1, &GetBoxParams::default()));
+    is_send_future(
+        client
+            .messages()
+            .create(&CreateMessageRequestContent::default()),
+    );
+    is_send_future(client.get("/anything"));
+    is_send_future(client.get_all("/anything"));
+    is_send_future(client.execute(client.request(Method::GET, "/anything")));
+    is_send_future(client.for_account(1));
+    is_send_future(client.next_page(&page));
+    is_send_future(client.each_page(page, |_| true));
+}

--- a/rust/hey-sdk/tests/pagination.rs
+++ b/rust/hey-sdk/tests/pagination.rs
@@ -137,8 +137,10 @@ async fn a_link_that_leaves_the_hey_origin_is_refused() {
     assert_eq!(server.received_requests().await.unwrap().len(), 2);
 }
 
+/// The pages visited stand; the walk says it was cut off rather than ending as if the
+/// last page visited were the last page there was.
 #[tokio::test]
-async fn reading_every_page_stops_at_the_page_limit() {
+async fn reading_every_page_stops_at_the_page_limit_and_says_so() {
     let server = MockServer::start().await;
     Mock::given(method("GET"))
         .and(path("/boxes.json"))
@@ -153,15 +155,46 @@ async fn reading_every_page_stops_at_the_page_limit() {
     let client = builder(&server).max_pages(3).build().unwrap();
     let first = client.boxes().list().await.unwrap();
     let mut visited = 0;
-    client
+    let error = client
         .each_page(first, |page| {
             visited += page.len();
             true
         })
         .await
-        .unwrap();
+        .unwrap_err();
 
-    assert_eq!(client.max_pages(), 3);
+    assert_eq!(error.code(), ErrorCode::Usage);
+    assert!(error.message().contains("page limit of 3"), "{error}");
     assert_eq!(visited, 3);
     assert_eq!(server.received_requests().await.unwrap().len(), 3);
+}
+
+/// A visitor that stops the walk stops it: no page after the one it declined is read,
+/// and reaching the limit while stopping is not a truncation.
+#[tokio::test]
+async fn a_visitor_that_stops_is_not_cut_off() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/boxes.json"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("Link", r#"</boxes.json?page=more>; rel="next""#)
+                .set_body_json(json!([{ "id": 7, "kind": "imbox", "name": "Imbox" }])),
+        )
+        .mount(&server)
+        .await;
+
+    let client = builder(&server).max_pages(2).build().unwrap();
+    let first = client.boxes().list().await.unwrap();
+    let mut visited = 0;
+    client
+        .each_page(first, |_| {
+            visited += 1;
+            visited < 2
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(visited, 2);
+    assert_eq!(server.received_requests().await.unwrap().len(), 2);
 }

--- a/rust/hey-sdk/tests/redaction.rs
+++ b/rust/hey-sdk/tests/redaction.rs
@@ -1,0 +1,120 @@
+//! Nothing a `{:?}` or a `{}` of the SDK's types can put in a log: no credential, no
+//! request body, no OAuth secret.
+
+mod support;
+
+use hey_sdk::http::Method;
+use hey_sdk::oauth::{ExchangeRequest, RefreshRequest};
+use hey_sdk::security::redact_headers;
+use hey_sdk::{Client, Config, SensitiveString, StaticTokenProvider};
+use serde_json::json;
+
+fn client() -> Client {
+    Client::builder(Config::default().with_base_url("https://hey.test"))
+        .token_provider(StaticTokenProvider::new("bearer-secret"))
+        .http_client(support::http_client())
+        .build()
+        .unwrap()
+}
+
+#[test]
+fn a_token_provider_prints_no_token() {
+    let provider = StaticTokenProvider::new("bearer-secret");
+    let printed = format!("{provider:?}");
+    assert!(!printed.contains("bearer-secret"), "{printed}");
+    assert!(printed.contains("[REDACTED]"), "{printed}");
+    assert_eq!(
+        format!("{}", SensitiveString::from("bearer-secret")),
+        "[REDACTED]"
+    );
+}
+
+#[test]
+fn an_operation_prints_the_shape_of_its_body_and_not_the_body() {
+    let client = client();
+    let mut operation = client.request(Method::POST, "/messages");
+    operation
+        .json(&json!({ "subject": "Quarterly plans", "content": "the private draft" }))
+        .unwrap();
+    let printed = format!("{operation:?}");
+    assert!(!printed.contains("private draft"), "{printed}");
+    assert!(!printed.contains("Quarterly"), "{printed}");
+    assert!(printed.contains("application/json"), "{printed}");
+
+    let mut form = client.request(Method::POST, "/workflows");
+    form.form(&[("workflow[name]", "Secret launch")]);
+    let printed = format!("{form:?}");
+    assert!(!printed.contains("Secret"), "{printed}");
+
+    let mut search = client.request(Method::GET, "/topics/search");
+    search.query("q", "secret plans");
+    let printed = format!("{search:?}");
+    assert!(!printed.contains("secret plans"), "{printed}");
+    assert!(printed.contains("\"q\""), "{printed}");
+
+    let written_in = client.request(Method::GET, "/topics/search?q=secret%20plans");
+    let printed = format!("{written_in:?}");
+    assert!(!printed.contains("secret"), "{printed}");
+    assert!(printed.contains("/topics/search"), "{printed}");
+}
+
+#[test]
+fn the_oauth_requests_print_no_secret() {
+    let exchange = ExchangeRequest {
+        token_endpoint: "https://hey.test/oauth/token".to_string(),
+        client_id: "client-1".to_string(),
+        client_secret: Some(SensitiveString::from("client-secret")),
+        code: SensitiveString::from("auth-code"),
+        code_verifier: SensitiveString::from("pkce-verifier"),
+        redirect_uri: "https://app.test/callback".to_string(),
+        install_id: "install-1".to_string(),
+    };
+    let printed = format!("{exchange:?}");
+    assert!(!printed.contains("client-secret"), "{printed}");
+    assert!(!printed.contains("pkce-verifier"), "{printed}");
+    assert!(!printed.contains("auth-code"), "{printed}");
+
+    let refresh = RefreshRequest {
+        token_endpoint: "https://hey.test/oauth/token".to_string(),
+        refresh_token: SensitiveString::from("refresh-secret"),
+        client_id: "client-1".to_string(),
+        client_secret: Some(SensitiveString::from("client-secret")),
+        install_id: "install-1".to_string(),
+    };
+    let printed = format!("{refresh:?}");
+    assert!(!printed.contains("refresh-secret"), "{printed}");
+    assert!(!printed.contains("client-secret"), "{printed}");
+}
+
+#[test]
+fn credential_headers_are_redacted_before_anything_sees_them() {
+    let mut headers = hey_sdk::http::HeaderMap::new();
+    headers.insert("authorization", "Bearer bearer-secret".parse().unwrap());
+    headers.insert("cookie", "session=cookie-secret".parse().unwrap());
+    headers.insert("x-request-id", "req-1".parse().unwrap());
+    let redacted = redact_headers(&headers);
+    let printed = format!("{redacted:?}");
+    assert!(!printed.contains("bearer-secret"), "{printed}");
+    assert!(!printed.contains("cookie-secret"), "{printed}");
+    assert!(printed.contains("req-1"), "{printed}");
+}
+
+/// A network failure's error names no URL: the transport's own text is kept as the hint,
+/// and with the shipped client that text carries no address.
+#[cfg(feature = "reqwest")]
+#[tokio::test]
+async fn a_network_error_names_no_url() {
+    let client = Client::builder(Config::default().with_base_url("http://127.0.0.1:1"))
+        .token_provider(StaticTokenProvider::new("t"))
+        .max_retries(0)
+        .build()
+        .unwrap();
+    let mut operation = client.request(Method::GET, "/topics/search");
+    operation.query("q", "secret plans");
+
+    let error = client.send_unit(operation).await.unwrap_err();
+
+    let printed = format!("{error} / {error:?}");
+    assert!(!printed.contains("secret"), "{printed}");
+    assert!(!printed.contains("topics"), "{printed}");
+}

--- a/scripts/rs-consumer-check
+++ b/scripts/rs-consumer-check
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Builds the packaged crate the way a consumer would: `cargo package` produces the .crate,
+# a throwaway crate in a temp dir depends on its unpacked contents by path, and that crate
+# is built with fresh dependency resolution — no workspace, no dev-dependencies — for the
+# default features and with none. This is what catches a file `include` forgot, a
+# dev-dependency a doc example leans on, or a feature that does not compile on its own.
+set -euo pipefail
+
+root="$(cd "$(dirname "$0")/.." && pwd)"
+crate="hey-sdk"
+version="$(sed -n 's/^version = "\(.*\)"/\1/p' "$root/rust/$crate/Cargo.toml" | head -1)"
+
+work="$(mktemp -d "${TMPDIR:-/tmp}/$crate-consumer.XXXXXX")"
+trap 'rm -rf "$work"' EXIT
+
+# Packaged into the temp dir, so what gets unpacked is what was just built and not an
+# older archive under whatever target dir Cargo was configured with.
+(cd "$root/rust" && cargo package -p "$crate" --allow-dirty --no-verify -q --target-dir "$work/package")
+package="$work/package/package/$crate-$version.crate"
+[ -f "$package" ] || { echo "no package at $package" >&2; exit 1; }
+tar -xzf "$package" -C "$work"
+
+mkdir -p "$work/consumer/src"
+cat > "$work/consumer/src/main.rs" <<'RS'
+use hey_sdk::{Client, Config, StaticTokenProvider};
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    let config = Config::default().with_base_url("https://app.hey.com");
+    let built = Client::builder(config)
+        .token_provider(StaticTokenProvider::new("token"))
+        .build();
+    let route = hey_sdk::routes::LIST_BOXES.id;
+    println!("{route}: {}", built.is_ok());
+}
+RS
+
+# The crate as a consumer takes it (its default features), and with none of them.
+export CARGO_TARGET_DIR="$work/target"
+for features in "" "default-features = false"; do
+    cat > "$work/consumer/Cargo.toml" <<TOML
+[package]
+name = "consumer"
+version = "0.0.0"
+edition = "2024"
+publish = false
+
+[workspace]
+
+[dependencies]
+$crate = { path = "../$crate-$version"${features:+, $features} }
+tokio = { version = "1", features = ["rt", "macros"] }
+TOML
+    echo "consumer: build with ${features:-default features}"
+    (cd "$work/consumer" && cargo build -q)
+done
+echo "consumer: ok ($crate $version)"


### PR DESCRIPTION
Card: [hey-sdk Rust: runtime and consumer contract tests](https://app.basecamp.com/2914079/buckets/46292715/card_tables/cards/10289485461)

Based on `origin/main`; independent of #165 (tracing), which touches the same `attempt()` loop — whichever lands second rebases.

## Contracts, and what the runtime had to change to keep them

- **Operation deadline ≠ transport timeout.** New `ClientBuilder::operation_timeout(Duration)`: bounds the whole call — gate wait, credentials, every attempt, every backoff, the refresh resend, the body read. Past it the work is dropped where it stands, which is what makes the existing `Running` guard report the end and the resilience layer give back its permit; the caller gets a retryable `Network` error naming the limit. Unset by default (no behaviour change). Tests in `tests/deadline.rs`: cut off while the transport would still wait, cut off during a 5 s backoff after one request, cut off while the token provider is slow before anything is sent, a cut-off call ending for the hooks and freeing the bulkhead's one permit for the next call, zero refused.
- **Concurrent 401s coalesce into one refresh.** `Shared` gains a refresh count and a refresh mutex; a request remembers the count it was signed under, and a 401 answered after someone else refreshed is resent on the new credentials without refreshing again. A refresh that fails leaves the count alone so the next 401 asks again. Tests in `tests/credential_refresh.rs` over an in-test `HttpClient` (reqwest's pool holds later requests to a new host until the first connection settles its protocol, which would sign them after the refresh and prove nothing): ten concurrent 401s → one refresh, twenty requests, ten on the new token; a call signed before the refresh does not burn a second rotating token; a failed refresh leaves every caller with its 401.
- **Pagination completeness and an explicit cap signal.** `get_all`, `get_all_with_limit`, `follow_pagination` and `each_page` end as `Error::pagination_capped(max_pages)` (`Usage`) when they reach the limit with a next page still named, instead of returning a shorter answer that looks complete; a walk that ends inside the limit, or a visitor that stops, is not a truncation. Tests: cap signalled, ends-inside-limit complete, empty page with a cursor followed, repeating cursor ends at the limit, failing page ends the walk with its status and request id. The two existing "stops at the limit" tests flip to expect the signal.
- **Diagnostics survive a decode failure.** `Response::json` keeps the status and `x-request-id`; `send`/`send_optional`/`send_page` prefix the operation. Test in `tests/errors.rs`.
- **Compile-time guarantees.** `tests/guarantees.rs`: `Client: Clone + Send + Sync`, `Error`/`Response`/`Page`/the trait objects `Send + Sync`, and every kind of call (generated read/write, raw, `get_all`, `execute`, `for_account`, `next_page`, `each_page`) a `Send` future — checked in a never-run function, so nothing needs a live server.
- **Redaction in anything formatted.** `tests/redaction.rs`: the token provider, the OAuth requests and `Token`, and credential headers print no secret; an `Operation` prints its body as content type and length, never bytes (custom `Debug` for `Body`); a transport failure names no URL — this one found a real leak: reqwest 0.13 writes the full URL, query included, into its error text, which became the hint and the `Debug` source. Fixed with `reqwest::Error::without_url()` at the three mapping sites.
- **External consumer build.** `make rs-consumer-check` (`scripts/rs-consumer-check`): `cargo package`, unpack the `.crate` into a temp dir, build a throwaway crate against it by path — its own `[workspace]`, no dev-dependencies, fresh resolution — with the default features and with `default-features = false`. Passes locally for 0.30.0. CI step: the CI-hardening card owns `test.yml`; the step to add is `make rs-consumer-check` in the Rust test job after `rs-check` (noted on that card).
- `TokenProvider` is now implemented for `Arc<P>`, as `Hooks` already is, so a provider can be shared with the client and watched by the application.

## Gate

On the branch as pushed (on `main` after #154): `make rs-check` green; `make rs-check-drift` green; `make conformance-rs` 191/191; `make rs-consumer-check` green (default and no-default features).

## Adversarial review

Codex CLI (`gpt-6-astra`, reasoning `xhigh`) review runs against this diff; findings and dispositions follow in a comment.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens the Rust SDK runtime and public contracts so failure handling is explicit, concurrent calls are safe, and diagnostics remain useful without exposing secrets. Pagination now reports incomplete walks instead of returning results that look complete.

**Runtime behavior**

- `ClientBuilder::operation_timeout` covers credentials, retries, backoff, refreshes, response reads, downloads, and multi-request helpers; the existing `timeout` remains per-request.
- Timed-out operations report the timeout to hooks, end dropped requests, and release resilience permits.
- Concurrent 401s serialize refreshes and reuse newly refreshed credentials; refreshes continue after a caller times out, while failed refreshes remain retryable.
- `get_all`, `get_all_with_limit`, `follow_pagination`, and `each_page` return `Error::pagination_capped(max_pages)` when more pages remain at the limit.
- Complete walks, visitor-initiated stops, and empty pages with cursors continue to work normally.
- JSON decode errors retain the HTTP status and request ID, and `send`, `send_optional`, and `send_page` include the operation name.
- Debug output redacts credentials, request bodies, query values, and OAuth secrets; transport errors no longer include URLs.
- `TokenProvider` implementations can now be shared through `Arc`.

**Tests and tooling**

- Adds runtime, pagination, redaction, diagnostics, and compile-time `Send`/`Sync` contract tests.
- Adds `make rs-consumer-check` to package the crate and build an external consumer with default and no default features.

<sup>Written for commit d6d2435be6732f2df39cc4213d01f6f37a8741a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-sdk/pull/168?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

