### PR TITLE
Read a workflow stage out of the page HEY serves for it, and write down the Go parity

### DIFF
--- a/conformance/runner/rust/Cargo.lock
+++ b/conformance/runner/rust/Cargo.lock
@@ -255,6 +255,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "cssparser"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c9cdaae01d5ed7882b04d795e7f752f46ff52d2fa3b50a20d28c464510bba98"
+dependencies = [
+ "cssparser-macros",
+ "dtoa-short",
+ "itoa",
+ "phf",
+ "smallvec",
+]
+
+[[package]]
+name = "cssparser-macros"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d045de693cb712d0b22c6a64be5b953f67b3ce00ab5ad3dd5d8b441886ab8e1a"
+dependencies = [
+ "quote",
+ "syn 3.0.4",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "digest"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -277,16 +321,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "dtoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590"
+
+[[package]]
+name = "dtoa-short"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87"
+dependencies = [
+ "dtoa",
+]
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
+name = "ego-tree"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b04dc5a38e4f151a79d9f2451ae6037fb6eaf5cba34771f44781f80e508498e3"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "fastrand"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "find-msvc-tools"
@@ -427,12 +498,14 @@ dependencies = [
  "base64 0.23.1",
  "bytes",
  "chrono",
+ "ego-tree",
  "futures-util",
  "http",
  "md5",
  "percent-encoding",
  "rand",
  "reqwest",
+ "scraper",
  "serde",
  "serde_json",
  "sha2",
@@ -440,6 +513,16 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
+]
+
+[[package]]
+name = "html5ever"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a1761807faccc9a19e86944bbf40610014066306f96edcdedc2fb714bcb7b8"
+dependencies = [
+ "log",
+ "markup5ever",
 ]
 
 [[package]]
@@ -789,6 +872,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -799,6 +891,17 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "markup5ever"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7122d987ec5f704ee56f6e5b41a7d93722e9aae27ae07cafa4036c4d3f9757de"
+dependencies = [
+ "log",
+ "tendril",
+ "web_atoms",
+]
 
 [[package]]
 name = "matchit"
@@ -836,6 +939,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -857,10 +966,86 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+ "serde",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+dependencies = [
+ "siphasher",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -882,6 +1067,12 @@ checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "proc-macro2"
@@ -988,6 +1179,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
 dependencies = [
  "rand_core",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -1161,6 +1361,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "scraper"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdd0be4d296f048bfb06dd01bbc80ef789ddd2e55583e8d2e6b804942abfabc2"
+dependencies = [
+ "cssparser",
+ "ego-tree",
+ "html5ever",
+ "precomputed-hash",
+ "selectors",
+ "tendril",
+]
+
+[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1181,6 +1401,25 @@ checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "selectors"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8adfa1c298912827b8a28b223b3b874357397ae706e6190acd9bf28cee99114d"
+dependencies = [
+ "bitflags",
+ "cssparser",
+ "derive_more",
+ "log",
+ "new_debug_unreachable",
+ "phf",
+ "phf_codegen",
+ "precomputed-hash",
+ "rustc-hash",
+ "servo_arc",
+ "smallvec",
 ]
 
 [[package]]
@@ -1256,6 +1495,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "servo_arc"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "170fb83ab34de17dc69aa7c67482b22218ddb85da56546f9bd6b929e32a05930"
+dependencies = [
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "sha2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1289,6 +1537,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1315,6 +1569,30 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "string_cache"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared",
+ "precomputed-hash",
+]
+
+[[package]]
+name = "string_cache_codegen"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585635e46db231059f76c5849798146164652513eb9e8ab2685939dd90f29b69"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+]
 
 [[package]]
 name = "subtle"
@@ -1362,6 +1640,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "tendril"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fed54709c5b3a53d09bb1c113ea4f5ceafd1e772ddcb0030a82e1d56c087b08"
+dependencies = [
+ "new_debug_unreachable",
 ]
 
 [[package]]
@@ -1677,6 +1964,18 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "web_atoms"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba8b815c1b593dc0baf78dd0f4fc8fdb2de53198fb1163738093e9a311c33fb3"
+dependencies = [
+ "phf",
+ "phf_codegen",
+ "string_cache",
+ "string_cache_codegen",
 ]
 
 [[package]]

--- a/conformance/runner/rust/src/operations.rs
+++ b/conformance/runner/rust/src/operations.rs
@@ -1074,7 +1074,7 @@ async fn execute_hey_operation(client: &Client, case: &TestCase) -> Result<Outco
         "GetWorkflowStage" => json(
             client
                 .workflows()
-                .get_stage(
+                .stage(
                     int64_param(path, "workflowId"),
                     int64_param(path, "stageId"),
                 )

--- a/conformance/tests/paths.json
+++ b/conformance/tests/paths.json
@@ -3512,8 +3512,8 @@
     ]
   },
   {
-    "name": "GetWorkflowStage uses the HTML workflow stage path",
-    "description": "Verifies that GetWorkflowStage requests a stage as HTML through the generated route.",
+    "name": "GetWorkflowStage uses the HTML workflow stage path and reads the stage out of it",
+    "description": "Verifies that GetWorkflowStage requests a stage as HTML through the generated route, and that the SDK reads the stage's name and its cards out of the page: subject and count from a full card, defaults from a sparse one, screen-reader text left out.",
     "operation": "GetWorkflowStage",
     "method": "GET",
     "path": "/workflows/{workflowId}/stages/{stageId}",
@@ -3530,7 +3530,7 @@
         "headers": {
           "Content-Type": "text/html; charset=utf-8"
         },
-        "body": "<section id=\"container_workflow_stage_5512\"></section>"
+        "body": "<section id=\"container_workflow_stage_5512\"><h2>Applied<span class=\"u-for-screen-reader\"> stage</span></h2><div class=\"workflow__card\" id=\"topic_4471829\" data-identifier=\"91\"><h3>Application<span class=\"u-for-screen-reader\">Thread: Application</span></h3><p class=\"card__detail\"><span class=\"u-for-screen-reader\">,</span>3 emails</p></div><div class=\"workflow__card\" id=\"topic_4471830\" data-identifier=\"92\"></div><div id=\"topic_not-a-number\" data-identifier=\"93\"></div></section>"
       }
     ],
     "assertions": [
@@ -3538,6 +3538,15 @@
         "type": "requestPath",
         "expected": "/workflows/8801/stages/5512"
       },
+      {"type": "responseBody", "path": "id", "expected": 5512},
+      {"type": "responseBody", "path": "name", "expected": "Applied"},
+      {"type": "responseBody", "path": "topics.0.topic_id", "expected": 4471829},
+      {"type": "responseBody", "path": "topics.0.staging_id", "expected": 91},
+      {"type": "responseBody", "path": "topics.0.subject", "expected": "Application"},
+      {"type": "responseBody", "path": "topics.0.entry_count", "expected": 3},
+      {"type": "responseBody", "path": "topics.1.topic_id", "expected": 4471830},
+      {"type": "responseBody", "path": "topics.1.subject", "expected": ""},
+      {"type": "responseBody", "path": "topics.1.entry_count", "expected": 0},
       {
         "type": "requestMethod",
         "expected": "GET"

--- a/go/pkg/hey/workflows.go
+++ b/go/pkg/hey/workflows.go
@@ -37,17 +37,17 @@ type Workflow struct {
 // WorkflowStageTopic is a thread card in a workflow stage.
 // StagingID identifies the workflow membership; TopicID identifies the email thread.
 type WorkflowStageTopic struct {
-	StagingID  int64
-	TopicID    int64
-	Subject    string
-	EntryCount int
+	StagingID  int64  `json:"staging_id"`
+	TopicID    int64  `json:"topic_id"`
+	Subject    string `json:"subject"`
+	EntryCount int    `json:"entry_count"`
 }
 
 // WorkflowStageView is the stage page HEY renders, including its thread cards.
 type WorkflowStageView struct {
-	ID     int64
-	Name   string
-	Topics []WorkflowStageTopic
+	ID     int64                `json:"id"`
+	Name   string               `json:"name"`
+	Topics []WorkflowStageTopic `json:"topics"`
 }
 
 // List returns the workflows on an account.

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -222,6 +222,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "cssparser"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c9cdaae01d5ed7882b04d795e7f752f46ff52d2fa3b50a20d28c464510bba98"
+dependencies = [
+ "cssparser-macros",
+ "dtoa-short",
+ "itoa",
+ "phf",
+ "smallvec",
+]
+
+[[package]]
+name = "cssparser-macros"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d045de693cb712d0b22c6a64be5b953f67b3ce00ab5ad3dd5d8b441886ab8e1a"
+dependencies = [
+ "quote",
+ "syn 3.0.4",
+]
+
+[[package]]
 name = "deadpool"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -238,6 +261,27 @@ name = "deadpool-runtime"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "digest"
@@ -262,16 +306,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "dtoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590"
+
+[[package]]
+name = "dtoa-short"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87"
+dependencies = [
+ "dtoa",
+]
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
+name = "ego-tree"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b04dc5a38e4f151a79d9f2451ae6037fb6eaf5cba34771f44781f80e508498e3"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "fastrand"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "find-msvc-tools"
@@ -460,12 +531,14 @@ dependencies = [
  "base64 0.23.1",
  "bytes",
  "chrono",
+ "ego-tree",
  "futures-util",
  "http",
  "md5",
  "percent-encoding",
  "rand",
  "reqwest",
+ "scraper",
  "serde",
  "serde_json",
  "sha2",
@@ -485,6 +558,16 @@ dependencies = [
  "serde",
  "serde_json",
  "toml",
+]
+
+[[package]]
+name = "html5ever"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a1761807faccc9a19e86944bbf40610014066306f96edcdedc2fb714bcb7b8"
+dependencies = [
+ "log",
+ "markup5ever",
 ]
 
 [[package]]
@@ -840,6 +923,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -850,6 +942,17 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "markup5ever"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7122d987ec5f704ee56f6e5b41a7d93722e9aae27ae07cafa4036c4d3f9757de"
+dependencies = [
+ "log",
+ "tendril",
+ "web_atoms",
+]
 
 [[package]]
 name = "md5"
@@ -873,6 +976,12 @@ dependencies = [
  "wasi",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "num-traits"
@@ -906,10 +1015,86 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+ "serde",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+dependencies = [
+ "siphasher",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -931,6 +1116,12 @@ checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "proc-macro2"
@@ -1037,6 +1228,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
 dependencies = [
  "rand_core",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -1233,6 +1433,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "scraper"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdd0be4d296f048bfb06dd01bbc80ef789ddd2e55583e8d2e6b804942abfabc2"
+dependencies = [
+ "cssparser",
+ "ego-tree",
+ "html5ever",
+ "precomputed-hash",
+ "selectors",
+ "tendril",
+]
+
+[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1253,6 +1473,25 @@ checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "selectors"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8adfa1c298912827b8a28b223b3b874357397ae706e6190acd9bf28cee99114d"
+dependencies = [
+ "bitflags",
+ "cssparser",
+ "derive_more",
+ "log",
+ "new_debug_unreachable",
+ "phf",
+ "phf_codegen",
+ "precomputed-hash",
+ "rustc-hash",
+ "servo_arc",
+ "smallvec",
 ]
 
 [[package]]
@@ -1315,6 +1554,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "servo_arc"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "170fb83ab34de17dc69aa7c67482b22218ddb85da56546f9bd6b929e32a05930"
+dependencies = [
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "sha2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1357,6 +1605,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1383,6 +1637,30 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "string_cache"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared",
+ "precomputed-hash",
+]
+
+[[package]]
+name = "string_cache_codegen"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585635e46db231059f76c5849798146164652513eb9e8ab2685939dd90f29b69"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+]
 
 [[package]]
 name = "subtle"
@@ -1430,6 +1708,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "tendril"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fed54709c5b3a53d09bb1c113ea4f5ceafd1e772ddcb0030a82e1d56c087b08"
+dependencies = [
+ "new_debug_unreachable",
 ]
 
 [[package]]
@@ -1802,6 +2089,18 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "web_atoms"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba8b815c1b593dc0baf78dd0f4fc8fdb2de53198fb1163738093e9a311c33fb3"
+dependencies = [
+ "phf",
+ "phf_codegen",
+ "string_cache",
+ "string_cache_codegen",
 ]
 
 [[package]]

--- a/rust/hey-sdk/Cargo.toml
+++ b/rust/hey-sdk/Cargo.toml
@@ -40,6 +40,7 @@ async-trait = "0.1"
 base64 = "0.23"
 bytes = "1"
 chrono = { version = "0.4", default-features = false, features = ["clock", "serde", "std"] }
+ego-tree = "0.11"
 futures-util = { version = "0.3", default-features = false, features = ["std"] }
 http = "1"
 # Active Storage checks an upload's integrity with a base64-encoded MD5, so the SDK has to
@@ -48,6 +49,7 @@ md5 = "0.8"
 percent-encoding = "2"
 rand = "0.10"
 reqwest = { version = "0.13", default-features = false, features = ["rustls", "http2"], optional = true }
+scraper = { version = "0.27.0", default-features = false }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = "0.11"

--- a/rust/hey-sdk/PARITY.md
+++ b/rust/hey-sdk/PARITY.md
@@ -7,7 +7,7 @@ request with the same behaviour — not one method name per method name: Rust ty
 passes as strings and zero values, and answers `Page<T>` where Go unwraps the payload.
 
 Counts at the time of writing: 202 Go methods; 131 modelled operations, each a Rust route and
-a generated method; 121 Rust conveniences. Every Go method has a Rust route to the same
+a generated method; 122 Rust conveniences. Every Go method has a Rust route to the same
 request except the waivers at the end. Both runners dispatch the whole shared conformance
 suite.
 
@@ -15,7 +15,7 @@ suite.
 
 | contract | Go | Rust |
 |---|---|---|
-| idempotency | per-operation literal in the generated client; form posts sent once | `Route::idempotent` → `Operation` → the retry budget; `Client::form` sends once |
+| idempotency | per-operation literal in the generated client; a form post is sent once, plus the one resend after a refreshed 401 | `Route::idempotent` → `Operation` → the retry budget; `Client::form` sends once, plus that same resend |
 | empty-on statuses | by hand at the one call site (`GetOngoing`) | `Route::empty_on` → `send_optional` → `Option` |
 | pagination style | by hand per `*Page` method | `Route::pagination` → generated methods answer `Page<T>`; `next_page`/`each_page` keep the route's policy |
 | retry policy | model policy under the client ceiling (#164) | model policy under the client ceiling (#154) |
@@ -34,7 +34,7 @@ Unqualified Rust names are conveniences; `gen` marks a generated method.
 | Postings.MoveToTrash / TrashForEveryone | TrashPostings | `move_to_trash` / `trash_for_everyone` | |
 | Postings.Mute / Unmute / MarkSpam | MutePostings / UnmutePostings / MarkPostingsSpam | `mute_postings` / `unmute_postings` / `mark_postings_spam` | |
 | Postings.AddToBoxGroup / RemoveFromBoxGroup | AddPostingsToBoxGroup / RemovePostingsFromBoxGroup | `add_postings_to_box_group` / `remove_postings_from_box_group` | |
-| Postings.File / Unfile / CreateFolder | FilePostings / UnfilePostings / CreateFolderForPostings | `file_postings` / `unfile_postings` / `create_folder_for_postings` | both omit `folder_id` when zero |
+| Postings.File / Unfile / CreateFolder | FilePostings / UnfilePostings / CreateFolderForPostings | `file_postings` / `unfile_postings` / `create_folder_for_postings` | `Unfile` omits `folder_id` when zero in both |
 | Postings.CancelBubbleUp / BubbleUpNow | CancelPostingsBubbleUp / BubbleUpPostingsNow | `cancel_postings_bubble_up` / `bubble_up_postings_now` | |
 | Postings.ScheduleBubbleUp(date) / ScheduleBubbleUpFor(slot) | SchedulePostingsBubbleUp | `schedule_postings_bubble_up(BubbleUpSlot, ids)` | one method, typed slot |
 | Postings.BundleUnseenPage | GetBundleUnseenPostings | gen `get_bundle_unseen` → `Page` | |
@@ -59,14 +59,14 @@ Unqualified Rust names are conveniences; `gen` marks a generated method.
 | Messages.Create | CreateMessage | `send(&MessageContent)` | Rust adds an optional `acting_sender_id` |
 | Messages.CreateDraft / UpdateDraft / SendDraft | CreateMessage / UpdateMessage | `create_draft` / `update_draft` / `send_draft` | neither resends; Go parses 422 `errors[]` itself, Rust maps 422 to `Validation` with the server message |
 | Entries.ListDrafts / ListDraftsPage | ListDrafts | gen `list_drafts` → `Page` | |
-| Entries.CreateReply / CreateReplyDraft | CreateReply | `reply` / `reply_draft` | both refuse no recipients |
+| Entries.CreateReply / CreateReplyDraft | CreateReply | `reply` / `reply_draft` | a reply refuses no recipients in both; a draft may have none |
 | Entries.MarkSpam / DeleteDraft / NewReply / NewForward | same ids | gen | |
 | Calendars.List / GetRecordings / GetRecordingsPage | ListCalendars / GetCalendarRecordings | gen | |
 | Calendars.Toggle | ToggleCalendar | `toggle_selection` | |
 | Calendars.ListWithChanges | GET `/calendars.json` | `list_with_changes` | |
 | Calendars.AllCalendarChanges / CalendarChanges / AllRecordingChanges / RecordingChanges | unmodelled change feeds | same names | |
 | CalendarEvents.Create / Update / UpdateOccurrence | forms | `create` / `update_event` / `update_occurrence` | Rust also has a narrower `update` |
-| CalendarEvents.Delete / DeleteOccurrence | DeleteCalendarEvent / DeleteCalendarEventOccurrence | gen `delete` / `delete_occurrence_scoped` | |
+| CalendarEvents.Delete / DeleteOccurrence | DeleteCalendarEvent / DeleteCalendarEventOccurrence | gen `delete` / `delete_occurrence_scoped` (hand-written over gen `delete_occurrence`) | |
 | CalendarPeriods.Day / Days / Week / Weeks / Year | GetCalendarDay … GetCalendarYear | `day` / `days` / `week` / `weeks` / `year` | |
 | CalendarTodos.Create / Update | CreateCalendarTodo / UpdateCalendarTodo | `create_todo(title, Option<Date>)` / `update_todo` | both bypass the generated timestamp payload for a bare date |
 | CalendarTodos.Complete / Uncomplete / Delete | same ids | gen | |
@@ -83,7 +83,7 @@ Unqualified Rust names are conveniences; `gen` marks a generated method.
 | TimeTracks.CreateCategory / UpdateCategory / DeleteCategory / Export | forms, CSV | same names | |
 | Workflows.List | autocomplete GET | `list` → `Vec<WorkflowSummary>` | |
 | Workflows.Get / Stages | GetWorkflow | gen `get` / `stages` | |
-| Workflows.GetStage → WorkflowStageView | GetWorkflowStage (HTML) | `stage` → `WorkflowStageView`; gen `get_stage` → the page | added with this file, same parser rules as Go |
+| Workflows.GetStage → WorkflowStageView | GetWorkflowStage (HTML) | `stage` → `WorkflowStageView`; gen `get_stage` → the page | added with this file, same parser rules as Go; a page without the stage is `NotFound` in Rust and a plain error in Go |
 | Workflows.Create / Update / Delete / CreateStage / UpdateStage / DeleteStage / UnstageTopic | forms | same names | |
 | Workflows.StageTopic / MoveTopic | CreateWorkflowStaging + MoveWorkflowStaging (form) | `stage_topic` / `move_topic_to_stage` | the read-back is `quiet()` in Rust; hooks hear one operation in both |
 | World.Publish / Update / Delete / ExportSubscribers / ImportSubscribers | forms, CSV, multipart | `publish` / `update_post` / `delete_post` / `export_subscribers` / `import_subscribers` | |

--- a/rust/hey-sdk/PARITY.md
+++ b/rust/hey-sdk/PARITY.md
@@ -1,0 +1,114 @@
+# Go ↔ Rust parity
+
+What the Go SDK's hand-written service methods (`go/pkg/hey/*.go`) map to in the Rust crate,
+where the Rust half is a generated method (`src/generated/services/*.rs`, one per modelled
+operation) or a hand-written convenience (`src/services/*.rs`). Parity is semantic — the same
+request with the same behaviour — not one method name per method name: Rust types what Go
+passes as strings and zero values, and answers `Page<T>` where Go unwraps the payload.
+
+Counts at the time of writing: 202 Go methods; 131 modelled operations, each a Rust route and
+a generated method; 121 Rust conveniences. Every Go method has a Rust route to the same
+request except the waivers at the end. Both runners dispatch the whole shared conformance
+suite.
+
+## Behaviour the model declares, and who honours it
+
+| contract | Go | Rust |
+|---|---|---|
+| idempotency | per-operation literal in the generated client; form posts sent once | `Route::idempotent` → `Operation` → the retry budget; `Client::form` sends once |
+| empty-on statuses | by hand at the one call site (`GetOngoing`) | `Route::empty_on` → `send_optional` → `Option` |
+| pagination style | by hand per `*Page` method | `Route::pagination` → generated methods answer `Page<T>`; `next_page`/`each_page` keep the route's policy |
+| retry policy | model policy under the client ceiling (#164) | model policy under the client ceiling (#154) |
+| HTML representation | by hand (`GetStage` strips `.json`, asks `text/html`) | `Route::html` → `Operation` asks as written |
+
+## Go method → Rust
+
+Unqualified Rust names are conveniences; `gen` marks a generated method.
+
+| Go | sends | Rust | notes |
+|---|---|---|---|
+| Postings.MarkSeen / MarkUnseen | MarkPostingsSeen / MarkPostingsUnseen | `mark_postings_seen` / `mark_postings_unseen` | every bulk method refuses an empty selection, as Go's `bulkAction` does |
+| Postings.Move(boxID, ids) | MovePostings | `move_to_box(box_id, ids)` | |
+| Postings.MoveToBox(kind) | ListBoxes + MovePostings | `move_to_kind(BoxKind)` | Go re-reads the box index on every miss; Rust reads once per client |
+| Postings.MoveToImbox … MoveToPaperTrail | as above | `move_to_imbox` … `move_to_paper_trail` | |
+| Postings.MoveToTrash / TrashForEveryone | TrashPostings | `move_to_trash` / `trash_for_everyone` | |
+| Postings.Mute / Unmute / MarkSpam | MutePostings / UnmutePostings / MarkPostingsSpam | `mute_postings` / `unmute_postings` / `mark_postings_spam` | |
+| Postings.AddToBoxGroup / RemoveFromBoxGroup | AddPostingsToBoxGroup / RemovePostingsFromBoxGroup | `add_postings_to_box_group` / `remove_postings_from_box_group` | |
+| Postings.File / Unfile / CreateFolder | FilePostings / UnfilePostings / CreateFolderForPostings | `file_postings` / `unfile_postings` / `create_folder_for_postings` | both omit `folder_id` when zero |
+| Postings.CancelBubbleUp / BubbleUpNow | CancelPostingsBubbleUp / BubbleUpPostingsNow | `cancel_postings_bubble_up` / `bubble_up_postings_now` | |
+| Postings.ScheduleBubbleUp(date) / ScheduleBubbleUpFor(slot) | SchedulePostingsBubbleUp | `schedule_postings_bubble_up(BubbleUpSlot, ids)` | one method, typed slot |
+| Postings.BundleUnseenPage | GetBundleUnseenPostings | gen `get_bundle_unseen` → `Page` | |
+| Postings.AllChanges / Changes | GetBoxPostingChanges | `all_changes` / `changes` | 409 → `full_sync_required`; both bypass the cache |
+| Boxes.List / Get / GetPage | ListBoxes / GetBox | gen `list` / `get` → `Page` | |
+| Boxes.GetImbox … GetBubblebox | GetImbox … GetBubblebox | gen `get_imbox` … `get_bubblebox` | |
+| Boxes.ListGroups / GetGroup / GetGroupPage / DeleteGroup / MarkSeen | ListBoxGroups / GetBoxGroup / DeleteBoxGroup / MarkBoxSeen | gen | |
+| Boxes.CreateGroup(boxID, ids) | CreateBoxGroup | `create_box_group` | |
+| Topics.Get / GetEntries / GetEntriesPage | GetTopic / GetTopicEntries | gen `get` / `get_entries` → `Page` | |
+| Topics.GetSent / GetSpam / GetTrash / GetEverything | same ids | gen → `Page` | |
+| Topics.Trash(id, confirm) | TrashTopic | `trash_topic` | both turn the removal redirect into a usage error |
+| Topics.Restore / MarkHam / EmptyTrash / EmptySpam | same ids | gen | |
+| Topics.Move(topicID, boxID) | MoveTopic | `move_to_box(topic_id, box_id)` | added with this file; gen `move_topic` takes the body |
+| Contacts.List / Get / ThreadsPage | ListContacts / GetContact | gen `list` / `get` → `Page` | |
+| Contacts.Bundle / Unbundle / Hide / Reveal / Note / DeleteNote | same ids | gen | |
+| Contacts.Screen(id, status) | UpdateContactClearance | `screen(id, ClearanceStatus)` | |
+| Contacts.Create / Update / SetNote | CreateContact / UpdateContact / UpdateContactNote | `create_contact` / `update_contact` / `set_note` | Rust always sends the alias list, so `Some(vec![])` clears it, which Go's `omitempty` cannot |
+| Clearances.PendingCount / Summary / Pending / PendingPage | GetClearances | `pending_count` / `summary` / `pending` / `pending_page` | |
+| Clearances.Screen / ScreenMany / Punt | UpdateClearance / BulkUpdateClearances / PuntClearances | `screen` / `screen_many` / gen `punt` | |
+| Clearances.Screened / ScreenedPage / Rescreen | GetMyClearances / UpdateMyClearance | `screened` / `screened_page` / `rescreen` | |
+| Messages.Get / GetEdit | GetMessage / GetMessageEdit | gen | |
+| Messages.Create | CreateMessage | `send(&MessageContent)` | Rust adds an optional `acting_sender_id` |
+| Messages.CreateDraft / UpdateDraft / SendDraft | CreateMessage / UpdateMessage | `create_draft` / `update_draft` / `send_draft` | neither resends; Go parses 422 `errors[]` itself, Rust maps 422 to `Validation` with the server message |
+| Entries.ListDrafts / ListDraftsPage | ListDrafts | gen `list_drafts` → `Page` | |
+| Entries.CreateReply / CreateReplyDraft | CreateReply | `reply` / `reply_draft` | both refuse no recipients |
+| Entries.MarkSpam / DeleteDraft / NewReply / NewForward | same ids | gen | |
+| Calendars.List / GetRecordings / GetRecordingsPage | ListCalendars / GetCalendarRecordings | gen | |
+| Calendars.Toggle | ToggleCalendar | `toggle_selection` | |
+| Calendars.ListWithChanges | GET `/calendars.json` | `list_with_changes` | |
+| Calendars.AllCalendarChanges / CalendarChanges / AllRecordingChanges / RecordingChanges | unmodelled change feeds | same names | |
+| CalendarEvents.Create / Update / UpdateOccurrence | forms | `create` / `update_event` / `update_occurrence` | Rust also has a narrower `update` |
+| CalendarEvents.Delete / DeleteOccurrence | DeleteCalendarEvent / DeleteCalendarEventOccurrence | gen `delete` / `delete_occurrence_scoped` | |
+| CalendarPeriods.Day / Days / Week / Weeks / Year | GetCalendarDay … GetCalendarYear | `day` / `days` / `week` / `weeks` / `year` | |
+| CalendarTodos.Create / Update | CreateCalendarTodo / UpdateCalendarTodo | `create_todo(title, Option<Date>)` / `update_todo` | both bypass the generated timestamp payload for a bare date |
+| CalendarTodos.Complete / Uncomplete / Delete | same ids | gen | |
+| Habits.Create / Update | CreateHabit / UpdateHabit | `create_habit` / `update_habit` | |
+| Habits.Complete / Uncomplete / Delete / Stop / Resume | same ids | gen | |
+| Journal.ListPage | ListJournalEntries | gen `list_entries` → `Page` | |
+| Journal.Get / GetContent / Update | GetJournalEntry / UpdateJournalEntry | `entry` / `get_content` / `update_content` → `Option` | a 204 is "nothing there" in both |
+| Identity.GetIdentity / GetNavigation | GetIdentity / GetNavigation | gen | |
+| Identity.UpdateFirstWeekDay / UpdateTimeFormat | same ids | `set_first_week_day(Weekday)` / `set_time_format` | |
+| TimeTracks.List / ListPage / Update / Create / Delete / Categories | same ids | gen | |
+| TimeTracks.GetOngoing | GetOngoingTimeTrack | gen `get_ongoing` → `Option` | from the model's `empty_on` |
+| TimeTracks.Start | StartTimeTrack | `start_tracking` | 409 → conflict |
+| TimeTracks.Stop / StopAndFile | UpdateTimeTrack as `StopTimeTrack` | `stop` / `stop_and_file` | |
+| TimeTracks.CreateCategory / UpdateCategory / DeleteCategory / Export | forms, CSV | same names | |
+| Workflows.List | autocomplete GET | `list` → `Vec<WorkflowSummary>` | |
+| Workflows.Get / Stages | GetWorkflow | gen `get` / `stages` | |
+| Workflows.GetStage → WorkflowStageView | GetWorkflowStage (HTML) | `stage` → `WorkflowStageView`; gen `get_stage` → the page | added with this file, same parser rules as Go |
+| Workflows.Create / Update / Delete / CreateStage / UpdateStage / DeleteStage / UnstageTopic | forms | same names | |
+| Workflows.StageTopic / MoveTopic | CreateWorkflowStaging + MoveWorkflowStaging (form) | `stage_topic` / `move_topic_to_stage` | the read-back is `quiet()` in Rust; hooks hear one operation in both |
+| World.Publish / Update / Delete / ExportSubscribers / ImportSubscribers | forms, CSV, multipart | `publish` / `update_post` / `delete_post` / `export_subscribers` / `import_subscribers` | |
+| Search.Search / SearchPage / Filters | AdvancedSearch / GetAdvancedSearchFilters | `search` / `search_page` / gen `get_advanced_filters` | |
+| Publications.Get / Create / Delete | GetTopicPublication, forms | gen `get` / `publish` / `unpublish` | |
+| Extenzions.List | GetNavigation | `list` | Go announces a nested `GetNavigation`; Rust announces `ListExtenzions` only |
+| Extenzions.Create / Update / Delete | forms, DeleteExtenzion | `create` / `update` → `Option<Extenzion>` / gen `delete` | |
+| Attachments.CreateDirectUpload / Upload | CreateDirectUpload, storage PUT | gen `create_direct_upload` / `upload` | Go refuses an empty reservation at the single call; Rust inside `upload` |
+| BulkReplies.Draft / Send / Undo | NewBulkReply / CreateBulkReply, form | `draft` / `send` / `undo` | |
+| Collections.List / Get / GetPage | ListCollections / GetCollection | gen | |
+| Collections.Update / Create / AddTopic / RemoveTopic | UpdateCollection, forms | `update_collection` / `create` / `add_topic` / `remove_topic` | |
+| Folders.Get / GetPage | GetFolder | gen `get` → `Page` | |
+| Clips.List / Create / Delete | ListClips, forms | gen `list` → `Page` / `create` / `delete` | |
+| Designations.Create / Destroy | CreateBoxDesignation / DeleteBoxDesignation | `create_box_designation` / gen `delete` | |
+| Snippets.List / Create / Update / Delete | ListSnippets, forms | gen `list` / `create` / `update` / `delete` | |
+| Stickies.List(limit) / Create / Update / Delete / Move | ListStickies … MoveSticky | `list_up_to` / `create_sticky` / `update_sticky` / gen `delete` / `move_to` | both clamp the limit to 100 |
+
+## Rust-only
+
+`CalendarEvents::update` (a six-field partial revision), `Boxes::kinds`, `FromStr` for the
+typed enums, `ContactConflict::from_error`, `services::write_info`, and every generated
+method Go reaches only through its generated client (`messages.create`, `topics.trash` with
+params, `clearances.get`, …).
+
+## Waived
+
+- `Contacts.Clearances` — deprecated in Go; `clearances().summary()` is the same read.
+- `Client.BoxIDByKind` lives on Go's client; Rust's `Boxes::id_by_kind` is the counterpart.

--- a/rust/hey-sdk/src/services/mod.rs
+++ b/rust/hey-sdk/src/services/mod.rs
@@ -78,7 +78,7 @@ pub use messages::{DeliverySchedule, DraftContent, MessageContent};
 pub use postings::{BubbleUpSlot, PostingChanges, PostingChangesCursor};
 pub use search::{SearchParams, SearchResults};
 pub use stickies::{MAX_STICKIES_LIMIT, MAX_STICKY_POSITION, StickySize};
-pub use workflows::WorkflowSummary;
+pub use workflows::{WorkflowStageTopic, WorkflowStageView, WorkflowSummary};
 pub use world::WORLD_ADDRESS;
 
 /// What a write to a path outside the model announces itself as. Build the request itself

--- a/rust/hey-sdk/src/services/topics.rs
+++ b/rust/hey-sdk/src/services/topics.rs
@@ -8,10 +8,18 @@
 use crate::client::Response;
 use crate::error::Error;
 use crate::generated::routes;
+use crate::generated::types::MoveTopicRequestContent;
 
 pub use crate::generated::services::topics::*;
 
 impl Topics<'_> {
+    /// Moves a topic to a box, by the box's id. The generated [`Topics::move_topic`] takes
+    /// the request body; this takes the one thing it carries.
+    pub async fn move_to_box(&self, topic_id: i64, box_id: i64) -> Result<(), Error> {
+        self.move_topic(topic_id, &MoveTopicRequestContent { box_id })
+            .await
+    }
+
     /// Trashes a topic.
     ///
     /// HEY will not trash a shared topic without being asked twice: it answers the removal

--- a/rust/hey-sdk/src/services/workflows.rs
+++ b/rust/hey-sdk/src/services/workflows.rs
@@ -5,7 +5,7 @@
 
 use std::borrow::Cow;
 
-use ego_tree::NodeRef;
+use ego_tree::iter::Edge;
 use scraper::{ElementRef, Html, Node, Selector};
 
 use crate::error::Error;
@@ -41,10 +41,12 @@ pub struct WorkflowStageView {
 
 impl WorkflowStageView {
     /// Reads the stage out of the page HEY serves for it, the way Go's `GetStage` does: the
-    /// element whose id names the stage, its first `h2` for the name, and every element
-    /// under it whose id is `topic_<id>` for a card. A card is skipped when its thread or
-    /// staging id will not parse, or when its detail line does not start with a count.
-    /// Text meant for screen readers is left out of names and subjects.
+    /// element whose id names the stage, the first `h2` at or under it for the name, and
+    /// every element under it whose id is `topic_<id>` for a card — the outermost such
+    /// element, since a card inside a card is that card's content. A card is skipped when
+    /// its thread or staging id will not parse as a positive number, or when its detail
+    /// line does not start with a count. Text meant for screen readers is left out of
+    /// names and subjects. Every rule is Go's, so the two SDKs read one page the same way.
     pub fn parse(html: &str, stage_id: i64) -> Result<WorkflowStageView, Error> {
         let document = Html::parse_document(html);
         let stage = document
@@ -53,14 +55,12 @@ impl WorkflowStageView {
             )))
             .next()
             .ok_or_else(|| Error::not_found("workflow stage", stage_id))?;
-        let name = stage
-            .select(&selector("h2"))
-            .next()
+        let name = first_at_or_under(stage, |element| element.value().name() == "h2")
             .map(visible_text)
             .unwrap_or_default();
         let topics = stage
             .select(&selector("[id^=\"topic_\"]"))
-            .filter(|card| !inside_another_card(*card))
+            .filter(|card| !inside_another_card(*card, stage))
             .filter_map(topic)
             .collect();
         Ok(WorkflowStageView {
@@ -74,18 +74,17 @@ impl WorkflowStageView {
 fn topic(card: ElementRef<'_>) -> Option<WorkflowStageTopic> {
     let topic_id = positive(card.attr("id")?.strip_prefix("topic_")?)?;
     let staging_id = positive(card.attr("data-identifier")?)?;
-    let subject = card
-        .select(&selector("h3"))
-        .next()
+    let subject = first_at_or_under(card, |element| element.value().name() == "h3")
         .map(visible_text)
         .unwrap_or_default();
-    let entry_count = match card.select(&selector("p.card__detail")).next() {
+    let entry_count = match first_at_or_under(card, is_detail_line) {
         None => 0,
         Some(detail) => visible_text(detail)
             .split_whitespace()
             .next()?
-            .parse()
-            .ok()?,
+            .parse::<i64>()
+            .ok()
+            .and_then(|count| u64::try_from(count).ok())?,
     };
     Some(WorkflowStageTopic {
         staging_id,
@@ -95,14 +94,36 @@ fn topic(card: ElementRef<'_>) -> Option<WorkflowStageTopic> {
     })
 }
 
+/// A `p` whose class mentions `card__detail`, as Go matches it: a substring, so a
+/// modifier class on the element still counts.
+fn is_detail_line(element: ElementRef<'_>) -> bool {
+    element.value().name() == "p"
+        && element
+            .attr("class")
+            .is_some_and(|class| class.contains("card__detail"))
+}
+
 fn positive(value: &str) -> Option<i64> {
     value.parse::<i64>().ok().filter(|id| *id > 0)
 }
 
-/// Whether a card sits inside another: the walk that finds cards stops at each one, so a
-/// card rendered inside a card is that card's content, not a card of its own.
-fn inside_another_card(card: ElementRef<'_>) -> bool {
+/// The first element at or under `root`, in document order, that `matches` — the element
+/// itself included, as Go's `findNode` includes it.
+fn first_at_or_under<'a>(
+    root: ElementRef<'a>,
+    matches: impl Fn(ElementRef<'a>) -> bool,
+) -> Option<ElementRef<'a>> {
+    root.descendants()
+        .filter_map(ElementRef::wrap)
+        .find(|element| matches(*element))
+}
+
+/// Whether a card sits inside another card of the same stage: the walk that finds cards
+/// stops at each one, so a card rendered inside a card is that card's content, not a card
+/// of its own. Only the stage's own subtree counts; what surrounds the stage is not a card.
+fn inside_another_card(card: ElementRef<'_>, stage: ElementRef<'_>) -> bool {
     card.ancestors()
+        .take_while(|ancestor| ancestor.id() != stage.id())
         .filter_map(ElementRef::wrap)
         .any(|ancestor| {
             ancestor
@@ -112,30 +133,42 @@ fn inside_another_card(card: ElementRef<'_>) -> bool {
 }
 
 /// The text a reader sees under an element, whitespace collapsed: text meant for screen
-/// readers only is left out.
+/// readers only is left out. Walked without recursion, since the page is the server's and
+/// its nesting is not bounded.
 fn visible_text(element: ElementRef<'_>) -> String {
     let mut text = String::new();
-    collect_visible_text(*element, &mut text);
+    let mut hidden_depth = 0usize;
+    for edge in element.traverse() {
+        match edge {
+            Edge::Open(node) => {
+                if hidden_depth > 0 {
+                    hidden_depth += 1;
+                } else {
+                    match node.value() {
+                        Node::Element(element) if is_visually_hidden(element) => {
+                            hidden_depth = 1;
+                        }
+                        Node::Text(content) => text.push_str(content),
+                        _ => {}
+                    }
+                }
+            }
+            Edge::Close(_) => hidden_depth = hidden_depth.saturating_sub(1),
+        }
+    }
     text.split_whitespace().collect::<Vec<_>>().join(" ")
 }
 
-fn collect_visible_text(node: NodeRef<'_, Node>, text: &mut String) {
-    match node.value() {
-        Node::Text(content) => text.push_str(content),
-        Node::Element(element) if is_visually_hidden(element) => return,
-        _ => {}
-    }
-    for child in node.children() {
-        collect_visible_text(child, text);
-    }
-}
-
+/// Split on whitespace as Go's `strings.Fields` splits a class attribute: any Unicode
+/// whitespace, not only the ASCII the HTML spec names.
 fn is_visually_hidden(element: &scraper::node::Element) -> bool {
-    element.classes().any(|class| {
-        matches!(
-            class,
-            "sr-only" | "screen-reader-only" | "u-for-screen-reader" | "visually-hidden"
-        )
+    element.attr("class").is_some_and(|classes| {
+        classes.split_whitespace().any(|class| {
+            matches!(
+                class,
+                "sr-only" | "screen-reader-only" | "u-for-screen-reader" | "visually-hidden"
+            )
+        })
     })
 }
 

--- a/rust/hey-sdk/src/services/workflows.rs
+++ b/rust/hey-sdk/src/services/workflows.rs
@@ -5,6 +5,9 @@
 
 use std::borrow::Cow;
 
+use ego_tree::NodeRef;
+use scraper::{ElementRef, Html, Node, Selector};
+
 use crate::error::Error;
 use crate::generated::routes;
 use crate::generated::types::WorkflowStage;
@@ -13,6 +16,133 @@ use crate::observability::OperationInfo;
 use crate::services::write_info;
 
 pub use crate::generated::services::workflows::*;
+
+/// One thread on a workflow stage, as the stage page renders its card.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct WorkflowStageTopic {
+    /// The staging record that puts the thread on this stage, which is what
+    /// [`Workflows::stage_topic`] moves.
+    pub staging_id: i64,
+    pub topic_id: i64,
+    /// The card's title; empty when the card renders none.
+    pub subject: String,
+    /// How many emails the card says the thread holds; zero when the card does not say.
+    pub entry_count: u64,
+}
+
+/// A workflow stage as HEY renders it — the stage page is the only place a stage's threads
+/// are listed — with the cards it shows.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct WorkflowStageView {
+    pub id: i64,
+    pub name: String,
+    pub topics: Vec<WorkflowStageTopic>,
+}
+
+impl WorkflowStageView {
+    /// Reads the stage out of the page HEY serves for it, the way Go's `GetStage` does: the
+    /// element whose id names the stage, its first `h2` for the name, and every element
+    /// under it whose id is `topic_<id>` for a card. A card is skipped when its thread or
+    /// staging id will not parse, or when its detail line does not start with a count.
+    /// Text meant for screen readers is left out of names and subjects.
+    pub fn parse(html: &str, stage_id: i64) -> Result<WorkflowStageView, Error> {
+        let document = Html::parse_document(html);
+        let stage = document
+            .select(&selector(&format!(
+                "[id=\"container_workflow_stage_{stage_id}\"]"
+            )))
+            .next()
+            .ok_or_else(|| Error::not_found("workflow stage", stage_id))?;
+        let name = stage
+            .select(&selector("h2"))
+            .next()
+            .map(visible_text)
+            .unwrap_or_default();
+        let topics = stage
+            .select(&selector("[id^=\"topic_\"]"))
+            .filter(|card| !inside_another_card(*card))
+            .filter_map(topic)
+            .collect();
+        Ok(WorkflowStageView {
+            id: stage_id,
+            name,
+            topics,
+        })
+    }
+}
+
+fn topic(card: ElementRef<'_>) -> Option<WorkflowStageTopic> {
+    let topic_id = positive(card.attr("id")?.strip_prefix("topic_")?)?;
+    let staging_id = positive(card.attr("data-identifier")?)?;
+    let subject = card
+        .select(&selector("h3"))
+        .next()
+        .map(visible_text)
+        .unwrap_or_default();
+    let entry_count = match card.select(&selector("p.card__detail")).next() {
+        None => 0,
+        Some(detail) => visible_text(detail)
+            .split_whitespace()
+            .next()?
+            .parse()
+            .ok()?,
+    };
+    Some(WorkflowStageTopic {
+        staging_id,
+        topic_id,
+        subject,
+        entry_count,
+    })
+}
+
+fn positive(value: &str) -> Option<i64> {
+    value.parse::<i64>().ok().filter(|id| *id > 0)
+}
+
+/// Whether a card sits inside another: the walk that finds cards stops at each one, so a
+/// card rendered inside a card is that card's content, not a card of its own.
+fn inside_another_card(card: ElementRef<'_>) -> bool {
+    card.ancestors()
+        .filter_map(ElementRef::wrap)
+        .any(|ancestor| {
+            ancestor
+                .attr("id")
+                .is_some_and(|id| id.starts_with("topic_"))
+        })
+}
+
+/// The text a reader sees under an element, whitespace collapsed: text meant for screen
+/// readers only is left out.
+fn visible_text(element: ElementRef<'_>) -> String {
+    let mut text = String::new();
+    collect_visible_text(*element, &mut text);
+    text.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn collect_visible_text(node: NodeRef<'_, Node>, text: &mut String) {
+    match node.value() {
+        Node::Text(content) => text.push_str(content),
+        Node::Element(element) if is_visually_hidden(element) => return,
+        _ => {}
+    }
+    for child in node.children() {
+        collect_visible_text(child, text);
+    }
+}
+
+fn is_visually_hidden(element: &scraper::node::Element) -> bool {
+    element.classes().any(|class| {
+        matches!(
+            class,
+            "sr-only" | "screen-reader-only" | "u-for-screen-reader" | "visually-hidden"
+        )
+    })
+}
+
+/// A selector written here, which is why parsing it cannot fail.
+fn selector(css: &str) -> Selector {
+    Selector::parse(css).unwrap_or_else(|error| unreachable!("selector {css:?}: {error}"))
+}
 
 /// A workflow as the autocomplete endpoint names it.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -54,6 +184,14 @@ impl Workflows<'_> {
     /// A workflow's stages, in position order.
     pub async fn stages(&self, workflow_id: i64) -> Result<Vec<WorkflowStage>, Error> {
         Ok(self.get(workflow_id).await?.stages.unwrap_or_default())
+    }
+
+    /// One stage and the threads on it, read out of the page HEY serves for the stage —
+    /// what [`Workflows::get_stage`] answers as HTML, parsed. HEY lists a stage's threads
+    /// nowhere else.
+    pub async fn stage(&self, workflow_id: i64, stage_id: i64) -> Result<WorkflowStageView, Error> {
+        let page = self.get_stage(workflow_id, stage_id).await?;
+        WorkflowStageView::parse(&page, stage_id)
     }
 
     /// Adds a workflow. No account — `None` or a zero id — leaves HEY to pick your first.

--- a/rust/hey-sdk/src/services/workflows.rs
+++ b/rust/hey-sdk/src/services/workflows.rs
@@ -23,6 +23,7 @@ pub struct WorkflowStageTopic {
     /// The staging record that puts the thread on this stage, which is what
     /// [`Workflows::stage_topic`] moves.
     pub staging_id: i64,
+    /// The thread the card is for.
     pub topic_id: i64,
     /// The card's title; empty when the card renders none.
     pub subject: String,
@@ -34,8 +35,11 @@ pub struct WorkflowStageTopic {
 /// are listed — with the cards it shows.
 #[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize)]
 pub struct WorkflowStageView {
+    /// The stage, as the caller asked for it.
     pub id: i64,
+    /// The stage's name as the page shows it; empty when the page names none.
     pub name: String,
+    /// The cards on the stage, in the order the page shows them.
     pub topics: Vec<WorkflowStageTopic>,
 }
 

--- a/rust/hey-sdk/src/services/workflows.rs
+++ b/rust/hey-sdk/src/services/workflows.rs
@@ -18,7 +18,7 @@ use crate::services::write_info;
 pub use crate::generated::services::workflows::*;
 
 /// One thread on a workflow stage, as the stage page renders its card.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize)]
 pub struct WorkflowStageTopic {
     /// The staging record that puts the thread on this stage, which is what
     /// [`Workflows::stage_topic`] moves.
@@ -32,7 +32,7 @@ pub struct WorkflowStageTopic {
 
 /// A workflow stage as HEY renders it — the stage page is the only place a stage's threads
 /// are listed — with the cards it shows.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize)]
 pub struct WorkflowStageView {
     pub id: i64,
     pub name: String,

--- a/rust/hey-sdk/src/services/workflows.rs
+++ b/rust/hey-sdk/src/services/workflows.rs
@@ -19,6 +19,7 @@ pub use crate::generated::services::workflows::*;
 
 /// One thread on a workflow stage, as the stage page renders its card.
 #[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize)]
+#[non_exhaustive]
 pub struct WorkflowStageTopic {
     /// The staging record that puts the thread on this stage, which is what
     /// [`Workflows::stage_topic`] moves.
@@ -34,6 +35,7 @@ pub struct WorkflowStageTopic {
 /// A workflow stage as HEY renders it — the stage page is the only place a stage's threads
 /// are listed — with the cards it shows.
 #[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize)]
+#[non_exhaustive]
 pub struct WorkflowStageView {
     /// The stage, as the caller asked for it.
     pub id: i64,

--- a/rust/hey-sdk/tests/services_topics.rs
+++ b/rust/hey-sdk/tests/services_topics.rs
@@ -115,3 +115,22 @@ async fn a_refusal_that_is_not_a_redirect_stays_a_failure() {
     assert_eq!(error.code(), ErrorCode::Api);
     assert_eq!(error.http_status(), Some(406));
 }
+
+#[tokio::test]
+async fn a_topic_is_moved_to_a_box_by_its_id() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/topics/9/moves.json"))
+        .respond_with(ResponseTemplate::new(204))
+        .mount(&server)
+        .await;
+
+    client(&server).topics().move_to_box(9, 5).await.unwrap();
+
+    let requests = server.received_requests().await.unwrap();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(
+        requests[0].body_json::<serde_json::Value>().unwrap(),
+        serde_json::json!({ "box_id": 5 })
+    );
+}

--- a/rust/hey-sdk/tests/services_workflows.rs
+++ b/rust/hey-sdk/tests/services_workflows.rs
@@ -376,11 +376,12 @@ async fn a_page_without_the_stage_is_not_found() {
 }
 
 /// A card whose detail line starts with something other than a count is left out, as Go
-/// leaves it out; a card inside a card is that card's content, not a card of its own; and
-/// a stage page with markup around it is still the stage.
+/// leaves it out; a card inside a card is that card's content, not a card of its own; a
+/// card is found by a detail class that merely mentions `card__detail`, and at the element
+/// itself; what wraps the stage is not a card; and the count is read as Go reads it.
 #[test]
 fn the_parser_keeps_to_the_cards_go_keeps_to() {
-    let page = r#"<html><body><nav>Boards</nav>
+    let page = r#"<html><body><nav>Boards</nav><div id="topic_shell">
       <section id="container_workflow_stage_7"><h2>  In  <b>review</b> </h2>
         <div id="topic_1" data-identifier="10"><h3>One</h3><p class="card__detail">1 email</p>
           <div id="topic_2" data-identifier="20"><h3>Nested</h3></div></div>
@@ -388,7 +389,11 @@ fn the_parser_keeps_to_the_cards_go_keeps_to() {
         <div id="topic_4" data-identifier="40"><h3>Four</h3><p class="card__detail"></p></div>
         <div id="topic_0" data-identifier="50"><h3>Zero</h3></div>
         <div id="topic_5" data-identifier="0"><h3>Unstaged</h3></div>
-      </section></body></html>"#;
+        <div id="topic_6" data-identifier="60"><h3>Six</h3><p class="card__detail--compact">6 emails</p></div>
+        <h3 id="topic_7" data-identifier="70">Seven</h3>
+        <div id="topic_8" data-identifier="80"><h3>Eight</h3><p class="card__detail">-1 emails</p></div>
+        <div id="topic_9" data-identifier="90"><h3><span class="sr-only&#160;x">Hidden</span>Nine</h3><p class="card__detail">-0 emails</p></div>
+      </section></div></body></html>"#;
 
     let stage = WorkflowStageView::parse(page, 7).unwrap();
 
@@ -405,5 +410,28 @@ fn the_parser_keeps_to_the_cards_go_keeps_to() {
             )
         })
         .collect();
-    assert_eq!(topics, [(1, 10, "One", 1)]);
+    assert_eq!(
+        topics,
+        [
+            (1, 10, "One", 1),
+            (6, 60, "Six", 6),
+            (7, 70, "Seven", 0),
+            (9, 90, "Nine", 0)
+        ]
+    );
+}
+
+/// A stage element that is itself the heading names the stage, as Go's inclusive search
+/// finds it, and a page nested past any sane depth is read without recursing into it.
+#[test]
+fn the_parser_reads_the_element_itself_and_survives_deep_nesting() {
+    let page = r#"<h2 id="container_workflow_stage_3">Ready</h2>"#;
+    assert_eq!(WorkflowStageView::parse(page, 3).unwrap().name, "Ready");
+
+    let deep = format!(
+        r#"<section id="container_workflow_stage_4"><h2>{}Deep{}</h2></section>"#,
+        "<span>".repeat(200_000),
+        "</span>".repeat(200_000)
+    );
+    assert_eq!(WorkflowStageView::parse(&deep, 4).unwrap().name, "Deep");
 }

--- a/rust/hey-sdk/tests/services_workflows.rs
+++ b/rust/hey-sdk/tests/services_workflows.rs
@@ -5,7 +5,7 @@ mod support;
 use std::sync::Arc;
 
 use hey_sdk::ErrorCode;
-use hey_sdk::services::{WorkflowStageTopic, WorkflowStageView};
+use hey_sdk::services::WorkflowStageView;
 use serde_json::json;
 use wiremock::matchers::{header, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -333,22 +333,21 @@ async fn a_stage_is_read_out_of_the_page_hey_serves_for_it() {
 
     assert_eq!(stage.id, 5512);
     assert_eq!(stage.name, "Applied");
+    let topics: Vec<(i64, i64, &str, u64)> = stage
+        .topics
+        .iter()
+        .map(|topic| {
+            (
+                topic.staging_id,
+                topic.topic_id,
+                topic.subject.as_str(),
+                topic.entry_count,
+            )
+        })
+        .collect();
     assert_eq!(
-        stage.topics,
-        [
-            WorkflowStageTopic {
-                staging_id: 91,
-                topic_id: 4_471_829,
-                subject: "Application".to_string(),
-                entry_count: 3,
-            },
-            WorkflowStageTopic {
-                staging_id: 92,
-                topic_id: 4_471_830,
-                subject: String::new(),
-                entry_count: 0,
-            },
-        ]
+        topics,
+        [(91, 4_471_829, "Application", 3), (92, 4_471_830, "", 0)]
     );
 }
 

--- a/rust/hey-sdk/tests/services_workflows.rs
+++ b/rust/hey-sdk/tests/services_workflows.rs
@@ -4,8 +4,10 @@ mod support;
 
 use std::sync::Arc;
 
+use hey_sdk::ErrorCode;
+use hey_sdk::services::{WorkflowStageTopic, WorkflowStageView};
 use serde_json::json;
-use wiremock::matchers::{method, path};
+use wiremock::matchers::{header, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 use support::{Operations, builder, client};
@@ -306,4 +308,102 @@ async fn mock_staging(server: &MockServer, verb: &str) {
 
 fn form(body: &[u8]) -> Vec<(String, String)> {
     url::form_urlencoded::parse(body).into_owned().collect()
+}
+
+/// The stage page as HEY renders it, read the way Go's `GetStage` reads it: the stage's
+/// name without its screen-reader suffix, a card with its subject and count, a sparse
+/// card with neither, and two cards whose ids will not parse left out.
+#[tokio::test]
+async fn a_stage_is_read_out_of_the_page_hey_serves_for_it() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/workflows/8801/stages/5512"))
+        .and(header("accept", "text/html"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/html; charset=utf-8")
+                .set_body_string(
+                    r#"<section id="container_workflow_stage_5512"><h2>Applied<span class="u-for-screen-reader"> stage</span></h2><div class="workflow__card" id="topic_4471829" data-identifier="91"><h3>Application<span class="u-for-screen-reader">Thread: Application</span></h3><p class="card__detail"><span class="u-for-screen-reader">,</span>3 emails</p></div><div class="workflow__card" id="topic_4471830" data-identifier="92"></div><div id="topic_not-a-number" data-identifier="93"></div><div id="topic_4471831" data-identifier="not-a-number"></div></section>"#,
+                ),
+        )
+        .mount(&server)
+        .await;
+
+    let stage = client(&server).workflows().stage(8801, 5512).await.unwrap();
+
+    assert_eq!(stage.id, 5512);
+    assert_eq!(stage.name, "Applied");
+    assert_eq!(
+        stage.topics,
+        [
+            WorkflowStageTopic {
+                staging_id: 91,
+                topic_id: 4471829,
+                subject: "Application".to_string(),
+                entry_count: 3,
+            },
+            WorkflowStageTopic {
+                staging_id: 92,
+                topic_id: 4471830,
+                subject: String::new(),
+                entry_count: 0,
+            },
+        ]
+    );
+}
+
+#[tokio::test]
+async fn a_page_without_the_stage_is_not_found() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/workflows/8801/stages/5512"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/html")
+                .set_body_string(r#"<section id="container_workflow_stage_9999"></section>"#),
+        )
+        .mount(&server)
+        .await;
+
+    let error = client(&server)
+        .workflows()
+        .stage(8801, 5512)
+        .await
+        .unwrap_err();
+
+    assert_eq!(error.code(), ErrorCode::NotFound);
+    assert!(error.message().contains("5512"), "{error}");
+}
+
+/// A card whose detail line starts with something other than a count is left out, as Go
+/// leaves it out; a card inside a card is that card's content, not a card of its own; and
+/// a stage page with markup around it is still the stage.
+#[test]
+fn the_parser_keeps_to_the_cards_go_keeps_to() {
+    let page = r#"<html><body><nav>Boards</nav>
+      <section id="container_workflow_stage_7"><h2>  In  <b>review</b> </h2>
+        <div id="topic_1" data-identifier="10"><h3>One</h3><p class="card__detail">1 email</p>
+          <div id="topic_2" data-identifier="20"><h3>Nested</h3></div></div>
+        <div id="topic_3" data-identifier="30"><h3>Three</h3><p class="card__detail">many emails</p></div>
+        <div id="topic_4" data-identifier="40"><h3>Four</h3><p class="card__detail"></p></div>
+        <div id="topic_0" data-identifier="50"><h3>Zero</h3></div>
+        <div id="topic_5" data-identifier="0"><h3>Unstaged</h3></div>
+      </section></body></html>"#;
+
+    let stage = WorkflowStageView::parse(page, 7).unwrap();
+
+    assert_eq!(stage.name, "In review");
+    let topics: Vec<(i64, i64, &str, u64)> = stage
+        .topics
+        .iter()
+        .map(|topic| {
+            (
+                topic.topic_id,
+                topic.staging_id,
+                topic.subject.as_str(),
+                topic.entry_count,
+            )
+        })
+        .collect();
+    assert_eq!(topics, [(1, 10, "One", 1)]);
 }

--- a/rust/hey-sdk/tests/services_workflows.rs
+++ b/rust/hey-sdk/tests/services_workflows.rs
@@ -338,13 +338,13 @@ async fn a_stage_is_read_out_of_the_page_hey_serves_for_it() {
         [
             WorkflowStageTopic {
                 staging_id: 91,
-                topic_id: 4471829,
+                topic_id: 4_471_829,
                 subject: "Application".to_string(),
                 entry_count: 3,
             },
             WorkflowStageTopic {
                 staging_id: 92,
-                topic_id: 4471830,
+                topic_id: 4_471_830,
                 subject: String::new(),
                 entry_count: 0,
             },


### PR DESCRIPTION
Card: [hey-sdk Rust: parity audit vs Go and WorkflowStageView](https://app.basecamp.com/2914079/buckets/46292715/card_tables/cards/10289485429)

Based on `origin/main`; independent of #165 and #168.

## WorkflowStageView

`Workflows::stage(workflow_id, stage_id)` answers a `WorkflowStageView` — `id`, `name`, and `topics: Vec<WorkflowStageTopic { staging_id, topic_id, subject, entry_count }>` — parsed from the HTML the generated `get_stage` returns (that method still answers the page, unchanged). The parser mirrors `parseWorkflowStageHTML` in `go/pkg/hey/workflows.go` rule for rule: the element whose id is `container_workflow_stage_{id}` (else `NotFound`), its first `h2` for the name, every element under it whose id is `topic_<n>` for a card, `data-identifier` for the staging id, first `h3` for the subject, the first whitespace field of `p.card__detail` for the count; a card is left out when either id will not parse as a positive integer or the detail line does not start with a count, and text under `sr-only` / `screen-reader-only` / `u-for-screen-reader` / `visually-hidden` is left out of names and subjects. One addition Go gets by construction: a card inside a card is that card's content, not a card of its own.

Parser: `scraper` with default features off (html5ever, selectors, cssparser, ego-tree, tendril — a spec-compliant HTML5 parser, which is what Go's `x/net/html` is too; ~20 crates on the lock). `WorkflowStageView::parse(html, stage_id)` is public so a page fetched some other way can be read the same way.

Tests: the wire test uses Go's own fixture from `TestWorkflowsService_GetStage` (name without its screen-reader suffix, a full card, a sparse card, two cards with unparsable ids left out), a not-found page, and a parser test for the rules the fixture does not reach (count line without a count, empty detail, nested card, non-positive ids, surrounding markup, whitespace collapse).

## Parity audit

`rust/hey-sdk/PARITY.md` is the checked-in Go → Rust mapping: every one of the 202 exported Go service methods against its Rust counterpart (131 generated methods, one per modelled operation and route, plus 121 conveniences), the behaviour the model declares and how each SDK honours it, the Rust-only surface, and the waivers.

Findings:

- 200 of 202 Go methods already had a Rust route to the same request. The two gaps were `GetStage` parsing (closed here) and `Topics.Move(topicID, boxID)` — Rust only had the generated `move_topic(id, &body)` — closed here as `Topics::move_to_box(topic_id, box_id)` with a wire test.
- Waived: `Contacts.Clearances` (deprecated in Go; `clearances().summary()` is the same read) and `Client.BoxIDByKind` (a client method in Go; `Boxes::id_by_kind` is the counterpart).
- Behaviour model: Rust honours idempotency, empty-on, pagination style, retry policy and the HTML representation from the route table; Go honours idempotency and retry policy from its generated client and the rest by hand at each call site. Two metadata wrinkles noted, not acted on: `generated.IsIdempotent("UpdateMessage")` and `behavior-model.json` say idempotent while `x-hey-idempotent.natural` is false and both runtimes send it once; the `Window` pagination style is carried on `GetCalendarRecordings` but read as a Link page in both.
- Conformance: 195 shared cases, both runners dispatch all of them.
- Not added, deliberately: the Go-deprecated alias; `Journal::list_page` / `Contacts::get_contact` ergonomics over generated methods that already answer the same thing.

## Gate

On the branch as pushed (on `main` at `1d3d047`): `make rs-check` green, `make rs-check-drift` green, `make conformance-rs` 195/195.

## Adversarial review

Codex CLI (`gpt-6-astra`, reasoning `xhigh`) review runs against this diff; findings and dispositions follow in a comment.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `Workflows::stage`, which parses the HTML HEY serves for a workflow stage into a `WorkflowStageView` (stage id, name, and topic cards), mirroring Go's `GetStage` rule for rule, and closes the last two Go/Rust parity gaps with `Topics::move_to_box` and a checked-in parity audit. The shared conformance case now asserts the parsed stage in both runners, which is why Go's stage structs gained JSON tags.

**New Features**
- The parser reads the stage container element, its first `h2` for the name, and every `topic_<id>` element under it for a card; a card inside a card is that card's content, not a card of its own.
- Parsing uses `scraper` (html5ever underneath), a spec-compliant HTML5 parser like Go's `x/net/html`.
- A card is left out when its thread or staging id will not parse as a positive integer, or when its detail line does not start with a count.
- Text under `sr-only`, `screen-reader-only`, `u-for-screen-reader`, or `visually-hidden` is left out of names and subjects.
- `WorkflowStageView::parse` is public so a page fetched some other way can be read the same way.
- `WorkflowStageTopic` and `WorkflowStageView` are `#[non_exhaustive]`, so future fields are not a breaking change.
- `Topics::move_to_box(topic_id, box_id)` mirrors Go's `Topics.Move` and sends the same body the generated `move_topic` carries.
- `PARITY.md` maps all 202 Go service methods to their Rust counterparts, records how each SDK honours idempotency, empty-on, pagination, retry, and HTML behaviour, and lists the two waivers.

<sup>Written for commit 228f747a36587031a1481db25a5664f301535405. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-sdk/pull/169?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

