### PR TITLE
Let the tracing label go away with the feature

### DIFF
--- a/rust/hey-sdk/src/client.rs
+++ b/rust/hey-sdk/src/client.rs
@@ -26,7 +26,9 @@ use crate::pagination::Page;
 use crate::route::Route;
 use crate::security::{is_same_origin, require_secure_endpoint};
 use crate::services::boxes::BoxKinds;
-use crate::trace::{AttemptSpan, OperationSpan, label};
+#[cfg(feature = "tracing")]
+use crate::trace::label;
+use crate::trace::{AttemptSpan, OperationSpan};
 use crate::version::default_user_agent;
 
 pub const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);

--- a/rust/hey-sdk/src/trace.rs
+++ b/rust/hey-sdk/src/trace.rs
@@ -10,6 +10,7 @@
 //! query it carries are the caller's; the hooks are where the URL goes.
 
 use crate::http::StatusCode;
+#[cfg(feature = "tracing")]
 use crate::observability::OperationInfo;
 use crate::operation::Operation;
 
@@ -95,6 +96,8 @@ impl OperationSpan {
 
 /// What a span or an event calls the operation: the name the model or a wrapper gave it,
 /// or the method alone for a path the caller wrote, whose path is the caller's own.
+/// Without the feature nothing is emitted, so nothing asks.
+#[cfg(feature = "tracing")]
 pub(crate) fn label(operation: &Operation) -> &str {
     if is_raw(&operation.info) {
         operation.method.as_str()
@@ -103,6 +106,7 @@ pub(crate) fn label(operation: &Operation) -> &str {
     }
 }
 
+#[cfg(feature = "tracing")]
 fn is_raw(info: &OperationInfo) -> bool {
     info.service == "Raw"
 }


### PR DESCRIPTION
`main` fails `make rs-check` (Rust Tests red at `5680b25`) since #165 met the `--no-default-features` clippy pass that landed with the CI hardening: `trace::label`, `is_raw` and the `OperationInfo` import exist only to name spans and events, and without the `tracing` feature the event macros expand to nothing, so nothing asks for the label and clippy's `-D dead-code` refuses the build. All three, and the import in `client.rs`, now go away with the feature.

Three `#[cfg]` lines, no behaviour change. Every Rust PR rebased onto `main` fails the gate until this lands, so it goes ahead of #168 and #169.

Gate: `make rs-check` (default, `--no-default-features`, `--all-features`), on `main` + this commit, green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gates the tracing label helpers behind the `tracing` feature so `--no-default-features` builds pass clippy's dead-code check. No behavior change.

<sup>Written for commit 40358535348ca2e0cbab9c1601e83608bed5095a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-sdk/pull/172?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

