### PR TITLE
Gate the tracing label behind the tracing feature

### DIFF
--- a/rust/hey-sdk/src/client.rs
+++ b/rust/hey-sdk/src/client.rs
@@ -26,7 +26,7 @@ use crate::pagination::Page;
 use crate::route::Route;
 use crate::security::{is_same_origin, require_secure_endpoint};
 use crate::services::boxes::BoxKinds;
-use crate::trace::{AttemptSpan, OperationSpan, label};
+use crate::trace::{AttemptSpan, OperationSpan};
 use crate::version::default_user_agent;
 
 pub const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
@@ -628,7 +628,7 @@ impl Client {
                         },
                     );
                     if attempt < attempts {
-                        crate::trace::debug!(operation = label(operation), attempt, error = %error.code(), "request failed, retrying");
+                        crate::trace::debug!(operation = crate::trace::label(operation), attempt, error = %error.code(), "request failed, retrying");
                         hooks.on_retry(&info, attempt + 1, &error);
                         self.wait(delay).await;
                         delay = self.next_delay(delay);
@@ -658,7 +658,7 @@ impl Client {
                             },
                         );
                         crate::trace::debug!(
-                            operation = label(operation),
+                            operation = crate::trace::label(operation),
                             "credentials refreshed, resending"
                         );
                         hooks.on_retry(&info, attempt + 1, &cause);
@@ -683,7 +683,7 @@ impl Client {
                                 retry_after,
                             },
                         );
-                        crate::trace::debug!(operation = label(operation), attempt, %status, "retryable status, retrying");
+                        crate::trace::debug!(operation = crate::trace::label(operation), attempt, %status, "retryable status, retrying");
                         hooks.on_retry(&info, attempt + 1, &cause);
                         match retry_after {
                             Some(seconds)

--- a/rust/hey-sdk/src/trace.rs
+++ b/rust/hey-sdk/src/trace.rs
@@ -10,7 +10,6 @@
 //! query it carries are the caller's; the hooks are where the URL goes.
 
 use crate::http::StatusCode;
-use crate::observability::OperationInfo;
 use crate::operation::Operation;
 
 #[cfg(feature = "tracing")]
@@ -95,16 +94,13 @@ impl OperationSpan {
 
 /// What a span or an event calls the operation: the name the model or a wrapper gave it,
 /// or the method alone for a path the caller wrote, whose path is the caller's own.
+#[cfg(feature = "tracing")]
 pub(crate) fn label(operation: &Operation) -> &str {
-    if is_raw(&operation.info) {
+    if operation.info.service == "Raw" {
         operation.method.as_str()
     } else {
         &operation.info.operation
     }
-}
-
-fn is_raw(info: &OperationInfo) -> bool {
-    info.service == "Raw"
 }
 
 /// The span one send runs inside, a child of the operation's. Numbered the way the hooks


### PR DESCRIPTION
Main has been red on Rust Tests since #165 merged: `cargo clippy --no-default-features -D warnings` fails on `trace::label` and `trace::is_raw` being dead and the `label` import in `client.rs` unused. Without the `tracing` feature the `debug!` macro expands to nothing, so the `label(operation)` in its arguments is never referenced.

#155 added that clippy step and #165 added the spans. Each was green on its own; #165's CI ran before #155 landed and it merged without a re-run.

The fix gates `label` behind the feature, folds the one-line `is_raw` helper into it so the `OperationInfo` import can go, and names `label` fully qualified at the three call sites the way they already name the macro, so the import line needs no cfg.

`make rs-check rs-check-drift` is green locally. #171 (the zizmor-action bump) inherits this failure through its merge commit and will need a rebase once this lands.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `cargo clippy --no-default-features -D warnings` failure on main by gating the tracing label behind the `tracing` feature.

- Folds the `is_raw` helper into `label` so the unused `OperationInfo` import goes away.
- Names `label` fully qualified at call sites so the import line needs no cfg.

<sup>Written for commit 76144feba7530fe60dfaf30876251fae6c03e126. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-sdk/pull/173?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

