### PR TITLE
Reference local reusable workflows with GitHub's self-repository syntax

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,9 @@
+# actionlint's rules for this repository. See https://github.com/rhysd/actionlint/blob/main/docs/config.md
+paths:
+  .github/workflows/**/*.yml:
+    ignore:
+      # GitHub's self-repository `uses: $/...` syntax (July 2026) is what zizmor's
+      # self-repository audit asks for in place of `./...`, and what our reusable-workflow
+      # calls use. actionlint 1.7.12 predates it and has no release that knows it
+      # (rhysd/actionlint#711); drop this once one does.
+      - 'reusable workflow call "\$/.+" at "uses" is not following the format'

--- a/.github/workflows/release-go.yml
+++ b/.github/workflows/release-go.yml
@@ -16,7 +16,7 @@ jobs:
   smithy:
     permissions:
       contents: read
-    uses: ./.github/workflows/smithy-verify.yml
+    uses: $/.github/workflows/smithy-verify.yml
 
   test:
     name: Test before release

--- a/.github/workflows/release-rust.yml
+++ b/.github/workflows/release-rust.yml
@@ -19,7 +19,7 @@ jobs:
   smithy:
     permissions:
       contents: read
-    uses: ./.github/workflows/smithy-verify.yml
+    uses: $/.github/workflows/smithy-verify.yml
 
   test:
     name: Test before release

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
   smithy-verify:
     permissions:
       contents: read
-    uses: ./.github/workflows/smithy-verify.yml
+    uses: $/.github/workflows/smithy-verify.yml
 
   test-go:
     name: Go Tests


### PR DESCRIPTION
Dependabot's zizmor-action bump (#171, 0.6.2 → 0.6.3) fails the GitHub Actions audit, and Dependabot can't rebase that PR because it carries hand edits. This PR lands the workflow change on main by itself so the bump can be recreated cleanly on top.

## Why the bump fails

zizmor-action's `version` input defaults to `latest`, resolved from a manifest bundled with the action: 0.6.2 resolves to zizmor 1.29.0, 0.6.3 to 1.30.0. zizmor 1.30.0 adds the [`self-repository`](https://docs.zizmor.sh/audits/#self-repository) audit, which flags each of our three `uses: ./.github/workflows/smithy-verify.yml` reusable-workflow calls (3 low findings, exit 12) and asks for GitHub's newer `$/...` self-repository syntax. zizmor has parsed `$/` since 1.29.0, so the fix is green on main today with the action still at 0.6.2 — verified locally with `zizmor==1.29.0` and `1.30.0` over `.github/workflows` (no findings, 5 ignored, 11 suppressed on both).

## What changes

- `release-go.yml`, `release-rust.yml`, `test.yml`: `uses: ./.github/workflows/smithy-verify.yml` → `uses: $/.github/workflows/smithy-verify.yml`.
- `.github/actionlint.yaml`: actionlint 1.7.12 (still the latest release, 2026-03) predates the `$/` syntax and rejects it as malformed ([rhysd/actionlint#711](https://github.com/rhysd/actionlint/issues/711), open); ignore that one message until a release knows the syntax. Same two commits that were pushed onto #171 (where they pass the audit and actionlint), rebased onto main.

## Follow-up

Once this merges, comment `@dependabot recreate` on #171 so Dependabot regenerates the bump on top of it; the bump then passes the audit as-is. #171's remaining red check (Rust Tests) is unrelated — it's on a stale base predating #163's clippy fix, and the recreate resolves that too.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates reusable workflow calls to use GitHub's self-repository `$/...` syntax so the repository passes zizmor's new self-repository audit (introduced in zizmor 1.30.0, which the upcoming dependabot bump would use). Adds an `actionlint` config to ignore the lint message for this new syntax, since `actionlint` doesn't support it yet.

<sup>Written for commit ad11076324c6a9e73b146bb0331ed6041b0a6075. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-sdk/pull/174?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

