### PR TITLE
Bump version to 0.31.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,13 +158,13 @@ by default, and lets an application bring its own HTTP stack instead.
 
 ```toml
 [dependencies]
-hey-sdk = "0.30"
+hey-sdk = "0.31"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 ```
 
 The crate is [`hey-sdk` on crates.io](https://crates.io/crates/hey-sdk), documented on
 [docs.rs](https://docs.rs/hey-sdk). To track the repository instead, depend on it at a release
-tag: `hey-sdk = { git = "https://github.com/basecamp/hey-sdk", tag = "v0.30.0" }`. Requires
+tag: `hey-sdk = { git = "https://github.com/basecamp/hey-sdk", tag = "v0.31.0" }`. Requires
 Rust 1.88 or newer (`rust-version` in `rust/Cargo.toml`, built on exactly that in CI); the
 crate's [Versioning](rust/hey-sdk/README.md#versioning) section says when that floor moves
 and what a version bump means.

--- a/conformance/runner/rust/Cargo.lock
+++ b/conformance/runner/rust/Cargo.lock
@@ -492,7 +492,7 @@ dependencies = [
 
 [[package]]
 name = "hey-sdk"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "async-trait",
  "base64 0.23.1",

--- a/go/pkg/hey/version.go
+++ b/go/pkg/hey/version.go
@@ -1,7 +1,7 @@
 package hey
 
 // Version is the current version of the HEY Go SDK.
-const Version = "0.30.0"
+const Version = "0.31.0"
 
 // APIVersion is the HEY API version this SDK targets.
 const APIVersion = "2026-08-21"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -525,7 +525,7 @@ checksum = "e17592d60ebacc7d5e169f4663c5f84f9161cc90328abcfe8456f41e4dfcb284"
 
 [[package]]
 name = "hey-sdk"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "async-trait",
  "base64 0.23.1",

--- a/rust/hey-sdk/Cargo.toml
+++ b/rust/hey-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hey-sdk"
-version = "0.30.0"
+version = "0.31.0"
 description = "Rust client for the HEY API, generated from a Smithy model of the API"
 homepage = "https://github.com/basecamp/hey-sdk"
 documentation = "https://docs.rs/hey-sdk"

--- a/rust/hey-sdk/README.md
+++ b/rust/hey-sdk/README.md
@@ -6,7 +6,7 @@ is what HEY serves.
 
 ```toml
 [dependencies]
-hey-sdk = "0.30"
+hey-sdk = "0.31"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 ```
 
@@ -16,7 +16,7 @@ tag — the repository's `vX.Y.Z` tags are the crate's releases, and there is no
 tag to look for:
 
 ```toml
-hey-sdk = { git = "https://github.com/basecamp/hey-sdk", tag = "v0.30.0" }
+hey-sdk = { git = "https://github.com/basecamp/hey-sdk", tag = "v0.31.0" }
 ```
 
 Requires Rust 1.88 or newer; see [Versioning](#versioning).

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -36,14 +36,20 @@ if ! grep -Fxq "version = \"$VERSION\"" "$CARGO_FILE"; then
   exit 1
 fi
 
-# The READMEs tell a consumer which minor to request alongside the git source, and Cargo
-# rejects a fetched crate that fails that requirement, so the constraint moves with the
-# version.
+# The READMEs show a consumer two ways in: the crates.io requirement, which names the minor
+# (Cargo reads "0.31" as ">=0.31.0, <0.32.0"), and the git dependency pinned to the release
+# tag, which names the whole version. Both move with the bump, and a README that no longer
+# carries either line is a README the bump cannot keep true, so each substitution is checked.
 MINOR="${VERSION%.*}"
 for README in "$REPO_ROOT/README.md" "$REPO_ROOT/rust/hey-sdk/README.md"; do
-  sedi "s|\(hey-sdk = { git = \"https://github.com/basecamp/hey-sdk\", version = \"\)[0-9.]*\"|\1$MINOR\"|" "$README"
-  if ! grep -Fq "hey-sdk = { git = \"https://github.com/basecamp/hey-sdk\", version = \"$MINOR\" }" "$README"; then
-    echo "ERROR: Rust constraint substitution did not match in $README" >&2
+  sedi "s|^hey-sdk = \"[0-9.]*\"$|hey-sdk = \"$MINOR\"|" "$README"
+  if ! grep -Fxq "hey-sdk = \"$MINOR\"" "$README"; then
+    echo "ERROR: crates.io requirement substitution did not match in $README" >&2
+    exit 1
+  fi
+  sedi "s|\(hey-sdk = { git = \"https://github.com/basecamp/hey-sdk\", tag = \"v\)[0-9.]*\"|\1$VERSION\"|" "$README"
+  if ! grep -Fq "hey-sdk = { git = \"https://github.com/basecamp/hey-sdk\", tag = \"v$VERSION\" }" "$README"; then
+    echo "ERROR: git tag substitution did not match in $README" >&2
     exit 1
   fi
 done


### PR DESCRIPTION
Since v0.30.0 the Rust crate's response types and enums are `#[non_exhaustive]` (#166, breaking), the Rust client honors each route's retry policy and the Go client holds its retry settings as a ceiling over it (#154, #164), operations carry tracing spans behind a feature (#165), a workflow stage is read out of the page HEY serves (#169), and the crate publishes to crates.io on the tag (#162). `cargo semver-checks` against v0.30.0 asks for the minor.

The bump script still looked for the README dependency line #160 replaced. The READMEs now show the crates.io requirement, which names the minor, and the git dependency pinned to the release tag, which names the whole version; the script moves both and checks each.

After this merges: `make release VERSION=0.31.0` on main.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps the Go and Rust SDKs to 0.31.0 and updates the version bump script for the READMEs' new dependency lines.

**Bug Fixes**
- The script now updates the crates.io requirement and the pinned git tag in both READMEs, and fails if either substitution doesn't match.

<sup>Written for commit b3ff41c41296dd63b53dbde021acf0ba647888cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-sdk/pull/175?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

