### PR TITLE
Drop the unpacked crate after packaging so rust-cache stops reporting it

### DIFF
--- a/.github/workflows/release-rust.yml
+++ b/.github/workflows/release-rust.yml
@@ -120,6 +120,9 @@ jobs:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
           cargo package -p "$CRATE" --locked
+          # The unpacked copy it built from carries tests/, which rust-cache's cleanup
+          # probes for nested target dirs and reports as errors when they are not there.
+          rm -rf "target/package/$CRATE-$VERSION"
           crate="target/package/$CRATE-$VERSION.crate"
           stamp=$(tar xzOf "$crate" "$CRATE-$VERSION/.cargo_vcs_info.json")
           echo "$stamp"

--- a/rust/Makefile
+++ b/rust/Makefile
@@ -64,9 +64,15 @@ deny:
 # tarball, check the metadata, so a missing file, a path dependency or a metadata slip
 # surfaces on the pull request rather than on the tag. --allow-dirty so it runs before a
 # commit as well as after; CI's checkout is clean anyway.
+# The dry run unpacks the crate under target/package to build it once more from the
+# tarball. That copy carries the crate's tests/ directory, and rust-cache's cleanup probes
+# every tests/ it finds in target/ for the nested target dirs that trybuild and macrotest
+# make, reporting each miss as an error annotation on the job. The tarball is what matters;
+# the unpacked copy goes as soon as it has been built.
 .PHONY: publish-check
 publish-check:
 	$(CARGO) publish -p hey-sdk --dry-run --locked --allow-dirty
+	rm -rf target/package/hey-sdk-*/
 
 # Run all checks: the same steps as CI's test-rust job, in the same order
 .PHONY: check


### PR DESCRIPTION
Every job that packages the crate and uses rust-cache ends with error annotations, eight on the v0.31.0 release run: `ENOENT ... opendir target/package/hey-sdk-0.31.0/tests/target` and `tests/trybuild`, each twice. The jobs pass; the annotations are noise, but they read as failures.

**Why.** `cargo package` unpacks the tarball to `target/package/hey-sdk-X.Y.Z/` to build it once more, and that copy carries the crate's `tests/` directory since the manifest ships it. rust-cache's post-job cleanup walks `target/` and, on any directory named `tests`, probes for the nested target dirs that trybuild and macrotest create ([cleanup.ts at v2.9.2](https://github.com/Swatinem/rust-cache/blob/6323deb102c322ba6fcbdcafc7e3dddab59af2b6/src/cleanup.ts#L45-L54)). Those two `cleanTargetDir` calls are not awaited, so each miss escapes its `try/catch` as an unhandled rejection, which the runner prints as an error annotation. That is an upstream bug and a fix is going up separately.

**What this does.** The tarball is the artifact; the unpacked copy has done its job once the verify build finishes. `publish-check` in the Makefile (which `rs-check` runs, so the Rust Tests job and the release's "Test before release" job) and the release workflow's package step now remove it. The publish job's second `cargo package --no-verify` does not unpack, so it needs nothing.

Verified locally that the trailing-slash glob removes only the directory and leaves the `.crate` beside it; the Rust Tests job on this PR should show no annotations.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the unpacked crate directory that `cargo package` leaves in `target/package/` after the verification build, so rust-cache’s cleanup no longer probes its nested `tests/` directories and reports ENOENT error annotations on jobs. The tarball artifact stays untouched; the unpacked copy is deleted after it has been built, and the `--no-verify` package step doesn't unpack so needs no change.

<sup>Written for commit 4c0392dcd88fe17ac6673d4092544c9efed4559c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-sdk/pull/176?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

