### PR TITLE
Describe the crate as the official client for HEY

### DIFF
--- a/rust/hey-sdk/Cargo.toml
+++ b/rust/hey-sdk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hey-sdk"
 version = "0.31.0"
-description = "Rust client for the HEY API, generated from a Smithy model of the API"
+description = "Official client for HEY - https://www.hey.com"
 homepage = "https://github.com/basecamp/hey-sdk"
 documentation = "https://docs.rs/hey-sdk"
 keywords = ["hey", "email", "37signals", "api", "sdk"]


### PR DESCRIPTION
Stanko asked in Campfire that the next Rust release clean up each crate's description: the "generated from the Smithy model in ..." part isn't what crates.io readers need; it should just say "Official client for <product> - <product URL>".

Before: `Rust client for the HEY API, generated from a Smithy model of the API`
After: `Official client for HEY - https://www.hey.com`

Notes:
- The `description` field is hand-maintained in `rust/hey-sdk/Cargo.toml`; nothing generates it (the generator emits `src/generated`, `scripts/bump-version.sh` only touches `version`), so this one-line edit is the change.
- The product URL follows the repository's own usage: the root README and the crate README both link `https://www.hey.com`, and `https://hey.com` 301s there.
- The crate README and the `lib.rs` crate doc mention the Smithy model in their own prose rather than repeating the crates.io description verbatim, so they are left alone.
- No version bump.

Checked with `cargo metadata` (the new description round-trips) and `make -C rust publish-check` (`cargo publish --dry-run`) passes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the `hey-sdk` crate description to "Official client for HEY - https://www.hey.com", replacing the old "generated from a Smithy model" text. The description is hand-maintained in `Cargo.toml`, so this one-line edit is the full change; no version bump or code changes.

<sup>Written for commit 08b8bdd33cdd61f61cf8c24c64061a66cecf085e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-sdk/pull/177?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

