### PR TITLE
Scope the actionlint ignore to the calls it covers

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -5,5 +5,6 @@ paths:
       # GitHub's self-repository `uses: $/...` syntax (July 2026) is what zizmor's
       # self-repository audit asks for in place of `./...`, and what our reusable-workflow
       # calls use. actionlint 1.7.12 predates it and has no release that knows it
-      # (rhysd/actionlint#711); drop this once one does.
-      - 'reusable workflow call "\$/.+" at "uses" is not following the format'
+      # (rhysd/actionlint#711); drop this once one does. The ignore names the exact calls,
+      # so a new `$/` call is a deliberate edit here rather than a silent pass.
+      - 'reusable workflow call "\$/\.github/workflows/(smithy-verify)\.yml" at "uses" is not following the format'


### PR DESCRIPTION
The ignore for actionlint 1.7.12's rejection of the `$/` reusable-workflow
form now names the exact calls this repository makes, so a new `$/` call is
a deliberate edit to the config rather than a silent pass. actionlint accepts
`$/path@ref` as the owner/repo/path@ref shape with or without this ignore, so
the scoping is about new sites, not malformed references.

Harmonizes with the same config across basecamp-cli, basecamp-sdk, cli, fizzy-sdk, hey-cli, once and openclaw-basecamp.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes the actionlint ignore for the `$/` reusable-workflow form to the exact calls this repository makes, so a new `$/` call requires a deliberate config edit instead of a silent pass. actionlint accepts `$/path@ref` with or without the ignore, so this only affects new call sites, not malformed references. Harmonizes the config with `basecamp-cli`, `basecamp-sdk`, `cli`, `fizzy-sdk`, `hey-cli`, `once`, and `openclaw-basecamp`.

<sup>Written for commit ba6291c8e58140eafb58220f259e4b0b0ca0289f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-sdk/pull/178?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

