### PR TITLE
Redact the request URL from a transport error before it becomes the hint

### DIFF
--- a/go/pkg/hey/attachments.go
+++ b/go/pkg/hey/attachments.go
@@ -93,7 +93,7 @@ func (s *AttachmentsService) Upload(ctx context.Context, filename, contentType s
 	}
 
 	// The upload URL is signed: the hooks see it projected, never whole.
-	req, err := http.NewRequestWithContext(markStorageRequest(ctx), http.MethodPut, upload.DirectUpload.Url, content)
+	req, err := http.NewRequestWithContext(markProjectedRequest(ctx), http.MethodPut, upload.DirectUpload.Url, content)
 	if err != nil {
 		return nil, fmt.Errorf("create attachment upload request: %w", err)
 	}

--- a/go/pkg/hey/attachments.go
+++ b/go/pkg/hey/attachments.go
@@ -92,7 +92,8 @@ func (s *AttachmentsService) Upload(ctx context.Context, filename, contentType s
 		return nil, fmt.Errorf("unsafe attachment upload target: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPut, upload.DirectUpload.Url, content)
+	// The upload URL is signed: the hooks see it projected, never whole.
+	req, err := http.NewRequestWithContext(markStorageRequest(ctx), http.MethodPut, upload.DirectUpload.Url, content)
 	if err != nil {
 		return nil, fmt.Errorf("create attachment upload request: %w", err)
 	}

--- a/go/pkg/hey/client.go
+++ b/go/pkg/hey/client.go
@@ -715,7 +715,7 @@ func (c *Client) doRequestURLWithBudget(ctx context.Context, method, url string,
 	// transport projects (a blob download's URL can carry a query of its own).
 	displayURL := url
 	if isProjectedRequest(ctx) {
-		displayURL = redactURL(url)
+		displayURL = projectURL(url, false)
 	}
 
 	// Non-idempotent mutations: Don't retry on 429/5xx to avoid duplicating data.

--- a/go/pkg/hey/client.go
+++ b/go/pkg/hey/client.go
@@ -380,6 +380,9 @@ func (c *Client) GetBlob(ctx context.Context, path string) (*Response, error) {
 
 	ctx = contextWithAccept(ctx, "*/*")
 	ctx = contextWithoutCache(ctx)
+	// HEY answers with a redirect to a signed storage URL, followed on this context:
+	// the hooks see every hop projected.
+	ctx = markProjectedRequest(ctx)
 	return c.doRequestURL(ctx, http.MethodGet, resolvedURL, nil)
 }
 
@@ -396,6 +399,7 @@ func (c *Client) DownloadBlob(ctx context.Context, path string, destination io.W
 
 	ctx = contextWithAccept(ctx, "*/*")
 	ctx = contextWithoutCache(ctx)
+	ctx = markProjectedRequest(ctx)
 	ctx, stream := contextWithStreamDestination(ctx, destination)
 	resp, err := c.doRequestURL(ctx, http.MethodGet, resolvedURL, nil)
 	if err != nil {

--- a/go/pkg/hey/client.go
+++ b/go/pkg/hey/client.go
@@ -327,6 +327,17 @@ func retryCause(retry generated.Retry, apiOrigin string) error {
 	return cause
 }
 
+// trustedOrigin is the API origin a network error on this request may keep its cause
+// beneath, or none for a request the hooks see projected: a blob download's redirect
+// can land on a signed URL of HEY's own origin, and there nothing beneath the URL is
+// this package's text.
+func (c *Client) trustedOrigin(ctx context.Context) string {
+	if isProjectedRequest(ctx) {
+		return ""
+	}
+	return c.cfg.BaseURL
+}
+
 // withJSONExtension appends ".json" to a request path whose last segment has no
 // extension. HEY routes all take an optional format, and every generated operation
 // speaks JSON, but Smithy cannot express "{label}.json" inside one URI segment, so
@@ -700,6 +711,12 @@ func (c *Client) doRequestURLWithBudget(ctx context.Context, method, url string,
 		return nil, err
 	}
 	url = requestURL
+	// The retry hook sees the URL as the request hooks do: projected on a request the
+	// transport projects (a blob download's URL can carry a query of its own).
+	displayURL := url
+	if isProjectedRequest(ctx) {
+		displayURL = redactURL(url)
+	}
 
 	// Non-idempotent mutations: Don't retry on 429/5xx to avoid duplicating data.
 	// Only retry once after successful 401 token refresh.
@@ -710,7 +727,7 @@ func (c *Client) doRequestURLWithBudget(ctx context.Context, method, url string,
 		}
 		if apiErr, ok := err.(*Error); ok && apiErr.Retryable && apiErr.Code == CodeAuth {
 			c.logger.Debug("token refreshed, retrying mutation", "method", method)
-			info := RequestInfo{Method: method, URL: url, Attempt: 1}
+			info := RequestInfo{Method: method, URL: displayURL, Attempt: 1}
 			c.hooks.OnRetry(ctx, info, 2, err)
 			return c.singleRequest(ctx, method, url, body, 2)
 		}
@@ -759,7 +776,7 @@ func (c *Client) doRequestURLWithBudget(ctx context.Context, method, url string,
 			"errorCode", errorCodeForLog(lastErr),
 		)
 
-		info := RequestInfo{Method: method, URL: url, Attempt: attempt}
+		info := RequestInfo{Method: method, URL: displayURL, Attempt: attempt}
 		c.hooks.OnRetry(ctx, info, attempt+1, lastErr)
 
 		select {
@@ -819,7 +836,7 @@ func (c *Client) singleRequest(ctx context.Context, method, url string, body any
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return nil, networkError(err, c.cfg.BaseURL)
+		return nil, networkError(err, c.trustedOrigin(ctx))
 	}
 	defer func() { _ = resp.Body.Close() }()
 

--- a/go/pkg/hey/client.go
+++ b/go/pkg/hey/client.go
@@ -670,14 +670,40 @@ func isAbsoluteURL(path string) bool {
 	return strings.HasPrefix(path, "https://") || strings.HasPrefix(path, "http://")
 }
 
-// markCallerURL marks ctx when path is a caller's absolute URL rather than an API
-// path: it can be a signed one, on any origin, and the hooks, the network error and
-// the SDK's own error text see it projected, as they see a storage request.
+// markCallerURL marks ctx when path is one that can carry a credential: a caller's
+// absolute URL, on any origin, or one of HEY's own signed storage paths in relative
+// form. Either way the hooks, the network error and the SDK's own error text see it
+// projected, as they see a storage request. These two are the shapes a credential can
+// take in a URL here; an ordinary API path is not one, and keeps its detail.
 func markCallerURL(ctx context.Context, path string) context.Context {
-	if isAbsoluteURL(path) {
+	if isAbsoluteURL(path) || isSignedStoragePath(path) {
 		return markProjectedRequest(ctx)
 	}
 	return ctx
+}
+
+// signedStoragePrefixes are the Active Storage routes on HEY's origin whose path is the
+// credential: the disk service's encoded key, and the signed ids of blob redirects,
+// proxies and representations. A direct upload is created under the same mount but
+// carries nothing in its path, and stays an ordinary API call.
+var signedStoragePrefixes = []string{
+	"/rails/active_storage/disk/",
+	"/rails/active_storage/blobs/",
+	"/rails/active_storage/representations/",
+}
+
+// isSignedStoragePath reports whether path, as buildURL will read it, is a signed
+// storage route in relative form.
+func isSignedStoragePath(path string) bool {
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	for _, prefix := range signedStoragePrefixes {
+		if strings.HasPrefix(path, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 func (c *Client) doRequestURL(ctx context.Context, method, url string, body any) (*Response, error) {

--- a/go/pkg/hey/client.go
+++ b/go/pkg/hey/client.go
@@ -510,6 +510,7 @@ func (c *Client) doBodyRequest(ctx context.Context, method, path, contentType st
 	if err != nil {
 		return nil, err
 	}
+	ctx = markCallerURL(ctx, path)
 
 	resp, err := c.sendBodyRequest(ctx, method, reqURL, contentType, body, 1)
 	if apiErr, ok := err.(*Error); ok && apiErr.Retryable && apiErr.Code == CodeAuth {
@@ -557,7 +558,7 @@ func (c *Client) sendBodyRequest(ctx context.Context, method, reqURL, contentTyp
 
 	resp, err := noRedirectClient.Do(req)
 	if err != nil {
-		return nil, networkError(err, c.cfg.BaseURL)
+		return nil, networkError(err, c.trustedOrigin(ctx))
 	}
 	defer func() { _ = resp.Body.Close() }()
 
@@ -576,7 +577,7 @@ func (c *Client) sendBodyRequest(ctx context.Context, method, reqURL, contentTyp
 		// singleRequest bounds its own reads.
 		responseBody, err := limitedReadAll(resp.Body, MaxResponseBodyBytes)
 		if err != nil {
-			return nil, networkError(err, c.cfg.BaseURL)
+			return nil, networkError(err, c.trustedOrigin(ctx))
 		}
 		return &FormResponse{StatusCode: resp.StatusCode, Body: string(responseBody)}, nil
 
@@ -661,17 +662,22 @@ func (c *Client) doRequest(ctx context.Context, method, path string, body any) (
 	if err != nil {
 		return nil, err
 	}
-	if isAbsoluteURL(path) {
-		// A caller's absolute URL can be a signed one, on any origin: the hooks and
-		// the network error see it projected, as they see a storage request.
-		ctx = markProjectedRequest(ctx)
-	}
-	return c.doRequestURL(ctx, method, url, body)
+	return c.doRequestURL(markCallerURL(ctx, path), method, url, body)
 }
 
 // isAbsoluteURL reports whether path is an absolute URL rather than an API path.
 func isAbsoluteURL(path string) bool {
 	return strings.HasPrefix(path, "https://") || strings.HasPrefix(path, "http://")
+}
+
+// markCallerURL marks ctx when path is a caller's absolute URL rather than an API
+// path: it can be a signed one, on any origin, and the hooks, the network error and
+// the SDK's own error text see it projected, as they see a storage request.
+func markCallerURL(ctx context.Context, path string) context.Context {
+	if isAbsoluteURL(path) {
+		return markProjectedRequest(ctx)
+	}
+	return ctx
 }
 
 func (c *Client) doRequestURL(ctx context.Context, method, url string, body any) (*Response, error) {
@@ -723,10 +729,7 @@ func (c *Client) doRequestURLWithBudget(ctx context.Context, method, url string,
 	url = requestURL
 	// The retry hook sees the URL as the request hooks do: projected on a request the
 	// transport projects (a blob download's URL can carry a query of its own).
-	displayURL := url
-	if isProjectedRequest(ctx) {
-		displayURL = projectURL(url, false)
-	}
+	hookURL := displayURL(ctx, url)
 
 	// Non-idempotent mutations: Don't retry on 429/5xx to avoid duplicating data.
 	// Only retry once after successful 401 token refresh.
@@ -737,7 +740,7 @@ func (c *Client) doRequestURLWithBudget(ctx context.Context, method, url string,
 		}
 		if apiErr, ok := err.(*Error); ok && apiErr.Retryable && apiErr.Code == CodeAuth {
 			c.logger.Debug("token refreshed, retrying mutation", "method", method)
-			info := RequestInfo{Method: method, URL: displayURL, Attempt: 1}
+			info := RequestInfo{Method: method, URL: hookURL, Attempt: 1}
 			c.hooks.OnRetry(ctx, info, 2, err)
 			return c.singleRequest(ctx, method, url, body, 2)
 		}
@@ -786,7 +789,7 @@ func (c *Client) doRequestURLWithBudget(ctx context.Context, method, url string,
 			"errorCode", errorCodeForLog(lastErr),
 		)
 
-		info := RequestInfo{Method: method, URL: displayURL, Attempt: attempt}
+		info := RequestInfo{Method: method, URL: hookURL, Attempt: attempt}
 		c.hooks.OnRetry(ctx, info, attempt+1, lastErr)
 
 		select {
@@ -926,7 +929,7 @@ func (c *Client) singleRequest(ctx context.Context, method, url string, body any
 		return nil, ErrForbidden("Access denied")
 
 	case http.StatusNotFound:
-		return nil, ErrNotFound("Resource", url)
+		return nil, ErrNotFound("Resource", displayURL(ctx, url))
 
 	case http.StatusInternalServerError:
 		return nil, ErrAPI(500, "Server error (500)")
@@ -986,7 +989,7 @@ func (c *Client) buildURL(path string) (string, error) {
 				return path, nil
 			}
 		}
-		return "", fmt.Errorf("URL must use HTTPS, got: %s", path)
+		return "", fmt.Errorf("URL must use HTTPS, got: %s", describeOrigin(path))
 	}
 	if !strings.HasPrefix(path, "/") {
 		path = "/" + path

--- a/go/pkg/hey/client.go
+++ b/go/pkg/hey/client.go
@@ -661,7 +661,17 @@ func (c *Client) doRequest(ctx context.Context, method, path string, body any) (
 	if err != nil {
 		return nil, err
 	}
+	if isAbsoluteURL(path) {
+		// A caller's absolute URL can be a signed one, on any origin: the hooks and
+		// the network error see it projected, as they see a storage request.
+		ctx = markProjectedRequest(ctx)
+	}
 	return c.doRequestURL(ctx, method, url, body)
+}
+
+// isAbsoluteURL reports whether path is an absolute URL rather than an API path.
+func isAbsoluteURL(path string) bool {
+	return strings.HasPrefix(path, "https://") || strings.HasPrefix(path, "http://")
 }
 
 func (c *Client) doRequestURL(ctx context.Context, method, url string, body any) (*Response, error) {

--- a/go/pkg/hey/client.go
+++ b/go/pkg/hey/client.go
@@ -287,7 +287,7 @@ func (c *Client) initGeneratedClient() {
 				url = scoped
 			}
 			info := RequestInfo{Method: retry.Request.Method, URL: url, Attempt: retry.Attempt - 1}
-			c.hooks.OnRetry(ctx, info, retry.Attempt, retryCause(retry))
+			c.hooks.OnRetry(ctx, info, retry.Attempt, retryCause(retry, c.cfg.BaseURL))
 		}
 
 		// A client with a response cache sends generated requests through it, so the
@@ -315,9 +315,9 @@ func (c *Client) initGeneratedClient() {
 // it to OnRetry: a transport failure as the SDK's network error, a response as CheckResponse
 // classifies it, and the 401 a credential refresh answered as the retryable authentication
 // error singleRequest hands doRequestURL, since the resend is the SDK's own doing.
-func retryCause(retry generated.Retry) error {
+func retryCause(retry generated.Retry, apiOrigin string) error {
 	if retry.Response == nil {
-		return ErrNetwork(retry.Err)
+		return networkError(retry.Err, apiOrigin)
 	}
 	cause := CheckResponse(retry.Response)
 	if authErr, ok := cause.(*Error); ok && authErr.Code == CodeAuth {
@@ -546,7 +546,7 @@ func (c *Client) sendBodyRequest(ctx context.Context, method, reqURL, contentTyp
 
 	resp, err := noRedirectClient.Do(req)
 	if err != nil {
-		return nil, ErrNetwork(err)
+		return nil, networkError(err, c.cfg.BaseURL)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
@@ -565,7 +565,7 @@ func (c *Client) sendBodyRequest(ctx context.Context, method, reqURL, contentTyp
 		// singleRequest bounds its own reads.
 		responseBody, err := limitedReadAll(resp.Body, MaxResponseBodyBytes)
 		if err != nil {
-			return nil, ErrNetwork(err)
+			return nil, networkError(err, c.cfg.BaseURL)
 		}
 		return &FormResponse{StatusCode: resp.StatusCode, Body: string(responseBody)}, nil
 
@@ -819,7 +819,7 @@ func (c *Client) singleRequest(ctx context.Context, method, url string, body any
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return nil, ErrNetwork(err)
+		return nil, networkError(err, c.cfg.BaseURL)
 	}
 	defer func() { _ = resp.Body.Close() }()
 

--- a/go/pkg/hey/errors.go
+++ b/go/pkg/hey/errors.go
@@ -183,11 +183,21 @@ func ErrRateLimit(retryAfter int) *Error {
 	}
 }
 
-// ErrNetwork creates a network error. The cause's rendering becomes the hint, so a
-// transport failure is redacted first: net/http's *url.Error carries the whole
-// request URL, and a signed URL carries its credential in the query.
+// ErrNetwork creates a network error from a transport failure. The cause's rendering
+// becomes the hint, and net/http's *url.Error carries the whole request URL, so the
+// cause is redacted first, with every URL it carries treated as one that can be
+// signed; the SDK's own request paths use networkError, which knows the API origin.
 func ErrNetwork(cause error) *Error {
-	cause = redactTransportError(cause)
+	return networkError(cause, "")
+}
+
+// networkError creates a network error from a transport failure on a request the SDK
+// issued, apiOrigin being its API origin: a URL there carries no credential — the token
+// rides in the Authorization header — so beneath it the transport's cause is kept as
+// the failure's diagnostic, while beneath a projected URL anywhere else only the
+// failure's classification survives (see redactTransportError).
+func networkError(cause error, apiOrigin string) *Error {
+	cause = redactTransportError(cause, apiOrigin)
 	return &Error{
 		Code:      CodeNetwork,
 		Message:   "Network error",
@@ -250,7 +260,7 @@ func AsError(err error) *Error {
 	if errors.As(err, &e) {
 		return e
 	}
-	err = redactTransportError(err)
+	err = redactTransportError(err, "")
 	return &Error{
 		Code:    CodeAPI,
 		Message: err.Error(),

--- a/go/pkg/hey/errors.go
+++ b/go/pkg/hey/errors.go
@@ -183,8 +183,11 @@ func ErrRateLimit(retryAfter int) *Error {
 	}
 }
 
-// ErrNetwork creates a network error.
+// ErrNetwork creates a network error. The cause's rendering becomes the hint, so a
+// transport failure is redacted first: net/http's *url.Error carries the whole
+// request URL, and a signed URL carries its credential in the query.
 func ErrNetwork(cause error) *Error {
+	cause = redactTransportError(cause)
 	return &Error{
 		Code:      CodeNetwork,
 		Message:   "Network error",
@@ -247,6 +250,7 @@ func AsError(err error) *Error {
 	if errors.As(err, &e) {
 		return e
 	}
+	err = redactTransportError(err)
 	return &Error{
 		Code:    CodeAPI,
 		Message: err.Error(),

--- a/go/pkg/hey/http.go
+++ b/go/pkg/hey/http.go
@@ -183,6 +183,23 @@ func attemptFromContext(ctx context.Context) int {
 	return generated.AttemptFromContext(ctx)
 }
 
+// storageRequestKey is the context key marking a request to the storage host — the
+// attachment upload — whose URL is the credential: the hooks see it projected to
+// scheme, host and path. An API request's URL carries no credential (the token is in
+// the Authorization header), so the hooks see it whole.
+type storageRequestKey struct{}
+
+// markStorageRequest marks ctx as belonging to a request whose URL is signed.
+func markStorageRequest(ctx context.Context) context.Context {
+	return context.WithValue(ctx, storageRequestKey{}, true)
+}
+
+// isStorageRequest reports whether ctx carries the storage request marker.
+func isStorageRequest(ctx context.Context) bool {
+	v, _ := ctx.Value(storageRequestKey{}).(bool)
+	return v
+}
+
 // loggingTransport wraps an http.RoundTripper to log requests and responses,
 // and calls observability hooks for all HTTP requests.
 type loggingTransport struct {
@@ -192,9 +209,13 @@ type loggingTransport struct {
 
 // RoundTrip implements http.RoundTripper with logging and hooks.
 func (t *loggingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	displayURL := req.URL.String()
+	if isStorageRequest(req.Context()) {
+		displayURL = redactURL(displayURL)
+	}
 	info := RequestInfo{
 		Method:  req.Method,
-		URL:     req.URL.String(),
+		URL:     displayURL,
 		Attempt: attemptFromContext(req.Context()),
 	}
 	hookCtx := t.client.hooks.OnRequestStart(req.Context(), info)

--- a/go/pkg/hey/http.go
+++ b/go/pkg/hey/http.go
@@ -223,6 +223,11 @@ func (t *loggingTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 		Attempt: attemptFromContext(req.Context()),
 	}
 	hookCtx := t.client.hooks.OnRequestStart(req.Context(), info)
+	if projected {
+		// A hook may hand back a context of its own; the redirect net/http derives
+		// from this request must still carry the mark.
+		hookCtx = markProjectedRequest(hookCtx)
+	}
 	startTime := time.Now()
 
 	req = req.WithContext(hookCtx)
@@ -242,9 +247,10 @@ func (t *loggingTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 	if err != nil {
 		result.Error = err
 		if projected {
-			// A custom transport can report its failure as a *url.Error of its own,
-			// which renders the same signed URL.
-			result.Error = redactTransportError(err, "")
+			// A custom transport's failure is text this package cannot vouch for —
+			// a *url.Error of its own, or a message interpolating the URL — so the
+			// hooks get its classification alone.
+			result.Error, _ = classifyFailure(err)
 		}
 	} else {
 		result.StatusCode = resp.StatusCode

--- a/go/pkg/hey/http.go
+++ b/go/pkg/hey/http.go
@@ -243,7 +243,7 @@ func (t *loggingTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 		if projected {
 			// A custom transport can report its failure as a *url.Error of its own,
 			// which renders the same signed URL.
-			result.Error = redactTransportError(err)
+			result.Error = redactTransportError(err, "")
 		}
 	} else {
 		result.StatusCode = resp.StatusCode

--- a/go/pkg/hey/http.go
+++ b/go/pkg/hey/http.go
@@ -187,8 +187,9 @@ func attemptFromContext(ctx context.Context) int {
 // the credential: the attachment upload's PUT to the signed storage URL, and a blob
 // download, which HEY answers with a redirect to a signed storage URL that net/http
 // follows on the same context. The hooks see every hop of such a request projected to
-// scheme, host and path. An API request's URL carries no credential (the token is in
-// the Authorization header), so the hooks see it whole.
+// its origin — a storage service can sign the query or the path. An API request's URL
+// carries no credential (the token is in the Authorization header), so the hooks see
+// it whole.
 type projectedRequestKey struct{}
 
 // markProjectedRequest marks ctx as belonging to a request the hooks see projected.
@@ -214,7 +215,7 @@ func (t *loggingTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 	projected := isProjectedRequest(req.Context())
 	displayURL := req.URL.String()
 	if projected {
-		displayURL = redactURL(displayURL)
+		displayURL = projectURL(displayURL, false)
 	}
 	info := RequestInfo{
 		Method:  req.Method,

--- a/go/pkg/hey/http.go
+++ b/go/pkg/hey/http.go
@@ -209,8 +209,9 @@ type loggingTransport struct {
 
 // RoundTrip implements http.RoundTripper with logging and hooks.
 func (t *loggingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	storage := isStorageRequest(req.Context())
 	displayURL := req.URL.String()
-	if isStorageRequest(req.Context()) {
+	if storage {
 		displayURL = redactURL(displayURL)
 	}
 	info := RequestInfo{
@@ -237,6 +238,11 @@ func (t *loggingTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 
 	if err != nil {
 		result.Error = err
+		if storage {
+			// A custom transport can report its failure as a *url.Error of its own,
+			// which renders the same signed URL.
+			result.Error = redactTransportError(err)
+		}
 	} else {
 		result.StatusCode = resp.StatusCode
 		if resp.StatusCode == 429 || resp.StatusCode == 503 {

--- a/go/pkg/hey/http.go
+++ b/go/pkg/hey/http.go
@@ -203,6 +203,15 @@ func isProjectedRequest(ctx context.Context) bool {
 	return v
 }
 
+// displayURL is url as the hooks and the SDK's own error text show it: whole on an
+// API request, its origin alone on a request the transport projects.
+func displayURL(ctx context.Context, url string) string {
+	if isProjectedRequest(ctx) {
+		return projectURL(url, false)
+	}
+	return url
+}
+
 // loggingTransport wraps an http.RoundTripper to log requests and responses,
 // and calls observability hooks for all HTTP requests.
 type loggingTransport struct {

--- a/go/pkg/hey/http.go
+++ b/go/pkg/hey/http.go
@@ -183,20 +183,22 @@ func attemptFromContext(ctx context.Context) int {
 	return generated.AttemptFromContext(ctx)
 }
 
-// storageRequestKey is the context key marking a request to the storage host — the
-// attachment upload — whose URL is the credential: the hooks see it projected to
+// projectedRequestKey is the context key marking a request whose URL, on some hop, is
+// the credential: the attachment upload's PUT to the signed storage URL, and a blob
+// download, which HEY answers with a redirect to a signed storage URL that net/http
+// follows on the same context. The hooks see every hop of such a request projected to
 // scheme, host and path. An API request's URL carries no credential (the token is in
 // the Authorization header), so the hooks see it whole.
-type storageRequestKey struct{}
+type projectedRequestKey struct{}
 
-// markStorageRequest marks ctx as belonging to a request whose URL is signed.
-func markStorageRequest(ctx context.Context) context.Context {
-	return context.WithValue(ctx, storageRequestKey{}, true)
+// markProjectedRequest marks ctx as belonging to a request the hooks see projected.
+func markProjectedRequest(ctx context.Context) context.Context {
+	return context.WithValue(ctx, projectedRequestKey{}, true)
 }
 
-// isStorageRequest reports whether ctx carries the storage request marker.
-func isStorageRequest(ctx context.Context) bool {
-	v, _ := ctx.Value(storageRequestKey{}).(bool)
+// isProjectedRequest reports whether ctx carries the projection marker.
+func isProjectedRequest(ctx context.Context) bool {
+	v, _ := ctx.Value(projectedRequestKey{}).(bool)
 	return v
 }
 
@@ -209,9 +211,9 @@ type loggingTransport struct {
 
 // RoundTrip implements http.RoundTripper with logging and hooks.
 func (t *loggingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	storage := isStorageRequest(req.Context())
+	projected := isProjectedRequest(req.Context())
 	displayURL := req.URL.String()
-	if storage {
+	if projected {
 		displayURL = redactURL(displayURL)
 	}
 	info := RequestInfo{
@@ -238,7 +240,7 @@ func (t *loggingTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 
 	if err != nil {
 		result.Error = err
-		if storage {
+		if projected {
 			// A custom transport can report its failure as a *url.Error of its own,
 			// which renders the same signed URL.
 			result.Error = redactTransportError(err)

--- a/go/pkg/hey/observability.go
+++ b/go/pkg/hey/observability.go
@@ -22,8 +22,9 @@ type GatingHooks interface {
 
 // RequestInfo contains information about an HTTP request. URL is the request URL
 // whole, except on the requests whose URL can be signed — the attachment upload's
-// storage request, and every hop of a blob download, which HEY answers with a redirect
-// to a signed storage URL: those reach the hooks as their origin alone.
+// storage request, every hop of a blob download, which HEY answers with a redirect to
+// a signed storage URL, and a request built from a caller's absolute URL: those reach
+// the hooks as their origin alone.
 type RequestInfo struct {
 	Method  string
 	URL     string

--- a/go/pkg/hey/observability.go
+++ b/go/pkg/hey/observability.go
@@ -20,7 +20,9 @@ type GatingHooks interface {
 	OnOperationGate(ctx context.Context, op OperationInfo) (context.Context, error)
 }
 
-// RequestInfo contains information about an HTTP request.
+// RequestInfo contains information about an HTTP request. URL is the request URL
+// whole, except for the attachment upload's storage request, whose URL is signed: that
+// one reaches the hooks as its scheme, host and path.
 type RequestInfo struct {
 	Method  string
 	URL     string

--- a/go/pkg/hey/observability.go
+++ b/go/pkg/hey/observability.go
@@ -23,7 +23,7 @@ type GatingHooks interface {
 // RequestInfo contains information about an HTTP request. URL is the request URL
 // whole, except on the requests whose URL can be signed — the attachment upload's
 // storage request, and every hop of a blob download, which HEY answers with a redirect
-// to a signed storage URL: those reach the hooks as their scheme, host and path.
+// to a signed storage URL: those reach the hooks as their origin alone.
 type RequestInfo struct {
 	Method  string
 	URL     string

--- a/go/pkg/hey/observability.go
+++ b/go/pkg/hey/observability.go
@@ -21,8 +21,9 @@ type GatingHooks interface {
 }
 
 // RequestInfo contains information about an HTTP request. URL is the request URL
-// whole, except for the attachment upload's storage request, whose URL is signed: that
-// one reaches the hooks as its scheme, host and path.
+// whole, except on the requests whose URL can be signed — the attachment upload's
+// storage request, and every hop of a blob download, which HEY answers with a redirect
+// to a signed storage URL: those reach the hooks as their scheme, host and path.
 type RequestInfo struct {
 	Method  string
 	URL     string

--- a/go/pkg/hey/pagination.go
+++ b/go/pkg/hey/pagination.go
@@ -168,6 +168,7 @@ func (c *Client) GetAllWithLimit(ctx context.Context, path string, limit int) ([
 	if err != nil {
 		return nil, err
 	}
+	ctx = markCallerURL(ctx, path)
 	url := baseURL
 	var page int
 

--- a/go/pkg/hey/security.go
+++ b/go/pkg/hey/security.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -205,7 +206,8 @@ func projectTransportError(err error, apiOrigin string) (projected bool, result 
 		trusted := trustedURL(e.URL, apiOrigin)
 		projectedURL := projectURL(e.URL, trusted)
 		if !trusted {
-			return true, &url.Error{Op: transportOp(e.Op), URL: projectedURL, Err: classifyTransportFailure(e)}
+			stand, _ := classifyFailure(e)
+			return true, &url.Error{Op: transportOp(e.Op), URL: projectedURL, Err: stand}
 		}
 		innerProjected, inner := projectTransportError(e.Err, apiOrigin)
 		if projectedURL == e.URL && !innerProjected {
@@ -216,12 +218,11 @@ func projectTransportError(err error, apiOrigin string) (projected bool, result 
 		members := e.Unwrap()
 		kept := make([]error, 0, len(members))
 		for _, member := range members {
-			switch memberProjected, projectedMember := projectTransportError(member, apiOrigin); {
-			case memberProjected:
+			if memberProjected, projectedMember := projectTransportError(member, apiOrigin); memberProjected {
 				projected = true
 				kept = append(kept, projectedMember)
-			case contextSentinels(member) != nil:
-				kept = append(kept, contextSentinels(member))
+			} else if stand, classified := classifyFailure(member); classified {
+				kept = append(kept, stand)
 			}
 		}
 		if !projected {
@@ -234,6 +235,14 @@ func projectTransportError(err error, apiOrigin string) (projected bool, result 
 			return false, err
 		}
 		return true, projectedCause
+	}
+	// An error can expose a *url.Error through an As method without unwrapping to it;
+	// its own rendering is then text this package cannot vouch for, and the transport
+	// error it exposes is what is kept, projected.
+	var exposed *url.Error
+	if errors.As(err, &exposed) {
+		_, projectedExposed := projectTransportError(exposed, apiOrigin)
+		return true, projectedExposed
 	}
 	return false, err
 }
@@ -277,12 +286,20 @@ func transportOp(op string) string {
 	return op
 }
 
-// classifyTransportFailure is what stands beneath a projected URL in place of the
-// transport's own cause: a transportFailureError carrying the net.Error flags the
-// *url.Error delegated to that cause, unwrapping to the context sentinels the cause
-// wrapped, so errors.Is still sees a cancellation or a deadline.
-func classifyTransportFailure(e *url.Error) error {
-	return &transportFailureError{timeout: e.Timeout(), temporary: e.Temporary(), sentinel: contextSentinels(e.Err)}
+// classifyFailure is what stands in for a transport failure whose text this package
+// cannot vouch for: a transportFailureError carrying the net.Error flags the failure
+// reports — a *url.Error delegates them to its immediate cause, as before — and
+// unwrapping to the context sentinels it wrapped, so errors.Is still sees a
+// cancellation or a deadline. classified reports whether the failure had any of those
+// to carry; beneath a projected URL the stand-in is kept either way.
+func classifyFailure(err error) (stand *transportFailureError, classified bool) {
+	stand = &transportFailureError{sentinel: contextSentinels(err)}
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		stand.timeout, stand.temporary = netErr.Timeout(), netErr.Temporary()
+		classified = true
+	}
+	return stand, classified || stand.sentinel != nil
 }
 
 // contextSentinels is every bare context sentinel err wraps — one, both joined, or

--- a/go/pkg/hey/security.go
+++ b/go/pkg/hey/security.go
@@ -180,10 +180,10 @@ func redactTransportError(err error) error {
 
 // projectTransportError rebuilds err's tree with every *url.Error projected, reporting
 // whether anything was, so a tree with nothing to drop comes back untouched at every
-// level. A wrapper around a projected error keeps its own text with the projection
-// substituted for the rendering it embedded, or is dropped in favour of the
-// projection when it rendered its cause in a form this function cannot locate; a
-// multi-error is rebuilt as errors.Join of its projected members.
+// level. A wrapper around a projected error is dropped in favour of the projection:
+// its text can carry the URL on its own (fmt.Errorf("%s: %w", req.URL, err)), in any
+// spelling, and nothing built from that text can be shown not to. A multi-error is
+// rebuilt as errors.Join of its projected members.
 func projectTransportError(err error) (projected bool, result error) {
 	switch e := err.(type) { //nolint:errorlint // rebuilding the tree node by node is the point
 	case nil:
@@ -208,19 +208,11 @@ func projectTransportError(err error) (projected bool, result error) {
 		}
 		return true, errors.Join(rebuilt...)
 	case interface{ Unwrap() error }:
-		cause := e.Unwrap()
-		causeProjected, projectedCause := projectTransportError(cause)
+		causeProjected, projectedCause := projectTransportError(e.Unwrap())
 		if !causeProjected {
 			return false, err
 		}
-		text := err.Error()
-		if !strings.Contains(text, cause.Error()) {
-			return true, projectedCause
-		}
-		return true, &redactedTransportError{
-			text:  strings.ReplaceAll(text, cause.Error(), projectedCause.Error()),
-			cause: projectedCause,
-		}
+		return true, projectedCause
 	}
 	return false, err
 }
@@ -234,15 +226,3 @@ func redactURL(rawURL string) string {
 	}
 	return (&url.URL{Scheme: u.Scheme, Host: u.Host, Path: u.Path, RawPath: u.RawPath}).String()
 }
-
-// redactedTransportError is a wrapper around a projected transport error: the wrapper's
-// text with the projection substituted, unwrapping to the projected cause so errors.Is
-// and errors.As classify the failure as before.
-type redactedTransportError struct {
-	text  string
-	cause error
-}
-
-func (e *redactedTransportError) Error() string { return e.text }
-
-func (e *redactedTransportError) Unwrap() error { return e.cause }

--- a/go/pkg/hey/security.go
+++ b/go/pkg/hey/security.go
@@ -64,15 +64,31 @@ func truncateString(s string, maxLen int) string {
 }
 
 // requireHTTPS validates that the given URL uses the https:// scheme.
+// requireHTTPS rejects a URL whose scheme is not https. The error names the URL's
+// origin alone: HEY's direct-upload URL is signed, and the rejection is what a caller
+// logs.
 func requireHTTPS(rawURL string) error {
 	u, err := url.Parse(rawURL)
 	if err != nil {
+		var parseErr *url.Error
+		if errors.As(err, &parseErr) {
+			err = parseErr.Err
+		}
 		return fmt.Errorf("invalid URL: %w", err)
 	}
 	if !strings.EqualFold(u.Scheme, "https") {
-		return fmt.Errorf("URL must use HTTPS: %s", rawURL)
+		return fmt.Errorf("URL must use HTTPS: %s", describeOrigin(rawURL))
 	}
 	return nil
+}
+
+// describeOrigin is rawURL's origin for an error's text, or a fixed token for a URL
+// with neither scheme nor host.
+func describeOrigin(rawURL string) string {
+	if origin := projectURL(rawURL, false); origin != "" {
+		return origin
+	}
+	return "a URL with no scheme"
 }
 
 // isSameOrigin checks whether two absolute URLs share the same scheme and host.

--- a/go/pkg/hey/security.go
+++ b/go/pkg/hey/security.go
@@ -169,61 +169,60 @@ func RedactHeaders(headers http.Header) http.Header {
 // query, and a proxy URL its password in the userinfo, so through ErrNetwork that
 // rendering would become the hint, the message and every log line printing the error.
 // The projection keeps what a reader needs to place the failure and drops the rest
-// before any text is built. Every *url.Error in the chain is projected — a transport
-// built on another http.Client nests one inside another. An error that carries no
-// *url.Error, or none whose URL has anything to drop, is returned as it is.
+// before any text is built, and walks the whole error tree: a transport built on
+// another http.Client nests one *url.Error inside another, and errors.Join holds
+// several side by side. An error with no *url.Error whose URL has anything to drop is
+// returned as it is.
 func redactTransportError(err error) error {
 	_, redacted := projectTransportError(err)
 	return redacted
 }
 
-// projectTransportError is redactTransportError reporting whether it projected
-// anything, so a chain with nothing to drop comes back untouched at every level.
+// projectTransportError rebuilds err's tree with every *url.Error projected, reporting
+// whether anything was, so a tree with nothing to drop comes back untouched at every
+// level. A wrapper around a projected error keeps its own text with the projection
+// substituted for the rendering it embedded, or is dropped in favour of the
+// projection when it rendered its cause in a form this function cannot locate; a
+// multi-error is rebuilt as errors.Join of its projected members.
 func projectTransportError(err error) (projected bool, result error) {
-	var urlErr *url.Error
-	if !errors.As(err, &urlErr) {
-		return false, err
-	}
-	innerProjected, inner := projectTransportError(urlErr.Err)
-	projectedURL := redactURL(urlErr.URL)
-	if projectedURL == urlErr.URL && !innerProjected {
-		return false, err
-	}
-	redacted := &url.Error{Op: urlErr.Op, URL: projectedURL, Err: inner}
-	text := err.Error()
-	if text == urlErr.Error() || !strings.Contains(text, urlErr.Error()) || holdsAnotherURLError(err, urlErr) {
-		// Nothing wraps the transport error; or a wrapper renders it in a form this
-		// function cannot locate, or holds a second transport error beside it (an
-		// errors.Join) whose rendering it cannot rebuild: the projected transport
-		// error alone is kept.
-		return true, redacted
-	}
-	return true, &redactedTransportError{
-		text:  strings.ReplaceAll(text, urlErr.Error(), redacted.Error()),
-		cause: redacted,
-	}
-}
-
-// holdsAnotherURLError reports whether err's tree holds a *url.Error other than found,
-// found's own chain aside — the case a wrapper's text cannot be rebuilt from one
-// substitution. The walk is deliberately per node, not through errors.As, which would
-// find found again.
-func holdsAnotherURLError(err error, found *url.Error) bool {
-	switch e := err.(type) { //nolint:errorlint // walking the tree node by node is the point
+	switch e := err.(type) { //nolint:errorlint // rebuilding the tree node by node is the point
 	case nil:
-		return false
+		return false, nil
 	case *url.Error:
-		return e != found
-	case interface{ Unwrap() error }:
-		return holdsAnotherURLError(e.Unwrap(), found)
+		innerProjected, inner := projectTransportError(e.Err)
+		projectedURL := redactURL(e.URL)
+		if projectedURL == e.URL && !innerProjected {
+			return false, err
+		}
+		return true, &url.Error{Op: e.Op, URL: projectedURL, Err: inner}
 	case interface{ Unwrap() []error }:
-		for _, joined := range e.Unwrap() {
-			if holdsAnotherURLError(joined, found) {
-				return true
-			}
+		members := e.Unwrap()
+		rebuilt := make([]error, 0, len(members))
+		for _, member := range members {
+			memberProjected, projectedMember := projectTransportError(member)
+			projected = projected || memberProjected
+			rebuilt = append(rebuilt, projectedMember)
+		}
+		if !projected {
+			return false, err
+		}
+		return true, errors.Join(rebuilt...)
+	case interface{ Unwrap() error }:
+		cause := e.Unwrap()
+		causeProjected, projectedCause := projectTransportError(cause)
+		if !causeProjected {
+			return false, err
+		}
+		text := err.Error()
+		if !strings.Contains(text, cause.Error()) {
+			return true, projectedCause
+		}
+		return true, &redactedTransportError{
+			text:  strings.ReplaceAll(text, cause.Error(), projectedCause.Error()),
+			cause: projectedCause,
 		}
 	}
-	return false
+	return false, err
 }
 
 // redactURL projects rawURL to its scheme, host and path, dropping userinfo, query
@@ -236,12 +235,12 @@ func redactURL(rawURL string) string {
 	return (&url.URL{Scheme: u.Scheme, Host: u.Host, Path: u.Path, RawPath: u.RawPath}).String()
 }
 
-// redactedTransportError is a wrapped transport error rendered with its URL projected:
-// the wrapper's text with the projection substituted, unwrapping to the projected
-// *url.Error so errors.Is and errors.As classify the failure as before.
+// redactedTransportError is a wrapper around a projected transport error: the wrapper's
+// text with the projection substituted, unwrapping to the projected cause so errors.Is
+// and errors.As classify the failure as before.
 type redactedTransportError struct {
 	text  string
-	cause *url.Error
+	cause error
 }
 
 func (e *redactedTransportError) Error() string { return e.text }

--- a/go/pkg/hey/security.go
+++ b/go/pkg/hey/security.go
@@ -164,21 +164,22 @@ func RedactHeaders(headers http.Header) http.Header {
 	return result
 }
 
-// redactTransportError returns err with the URL Go's *url.Error renders projected to
-// its scheme, host and path. net/http reports every transport failure as a *url.Error
-// carrying the whole request URL; a signed storage URL carries its credential in the
-// query, and a proxy URL its password in the userinfo, so through ErrNetwork that
-// rendering would become the hint, the message and every log line printing the error.
-// The projection keeps what a reader needs to place the failure and drops the rest
-// before any text is built, and walks the whole error tree: a transport built on
-// another http.Client nests one *url.Error inside another, and errors.Join holds
-// several side by side. An error with no *url.Error whose URL has anything to drop is
+// redactTransportError returns err with every URL Go's *url.Error renders projected.
+// net/http reports every transport failure as a *url.Error carrying the whole request
+// URL, and a URL off the SDK's API origin can carry a credential anywhere a storage
+// service puts one — a signed query, a token in the path, a password in the userinfo
+// — so through ErrNetwork that rendering would become the hint, the message and every
+// log line printing the error. The projection keeps what a reader needs to place the
+// failure and drops the rest before any text is built, and walks the whole error
+// tree: a transport built on another http.Client nests one *url.Error inside another,
+// and errors.Join holds several side by side. An error with nothing to drop is
 // returned as it is.
 //
-// apiOrigin is the SDK's own API origin, or empty. A URL on it carries no credential —
-// the token rides in the Authorization header — so beneath it the transport's cause
-// is kept, and its text with it, as the failure's diagnostic. Beneath any other
-// projected URL only the failure's classification survives.
+// apiOrigin is the SDK's own API origin, or empty. A URL on it, carrying no userinfo,
+// is trusted: its path stays — the token rides in the Authorization header, and the
+// query is paging and filtering — and beneath it the transport's cause is kept, and
+// its text with it, as the failure's diagnostic. Every other URL is projected to its
+// origin, and beneath it only the failure's classification survives.
 func redactTransportError(err error, apiOrigin string) error {
 	_, redacted := projectTransportError(err, apiOrigin)
 	return redacted
@@ -186,29 +187,31 @@ func redactTransportError(err error, apiOrigin string) error {
 
 // projectTransportError rebuilds err's tree with every *url.Error projected, reporting
 // whether anything was, so a tree with nothing to drop comes back untouched at every
-// level. A projected *url.Error off the API origin is built from fixed parts alone:
-// its Op kept only as the method token net/http writes there, its cause replaced by
-// what classifies the failure — the context sentinel it wrapped and its net.Error
-// flags — because whatever a transport put there is text this package did not build
-// (a custom transport's own wrapper, a message interpolating the request URL) and
-// cannot be shown free of the URL in any spelling. Around a projected URL the same
-// holds: a wrapper is dropped in favour of the projection, and a multi-error is
-// rebuilt as errors.Join of its projected members and their sentinel siblings, the
-// opaque siblings dropped.
+// level. A projected *url.Error off the trusted origin is built from fixed parts
+// alone: its Op kept only as the method token net/http writes there, its URL as the
+// origin, its cause replaced by what classifies the failure — the context sentinels
+// it wrapped and its net.Error flags — because whatever a transport put there is text
+// this package did not build (a custom transport's own wrapper, a message
+// interpolating the request URL) and cannot be shown free of the URL in any spelling.
+// Around a projected URL the same holds: an ancestor keeps only that Op token, a
+// wrapper is dropped in favour of the projection, and a multi-error is rebuilt as
+// errors.Join of its projected members and their sentinel siblings, the opaque
+// siblings dropped.
 func projectTransportError(err error, apiOrigin string) (projected bool, result error) {
 	switch e := err.(type) { //nolint:errorlint // rebuilding the tree node by node is the point
 	case nil:
 		return false, nil
 	case *url.Error:
-		projectedURL := redactURL(e.URL)
-		if projectedURL != e.URL && (apiOrigin == "" || !isSameOrigin(e.URL, apiOrigin)) {
+		trusted := trustedURL(e.URL, apiOrigin)
+		projectedURL := projectURL(e.URL, trusted)
+		if !trusted {
 			return true, &url.Error{Op: transportOp(e.Op), URL: projectedURL, Err: classifyTransportFailure(e)}
 		}
 		innerProjected, inner := projectTransportError(e.Err, apiOrigin)
 		if projectedURL == e.URL && !innerProjected {
 			return false, err
 		}
-		return true, &url.Error{Op: e.Op, URL: projectedURL, Err: inner}
+		return true, &url.Error{Op: transportOp(e.Op), URL: projectedURL, Err: inner}
 	case interface{ Unwrap() []error }:
 		members := e.Unwrap()
 		kept := make([]error, 0, len(members))
@@ -217,8 +220,8 @@ func projectTransportError(err error, apiOrigin string) (projected bool, result 
 			case memberProjected:
 				projected = true
 				kept = append(kept, projectedMember)
-			case contextSentinel(member) != nil:
-				kept = append(kept, contextSentinel(member))
+			case contextSentinels(member) != nil:
+				kept = append(kept, contextSentinels(member))
 			}
 		}
 		if !projected {
@@ -233,6 +236,31 @@ func projectTransportError(err error, apiOrigin string) (projected bool, result 
 		return true, projectedCause
 	}
 	return false, err
+}
+
+// trustedURL reports whether rawURL is on apiOrigin and carries no userinfo: a URL
+// whose path and query are the API's own, with no credential anywhere in it.
+func trustedURL(rawURL, apiOrigin string) bool {
+	if apiOrigin == "" || !isSameOrigin(rawURL, apiOrigin) {
+		return false
+	}
+	u, err := url.Parse(rawURL)
+	return err == nil && u.User == nil
+}
+
+// projectURL projects rawURL to its origin — scheme and host — or, for a trusted URL,
+// to its scheme, host and path. A URL that does not parse projects to the fixed token
+// "unparsable".
+func projectURL(rawURL string, keepPath bool) string {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return "unparsable"
+	}
+	projected := &url.URL{Scheme: u.Scheme, Host: u.Host}
+	if keepPath {
+		projected.Path, projected.RawPath = u.Path, u.RawPath
+	}
+	return projected.String()
 }
 
 // transportOp is op as net/http writes it — the request method, letters alone — or
@@ -251,35 +279,26 @@ func transportOp(op string) string {
 
 // classifyTransportFailure is what stands beneath a projected URL in place of the
 // transport's own cause: a transportFailureError carrying the net.Error flags the
-// *url.Error delegated to that cause, unwrapping to the context sentinel the cause
+// *url.Error delegated to that cause, unwrapping to the context sentinels the cause
 // wrapped, so errors.Is still sees a cancellation or a deadline.
 func classifyTransportFailure(e *url.Error) error {
-	return &transportFailureError{timeout: e.Timeout(), temporary: e.Temporary(), sentinel: contextSentinel(e.Err)}
+	return &transportFailureError{timeout: e.Timeout(), temporary: e.Temporary(), sentinel: contextSentinels(e.Err)}
 }
 
-// contextSentinel is the bare context sentinel err wraps, or nil.
-func contextSentinel(err error) error {
-	switch {
-	case errors.Is(err, context.Canceled):
-		return context.Canceled
-	case errors.Is(err, context.DeadlineExceeded):
-		return context.DeadlineExceeded
+// contextSentinels is every bare context sentinel err wraps — one, both joined, or
+// nil.
+func contextSentinels(err error) error {
+	var sentinels []error
+	for _, sentinel := range []error{context.Canceled, context.DeadlineExceeded} {
+		if errors.Is(err, sentinel) {
+			sentinels = append(sentinels, sentinel)
+		}
 	}
-	return nil
-}
-
-// redactURL projects rawURL to its scheme, host and path, dropping userinfo, query
-// and fragment. A URL that does not parse projects to the fixed token "unparsable".
-func redactURL(rawURL string) string {
-	u, err := url.Parse(rawURL)
-	if err != nil {
-		return "unparsable"
-	}
-	return (&url.URL{Scheme: u.Scheme, Host: u.Host, Path: u.Path, RawPath: u.RawPath}).String()
+	return errors.Join(sentinels...)
 }
 
 // transportFailureError is the cause beneath a projected URL: a transport failure
-// known only by its net.Error classification and the context sentinel it wrapped.
+// known only by its net.Error classification and the context sentinels it wrapped.
 type transportFailureError struct {
 	timeout, temporary bool
 	sentinel           error

--- a/go/pkg/hey/security.go
+++ b/go/pkg/hey/security.go
@@ -1,6 +1,7 @@
 package hey
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -180,21 +181,26 @@ func redactTransportError(err error) error {
 
 // projectTransportError rebuilds err's tree with every *url.Error projected, reporting
 // whether anything was, so a tree with nothing to drop comes back untouched at every
-// level. A wrapper around a projected error is dropped in favour of the projection:
-// its text can carry the URL on its own (fmt.Errorf("%s: %w", req.URL, err)), in any
-// spelling, and nothing built from that text can be shown not to. A multi-error is
-// rebuilt as errors.Join of its projected members.
+// level. Beneath a projected URL only the failure's classification survives: whatever
+// the transport reported there is text this package did not build — a custom
+// transport's own wrapper, a message interpolating the request URL — and cannot be
+// shown free of the URL in any spelling, so it is replaced by the context sentinel it
+// wraps or a fixed transport failure carrying its net.Error flags. Above one, a
+// wrapper is dropped in favour of the projection for the same reason, and a
+// multi-error is rebuilt as errors.Join of its projected members.
 func projectTransportError(err error) (projected bool, result error) {
 	switch e := err.(type) { //nolint:errorlint // rebuilding the tree node by node is the point
 	case nil:
 		return false, nil
 	case *url.Error:
+		if projectedURL := redactURL(e.URL); projectedURL != e.URL {
+			return true, &url.Error{Op: e.Op, URL: projectedURL, Err: classifyTransportFailure(e)}
+		}
 		innerProjected, inner := projectTransportError(e.Err)
-		projectedURL := redactURL(e.URL)
-		if projectedURL == e.URL && !innerProjected {
+		if !innerProjected {
 			return false, err
 		}
-		return true, &url.Error{Op: e.Op, URL: projectedURL, Err: inner}
+		return true, &url.Error{Op: e.Op, URL: e.URL, Err: inner}
 	case interface{ Unwrap() []error }:
 		members := e.Unwrap()
 		rebuilt := make([]error, 0, len(members))
@@ -217,6 +223,20 @@ func projectTransportError(err error) (projected bool, result error) {
 	return false, err
 }
 
+// classifyTransportFailure is what stands beneath a projected URL in place of the
+// transport's own cause: the context sentinel the failure wraps, so errors.Is still
+// sees a cancellation or a deadline, or a transportFailureError carrying the
+// net.Error flags the *url.Error delegated to that cause.
+func classifyTransportFailure(e *url.Error) error {
+	switch {
+	case errors.Is(e.Err, context.Canceled):
+		return context.Canceled
+	case errors.Is(e.Err, context.DeadlineExceeded):
+		return context.DeadlineExceeded
+	}
+	return &transportFailureError{timeout: e.Timeout(), temporary: e.Temporary()}
+}
+
 // redactURL projects rawURL to its scheme, host and path, dropping userinfo, query
 // and fragment. A URL that does not parse projects to the fixed token "unparsable".
 func redactURL(rawURL string) string {
@@ -226,3 +246,18 @@ func redactURL(rawURL string) string {
 	}
 	return (&url.URL{Scheme: u.Scheme, Host: u.Host, Path: u.Path, RawPath: u.RawPath}).String()
 }
+
+// transportFailureError is the cause beneath a projected URL: a transport failure
+// known only by its net.Error classification.
+type transportFailureError struct{ timeout, temporary bool }
+
+func (e *transportFailureError) Error() string {
+	if e.timeout {
+		return "transport timeout"
+	}
+	return "transport failure"
+}
+
+func (e *transportFailureError) Timeout() bool { return e.timeout }
+
+func (e *transportFailureError) Temporary() bool { return e.temporary }

--- a/go/pkg/hey/security.go
+++ b/go/pkg/hey/security.go
@@ -174,38 +174,44 @@ func RedactHeaders(headers http.Header) http.Header {
 // another http.Client nests one *url.Error inside another, and errors.Join holds
 // several side by side. An error with no *url.Error whose URL has anything to drop is
 // returned as it is.
-func redactTransportError(err error) error {
-	_, redacted := projectTransportError(err)
+//
+// apiOrigin is the SDK's own API origin, or empty. A URL on it carries no credential —
+// the token rides in the Authorization header — so beneath it the transport's cause
+// is kept, and its text with it, as the failure's diagnostic. Beneath any other
+// projected URL only the failure's classification survives.
+func redactTransportError(err error, apiOrigin string) error {
+	_, redacted := projectTransportError(err, apiOrigin)
 	return redacted
 }
 
 // projectTransportError rebuilds err's tree with every *url.Error projected, reporting
 // whether anything was, so a tree with nothing to drop comes back untouched at every
-// level. Beneath a projected URL only the failure's classification survives: whatever
-// the transport reported there is text this package did not build — a custom
-// transport's own wrapper, a message interpolating the request URL — and cannot be
-// shown free of the URL in any spelling, so it is replaced by the context sentinel it
-// wraps or a fixed transport failure carrying its net.Error flags. Above one, a
-// wrapper is dropped in favour of the projection for the same reason, and a
-// multi-error is rebuilt as errors.Join of its projected members.
-func projectTransportError(err error) (projected bool, result error) {
+// level. Beneath a projected URL off the API origin only the failure's classification
+// survives: whatever the transport reported there is text this package did not build
+// — a custom transport's own wrapper, a message interpolating the request URL — and
+// cannot be shown free of the URL in any spelling, so it is replaced by the context
+// sentinel it wraps or a fixed transport failure carrying its net.Error flags. Above
+// a projected URL, a wrapper is dropped in favour of the projection for the same
+// reason, and a multi-error is rebuilt as errors.Join of its projected members.
+func projectTransportError(err error, apiOrigin string) (projected bool, result error) {
 	switch e := err.(type) { //nolint:errorlint // rebuilding the tree node by node is the point
 	case nil:
 		return false, nil
 	case *url.Error:
-		if projectedURL := redactURL(e.URL); projectedURL != e.URL {
+		projectedURL := redactURL(e.URL)
+		if projectedURL != e.URL && (apiOrigin == "" || !isSameOrigin(e.URL, apiOrigin)) {
 			return true, &url.Error{Op: e.Op, URL: projectedURL, Err: classifyTransportFailure(e)}
 		}
-		innerProjected, inner := projectTransportError(e.Err)
-		if !innerProjected {
+		innerProjected, inner := projectTransportError(e.Err, apiOrigin)
+		if projectedURL == e.URL && !innerProjected {
 			return false, err
 		}
-		return true, &url.Error{Op: e.Op, URL: e.URL, Err: inner}
+		return true, &url.Error{Op: e.Op, URL: projectedURL, Err: inner}
 	case interface{ Unwrap() []error }:
 		members := e.Unwrap()
 		rebuilt := make([]error, 0, len(members))
 		for _, member := range members {
-			memberProjected, projectedMember := projectTransportError(member)
+			memberProjected, projectedMember := projectTransportError(member, apiOrigin)
 			projected = projected || memberProjected
 			rebuilt = append(rebuilt, projectedMember)
 		}
@@ -214,7 +220,7 @@ func projectTransportError(err error) (projected bool, result error) {
 		}
 		return true, errors.Join(rebuilt...)
 	case interface{ Unwrap() error }:
-		causeProjected, projectedCause := projectTransportError(e.Unwrap())
+		causeProjected, projectedCause := projectTransportError(e.Unwrap(), apiOrigin)
 		if !causeProjected {
 			return false, err
 		}

--- a/go/pkg/hey/security.go
+++ b/go/pkg/hey/security.go
@@ -169,28 +169,61 @@ func RedactHeaders(headers http.Header) http.Header {
 // query, and a proxy URL its password in the userinfo, so through ErrNetwork that
 // rendering would become the hint, the message and every log line printing the error.
 // The projection keeps what a reader needs to place the failure and drops the rest
-// before any text is built. An error that carries no *url.Error, or one whose URL has
-// nothing to drop, is returned as it is.
+// before any text is built. Every *url.Error in the chain is projected — a transport
+// built on another http.Client nests one inside another. An error that carries no
+// *url.Error, or none whose URL has anything to drop, is returned as it is.
 func redactTransportError(err error) error {
+	_, redacted := projectTransportError(err)
+	return redacted
+}
+
+// projectTransportError is redactTransportError reporting whether it projected
+// anything, so a chain with nothing to drop comes back untouched at every level.
+func projectTransportError(err error) (projected bool, result error) {
 	var urlErr *url.Error
-	if !errors.As(err, &urlErr) || urlErr.URL == "" {
-		return err
+	if !errors.As(err, &urlErr) {
+		return false, err
 	}
-	redacted := &url.Error{Op: urlErr.Op, URL: redactURL(urlErr.URL), Err: urlErr.Err}
-	if redacted.URL == urlErr.URL {
-		return err
+	innerProjected, inner := projectTransportError(urlErr.Err)
+	projectedURL := redactURL(urlErr.URL)
+	if projectedURL == urlErr.URL && !innerProjected {
+		return false, err
 	}
+	redacted := &url.Error{Op: urlErr.Op, URL: projectedURL, Err: inner}
 	text := err.Error()
-	if text == urlErr.Error() || !strings.Contains(text, urlErr.URL) {
-		// Nothing wraps the transport error, or a wrapper renders the URL in a form
-		// this function cannot locate: the transport error's own rendering is what
-		// is kept.
-		return redacted
+	if text == urlErr.Error() || !strings.Contains(text, urlErr.Error()) || holdsAnotherURLError(err, urlErr) {
+		// Nothing wraps the transport error; or a wrapper renders it in a form this
+		// function cannot locate, or holds a second transport error beside it (an
+		// errors.Join) whose rendering it cannot rebuild: the projected transport
+		// error alone is kept.
+		return true, redacted
 	}
-	return &redactedTransportError{
-		text:  strings.ReplaceAll(text, urlErr.URL, redacted.URL),
+	return true, &redactedTransportError{
+		text:  strings.ReplaceAll(text, urlErr.Error(), redacted.Error()),
 		cause: redacted,
 	}
+}
+
+// holdsAnotherURLError reports whether err's tree holds a *url.Error other than found,
+// found's own chain aside — the case a wrapper's text cannot be rebuilt from one
+// substitution. The walk is deliberately per node, not through errors.As, which would
+// find found again.
+func holdsAnotherURLError(err error, found *url.Error) bool {
+	switch e := err.(type) { //nolint:errorlint // walking the tree node by node is the point
+	case nil:
+		return false
+	case *url.Error:
+		return e != found
+	case interface{ Unwrap() error }:
+		return holdsAnotherURLError(e.Unwrap(), found)
+	case interface{ Unwrap() []error }:
+		for _, joined := range e.Unwrap() {
+			if holdsAnotherURLError(joined, found) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // redactURL projects rawURL to its scheme, host and path, dropping userinfo, query

--- a/go/pkg/hey/security.go
+++ b/go/pkg/hey/security.go
@@ -1,6 +1,7 @@
 package hey
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -161,3 +162,55 @@ func RedactHeaders(headers http.Header) http.Header {
 	}
 	return result
 }
+
+// redactTransportError returns err with the URL Go's *url.Error renders projected to
+// its scheme, host and path. net/http reports every transport failure as a *url.Error
+// carrying the whole request URL; a signed storage URL carries its credential in the
+// query, and a proxy URL its password in the userinfo, so through ErrNetwork that
+// rendering would become the hint, the message and every log line printing the error.
+// The projection keeps what a reader needs to place the failure and drops the rest
+// before any text is built. An error that carries no *url.Error, or one whose URL has
+// nothing to drop, is returned as it is.
+func redactTransportError(err error) error {
+	var urlErr *url.Error
+	if !errors.As(err, &urlErr) || urlErr.URL == "" {
+		return err
+	}
+	redacted := &url.Error{Op: urlErr.Op, URL: redactURL(urlErr.URL), Err: urlErr.Err}
+	if redacted.URL == urlErr.URL {
+		return err
+	}
+	text := err.Error()
+	if text == urlErr.Error() || !strings.Contains(text, urlErr.URL) {
+		// Nothing wraps the transport error, or a wrapper renders the URL in a form
+		// this function cannot locate: the transport error's own rendering is what
+		// is kept.
+		return redacted
+	}
+	return &redactedTransportError{
+		text:  strings.ReplaceAll(text, urlErr.URL, redacted.URL),
+		cause: redacted,
+	}
+}
+
+// redactURL projects rawURL to its scheme, host and path, dropping userinfo, query
+// and fragment. A URL that does not parse projects to the fixed token "unparsable".
+func redactURL(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return "unparsable"
+	}
+	return (&url.URL{Scheme: u.Scheme, Host: u.Host, Path: u.Path, RawPath: u.RawPath}).String()
+}
+
+// redactedTransportError is a wrapped transport error rendered with its URL projected:
+// the wrapper's text with the projection substituted, unwrapping to the projected
+// *url.Error so errors.Is and errors.As classify the failure as before.
+type redactedTransportError struct {
+	text  string
+	cause *url.Error
+}
+
+func (e *redactedTransportError) Error() string { return e.text }
+
+func (e *redactedTransportError) Unwrap() error { return e.cause }

--- a/go/pkg/hey/security.go
+++ b/go/pkg/hey/security.go
@@ -186,13 +186,15 @@ func redactTransportError(err error, apiOrigin string) error {
 
 // projectTransportError rebuilds err's tree with every *url.Error projected, reporting
 // whether anything was, so a tree with nothing to drop comes back untouched at every
-// level. Beneath a projected URL off the API origin only the failure's classification
-// survives: whatever the transport reported there is text this package did not build
-// — a custom transport's own wrapper, a message interpolating the request URL — and
-// cannot be shown free of the URL in any spelling, so it is replaced by the context
-// sentinel it wraps or a fixed transport failure carrying its net.Error flags. Above
-// a projected URL, a wrapper is dropped in favour of the projection for the same
-// reason, and a multi-error is rebuilt as errors.Join of its projected members.
+// level. A projected *url.Error off the API origin is built from fixed parts alone:
+// its Op kept only as the method token net/http writes there, its cause replaced by
+// what classifies the failure — the context sentinel it wrapped and its net.Error
+// flags — because whatever a transport put there is text this package did not build
+// (a custom transport's own wrapper, a message interpolating the request URL) and
+// cannot be shown free of the URL in any spelling. Around a projected URL the same
+// holds: a wrapper is dropped in favour of the projection, and a multi-error is
+// rebuilt as errors.Join of its projected members and their sentinel siblings, the
+// opaque siblings dropped.
 func projectTransportError(err error, apiOrigin string) (projected bool, result error) {
 	switch e := err.(type) { //nolint:errorlint // rebuilding the tree node by node is the point
 	case nil:
@@ -200,7 +202,7 @@ func projectTransportError(err error, apiOrigin string) (projected bool, result 
 	case *url.Error:
 		projectedURL := redactURL(e.URL)
 		if projectedURL != e.URL && (apiOrigin == "" || !isSameOrigin(e.URL, apiOrigin)) {
-			return true, &url.Error{Op: e.Op, URL: projectedURL, Err: classifyTransportFailure(e)}
+			return true, &url.Error{Op: transportOp(e.Op), URL: projectedURL, Err: classifyTransportFailure(e)}
 		}
 		innerProjected, inner := projectTransportError(e.Err, apiOrigin)
 		if projectedURL == e.URL && !innerProjected {
@@ -209,16 +211,20 @@ func projectTransportError(err error, apiOrigin string) (projected bool, result 
 		return true, &url.Error{Op: e.Op, URL: projectedURL, Err: inner}
 	case interface{ Unwrap() []error }:
 		members := e.Unwrap()
-		rebuilt := make([]error, 0, len(members))
+		kept := make([]error, 0, len(members))
 		for _, member := range members {
-			memberProjected, projectedMember := projectTransportError(member, apiOrigin)
-			projected = projected || memberProjected
-			rebuilt = append(rebuilt, projectedMember)
+			switch memberProjected, projectedMember := projectTransportError(member, apiOrigin); {
+			case memberProjected:
+				projected = true
+				kept = append(kept, projectedMember)
+			case contextSentinel(member) != nil:
+				kept = append(kept, contextSentinel(member))
+			}
 		}
 		if !projected {
 			return false, err
 		}
-		return true, errors.Join(rebuilt...)
+		return true, errors.Join(kept...)
 	case interface{ Unwrap() error }:
 		causeProjected, projectedCause := projectTransportError(e.Unwrap(), apiOrigin)
 		if !causeProjected {
@@ -229,18 +235,37 @@ func projectTransportError(err error, apiOrigin string) (projected bool, result 
 	return false, err
 }
 
+// transportOp is op as net/http writes it — the request method, letters alone — or
+// the fixed "Request" when a transport put anything else there.
+func transportOp(op string) string {
+	for _, r := range op {
+		if (r < 'A' || r > 'Z') && (r < 'a' || r > 'z') {
+			return "Request"
+		}
+	}
+	if op == "" {
+		return "Request"
+	}
+	return op
+}
+
 // classifyTransportFailure is what stands beneath a projected URL in place of the
-// transport's own cause: the context sentinel the failure wraps, so errors.Is still
-// sees a cancellation or a deadline, or a transportFailureError carrying the
-// net.Error flags the *url.Error delegated to that cause.
+// transport's own cause: a transportFailureError carrying the net.Error flags the
+// *url.Error delegated to that cause, unwrapping to the context sentinel the cause
+// wrapped, so errors.Is still sees a cancellation or a deadline.
 func classifyTransportFailure(e *url.Error) error {
+	return &transportFailureError{timeout: e.Timeout(), temporary: e.Temporary(), sentinel: contextSentinel(e.Err)}
+}
+
+// contextSentinel is the bare context sentinel err wraps, or nil.
+func contextSentinel(err error) error {
 	switch {
-	case errors.Is(e.Err, context.Canceled):
+	case errors.Is(err, context.Canceled):
 		return context.Canceled
-	case errors.Is(e.Err, context.DeadlineExceeded):
+	case errors.Is(err, context.DeadlineExceeded):
 		return context.DeadlineExceeded
 	}
-	return &transportFailureError{timeout: e.Timeout(), temporary: e.Temporary()}
+	return nil
 }
 
 // redactURL projects rawURL to its scheme, host and path, dropping userinfo, query
@@ -254,15 +279,23 @@ func redactURL(rawURL string) string {
 }
 
 // transportFailureError is the cause beneath a projected URL: a transport failure
-// known only by its net.Error classification.
-type transportFailureError struct{ timeout, temporary bool }
+// known only by its net.Error classification and the context sentinel it wrapped.
+type transportFailureError struct {
+	timeout, temporary bool
+	sentinel           error
+}
 
 func (e *transportFailureError) Error() string {
-	if e.timeout {
+	switch {
+	case e.sentinel != nil:
+		return e.sentinel.Error()
+	case e.timeout:
 		return "transport timeout"
 	}
 	return "transport failure"
 }
+
+func (e *transportFailureError) Unwrap() error { return e.sentinel }
 
 func (e *transportFailureError) Timeout() bool { return e.timeout }
 

--- a/go/pkg/hey/transport_error_test.go
+++ b/go/pkg/hey/transport_error_test.go
@@ -540,6 +540,62 @@ func callerURLRequests(client *Client, target string) map[string]func() error {
 	}
 }
 
+// TestCallerRelativeStoragePathReachesHooksProjected hands each method that takes a
+// caller's path a signed storage path in relative form — the disk-service token in the
+// path, the origin left off — and checks it is projected exactly as the absolute form
+// is, while an ordinary API path keeps its detail.
+func TestCallerRelativeStoragePathReachesHooksProjected(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.Header().Set("Location", "/done")
+			w.WriteHeader(http.StatusFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	t.Cleanup(server.Close)
+	hooks := &requestRecordingHooks{}
+	client := NewClient(&Config{BaseURL: server.URL}, &StaticTokenProvider{Token: "test-token"},
+		WithMaxRetries(0), WithHooks(hooks))
+
+	for name, request := range callerURLRequests(client, "/rails/active_storage/disk/SECRETVALUE/file.txt") {
+		t.Run(name, func(t *testing.T) {
+			hooks.infos = nil
+			if err := request(); err != nil {
+				t.Fatal(err)
+			}
+			if len(hooks.infos) != 1 {
+				t.Fatalf("expected one request in the hooks, got %+v", hooks.infos)
+			}
+			if got := hooks.infos[0].URL; got != server.URL {
+				t.Errorf("the request reached the hooks as %q, want the projected URL", got)
+			}
+		})
+	}
+
+	t.Run("an ordinary API path keeps its detail", func(t *testing.T) {
+		hooks.infos = nil
+		if _, err := client.Get(context.Background(), "/boxes"); err != nil {
+			t.Fatal(err)
+		}
+		if got, want := hooks.infos[0].URL, server.URL+"/boxes"; got != want {
+			t.Errorf("the request reached the hooks as %q, want %q", got, want)
+		}
+	})
+
+	t.Run("a direct upload stays an ordinary API call", func(t *testing.T) {
+		if isSignedStoragePath("/rails/active_storage/direct_uploads.json") {
+			t.Error("a direct upload's path carries no credential and should not be projected")
+		}
+		for _, path := range []string{"rails/active_storage/disk/KEY/file", "/rails/active_storage/blobs/redirect/ID/file", "/rails/active_storage/representations/redirect/ID/V/file"} {
+			if !isSignedStoragePath(path) {
+				t.Errorf("%q should be projected", path)
+			}
+		}
+	})
+}
+
 // TestCallerAbsoluteURLReachesHooksProjected hands each method that takes a caller's
 // absolute URL a signed one — a disk-service token in the path, on HEY's own origin
 // — and checks the hooks see its origin alone, and a 404 names no more.

--- a/go/pkg/hey/transport_error_test.go
+++ b/go/pkg/hey/transport_error_test.go
@@ -129,6 +129,37 @@ func TestRedactTransportError(t *testing.T) {
 		}
 	})
 
+	t.Run("projects every transport error in a nested chain", func(t *testing.T) {
+		outer := &url.Error{Op: "Get", URL: "https://proxy.example.com/relay", Err: signed}
+		got := redactTransportError(outer)
+		want := `Get "https://proxy.example.com/relay": Get "https://storage.example.com/blob/1": context canceled`
+		if got.Error() != want {
+			t.Errorf("got %q, want %q", got.Error(), want)
+		}
+		for _, text := range renderings(got) {
+			if strings.Contains(text, "SECRETVALUE") {
+				t.Errorf("the signed query leaked into %q", text)
+			}
+		}
+		got = redactTransportError(fmt.Errorf("relaying: %w", outer))
+		if got.Error() != "relaying: "+want {
+			t.Errorf("got %q, want %q", got.Error(), "relaying: "+want)
+		}
+	})
+
+	t.Run("keeps only the first transport error of a joined pair", func(t *testing.T) {
+		other := &url.Error{Op: "Get", URL: "https://other.example.com/x?token=SECRETVALUE", Err: errors.New("reset")}
+		got := redactTransportError(errors.Join(signed, other))
+		if got.Error() != `Get "https://storage.example.com/blob/1": context canceled` {
+			t.Errorf("got %q", got.Error())
+		}
+		for _, text := range renderings(got) {
+			if strings.Contains(text, "SECRETVALUE") {
+				t.Errorf("the signed query leaked into %q", text)
+			}
+		}
+	})
+
 	t.Run("returns an error with nothing to drop unchanged", func(t *testing.T) {
 		plain := &url.Error{Op: "Get", URL: "https://api.example.com/x", Err: context.Canceled}
 		if got := redactTransportError(plain); got != plain { //nolint:errorlint // identity is the point
@@ -136,6 +167,10 @@ func TestRedactTransportError(t *testing.T) {
 		}
 		other := errors.New("not a transport error")
 		if got := redactTransportError(other); got != other { //nolint:errorlint // identity is the point
+			t.Errorf("got %v, want the same error", got)
+		}
+		nested := &url.Error{Op: "Get", URL: "https://proxy.example.com/relay", Err: plain}
+		if got := redactTransportError(nested); got != nested { //nolint:errorlint // identity is the point
 			t.Errorf("got %v, want the same error", got)
 		}
 	})

--- a/go/pkg/hey/transport_error_test.go
+++ b/go/pkg/hey/transport_error_test.go
@@ -1,0 +1,166 @@
+package hey
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// renderings is every text a caller or a logger can get out of err: its Error, its
+// %+v, and the Error of every link of its cause chain.
+func renderings(err error) []string {
+	out := []string{err.Error(), fmt.Sprintf("%+v", err)}
+	for cause := errors.Unwrap(err); cause != nil; cause = errors.Unwrap(cause) {
+		out = append(out, cause.Error(), fmt.Sprintf("%+v", cause))
+	}
+	return out
+}
+
+type requestRecordingHooks struct {
+	NoopHooks
+	infos   []RequestInfo
+	results []RequestResult
+}
+
+func (h *requestRecordingHooks) OnRequestStart(ctx context.Context, info RequestInfo) context.Context {
+	h.infos = append(h.infos, info)
+	return ctx
+}
+
+func (h *requestRecordingHooks) OnRequestEnd(_ context.Context, _ RequestInfo, result RequestResult) {
+	h.results = append(h.results, result)
+}
+
+// TestAttachmentsUploadTransportErrorRendersNoSignedURL forces a dial failure on the
+// storage hop of an attachment upload — the one request the SDK issues to a URL whose
+// query is the credential — and checks the signature reaches neither the error's
+// renderings nor the request hooks. net/http's *url.Error carries the whole URL, and
+// ErrNetwork used to copy it into the hint verbatim.
+func TestAttachmentsUploadTransportErrorRendersNoSignedURL(t *testing.T) {
+	const signedURL = "http://127.0.0.1:1/blob?signature=SECRETVALUE"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"signed_id":"signed-123",
+			"attachable_sgid":"sgid-456",
+			"direct_upload":{"url":"` + signedURL + `","headers":{"Content-Type":"text/plain"}}
+		}`))
+	}))
+	t.Cleanup(server.Close)
+	hooks := &requestRecordingHooks{}
+	client := NewClient(&Config{BaseURL: server.URL}, &StaticTokenProvider{Token: "test-token"},
+		WithMaxRetries(0), WithHooks(hooks))
+
+	_, err := client.Attachments().Upload(context.Background(), "note.txt", "text/plain", strings.NewReader("contents"))
+	if err == nil {
+		t.Fatal("expected a network error dialing a closed port")
+	}
+	var sdkErr *Error
+	if !errors.As(err, &sdkErr) || sdkErr.Code != CodeNetwork {
+		t.Fatalf("expected a network *Error, got %T: %v", err, err)
+	}
+	for _, text := range append(renderings(err), sdkErr.Hint, sdkErr.Message) {
+		if strings.Contains(text, "SECRETVALUE") {
+			t.Errorf("the signed query leaked into %q", text)
+		}
+	}
+	if !strings.Contains(sdkErr.Hint, `"http://127.0.0.1:1/blob"`) {
+		t.Errorf("hint should keep the URL's scheme, host and path, got %q", sdkErr.Hint)
+	}
+	var urlErr *url.Error
+	if !errors.As(err, &urlErr) || urlErr.URL != "http://127.0.0.1:1/blob" {
+		t.Errorf("the cause chain should still classify as the projected *url.Error, got %v", err)
+	}
+
+	if len(hooks.infos) != 2 || len(hooks.results) != 2 {
+		t.Fatalf("expected the API request and the storage request in the hooks, got %d starts, %d ends", len(hooks.infos), len(hooks.results))
+	}
+	if storage := hooks.infos[1]; storage.Method != http.MethodPut || storage.URL != "http://127.0.0.1:1/blob" {
+		t.Errorf("storage request reached the hooks as %s %q, want the projected URL", storage.Method, storage.URL)
+	}
+	if api := hooks.infos[0]; !strings.HasPrefix(api.URL, server.URL+"/") {
+		t.Errorf("API request URL should reach the hooks whole, got %q", api.URL)
+	}
+	for _, result := range hooks.results {
+		if result.Error != nil && strings.Contains(result.Error.Error(), "SECRETVALUE") {
+			t.Errorf("the signed query leaked into a hook result: %q", result.Error.Error())
+		}
+	}
+}
+
+func TestRedactTransportError(t *testing.T) {
+	signed := &url.Error{Op: "Get", URL: "https://user:pw@storage.example.com/blob/1?sig=SECRETVALUE#frag", Err: context.Canceled}
+
+	t.Run("projects the URL of a bare transport error and keeps its classification", func(t *testing.T) {
+		got := redactTransportError(signed)
+		want := `Get "https://storage.example.com/blob/1": context canceled`
+		if got.Error() != want {
+			t.Errorf("got %q, want %q", got.Error(), want)
+		}
+		if !errors.Is(got, context.Canceled) {
+			t.Error("the cause chain should still reach the context sentinel")
+		}
+	})
+
+	t.Run("keeps a wrapper's text around the projection", func(t *testing.T) {
+		got := redactTransportError(fmt.Errorf("fetching the blob: %w", signed))
+		want := `fetching the blob: Get "https://storage.example.com/blob/1": context canceled`
+		if got.Error() != want {
+			t.Errorf("got %q, want %q", got.Error(), want)
+		}
+		var urlErr *url.Error
+		if !errors.As(got, &urlErr) || urlErr.URL != "https://storage.example.com/blob/1" {
+			t.Errorf("should unwrap to the projected *url.Error, got %v", got)
+		}
+		if !errors.Is(got, context.Canceled) {
+			t.Error("the cause chain should still reach the context sentinel")
+		}
+	})
+
+	t.Run("keeps only the transport error when a wrapper hides the URL", func(t *testing.T) {
+		got := redactTransportError(&opaqueWrapperError{cause: signed})
+		if got.Error() != `Get "https://storage.example.com/blob/1": context canceled` {
+			t.Errorf("got %q", got.Error())
+		}
+	})
+
+	t.Run("returns an error with nothing to drop unchanged", func(t *testing.T) {
+		plain := &url.Error{Op: "Get", URL: "https://api.example.com/x", Err: context.Canceled}
+		if got := redactTransportError(plain); got != plain { //nolint:errorlint // identity is the point
+			t.Errorf("got %v, want the same error", got)
+		}
+		other := errors.New("not a transport error")
+		if got := redactTransportError(other); got != other { //nolint:errorlint // identity is the point
+			t.Errorf("got %v, want the same error", got)
+		}
+	})
+
+	t.Run("projects an unparsable URL to a fixed token", func(t *testing.T) {
+		bad := &url.Error{Op: "Get", URL: "http://[::1/x?sig=SECRETVALUE", Err: context.Canceled}
+		got := redactTransportError(bad)
+		if strings.Contains(got.Error(), "SECRETVALUE") || !strings.Contains(got.Error(), `"unparsable"`) {
+			t.Errorf("got %q", got.Error())
+		}
+	})
+}
+
+func TestAsErrorRendersNoSignedQuery(t *testing.T) {
+	signed := &url.Error{Op: "Put", URL: "https://storage.example.com/blob?sig=SECRETVALUE", Err: errors.New("connection reset")}
+	e := AsError(signed)
+	for _, text := range append(renderings(e), e.Message) {
+		if strings.Contains(text, "SECRETVALUE") {
+			t.Errorf("the signed query leaked into %q", text)
+		}
+	}
+}
+
+// opaqueWrapperError wraps an error without rendering it.
+type opaqueWrapperError struct{ cause error }
+
+func (w *opaqueWrapperError) Error() string { return "request failed" }
+func (w *opaqueWrapperError) Unwrap() error { return w.cause }

--- a/go/pkg/hey/transport_error_test.go
+++ b/go/pkg/hey/transport_error_test.go
@@ -486,3 +486,156 @@ type opaqueWrapperError struct{ cause error }
 
 func (w *opaqueWrapperError) Error() string { return "request failed" }
 func (w *opaqueWrapperError) Unwrap() error { return w.cause }
+
+// TestAttachmentsUploadInsecureTargetRendersNoSignedURL hands Upload a direct-upload
+// URL RequireSecureEndpoint rejects — plain http off localhost — and checks the
+// rejection names the target's origin, not the signed URL.
+func TestAttachmentsUploadInsecureTargetRendersNoSignedURL(t *testing.T) {
+	const signedURL = "http://storage.example/blob?signature=SECRETVALUE"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"signed_id":"signed-123",
+			"attachable_sgid":"sgid-456",
+			"direct_upload":{"url":"` + signedURL + `","headers":{"Content-Type":"text/plain"}}
+		}`))
+	}))
+	t.Cleanup(server.Close)
+	client := NewClient(&Config{BaseURL: server.URL}, &StaticTokenProvider{Token: "test-token"}, WithMaxRetries(0))
+
+	_, err := client.Attachments().Upload(context.Background(), "note.txt", "text/plain", strings.NewReader("contents"))
+	if err == nil {
+		t.Fatal("expected the insecure upload target to be rejected")
+	}
+	for _, text := range renderings(err) {
+		if strings.Contains(text, "SECRETVALUE") {
+			t.Errorf("the signed query leaked into %q", text)
+		}
+	}
+	if !strings.Contains(err.Error(), "http://storage.example") {
+		t.Errorf("the rejection should name the target's origin, got %q", err)
+	}
+}
+
+// callerURLRequests is every request method that takes a caller's absolute URL, each
+// sending one to the given server.
+func callerURLRequests(client *Client, target string) map[string]func() error {
+	return map[string]func() error{
+		"Get": func() error {
+			_, err := client.Get(context.Background(), target)
+			return err
+		},
+		"GetAll": func() error {
+			_, err := client.GetAll(context.Background(), target)
+			return err
+		},
+		"PostForm": func() error {
+			_, err := client.PostForm(context.Background(), target, url.Values{"name": {"value"}})
+			return err
+		},
+		"PostMultipart": func() error {
+			_, err := client.PostMultipart(context.Background(), target, "multipart/form-data; boundary=b", []byte("--b--"))
+			return err
+		},
+	}
+}
+
+// TestCallerAbsoluteURLReachesHooksProjected hands each method that takes a caller's
+// absolute URL a signed one — a disk-service token in the path, on HEY's own origin
+// — and checks the hooks see its origin alone, and a 404 names no more.
+func TestCallerAbsoluteURLReachesHooksProjected(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/missing") {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		if r.Method != http.MethodGet {
+			w.Header().Set("Location", "/done")
+			w.WriteHeader(http.StatusFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	t.Cleanup(server.Close)
+	hooks := &requestRecordingHooks{}
+	client := NewClient(&Config{BaseURL: server.URL}, &StaticTokenProvider{Token: "test-token"},
+		WithMaxRetries(0), WithHooks(hooks))
+
+	for name, request := range callerURLRequests(client, server.URL+"/rails/active_storage/disk/SECRETVALUE/file.txt") {
+		t.Run(name, func(t *testing.T) {
+			hooks.infos = nil
+			if err := request(); err != nil {
+				t.Fatal(err)
+			}
+			if len(hooks.infos) != 1 {
+				t.Fatalf("expected one request in the hooks, got %+v", hooks.infos)
+			}
+			if got := hooks.infos[0].URL; got != server.URL {
+				t.Errorf("the request reached the hooks as %q, want the projected URL", got)
+			}
+		})
+	}
+
+	t.Run("not found", func(t *testing.T) {
+		_, err := client.Get(context.Background(), server.URL+"/rails/active_storage/disk/SECRETVALUE/missing")
+		var sdkErr *Error
+		if !errors.As(err, &sdkErr) || sdkErr.Code != CodeNotFound {
+			t.Fatalf("expected a not-found *Error, got %T: %v", err, err)
+		}
+		for _, text := range append(renderings(err), sdkErr.Message) {
+			if strings.Contains(text, "SECRETVALUE") {
+				t.Errorf("the signed path leaked into %q", text)
+			}
+		}
+		if !strings.Contains(sdkErr.Message, server.URL) {
+			t.Errorf("the not-found error should name the origin, got %q", sdkErr.Message)
+		}
+	})
+}
+
+// TestCallerAbsoluteURLTransportErrorRendersNoSignedURL dials a closed port through
+// each method that takes a caller's absolute URL — a signed one on the API origin
+// itself, as the disk service serves — and checks the network error keeps the origin
+// and nothing beneath it.
+func TestCallerAbsoluteURLTransportErrorRendersNoSignedURL(t *testing.T) {
+	const origin = "https://127.0.0.1:1"
+	client := NewClient(&Config{BaseURL: origin}, &StaticTokenProvider{Token: "test-token"}, WithMaxRetries(0))
+
+	for name, request := range callerURLRequests(client, origin+"/rails/active_storage/disk/SECRETVALUE/file.txt") {
+		t.Run(name, func(t *testing.T) {
+			err := request()
+			var sdkErr *Error
+			if !errors.As(err, &sdkErr) || sdkErr.Code != CodeNetwork {
+				t.Fatalf("expected a network *Error, got %T: %v", err, err)
+			}
+			for _, text := range append(renderings(err), sdkErr.Hint) {
+				if strings.Contains(text, "SECRETVALUE") {
+					t.Errorf("the signed query leaked into %q", text)
+				}
+			}
+			if !strings.Contains(sdkErr.Hint, `"`+origin+`"`) {
+				t.Errorf("hint should keep the origin, got %q", sdkErr.Hint)
+			}
+		})
+	}
+}
+
+// TestCallerInsecureURLRendersNoSignedURL hands Get a signed http URL on another host,
+// which buildURL rejects, and checks the rejection names the origin alone.
+func TestCallerInsecureURLRendersNoSignedURL(t *testing.T) {
+	server := httptest.NewServer(http.NotFoundHandler())
+	t.Cleanup(server.Close)
+	client := NewClient(&Config{BaseURL: server.URL}, &StaticTokenProvider{Token: "test-token"})
+
+	_, err := client.Get(context.Background(), "http://storage.example/blob?signature=SECRETVALUE")
+	if err == nil {
+		t.Fatal("expected the http URL on another host to be rejected")
+	}
+	if strings.Contains(err.Error(), "SECRETVALUE") {
+		t.Errorf("the signed query leaked into %q", err)
+	}
+	if !strings.Contains(err.Error(), "http://storage.example") {
+		t.Errorf("the rejection should name the origin, got %q", err)
+	}
+}

--- a/go/pkg/hey/transport_error_test.go
+++ b/go/pkg/hey/transport_error_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -146,6 +147,53 @@ func TestAttachmentsUploadCustomTransportErrorRendersNoSignedURL(t *testing.T) {
 	}
 	if !strings.Contains(hooks.results[1].Error.Error(), `"http://127.0.0.1:1/blob"`) {
 		t.Errorf("hook result should keep the URL's scheme, host and path, got %q", hooks.results[1].Error.Error())
+	}
+}
+
+// TestBlobDownloadRedirectReachesHooksProjected downloads a blob HEY answers with a
+// redirect to a signed storage URL and checks the hooks see the storage hop projected:
+// net/http follows the redirect on the same context, and a successful download has no
+// error for ErrNetwork to project.
+func TestBlobDownloadRedirectReachesHooksProjected(t *testing.T) {
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "download")
+	}))
+	t.Cleanup(target.Close)
+	source := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL+"/signed-download?signature=SECRETVALUE", http.StatusFound)
+	}))
+	t.Cleanup(source.Close)
+	hooks := &requestRecordingHooks{}
+	client := NewClient(&Config{BaseURL: source.URL}, &StaticTokenProvider{Token: "test-token"},
+		WithMaxRetries(0), WithHooks(hooks))
+
+	for name, download := range map[string]func() error{
+		"GetBlob": func() error {
+			_, err := client.GetBlob(context.Background(), "/blob")
+			return err
+		},
+		"DownloadBlob": func() error {
+			_, _, err := client.DownloadBlob(context.Background(), "/blob", io.Discard)
+			return err
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			hooks.infos = nil
+			if err := download(); err != nil {
+				t.Fatal(err)
+			}
+			if len(hooks.infos) != 2 {
+				t.Fatalf("expected the HEY hop and the storage hop in the hooks, got %+v", hooks.infos)
+			}
+			if got := hooks.infos[1].URL; got != target.URL+"/signed-download" {
+				t.Errorf("storage hop reached the hooks as %q, want the projected URL", got)
+			}
+			for _, info := range hooks.infos {
+				if strings.Contains(info.URL, "SECRETVALUE") {
+					t.Errorf("the signed query leaked into a hook argument: %q", info.URL)
+				}
+			}
+		})
 	}
 }
 

--- a/go/pkg/hey/transport_error_test.go
+++ b/go/pkg/hey/transport_error_test.go
@@ -202,7 +202,7 @@ func TestRedactTransportError(t *testing.T) {
 	signed := &url.Error{Op: "Get", URL: "https://user:pw@storage.example.com/blob/1?sig=SECRETVALUE#frag", Err: context.Canceled}
 
 	t.Run("projects the URL of a bare transport error and keeps its classification", func(t *testing.T) {
-		got := redactTransportError(signed)
+		got := redactTransportError(signed, "")
 		want := `Get "https://storage.example.com/blob/1": context canceled`
 		if got.Error() != want {
 			t.Errorf("got %q, want %q", got.Error(), want)
@@ -218,7 +218,7 @@ func TestRedactTransportError(t *testing.T) {
 			"interpolated URL": fmt.Errorf("request %s failed: %w", signed.URL, signed),
 			"opaque":           &opaqueWrapperError{cause: signed},
 		} {
-			got := redactTransportError(wrapped)
+			got := redactTransportError(wrapped, "")
 			if want := `Get "https://storage.example.com/blob/1": context canceled`; got.Error() != want {
 				t.Errorf("%s: got %q, want %q", name, got.Error(), want)
 			}
@@ -234,7 +234,7 @@ func TestRedactTransportError(t *testing.T) {
 
 	t.Run("keeps only the classification beneath a projected URL", func(t *testing.T) {
 		opaque := &url.Error{Op: "Put", URL: "https://storage.example.com/blob/1?sig=SECRETVALUE", Err: timeoutError{}}
-		got := redactTransportError(opaque)
+		got := redactTransportError(opaque, "")
 		if want := `Put "https://storage.example.com/blob/1": transport timeout`; got.Error() != want {
 			t.Errorf("got %q, want %q", got.Error(), want)
 		}
@@ -247,7 +247,7 @@ func TestRedactTransportError(t *testing.T) {
 		if !errors.As(got, &netErr) || !netErr.Timeout() {
 			t.Errorf("the timeout classification should survive, got %v", got)
 		}
-		plain := redactTransportError(&url.Error{Op: "Put", URL: "https://storage.example.com/blob/1?sig=SECRETVALUE", Err: errors.New("connection refused")})
+		plain := redactTransportError(&url.Error{Op: "Put", URL: "https://storage.example.com/blob/1?sig=SECRETVALUE", Err: errors.New("connection refused")}, "")
 		if want := `Put "https://storage.example.com/blob/1": transport failure`; plain.Error() != want {
 			t.Errorf("got %q, want %q", plain.Error(), want)
 		}
@@ -258,7 +258,7 @@ func TestRedactTransportError(t *testing.T) {
 
 	t.Run("projects every transport error in a nested chain", func(t *testing.T) {
 		outer := &url.Error{Op: "Get", URL: "https://proxy.example.com/relay", Err: signed}
-		got := redactTransportError(outer)
+		got := redactTransportError(outer, "")
 		want := `Get "https://proxy.example.com/relay": Get "https://storage.example.com/blob/1": context canceled`
 		if got.Error() != want {
 			t.Errorf("got %q, want %q", got.Error(), want)
@@ -268,14 +268,14 @@ func TestRedactTransportError(t *testing.T) {
 				t.Errorf("the signed query leaked into %q", text)
 			}
 		}
-		if got = redactTransportError(fmt.Errorf("relaying to %s: %w", outer.URL, outer)); got.Error() != want {
+		if got = redactTransportError(fmt.Errorf("relaying to %s: %w", outer.URL, outer), ""); got.Error() != want {
 			t.Errorf("got %q, want %q", got.Error(), want)
 		}
 	})
 
 	t.Run("projects every member of a joined error and keeps the rest", func(t *testing.T) {
 		other := &url.Error{Op: "Get", URL: "https://other.example.com/x?token=SECRETVALUE", Err: errors.New("reset")}
-		got := redactTransportError(errors.Join(signed, context.DeadlineExceeded, other))
+		got := redactTransportError(errors.Join(signed, context.DeadlineExceeded, other), "")
 		want := "Get \"https://storage.example.com/blob/1\": context canceled\ncontext deadline exceeded\nGet \"https://other.example.com/x\": transport failure"
 		if got.Error() != want {
 			t.Errorf("got %q, want %q", got.Error(), want)
@@ -290,28 +290,40 @@ func TestRedactTransportError(t *testing.T) {
 		}
 	})
 
+	t.Run("keeps the cause beneath a URL on the API origin", func(t *testing.T) {
+		api := &url.Error{Op: "Get", URL: "https://api.example.com/boxes?page=2", Err: errors.New("connection refused")}
+		got := redactTransportError(api, "https://api.example.com")
+		if want := `Get "https://api.example.com/boxes": connection refused`; got.Error() != want {
+			t.Errorf("got %q, want %q", got.Error(), want)
+		}
+		off := redactTransportError(api, "https://other.example.com")
+		if want := `Get "https://api.example.com/boxes": transport failure`; off.Error() != want {
+			t.Errorf("got %q, want %q", off.Error(), want)
+		}
+	})
+
 	t.Run("returns an error with nothing to drop unchanged", func(t *testing.T) {
 		plain := &url.Error{Op: "Get", URL: "https://api.example.com/x", Err: context.Canceled}
-		if got := redactTransportError(plain); got != plain { //nolint:errorlint // identity is the point
+		if got := redactTransportError(plain, ""); got != plain { //nolint:errorlint // identity is the point
 			t.Errorf("got %v, want the same error", got)
 		}
 		other := errors.New("not a transport error")
-		if got := redactTransportError(other); got != other { //nolint:errorlint // identity is the point
+		if got := redactTransportError(other, ""); got != other { //nolint:errorlint // identity is the point
 			t.Errorf("got %v, want the same error", got)
 		}
 		nested := &url.Error{Op: "Get", URL: "https://proxy.example.com/relay", Err: plain}
-		if got := redactTransportError(nested); got != nested { //nolint:errorlint // identity is the point
+		if got := redactTransportError(nested, ""); got != nested { //nolint:errorlint // identity is the point
 			t.Errorf("got %v, want the same error", got)
 		}
 		wrapped := fmt.Errorf("fetching: %w", plain)
-		if got := redactTransportError(wrapped); got != wrapped { //nolint:errorlint // identity is the point
+		if got := redactTransportError(wrapped, ""); got != wrapped { //nolint:errorlint // identity is the point
 			t.Errorf("got %v, want the same error", got)
 		}
 	})
 
 	t.Run("projects an unparsable URL to a fixed token", func(t *testing.T) {
 		bad := &url.Error{Op: "Get", URL: "http://[::1/x?sig=SECRETVALUE", Err: context.Canceled}
-		got := redactTransportError(bad)
+		got := redactTransportError(bad, "")
 		if strings.Contains(got.Error(), "SECRETVALUE") || !strings.Contains(got.Error(), `"unparsable"`) {
 			t.Errorf("got %q", got.Error())
 		}

--- a/go/pkg/hey/transport_error_test.go
+++ b/go/pkg/hey/transport_error_test.go
@@ -72,18 +72,18 @@ func TestAttachmentsUploadTransportErrorRendersNoSignedURL(t *testing.T) {
 			t.Errorf("the signed query leaked into %q", text)
 		}
 	}
-	if !strings.Contains(sdkErr.Hint, `"http://127.0.0.1:1/blob"`) {
+	if !strings.Contains(sdkErr.Hint, `"http://127.0.0.1:1"`) {
 		t.Errorf("hint should keep the URL's scheme, host and path, got %q", sdkErr.Hint)
 	}
 	var urlErr *url.Error
-	if !errors.As(err, &urlErr) || urlErr.URL != "http://127.0.0.1:1/blob" {
+	if !errors.As(err, &urlErr) || urlErr.URL != "http://127.0.0.1:1" {
 		t.Errorf("the cause chain should still classify as the projected *url.Error, got %v", err)
 	}
 
 	if len(hooks.infos) != 2 || len(hooks.results) != 2 {
 		t.Fatalf("expected the API request and the storage request in the hooks, got %d starts, %d ends", len(hooks.infos), len(hooks.results))
 	}
-	if storage := hooks.infos[1]; storage.Method != http.MethodPut || storage.URL != "http://127.0.0.1:1/blob" {
+	if storage := hooks.infos[1]; storage.Method != http.MethodPut || storage.URL != "http://127.0.0.1:1" {
 		t.Errorf("storage request reached the hooks as %s %q, want the projected URL", storage.Method, storage.URL)
 	}
 	if api := hooks.infos[0]; !strings.HasPrefix(api.URL, server.URL+"/") {
@@ -147,7 +147,7 @@ func TestAttachmentsUploadCustomTransportErrorRendersNoSignedURL(t *testing.T) {
 			t.Errorf("the signed query leaked into a hook result: %q", text)
 		}
 	}
-	if !strings.Contains(hooks.results[1].Error.Error(), `"http://127.0.0.1:1/blob"`) {
+	if !strings.Contains(hooks.results[1].Error.Error(), `"http://127.0.0.1:1"`) {
 		t.Errorf("hook result should keep the URL's scheme, host and path, got %q", hooks.results[1].Error.Error())
 	}
 }
@@ -187,7 +187,7 @@ func TestBlobDownloadRedirectReachesHooksProjected(t *testing.T) {
 			if len(hooks.infos) != 2 {
 				t.Fatalf("expected the HEY hop and the storage hop in the hooks, got %+v", hooks.infos)
 			}
-			if got := hooks.infos[1].URL; got != target.URL+"/signed-download" {
+			if got := hooks.infos[1].URL; got != target.URL {
 				t.Errorf("storage hop reached the hooks as %q, want the projected URL", got)
 			}
 			for _, info := range hooks.infos {
@@ -216,7 +216,7 @@ func TestBlobDownloadRetryHookSeesProjectedURL(t *testing.T) {
 	if len(hooks.retries) != 1 {
 		t.Fatalf("expected one retry, got %+v", hooks.retries)
 	}
-	if got := hooks.retries[0].info.URL; got != server.URL+"/blob" {
+	if got := hooks.retries[0].info.URL; got != server.URL {
 		t.Errorf("retry hook saw %q, want the projected URL", got)
 	}
 	for _, start := range hooks.starts {
@@ -231,7 +231,7 @@ func TestRedactTransportError(t *testing.T) {
 
 	t.Run("projects the URL of a bare transport error and keeps its classification", func(t *testing.T) {
 		got := redactTransportError(signed, "")
-		want := `Get "https://storage.example.com/blob/1": context canceled`
+		want := `Get "https://storage.example.com": context canceled`
 		if got.Error() != want {
 			t.Errorf("got %q, want %q", got.Error(), want)
 		}
@@ -247,11 +247,11 @@ func TestRedactTransportError(t *testing.T) {
 			"opaque":           &opaqueWrapperError{cause: signed},
 		} {
 			got := redactTransportError(wrapped, "")
-			if want := `Get "https://storage.example.com/blob/1": context canceled`; got.Error() != want {
+			if want := `Get "https://storage.example.com": context canceled`; got.Error() != want {
 				t.Errorf("%s: got %q, want %q", name, got.Error(), want)
 			}
 			var urlErr *url.Error
-			if !errors.As(got, &urlErr) || urlErr.URL != "https://storage.example.com/blob/1" {
+			if !errors.As(got, &urlErr) || urlErr.URL != "https://storage.example.com" {
 				t.Errorf("%s: should unwrap to the projected *url.Error, got %v", name, got)
 			}
 			if !errors.Is(got, context.Canceled) {
@@ -263,7 +263,7 @@ func TestRedactTransportError(t *testing.T) {
 	t.Run("keeps only the classification beneath a projected URL", func(t *testing.T) {
 		opaque := &url.Error{Op: "Put", URL: "https://storage.example.com/blob/1?sig=SECRETVALUE", Err: timeoutError{}}
 		got := redactTransportError(opaque, "")
-		if want := `Put "https://storage.example.com/blob/1": transport timeout`; got.Error() != want {
+		if want := `Put "https://storage.example.com": transport timeout`; got.Error() != want {
 			t.Errorf("got %q, want %q", got.Error(), want)
 		}
 		for _, text := range renderings(got) {
@@ -276,7 +276,7 @@ func TestRedactTransportError(t *testing.T) {
 			t.Errorf("the timeout classification should survive, got %v", got)
 		}
 		plain := redactTransportError(&url.Error{Op: "Put", URL: "https://storage.example.com/blob/1?sig=SECRETVALUE", Err: errors.New("connection refused")}, "")
-		if want := `Put "https://storage.example.com/blob/1": transport failure`; plain.Error() != want {
+		if want := `Put "https://storage.example.com": transport failure`; plain.Error() != want {
 			t.Errorf("got %q, want %q", plain.Error(), want)
 		}
 		if !errors.As(plain, &netErr) || netErr.Timeout() {
@@ -287,7 +287,7 @@ func TestRedactTransportError(t *testing.T) {
 	t.Run("projects every transport error in a nested chain", func(t *testing.T) {
 		outer := &url.Error{Op: "Get", URL: "https://proxy.example.com/relay", Err: signed}
 		got := redactTransportError(outer, "")
-		want := `Get "https://proxy.example.com/relay": Get "https://storage.example.com/blob/1": context canceled`
+		want := `Get "https://proxy.example.com": context canceled`
 		if got.Error() != want {
 			t.Errorf("got %q, want %q", got.Error(), want)
 		}
@@ -304,7 +304,7 @@ func TestRedactTransportError(t *testing.T) {
 	t.Run("projects every member of a joined error and keeps the rest", func(t *testing.T) {
 		other := &url.Error{Op: "Get", URL: "https://other.example.com/x?token=SECRETVALUE", Err: errors.New("reset")}
 		got := redactTransportError(errors.Join(signed, context.DeadlineExceeded, other), "")
-		want := "Get \"https://storage.example.com/blob/1\": context canceled\ncontext deadline exceeded\nGet \"https://other.example.com/x\": transport failure"
+		want := "Get \"https://storage.example.com\": context canceled\ncontext deadline exceeded\nGet \"https://other.example.com\": transport failure"
 		if got.Error() != want {
 			t.Errorf("got %q, want %q", got.Error(), want)
 		}
@@ -322,7 +322,7 @@ func TestRedactTransportError(t *testing.T) {
 		const signedURL = "https://storage.example.com/blob/1?sig=SECRETVALUE"
 		cancelledTimeout := &url.Error{Op: "fetch " + signedURL, URL: signedURL, Err: cancelledTimeoutError{}}
 		got := redactTransportError(cancelledTimeout, "")
-		if want := `Request "https://storage.example.com/blob/1": context canceled`; got.Error() != want {
+		if want := `Request "https://storage.example.com": context canceled`; got.Error() != want {
 			t.Errorf("got %q, want %q", got.Error(), want)
 		}
 		for _, text := range renderings(got) {
@@ -336,7 +336,7 @@ func TestRedactTransportError(t *testing.T) {
 		}
 
 		joined := redactTransportError(errors.Join(signed, fmt.Errorf("request %s failed", signedURL), context.DeadlineExceeded), "")
-		if want := "Get \"https://storage.example.com/blob/1\": context canceled\ncontext deadline exceeded"; joined.Error() != want {
+		if want := "Get \"https://storage.example.com\": context canceled\ncontext deadline exceeded"; joined.Error() != want {
 			t.Errorf("got %q, want %q", joined.Error(), want)
 		}
 		if !errors.Is(joined, context.Canceled) || !errors.Is(joined, context.DeadlineExceeded) {
@@ -351,26 +351,41 @@ func TestRedactTransportError(t *testing.T) {
 			t.Errorf("got %q, want %q", got.Error(), want)
 		}
 		off := redactTransportError(api, "https://other.example.com")
-		if want := `Get "https://api.example.com/boxes": transport failure`; off.Error() != want {
+		if want := `Get "https://api.example.com": transport failure`; off.Error() != want {
 			t.Errorf("got %q, want %q", off.Error(), want)
+		}
+		withUser := &url.Error{Op: "Get", URL: "https://user:SECRETVALUE@api.example.com/x", Err: errors.New("request https://user:SECRETVALUE@api.example.com/x failed")}
+		got = redactTransportError(withUser, "https://api.example.com")
+		if want := `Get "https://api.example.com": transport failure`; got.Error() != want {
+			t.Errorf("userinfo on the API origin is not trusted: got %q, want %q", got.Error(), want)
+		}
+		ancestor := &url.Error{Op: "relay of https://storage.example.com/blob?sig=SECRETVALUE", URL: "https://api.example.com/relay", Err: signed}
+		got = redactTransportError(ancestor, "https://api.example.com")
+		if want := `Request "https://api.example.com/relay": Get "https://storage.example.com": context canceled`; got.Error() != want {
+			t.Errorf("an ancestor keeps only the Op token: got %q, want %q", got.Error(), want)
+		}
+		both := &url.Error{Op: "Get", URL: "https://storage.example.com/blob?sig=SECRETVALUE", Err: errors.Join(context.Canceled, context.DeadlineExceeded)}
+		got = redactTransportError(both, "")
+		if !errors.Is(got, context.Canceled) || !errors.Is(got, context.DeadlineExceeded) {
+			t.Errorf("both sentinels beneath a projected URL should survive, got %v", got)
 		}
 	})
 
 	t.Run("returns an error with nothing to drop unchanged", func(t *testing.T) {
 		plain := &url.Error{Op: "Get", URL: "https://api.example.com/x", Err: context.Canceled}
-		if got := redactTransportError(plain, ""); got != plain { //nolint:errorlint // identity is the point
+		if got := redactTransportError(plain, "https://api.example.com"); got != plain { //nolint:errorlint // identity is the point
 			t.Errorf("got %v, want the same error", got)
 		}
 		other := errors.New("not a transport error")
 		if got := redactTransportError(other, ""); got != other { //nolint:errorlint // identity is the point
 			t.Errorf("got %v, want the same error", got)
 		}
-		nested := &url.Error{Op: "Get", URL: "https://proxy.example.com/relay", Err: plain}
-		if got := redactTransportError(nested, ""); got != nested { //nolint:errorlint // identity is the point
+		nested := &url.Error{Op: "Get", URL: "https://api.example.com/relay", Err: plain}
+		if got := redactTransportError(nested, "https://api.example.com"); got != nested { //nolint:errorlint // identity is the point
 			t.Errorf("got %v, want the same error", got)
 		}
 		wrapped := fmt.Errorf("fetching: %w", plain)
-		if got := redactTransportError(wrapped, ""); got != wrapped { //nolint:errorlint // identity is the point
+		if got := redactTransportError(wrapped, "https://api.example.com"); got != wrapped { //nolint:errorlint // identity is the point
 			t.Errorf("got %v, want the same error", got)
 		}
 	})

--- a/go/pkg/hey/transport_error_test.go
+++ b/go/pkg/hey/transport_error_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -231,6 +232,30 @@ func TestRedactTransportError(t *testing.T) {
 		}
 	})
 
+	t.Run("keeps only the classification beneath a projected URL", func(t *testing.T) {
+		opaque := &url.Error{Op: "Put", URL: "https://storage.example.com/blob/1?sig=SECRETVALUE", Err: timeoutError{}}
+		got := redactTransportError(opaque)
+		if want := `Put "https://storage.example.com/blob/1": transport timeout`; got.Error() != want {
+			t.Errorf("got %q, want %q", got.Error(), want)
+		}
+		for _, text := range renderings(got) {
+			if strings.Contains(text, "SECRETVALUE") {
+				t.Errorf("the signed query leaked into %q", text)
+			}
+		}
+		var netErr net.Error
+		if !errors.As(got, &netErr) || !netErr.Timeout() {
+			t.Errorf("the timeout classification should survive, got %v", got)
+		}
+		plain := redactTransportError(&url.Error{Op: "Put", URL: "https://storage.example.com/blob/1?sig=SECRETVALUE", Err: errors.New("connection refused")})
+		if want := `Put "https://storage.example.com/blob/1": transport failure`; plain.Error() != want {
+			t.Errorf("got %q, want %q", plain.Error(), want)
+		}
+		if !errors.As(plain, &netErr) || netErr.Timeout() {
+			t.Errorf("a refused connection should not classify as a timeout, got %v", plain)
+		}
+	})
+
 	t.Run("projects every transport error in a nested chain", func(t *testing.T) {
 		outer := &url.Error{Op: "Get", URL: "https://proxy.example.com/relay", Err: signed}
 		got := redactTransportError(outer)
@@ -251,7 +276,7 @@ func TestRedactTransportError(t *testing.T) {
 	t.Run("projects every member of a joined error and keeps the rest", func(t *testing.T) {
 		other := &url.Error{Op: "Get", URL: "https://other.example.com/x?token=SECRETVALUE", Err: errors.New("reset")}
 		got := redactTransportError(errors.Join(signed, context.DeadlineExceeded, other))
-		want := "Get \"https://storage.example.com/blob/1\": context canceled\ncontext deadline exceeded\nGet \"https://other.example.com/x\": reset"
+		want := "Get \"https://storage.example.com/blob/1\": context canceled\ncontext deadline exceeded\nGet \"https://other.example.com/x\": transport failure"
 		if got.Error() != want {
 			t.Errorf("got %q, want %q", got.Error(), want)
 		}
@@ -302,6 +327,16 @@ func TestAsErrorRendersNoSignedQuery(t *testing.T) {
 		}
 	}
 }
+
+// timeoutError is a custom transport's failure: it classifies as a timeout and, being
+// text this package did not build, renders the request URL on its own.
+type timeoutError struct{}
+
+func (timeoutError) Error() string {
+	return "request https://storage.example.com/blob/1?sig=SECRETVALUE failed: i/o timeout"
+}
+func (timeoutError) Timeout() bool   { return true }
+func (timeoutError) Temporary() bool { return true }
 
 // opaqueWrapperError wraps an error without rendering it.
 type opaqueWrapperError struct{ cause error }

--- a/go/pkg/hey/transport_error_test.go
+++ b/go/pkg/hey/transport_error_test.go
@@ -211,25 +211,23 @@ func TestRedactTransportError(t *testing.T) {
 		}
 	})
 
-	t.Run("keeps a wrapper's text around the projection", func(t *testing.T) {
-		got := redactTransportError(fmt.Errorf("fetching the blob: %w", signed))
-		want := `fetching the blob: Get "https://storage.example.com/blob/1": context canceled`
-		if got.Error() != want {
-			t.Errorf("got %q, want %q", got.Error(), want)
-		}
-		var urlErr *url.Error
-		if !errors.As(got, &urlErr) || urlErr.URL != "https://storage.example.com/blob/1" {
-			t.Errorf("should unwrap to the projected *url.Error, got %v", got)
-		}
-		if !errors.Is(got, context.Canceled) {
-			t.Error("the cause chain should still reach the context sentinel")
-		}
-	})
-
-	t.Run("keeps only the transport error when a wrapper hides the URL", func(t *testing.T) {
-		got := redactTransportError(&opaqueWrapperError{cause: signed})
-		if got.Error() != `Get "https://storage.example.com/blob/1": context canceled` {
-			t.Errorf("got %q", got.Error())
+	t.Run("drops a wrapper around the projection, whatever its text carried", func(t *testing.T) {
+		for name, wrapped := range map[string]error{
+			"prefix":           fmt.Errorf("fetching the blob: %w", signed),
+			"interpolated URL": fmt.Errorf("request %s failed: %w", signed.URL, signed),
+			"opaque":           &opaqueWrapperError{cause: signed},
+		} {
+			got := redactTransportError(wrapped)
+			if want := `Get "https://storage.example.com/blob/1": context canceled`; got.Error() != want {
+				t.Errorf("%s: got %q, want %q", name, got.Error(), want)
+			}
+			var urlErr *url.Error
+			if !errors.As(got, &urlErr) || urlErr.URL != "https://storage.example.com/blob/1" {
+				t.Errorf("%s: should unwrap to the projected *url.Error, got %v", name, got)
+			}
+			if !errors.Is(got, context.Canceled) {
+				t.Errorf("%s: the cause chain should still reach the context sentinel", name)
+			}
 		}
 	})
 
@@ -245,9 +243,8 @@ func TestRedactTransportError(t *testing.T) {
 				t.Errorf("the signed query leaked into %q", text)
 			}
 		}
-		got = redactTransportError(fmt.Errorf("relaying: %w", outer))
-		if got.Error() != "relaying: "+want {
-			t.Errorf("got %q, want %q", got.Error(), "relaying: "+want)
+		if got = redactTransportError(fmt.Errorf("relaying to %s: %w", outer.URL, outer)); got.Error() != want {
+			t.Errorf("got %q, want %q", got.Error(), want)
 		}
 	})
 
@@ -279,6 +276,10 @@ func TestRedactTransportError(t *testing.T) {
 		}
 		nested := &url.Error{Op: "Get", URL: "https://proxy.example.com/relay", Err: plain}
 		if got := redactTransportError(nested); got != nested { //nolint:errorlint // identity is the point
+			t.Errorf("got %v, want the same error", got)
+		}
+		wrapped := fmt.Errorf("fetching: %w", plain)
+		if got := redactTransportError(wrapped); got != wrapped { //nolint:errorlint // identity is the point
 			t.Errorf("got %v, want the same error", got)
 		}
 	})

--- a/go/pkg/hey/transport_error_test.go
+++ b/go/pkg/hey/transport_error_test.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 )
 
 // renderings is every text a caller or a logger can get out of err: its Error, its
@@ -198,6 +199,33 @@ func TestBlobDownloadRedirectReachesHooksProjected(t *testing.T) {
 	}
 }
 
+// TestBlobDownloadRetryHookSeesProjectedURL retries a blob download whose own URL
+// carries a query and checks OnRetry sees it as the request hooks do.
+func TestBlobDownloadRetryHookSeesProjectedURL(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(server.Close)
+	hooks := &retryRecordingHooks{}
+	client := NewClient(&Config{BaseURL: server.URL}, &StaticTokenProvider{Token: "test-token"},
+		WithMaxRetries(1), WithBaseDelay(time.Millisecond), WithMaxJitter(time.Millisecond), WithHooks(hooks))
+
+	if _, err := client.GetBlob(context.Background(), "/blob?signature=SECRETVALUE"); err == nil {
+		t.Fatal("expected the 503 to surface")
+	}
+	if len(hooks.retries) != 1 {
+		t.Fatalf("expected one retry, got %+v", hooks.retries)
+	}
+	if got := hooks.retries[0].info.URL; got != server.URL+"/blob" {
+		t.Errorf("retry hook saw %q, want the projected URL", got)
+	}
+	for _, start := range hooks.starts {
+		if strings.Contains(start.URL, "SECRETVALUE") {
+			t.Errorf("the signed query leaked into a request hook argument: %q", start.URL)
+		}
+	}
+}
+
 func TestRedactTransportError(t *testing.T) {
 	signed := &url.Error{Op: "Get", URL: "https://user:pw@storage.example.com/blob/1?sig=SECRETVALUE#frag", Err: context.Canceled}
 
@@ -290,6 +318,32 @@ func TestRedactTransportError(t *testing.T) {
 		}
 	})
 
+	t.Run("builds a projected transport error from fixed parts alone", func(t *testing.T) {
+		const signedURL = "https://storage.example.com/blob/1?sig=SECRETVALUE"
+		cancelledTimeout := &url.Error{Op: "fetch " + signedURL, URL: signedURL, Err: cancelledTimeoutError{}}
+		got := redactTransportError(cancelledTimeout, "")
+		if want := `Request "https://storage.example.com/blob/1": context canceled`; got.Error() != want {
+			t.Errorf("got %q, want %q", got.Error(), want)
+		}
+		for _, text := range renderings(got) {
+			if strings.Contains(text, "SECRETVALUE") {
+				t.Errorf("the signed query leaked into %q", text)
+			}
+		}
+		var netErr net.Error
+		if !errors.Is(got, context.Canceled) || !errors.As(got, &netErr) || !netErr.Timeout() {
+			t.Errorf("the cancellation and the timeout classification should both survive, got %v", got)
+		}
+
+		joined := redactTransportError(errors.Join(signed, fmt.Errorf("request %s failed", signedURL), context.DeadlineExceeded), "")
+		if want := "Get \"https://storage.example.com/blob/1\": context canceled\ncontext deadline exceeded"; joined.Error() != want {
+			t.Errorf("got %q, want %q", joined.Error(), want)
+		}
+		if !errors.Is(joined, context.Canceled) || !errors.Is(joined, context.DeadlineExceeded) {
+			t.Error("the sentinel siblings should still be reachable through the chain")
+		}
+	})
+
 	t.Run("keeps the cause beneath a URL on the API origin", func(t *testing.T) {
 		api := &url.Error{Op: "Get", URL: "https://api.example.com/boxes?page=2", Err: errors.New("connection refused")}
 		got := redactTransportError(api, "https://api.example.com")
@@ -349,6 +403,15 @@ func (timeoutError) Error() string {
 }
 func (timeoutError) Timeout() bool   { return true }
 func (timeoutError) Temporary() bool { return true }
+
+// cancelledTimeoutError is a custom transport's failure that wraps a cancellation and
+// classifies as a timeout at once.
+type cancelledTimeoutError struct{}
+
+func (cancelledTimeoutError) Error() string   { return "cancelled: " + context.Canceled.Error() }
+func (cancelledTimeoutError) Unwrap() error   { return context.Canceled }
+func (cancelledTimeoutError) Timeout() bool   { return true }
+func (cancelledTimeoutError) Temporary() bool { return false }
 
 // opaqueWrapperError wraps an error without rendering it.
 type opaqueWrapperError struct{ cause error }

--- a/go/pkg/hey/transport_error_test.go
+++ b/go/pkg/hey/transport_error_test.go
@@ -28,10 +28,14 @@ type requestRecordingHooks struct {
 	NoopHooks
 	infos   []RequestInfo
 	results []RequestResult
+	fresh   bool // hand back a context of the hook's own, not derived from the request's
 }
 
 func (h *requestRecordingHooks) OnRequestStart(ctx context.Context, info RequestInfo) context.Context {
 	h.infos = append(h.infos, info)
+	if h.fresh {
+		return context.Background()
+	}
 	return ctx
 }
 
@@ -99,10 +103,16 @@ func TestAttachmentsUploadTransportErrorRendersNoSignedURL(t *testing.T) {
 // leakyStorageTransport is a custom transport that reports the storage request's
 // failure the way a transport built on another http.Client would: as a *url.Error of
 // its own, rendering the whole URL.
-type leakyStorageTransport struct{ inner http.RoundTripper }
+type leakyStorageTransport struct {
+	inner http.RoundTripper
+	plain bool // report a plain error interpolating the URL rather than a *url.Error
+}
 
 func (t *leakyStorageTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	if req.Method == http.MethodPut {
+		if t.plain {
+			return nil, fmt.Errorf("PUT %s failed", req.URL)
+		}
 		return nil, &url.Error{Op: "Put", URL: req.URL.String(), Err: errors.New("connection refused")}
 	}
 	return t.inner.RoundTrip(req)
@@ -112,6 +122,12 @@ func (t *leakyStorageTransport) RoundTrip(req *http.Request) (*http.Response, er
 // custom transport whose own error carries the signed URL: the hook result and the
 // SDK error are projected all the same.
 func TestAttachmentsUploadCustomTransportErrorRendersNoSignedURL(t *testing.T) {
+	for name, plain := range map[string]bool{"url.Error": false, "plain error": true} {
+		t.Run(name, func(t *testing.T) { testAttachmentsUploadCustomTransportError(t, plain) })
+	}
+}
+
+func testAttachmentsUploadCustomTransportError(t *testing.T, plain bool) {
 	const signedURL = "http://127.0.0.1:1/blob?signature=SECRETVALUE"
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -124,7 +140,7 @@ func TestAttachmentsUploadCustomTransportErrorRendersNoSignedURL(t *testing.T) {
 	t.Cleanup(server.Close)
 	hooks := &requestRecordingHooks{}
 	client := NewClient(&Config{BaseURL: server.URL}, &StaticTokenProvider{Token: "test-token"},
-		WithMaxRetries(0), WithHooks(hooks), WithTransport(&leakyStorageTransport{inner: http.DefaultTransport}))
+		WithMaxRetries(0), WithHooks(hooks), WithTransport(&leakyStorageTransport{inner: http.DefaultTransport, plain: plain}))
 
 	_, err := client.Attachments().Upload(context.Background(), "note.txt", "text/plain", strings.NewReader("contents"))
 	if err == nil {
@@ -147,8 +163,8 @@ func TestAttachmentsUploadCustomTransportErrorRendersNoSignedURL(t *testing.T) {
 			t.Errorf("the signed query leaked into a hook result: %q", text)
 		}
 	}
-	if !strings.Contains(hooks.results[1].Error.Error(), `"http://127.0.0.1:1"`) {
-		t.Errorf("hook result should keep the URL's scheme, host and path, got %q", hooks.results[1].Error.Error())
+	if got := hooks.results[1].Error.Error(); got != "transport failure" {
+		t.Errorf("hook result should be the failure's classification alone, got %q", got)
 	}
 }
 
@@ -176,6 +192,12 @@ func TestBlobDownloadRedirectReachesHooksProjected(t *testing.T) {
 		},
 		"DownloadBlob": func() error {
 			_, _, err := client.DownloadBlob(context.Background(), "/blob", io.Discard)
+			return err
+		},
+		"GetBlob under a hook returning its own context": func() error {
+			hooks.fresh = true
+			defer func() { hooks.fresh = false }()
+			_, err := client.GetBlob(context.Background(), "/blob")
 			return err
 		},
 	} {
@@ -344,6 +366,23 @@ func TestRedactTransportError(t *testing.T) {
 		}
 	})
 
+	t.Run("keeps a dropped sibling's classification and an exposed transport error", func(t *testing.T) {
+		joined := redactTransportError(errors.Join(timeoutError{}, signed), "")
+		var netErr net.Error
+		if !errors.As(joined, &netErr) || !netErr.Timeout() {
+			t.Errorf("a dropped net.Error sibling should leave its classification, got %v", joined)
+		}
+		for _, text := range renderings(joined) {
+			if strings.Contains(text, "SECRETVALUE") {
+				t.Errorf("the signed query leaked into %q", text)
+			}
+		}
+		exposed := redactTransportError(&asOnlyError{target: signed}, "")
+		if want := `Get "https://storage.example.com": context canceled`; exposed.Error() != want {
+			t.Errorf("got %q, want %q", exposed.Error(), want)
+		}
+	})
+
 	t.Run("keeps the cause beneath a URL on the API origin", func(t *testing.T) {
 		api := &url.Error{Op: "Get", URL: "https://api.example.com/boxes?page=2", Err: errors.New("connection refused")}
 		got := redactTransportError(api, "https://api.example.com")
@@ -427,6 +466,20 @@ func (cancelledTimeoutError) Error() string   { return "cancelled: " + context.C
 func (cancelledTimeoutError) Unwrap() error   { return context.Canceled }
 func (cancelledTimeoutError) Timeout() bool   { return true }
 func (cancelledTimeoutError) Temporary() bool { return false }
+
+// asOnlyError exposes a *url.Error through As alone, with no Unwrap, and renders the
+// signed URL on its own.
+type asOnlyError struct{ target *url.Error }
+
+func (e *asOnlyError) Error() string { return "request " + e.target.URL + " failed" }
+
+func (e *asOnlyError) As(target any) bool {
+	if p, ok := target.(**url.Error); ok {
+		*p = e.target
+		return true
+	}
+	return false
+}
 
 // opaqueWrapperError wraps an error without rendering it.
 type opaqueWrapperError struct{ cause error }

--- a/go/pkg/hey/transport_error_test.go
+++ b/go/pkg/hey/transport_error_test.go
@@ -93,6 +93,62 @@ func TestAttachmentsUploadTransportErrorRendersNoSignedURL(t *testing.T) {
 	}
 }
 
+// leakyStorageTransport is a custom transport that reports the storage request's
+// failure the way a transport built on another http.Client would: as a *url.Error of
+// its own, rendering the whole URL.
+type leakyStorageTransport struct{ inner http.RoundTripper }
+
+func (t *leakyStorageTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.Method == http.MethodPut {
+		return nil, &url.Error{Op: "Put", URL: req.URL.String(), Err: errors.New("connection refused")}
+	}
+	return t.inner.RoundTrip(req)
+}
+
+// TestAttachmentsUploadCustomTransportErrorRendersNoSignedURL is the same check with a
+// custom transport whose own error carries the signed URL: the hook result and the
+// SDK error are projected all the same.
+func TestAttachmentsUploadCustomTransportErrorRendersNoSignedURL(t *testing.T) {
+	const signedURL = "http://127.0.0.1:1/blob?signature=SECRETVALUE"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"signed_id":"signed-123",
+			"attachable_sgid":"sgid-456",
+			"direct_upload":{"url":"` + signedURL + `","headers":{"Content-Type":"text/plain"}}
+		}`))
+	}))
+	t.Cleanup(server.Close)
+	hooks := &requestRecordingHooks{}
+	client := NewClient(&Config{BaseURL: server.URL}, &StaticTokenProvider{Token: "test-token"},
+		WithMaxRetries(0), WithHooks(hooks), WithTransport(&leakyStorageTransport{inner: http.DefaultTransport}))
+
+	_, err := client.Attachments().Upload(context.Background(), "note.txt", "text/plain", strings.NewReader("contents"))
+	if err == nil {
+		t.Fatal("expected a network error")
+	}
+	var sdkErr *Error
+	if !errors.As(err, &sdkErr) || sdkErr.Code != CodeNetwork {
+		t.Fatalf("expected a network *Error, got %T: %v", err, err)
+	}
+	for _, text := range append(renderings(err), sdkErr.Hint) {
+		if strings.Contains(text, "SECRETVALUE") {
+			t.Errorf("the signed query leaked into %q", text)
+		}
+	}
+	if len(hooks.results) != 2 || hooks.results[1].Error == nil {
+		t.Fatalf("expected the storage request's failure in the hooks, got %+v", hooks.results)
+	}
+	for _, text := range renderings(hooks.results[1].Error) {
+		if strings.Contains(text, "SECRETVALUE") {
+			t.Errorf("the signed query leaked into a hook result: %q", text)
+		}
+	}
+	if !strings.Contains(hooks.results[1].Error.Error(), `"http://127.0.0.1:1/blob"`) {
+		t.Errorf("hook result should keep the URL's scheme, host and path, got %q", hooks.results[1].Error.Error())
+	}
+}
+
 func TestRedactTransportError(t *testing.T) {
 	signed := &url.Error{Op: "Get", URL: "https://user:pw@storage.example.com/blob/1?sig=SECRETVALUE#frag", Err: context.Canceled}
 
@@ -147,11 +203,15 @@ func TestRedactTransportError(t *testing.T) {
 		}
 	})
 
-	t.Run("keeps only the first transport error of a joined pair", func(t *testing.T) {
+	t.Run("projects every member of a joined error and keeps the rest", func(t *testing.T) {
 		other := &url.Error{Op: "Get", URL: "https://other.example.com/x?token=SECRETVALUE", Err: errors.New("reset")}
-		got := redactTransportError(errors.Join(signed, other))
-		if got.Error() != `Get "https://storage.example.com/blob/1": context canceled` {
-			t.Errorf("got %q", got.Error())
+		got := redactTransportError(errors.Join(signed, context.DeadlineExceeded, other))
+		want := "Get \"https://storage.example.com/blob/1\": context canceled\ncontext deadline exceeded\nGet \"https://other.example.com/x\": reset"
+		if got.Error() != want {
+			t.Errorf("got %q, want %q", got.Error(), want)
+		}
+		if !errors.Is(got, context.Canceled) || !errors.Is(got, context.DeadlineExceeded) {
+			t.Error("every member should still be reachable through the chain")
 		}
 		for _, text := range renderings(got) {
 			if strings.Contains(text, "SECRETVALUE") {


### PR DESCRIPTION
The Go side of the fix that strips the URL from the Rust SDKs' reqwest errors (fizzy-sdk#174, basecamp-sdk#869).

**The leak.** net/http reports every transport failure as a `*url.Error`, and `url.Error.Error()` renders the whole request URL (`Put "https://…/blob?signature=…": dial tcp …`). `ErrNetwork` copied that rendering into `Hint` and chained the error as `Cause`, so a refused connection, timeout or TLS failure on the one request the SDK issues to a signed URL — the attachment upload's PUT to the Active Storage direct-upload URL, where the query is the credential — put the signature into the SDK error's `Error()`, `%+v`, hint and cause chain: everywhere the error gets logged. The same request reached the request hooks with the signed URL whole in `RequestInfo.URL`, on success as much as on failure.

**The fix.** One helper, `redactTransportError` in `security.go` next to `RedactHeaders`, projects every `*url.Error`'s URL before any text is built, and keeps a projected `*url.Error` in the chain so `errors.Is` (context sentinels) and `errors.As` (`*url.Error`, `net.Error`) classify the failure as before. On the API origin the projection is scheme, host and path (the query dropped); anywhere else it is the origin alone, because a storage service can sign the query or the path — Active Storage's disk service, in this repo's route snapshot, puts its token in the path — which follows basecamp-sdk SPEC §9's "credential-bearing URL is rendered as its origin only" rather than this card's keep-the-path default, this repo having no spec of its own to say otherwise. The projection rebuilds the whole error tree. Every `*url.Error` has its URL projected. A URL on the SDK's own API origin carrying no userinfo is trusted — the SDK's request paths build their network error as `networkError(err, c.cfg.BaseURL)` — and beneath it the cause is kept, projected in turn: those URLs carry no credential (the token rides in the `Authorization` header; the query is paging and filtering) and the transport's diagnostic is what a reader needs. A `*url.Error` anywhere else — the storage host, a redirect's target, an API-origin URL with userinfo — is built from parts this package chose: `Op` kept only as the method token net/http writes there (else the fixed `Request`, on an ancestor of a projected one too), the URL as its origin, and in place of the cause a `transportFailureError` carrying the `net.Error` flags the transport error delegated and unwrapping to the context sentinels it wrapped (one or both), so `errors.Is` still sees a cancellation or a deadline. Whatever a transport put in those fields is text this package did not build and cannot show free of the URL; a join beside a projected member keeps its projected members and, of a dropped sibling, only its classification; an error exposing a `*url.Error` through `As` alone is replaced by that transport error projected. A request the hooks see projected trusts no origin at all (`c.trustedOrigin(ctx)`): a blob download's redirect can land on a signed URL of HEY's own origin, and its retry hook sees the same projection the request hooks do. Exported `ErrNetwork` has no origin to trust and treats every URL as one that can be signed, which is what `Attachments.Upload` and the hook result on a marked request use. A `*url.Error` with nothing to drop keeps its cause, projected in turn (a transport built on another `http.Client` nests one inside another), a multi-error as `errors.Join` of its projected members, and a wrapper dropped in favour of the projected cause (its text can carry the URL on its own, in any spelling — no SDK-owned site wraps the transport error before `ErrNetwork`, so the text lost is a custom transport's own prefix). An error with nothing to drop is returned unchanged, at every level. Sites: `ErrNetwork` (every transport-failure site funnels through it: `singleRequest`, `doFormRequest`, `retryCause` for the generated client's resends, the token refresh in `auth.go`, and `Attachments.Upload`) and `AsError` (a raw transport error handed to it took the same text into `Message`).

The hooks get the same projection on the requests whose URL can be signed: `Attachments.Upload` marks the storage PUT's context, `GetBlob` and `DownloadBlob` mark theirs, and so does `doRequest` for a caller's absolute URL (the SDK's one way to reach a URL it did not build) (HEY answers them with a redirect to a signed storage URL, which net/http follows on the same context, so the storage hop reached the hooks with the signature whole on every successful download), and `loggingTransport` hands `RequestInfo.URL` the origin alone for every hop of a marked request and `RequestResult.Error` the failure's classification alone (a custom `WithTransport` can report a `*url.Error` of its own, or a plain error interpolating the URL). The mark survives a hook that hands back a context of its own, so the redirect net/http derives from the request keeps it. API requests carry no credential in their URL (the token is in the `Authorization` header) and still reach the hooks whole, as `RequestInfo`'s doc now says. A signed storage path handed to a raw helper in relative form is the caller's own text and is not recognised: every signed URL HEY hands out is absolute, a relative blob path goes through `GetBlob`/`DownloadBlob`, which mark their own, and no fixed prefix covers HEY's credential-bearing routes; `markCallerURL`'s comment states that boundary. This is the shape basecamp-sdk's download hop 1 already has (basecamp-sdk#837).

**Review rounds.** Copilot and Codex found the nested `*url.Error` a custom transport produces (the projection now rebuilds the whole error tree: nested chains, `errors.Join` members, wrappers), the hook result on a custom transport, the blob-download redirect hop, and a wrapper interpolating the URL in its own prefix; on the fizzy side Codex then showed an opaque cause doing the same beneath the `*url.Error`, the point where searching text had to give way to keeping only the classification beneath a projected URL. All are fixed and tested here too. Declined: deriving the closed port from a freed ephemeral listener instead of port 1 (the freed port is what a parallel test's `httptest.NewServer` is handed next). A later round found the form helpers and `GetAll` taking a caller's absolute URL without the marker `Get` applies, `RequireSecureEndpoint` and `buildURL` rendering the rejected URL whole, and `ErrNotFound` naming a signed URL that answered 404; all fixed. Declined: replacing a custom transport's deferred body-read errors with their classification (net/http builds no `*url.Error` there; the default transport's read failures carry no URL, and the wrapper would drop the `unexpected EOF` a real truncated download reports), and looking for a custom `As` target on a type that also unwraps (the fall-through replaces a wrapper with nothing to drop by its trusted cause). The last round removed the relative-path prefix allowlist an earlier round had added, for the reason above, and bounded a caller URL's parse at `buildURL`, the one entry for a caller's string: a URL net/url rejects is rendered as the fixed token `invalid URL` there and in `RequireSecureEndpoint`, never as net/url's text, which quotes the input or the component it rejected, so `accountScopedURL` and `http.NewRequestWithContext` can no longer fail on a string `buildURL` returned.

**The test.** `TestAttachmentsUploadTransportErrorRendersNoSignedURL` serves a direct-upload URL of `http://127.0.0.1:1/blob?signature=SECRETVALUE` and runs `Attachments().Upload` through the shipped client, asserting `SECRETVALUE` is absent from `Error()`, `Hint`, `Message`, `%+v`, every link of the cause chain, `RequestInfo.URL` for the storage request and every `RequestResult.Error`; that the hint keeps `http://127.0.0.1:1`; that the chain still yields a `*url.Error` carrying the projection; and that the API request's URL still reaches the hooks whole. On `main` it fails with:

```
the signed query leaked into "Network error: Put \"http://127.0.0.1:1/blob?signature=SECRETVALUE\": dial tcp 127.0.0.1:1: connect: connection refused"
storage request reached the hooks as PUT "http://127.0.0.1:1/blob?signature=SECRETVALUE", want the projected URL
```

`TestRedactTransportError` covers the bare, wrapped, opaque-wrapper, nothing-to-drop and unparsable cases; `TestAsErrorRendersNoSignedQuery` covers `AsError`. `TestCallerAbsoluteURLReachesHooksProjected` and `TestCallerAbsoluteURLTransportErrorRendersNoSignedURL` run `Get`, `GetAll`, `PostForm` and `PostMultipart` with a signed URL on the API origin; `TestAttachmentsUploadInsecureTargetRendersNoSignedURL` and `TestCallerInsecureURLRendersNoSignedURL` cover the two rejections. `TestCallerMalformedURLRendersNoSignedValue` runs the same four methods with a bad escape and a signed value in the port position, on an unscoped and an account-scoped client, and `TestAttachmentsUploadMalformedTargetRendersNoSignedValue` covers the direct-upload URL: neither value appears in any rendering and no request reaches the hooks.

Gates run locally: `make go-check`, `make conformance-go` (195 passed).

Watching the review loop on this one through to convergence.


