### PR TITLE
Pin that a signed query never leaks from a transport error

### DIFF
--- a/rust/hey-sdk/tests/reqwest_client.rs
+++ b/rust/hey-sdk/tests/reqwest_client.rs
@@ -1,0 +1,74 @@
+//! The shipped [`ReqwestClient`] keeps a request's URL out of the error a transport failure
+//! becomes. reqwest writes the URL into its own error text, and a signed attachment or
+//! upload URL carries its credential in the query, so neither the hint nor the source
+//! chain may show it.
+
+#![cfg(feature = "reqwest")]
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::error::Error as _;
+use std::time::Duration;
+
+use bytes::Bytes;
+use hey_sdk::http::{HttpClient, Request, ReqwestClient};
+use hey_sdk::{Error, ErrorCode};
+use tokio::net::TcpListener;
+
+const SIGNATURE: &str = "sig-4f3c2a1b-never-logged";
+
+fn client() -> ReqwestClient {
+    ReqwestClient::with_timeout(Duration::from_secs(5)).unwrap()
+}
+
+fn signed_request(port: u16) -> Request<Bytes> {
+    Request::get(format!(
+        "http://127.0.0.1:{port}/storage/blob?signature={SIGNATURE}"
+    ))
+    .body(Bytes::new())
+    .unwrap()
+}
+
+/// Every rendering a caller or a log would see: the error itself, its hint and each link
+/// of its source chain, by `Display` and by `Debug`.
+fn renderings(error: &Error) -> Vec<String> {
+    let mut seen = vec![format!("{error}"), format!("{error:?}")];
+    seen.extend(error.hint().map(str::to_owned));
+    let mut source = error.source();
+    while let Some(cause) = source {
+        seen.push(format!("{cause}"));
+        seen.push(format!("{cause:?}"));
+        source = cause.source();
+    }
+    seen
+}
+
+fn assert_signature_withheld(error: &Error) {
+    assert_eq!(error.code(), ErrorCode::Network);
+    assert!(
+        error.source().is_some(),
+        "the transport failure is chained as the cause"
+    );
+    assert!(
+        error.hint().is_some_and(|hint| !hint.is_empty()),
+        "the failure is still described"
+    );
+    for text in renderings(error) {
+        assert!(
+            !text.contains(SIGNATURE),
+            "the signed query leaked into {text:?}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn a_refused_connection_withholds_the_signed_query() {
+    let port = TcpListener::bind("127.0.0.1:0")
+        .await
+        .unwrap()
+        .local_addr()
+        .unwrap()
+        .port();
+
+    let error = client().send(signed_request(port)).await.err().unwrap();
+    assert_signature_withheld(&error);
+}


### PR DESCRIPTION
Origin: Codex's review of basecamp/sdk#15 (fixed in the seed at basecamp/sdk@5c45cb3), which turned into fixes for basecamp-sdk (basecamp/basecamp-sdk#869) and fizzy-sdk (basecamp/fizzy-sdk#174). This crate already had the fix — `network()` in `src/http/reqwest.rs` calls `reqwest::Error::without_url()` before `Error::network` at all three conversion sites (#168) — but no test pinned it, so the strip could be lost in a refactor without anything noticing.

**What is pinned.** reqwest writes the request URL into its own error text (`error sending request for url (…)`) and `Debug`; `Error::network` copies that text into the hint and chains the reqwest error as the source. A signed attachment or upload URL carries its credential in the query, so without the strip a refused connection, timeout or TLS failure against one would put the signature into the SDK error's hint, `Display`, `Debug` and source chain: everywhere the error gets logged.

**The test.** `tests/reqwest_client.rs` — the same test as in the other two crates — sends through the shipped client to a closed port on 127.0.0.1 with `?signature=…` in the URL and asserts the error is `network`, still chains its cause and still carries a hint, and that the signature appears in none of `Display`, `Debug`, the hint, or any link of the source chain by either rendering.

It passes on `main`. With `without_url()` removed from `network()` it fails with:

```
the signed query leaked into "Network error: error sending request for url (http://127.0.0.1:59133/storage/blob?signature=sig-4f3c2a1b-never-logged)"
```

(The removal was only made locally to confirm that; it is not in this PR.)

Gates run locally: `make rs-check`, `make conformance-rs` (195/195).

Watching the review loop on this one through to convergence.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a regression test pinning that a signed query never leaks from a transport error. The shipped client already strips the request URL from `reqwest` errors, but nothing enforced it; this test sends to a closed port with a signature in the query and asserts the signature appears in none of the error's `Display`, `Debug`, hint, or source chain renderings.

<sup>Written for commit fc3ba506bace9cdadb5bf89af9a700705cca7399. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-sdk/pull/180?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

