### PR TITLE
Save the cargo cache from main only

### DIFF
--- a/.github/workflows/release-rust.yml
+++ b/.github/workflows/release-rust.yml
@@ -47,6 +47,7 @@ jobs:
           workspaces: |
             rust
             conformance/runner/rust
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install cargo-deny
         uses: taiki-e/install-action@c3ec0de9ae7f1019cea21aa96aa0a895b9552063 # v2.87.9
@@ -83,6 +84,7 @@ jobs:
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2 # zizmor: ignore[cache-poisoning] -- cache is branch-isolated; fork PRs cannot write to this cache
         with:
           workspaces: rust
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       # The version Cargo reads, not a grep over TOML; on a tag it has to be the tag's.
       - name: Read the crate version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,6 +119,7 @@ jobs:
           RUSTUP_TOOLCHAIN: ${{ steps.msrv.outputs.version }}
         with:
           workspaces: rust
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       # RUSTUP_TOOLCHAIN outranks rust-toolchain.toml, which would otherwise pick the
       # pinned stable back up.
@@ -152,6 +153,7 @@ jobs:
           RUSTUP_TOOLCHAIN: nightly
         with:
           workspaces: rust
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       # What docs.rs will do with the crate: nightly rustdoc with `--cfg docsrs`, so a
       # feature-gated item's badge renders and a nightly-only doc lint is heard here rather
@@ -248,6 +250,7 @@ jobs:
           workspaces: |
             rust
             conformance/runner/rust
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Run conformance tests
         run: make conformance-rs


### PR DESCRIPTION
Every remaining `Swatinem/rust-cache` step (MSRV, docs.rs and conformance in `test.yml`, both jobs in `release-rust.yml`; the Rust Tests job moved to mr-boxington-action in #182, which saves from main only by itself) gets `save-if: ${{ github.ref == 'refs/heads/main' }}`, so pull requests and tag builds restore the cache but no longer save entries of their own.

**Why.** GitHub caps a repository's cache at 10 GB and evicts least-recently-used. This repo sits at the cap (57 entries). Every PR run saves an entry scoped to that PR, which only a re-run of the same PR can restore, yet each one pushes main's entries, the ones every PR restores from, towards eviction. On basecamp-sdk the effect is already measurable: `Rust stable` found no cache on 4 of its last 8 runs, including a push to main, and took 341 s instead of 210 s. Here the last 8 Rust jobs all restored something, but the churn is identical, and this keeps main's entries in place.

**What changes for a pull request.** Restore is unchanged: PRs already read main's entries and could never write to them. What goes is the `Post Cache cargo` step, about 8 s of cleanup and upload at the end of each Rust job. Tag builds in `release-rust.yml` keep restoring from main and stop saving tag-scoped entries that nothing re-reads; a `workflow_dispatch` rehearsal from main still saves.

**Risk.** None: this changes when entries are written, not what is restored. Rollback is reverting this commit.

Numbers and rationale: [build cache assessment](https://app.basecamp.com/2914079/buckets/46292715/messages/10292037410), §4.3 and §5 Option A.
