### PR TITLE
Try mr-boxington as the Rust test job's build cache

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,12 +59,16 @@ jobs:
       - name: Set up Rust
         run: rustup toolchain install && rustup show
 
+      # mbx keys each compilation on the content it reads, with checkout paths mapped to
+      # placeholders, so the workspace crate restores on a pull request that leaves rust/
+      # untouched; a warm target tree cannot do that on a fresh checkout's mtimes. `objects`
+      # transports that content-addressed closure rather than the target tree. Entries are
+      # saved on pushes to main only; pull requests, forks included, restore.
       - name: Cache cargo
-        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2 # zizmor: ignore[cache-poisoning] -- cache is branch-isolated; fork PRs cannot write to this cache
+        uses: jdx/mr-boxington-action@7234d3dd1a6ca8f6c381eea8e4dfb03f18fcf777 # v1.3.0
         with:
-          workspaces: |
-            rust
-            conformance/runner/rust
+          version: 1.10.0
+          github-cache-mode: objects
 
       - name: Install cargo-deny
         uses: taiki-e/install-action@c3ec0de9ae7f1019cea21aa96aa0a895b9552063 # v2.87.9
@@ -73,12 +77,13 @@ jobs:
 
       # fmt, clippy, tests and docs with all features, then clippy and the tests again
       # with the shipped HTTP client off, cargo deny over both workspaces, and the crate
-      # packaged and built from its tarball. The same target a developer runs.
+      # packaged and built from its tarball. The same target a developer runs, with every
+      # cargo invocation going through mbx.
       - name: Format, lint and test
-        run: make rs-check
+        run: make rs-check CARGO=mbx
 
       - name: Check generated code is up to date
-        run: make rs-check-drift
+        run: make rs-check-drift CARGO=mbx
 
   msrv-rust:
     name: Rust MSRV

--- a/rust/Makefile
+++ b/rust/Makefile
@@ -1,6 +1,9 @@
 # HEY Rust SDK Makefile
 
 CARGO := cargo
+# make exports a command-line variable to every recipe, and mbx resolves the real cargo from
+# CARGO when it is set, so `make CARGO=mbx` would otherwise have mbx call itself.
+unexport CARGO
 
 .PHONY: all
 all: check


### PR DESCRIPTION
An experiment, per §5 Option C of the [build cache assessment](https://app.basecamp.com/2914079/buckets/46292715/messages/10292037410): the `Rust Tests` job swaps `Swatinem/rust-cache` for [`jdx/mr-boxington-action`](https://github.com/jdx/mr-boxington-action) (pinned to v1.3.0's commit, mbx pinned to 1.10.0) in `objects` mode, and `make rs-check` / `rs-check-drift` run cargo through `mbx` via the Makefile's existing `CARGO` variable (`mbx` passes every cargo subcommand the Makefile uses, `fmt`, `deny` and `publish` included, straight through to cargo; checked locally with mbx 1.10.0). The MSRV, docs.rs and conformance jobs keep rust-cache and are unchanged.

**How cargo reaches mbx.** `make rs-check CARGO=mbx`: the Makefile's `CARGO := cargo` is overridden on the command line and travels to the `rust/` sub-make through `MAKEFLAGS`. One line in `rust/Makefile` goes with it, `unexport CARGO`: make exports a command-line variable into every recipe's environment, and mbx resolves the real cargo from `CARGO` when it is set (that is how the mise wrapper hands it the toolchain's cargo), so without the unexport `mbx fmt` ran `mbx metadata` ran `mbx metadata`… The first push of this PR did exactly that and the runner died of it in 78 s ("Out of memory"); reproduced and fixed locally before the second push, and verified with `make -C rust fmt-check CARGO=mbx` running through mbx cleanly.

**Why.** With a full rust-cache hit, ~140 s of this job's 169 s is compiling the workspace crate and its ~40 test binaries: twice (all features, then no default features) and once more from the packaged tarball. Dependencies are 5–9 `Compiling` lines. 19 of the last 40 merged PRs did not touch `rust/`, yet the crate is recompiled on every one because cargo's fingerprint is mtime-based and a fresh checkout has fresh mtimes; no warm target tree fixes that. mbx keys each compilation on the content it reads and maps checkout paths to placeholders, so on a Rust-untouched PR the workspace-crate compile should restore. `objects` rather than the action's new default `target` mode because `target` transports a warm target tree without mbx's object store (rust-cache-style, same mtime problem), while `objects` transports the content-addressed closure.

**What to compare.** `Rust Tests` job wall time on PRs that don't touch `rust/`, against the 169 s baseline with a rust-cache hit (§4.2), and on PRs that do. mbx writes a cache summary (hits / misses / not looked up) to the job summary. Watch: closure-bundle restore and save time on a 4-vCPU runner; the Cargo registry download, which `objects` mode does not carry (Cargo re-downloads crates each run; cacheable separately with `actions/cache` if it turns out to matter); entry sizes against the 10 GB cap, which #181 addresses on the rust-cache side. This is unmeasured in CI so far. The author's own caveat is that it "doesn't yet consistently beat Swatinem/rust-cache on GitHub-hosted runners", and that in paired measurements `objects` restored and built a small edit ~10 s slower than `target`. If it does not beat the baseline after a week of PRs, revert.

**First run on this PR (cold, restore-only).** `Rust Tests` 286 s (17:35:05–17:39:51Z): action restore 1 s ("No mbx cache found", as expected before any push to main has saved an entry), `make rs-check` 264 s, post step 1 s (no save on a PR). mbx's summary for the clippy pass: "2 hits, 0 misses, 653 not looked up" — with no manifest from a prior save, nothing is looked up, so this run is a pure cold build plus the ~250 crate downloads that `objects` mode does not carry. Same-day rust-cache-hit baseline for this job: 193 s on #181, 194–204 s on the last three pushes to main. The number that matters, a PR running against an entry saved from main, only exists after this merges and main has run once.

**Kill switch.** Revert this commit. It touches one job (one action swap, two `CARGO=mbx` arguments), so a revert is smaller than a flag and leaves no second code path to keep coherent. Cost of the revert: if this has run for more than a week, main's `test-rust` rust-cache entry will have expired (7-day idle eviction), so the first push to main after the revert pays one cold job (~130 s extra, §4.3); every run after that is warm again.

**Security.** Save policy: the action saves an entry only on pushes to the default branch (`main`); pull requests, forks included, are restore-only, enforced by the action, and `save-on-workflow-dispatch` stays at its default `false` (this workflow has no `workflow_dispatch`). That is the same trust boundary rust-cache has through GitHub's branch scoping. No secrets are added: the action's `github-token` is the job's default `GITHUB_TOKEN` with `contents: read`, used only to resolve mbx release metadata, and it installs only a release GitHub reports as immutable with an asset digest (v1.10.0 is). The trust decision is a 3-week-old, single-maintainer binary in `RUSTC_WRAPPER` for this job. actionlint and zizmor pass locally.

Conflicts textually with #181 in this one step; that should land first and this rebases onto it.
