### PR TITLE
Say in AGENTS.md that CI runs the Rust gate through mr-boxington

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,10 +86,14 @@ the checked-in output matches the generator, not that the generator is right.
 `rs-check` is every step CI's `test-rust` job runs before it, in order — fmt, clippy,
 tests and docs with all features, clippy and tests again with `--no-default-features`, the
 examples, `cargo deny` over both workspaces, and `cargo package` — so a green
-`make rs-check rs-check-drift` locally is a green job. CI also builds the library on `rust-version` (`msrv-rust`), the docs on nightly as
-docs.rs would (`docs-rust`), and the public API against the pull request's base
-(`api-compat-rust`, `cargo semver-checks`; the `breaking` label skips it). The toolchain
-everything else runs on is pinned in `rust-toolchain.toml` at the repository root.
+`make rs-check rs-check-drift` locally is a green job. CI runs both as `make … CARGO=mbx`, so
+every cargo invocation goes through [mr-boxington](https://mr-boxington.jdx.dev) and a
+pull request that leaves `rust/` untouched can restore the workspace crate from main's cache
+instead of recompiling it; locally the Makefile's `CARGO` defaults to plain `cargo`. CI also
+builds the library on `rust-version` (`msrv-rust`), the docs on nightly as docs.rs would
+(`docs-rust`), and the public API against the pull request's base (`api-compat-rust`,
+`cargo semver-checks`; the `breaking` label skips it). The toolchain everything else runs on
+is pinned in `rust-toolchain.toml` at the repository root.
 
 `rust/hey-sdk/examples/*.rs` are the crate README's snippets as whole programs; they compile in
 the gate, so a change to the public API that breaks one shows up there.


### PR DESCRIPTION
AGENTS.md's account of the Rust gate stops at "a green `make rs-check rs-check-drift` locally is a green job", which was the whole story until #182. Since then CI runs both targets as `make … CARGO=mbx`, so the job's cargo invocations go through [mr-boxington](https://mr-boxington.jdx.dev) while a developer's `make rs-check` stays plain `cargo`. This adds that sentence, and what the difference buys: a pull request that leaves `rust/` untouched can restore the workspace crate from main's cache rather than recompile it.

Docs only; no code or workflow change.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates `AGENTS.md` to document that CI runs the Rust gate through `mr-boxington`, not plain `cargo` like a local `make rs-check rs-check-drift`.

This means a PR that leaves `rust/` untouched can restore the workspace crate from main's cache instead of recompiling. Docs only; no code or workflow change.

<sup>Written for commit faedf5e842cc4baca20407742dcce7a950a051d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-sdk/pull/183?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

