### PR TITLE
Run the conformance jobs alongside the unit tests instead of after them

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -210,7 +210,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    needs: [test-go]
     defaults:
       run:
         working-directory: conformance/runner/go
@@ -233,7 +232,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    needs: [test-rust]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:


### PR DESCRIPTION
`conformance` and `conformance-rust` lose their `needs:` on the unit-test jobs and start with everything else.

**Why.** The Test run's wall time is the chain `Rust Tests` → `Conformance Tests (Rust)`: 191–198 s for the tests, then 54–58 s for conformance, plus the dispatch gap, for 252–265 s per run (runs 34499111680, 34507731544, 34508302055; the [build cache assessment](https://app.basecamp.com/2914079/buckets/46292715/messages/10292037410) §4.1 measured 262 s/run over 20 runs). Nothing in the conformance jobs consumes the unit-test jobs' output: there are no artifacts, and each job checks out and builds on its own. The `needs:` only orders them, so on every green run — which is nearly all of them — it adds a minute to the critical path and buys nothing. On a red run it saves one conformance job's minutes, which on a public repository's hosted runners cost nothing.

**What changes.** Run wall time drops by the conformance job's length plus its dispatch gap, ~60 s, to roughly the `Rust Tests` job on its own. The Go pair is the same shape (`Go Tests` 43–65 s → `Conformance Tests` 34–36 s) and is off the critical path, but it goes for the same reason. The required checks and their names are unchanged; a failing unit test still fails the run.

**Measured on this PR's run** ([34514005593](https://github.com/basecamp/hey-sdk/actions/runs/34514005593)): `Conformance Tests (Rust)` was created with the rest of the jobs at 18:23:16Z and ran 18:23:19–18:24:14Z, while `Rust Tests` was still going; the run's wall time was the `Rust Tests` job plus 6 s. The docs-only PR #183, opened in the same minute with the `needs:` in place, had its conformance job created at 18:30:11Z, the second `Rust Tests` finished, and its run took 57 s longer than its `Rust Tests` job. (Both `Rust Tests` jobs were slow, 394 s and 430 s, for a reason that is its own PR: mbx's store sweep on the runner. The chain saving is independent of it.)
