### PR TITLE
Keep mbx from sweeping its store on the runner before the build reads it

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,11 +79,19 @@ jobs:
       # with the shipped HTTP client off, cargo deny over both workspaces, and the crate
       # packaged and built from its tarball. The same target a developer runs, with every
       # cargo invocation going through mbx.
+      # mbx sweeps its store down to 5% of the disk after a build, and the runner's disk is
+      # small enough that the sweep runs on the first cargo command and throws away half of
+      # what the cache step just restored, before any of it is looked up. The runner is
+      # thrown away at the end of the job; nothing here needs collecting.
       - name: Format, lint and test
         run: make rs-check CARGO=mbx
+        env:
+          MBX_GC_AUTO: "0"
 
       - name: Check generated code is up to date
         run: make rs-check-drift CARGO=mbx
+        env:
+          MBX_GC_AUTO: "0"
 
   msrv-rust:
     name: Rust MSRV


### PR DESCRIPTION
`MBX_GC_AUTO=0` on the two mbx steps of `Rust Tests`.

**What went wrong.** The first two pull requests to run against an entry saved from main (#183, #184; runs [34514007325](https://github.com/basecamp/hey-sdk/actions/runs/34514007325) and [34514005593](https://github.com/basecamp/hey-sdk/actions/runs/34514005593)) restored it exactly — `Cache hit for: linux-x64-mbx-v1-rust-…-2388759…`, 2.5 GB downloaded and imported as "1082 actions and 4860 objects (10.5 GiB)" in ~80 s — and then, on the job's very first cargo command (`mbx fmt`), mbx wrote:

```
mbx[gc]: evicted 1148 objects and 0 action results (5.5 GiB logical); 4.9 GiB logical remain
```

Its store budget defaults to 5% of the disk the cache lives on; on the runner that is well under the 10.5 GiB just restored, so the post-build sweep fired before any build and threw half the entry away. Every mbx session in both jobs then reported `0 hits … not looked up` on the workspace crate, and the jobs took 394 s and 430 s, against 191–204 s with a rust-cache hit and 264–328 s cold: paying for the restore and getting nothing for it.

**Why this and not a bigger budget.** The runner is discarded at the end of the job, so there is nothing for a sweep to keep tidy; turning it off is the whole answer, with no number to tune or to outgrow. `MBX_GC_MAX_SIZE` would have needed a value chosen against a runner disk that is not a constant.

**Measured on this PR's run.** To follow once the run completes; the number that matters is the `mbx[cache]` hit count on the `hey-sdk` compilations and the `Rust Tests` job time against the rust-cache baseline of 191–204 s.

If mbx still does not look up the workspace crate with the sweep off, the trial in #182 has not earned its keep and the next step is the revert it planned for, not another knob.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sets `MBX_GC_AUTO=0` on the two mbx steps of `Rust Tests` so the cache restored at job start survives until the build reads it.

- mbx was evicting half the restored 10.5 GiB cache on the first cargo command because the runner's disk budget is under that size, causing every mbx session to miss and stretching job time to 394–430 s from a 191–204 s baseline.
- The runner is discarded at job end, so the sweep has nothing useful to clean; disabling it avoids picking a budget number that would need retuning against a non-constant runner disk.

<sup>Written for commit 83af59898a66174e657a407cd93a1572b726e721. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-sdk/pull/185?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

