### PR TITLE
Build CI's debug profiles with line tables only

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,13 @@ on:
 
 permissions: {}
 
+# Debug builds carry full DWARF by default, and in this workspace that is most of the bytes:
+# the test job's ~110 linked test binaries run 50–200 MB each and put its cache entry at
+# 2.5 GB compressed. Line tables keep file:line in a failing test's backtrace, which is all
+# a CI log needs, at ~2.6x less: 0.9 GB. Nothing here is debugged under a debugger.
+env:
+  CARGO_PROFILE_DEV_DEBUG: line-tables-only
+
 jobs:
   smithy-verify:
     permissions:


### PR DESCRIPTION
`CARGO_PROFILE_DEV_DEBUG=line-tables-only` for every job in the Test workflow.

**Why.** The Rust jobs build debug profiles, and debug profiles carry full DWARF. Of the 9.3 GiB closure mbx exported from the `Rust Tests` job on main, 8.4 GiB is the ~110 linked test executables at 50–200 MB each (the rest, every rlib and rmeta, is 0.7 GiB); zstd brings that to the 2.5 GB entry each push to main now saves, in a 122–183 s post step, against a 10 GB repository cap that three pushes in three minutes blew through this afternoon (9.8 GB / ~60 entries → 12.3 GB / 36 entries). rust-cache's entries for the same jobs carry the same debuginfo in the dependency rlibs.

Measured on thelio with the same workspace, same commands (`cargo test --workspace --all-features`, `cargo test -p hey-sdk --lib --tests --no-default-features`, `cargo build --examples`), exported closure raw → zstd-3:

| profile debug | raw | zstd-3 |
|---|---|---|
| `true` (default) | 9.3 GiB | 2.37 GB |
| `line-tables-only` | 3.9 GiB | 0.93 GB |
| `0` | 2.3 GiB | 0.57 GB |

Line tables keep file and line in a failing test's backtrace, which is what a CI log is read for; nothing in these jobs runs under a debugger. `0` would be a third smaller again at the cost of those line numbers; not worth it. It is set as workflow-level `env`, not in `rust/Cargo.toml`, so a developer's `cargo test` keeps full debuginfo for a debugger.

**What to expect.** Smaller entries on every Rust job (mbx and rust-cache alike), a shorter save step on main, a shorter restore on PRs, and less link time per test binary. Compile time itself moves little: on thelio the cold build was 65 s with line tables vs 61 s with no debuginfo; the default was not timed cold in the same session.

**Measured on this PR's run** ([34515141833](https://github.com/basecamp/hey-sdk/actions/runs/34515141833)). As expected nothing restored from main's entry applied (different flags, so every key differs; mbx's store sweep also ran, which is #185's subject), so this is a cold `Rust Tests` job with line tables against the cold jobs of the same afternoon with full debuginfo:

| phase | full debuginfo (#183 / #185, cold after restore) | line tables (this PR) |
|---|---|---|
| clippy, all features | 65 s / 65 s | 64 s |
| `cargo test` build, all features | 1m 54s / 1m 59s | **1m 36s** |
| `cargo test` build, no default features | 1m 07s / 1m 01s | **44 s** |
| examples | 9–10 s | 8 s |
| publish dry-run build | 18 s | 16 s |
| `Rust Tests` job | 394 s / 411 s | **367 s** |

The compile-only pass (clippy) is unchanged; the passes that link test binaries are 15–30% shorter. The entry size lands on the first push to main after this merges.
