### PR TITLE
Revert the mr-boxington trial: it made every Rust Tests run slower

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,16 +59,13 @@ jobs:
       - name: Set up Rust
         run: rustup toolchain install && rustup show
 
-      # mbx keys each compilation on the content it reads, with checkout paths mapped to
-      # placeholders, so the workspace crate restores on a pull request that leaves rust/
-      # untouched; a warm target tree cannot do that on a fresh checkout's mtimes. `objects`
-      # transports that content-addressed closure rather than the target tree. Entries are
-      # saved on pushes to main only; pull requests, forks included, restore.
       - name: Cache cargo
-        uses: jdx/mr-boxington-action@7234d3dd1a6ca8f6c381eea8e4dfb03f18fcf777 # v1.3.0
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2 # zizmor: ignore[cache-poisoning] -- cache is branch-isolated; fork PRs cannot write to this cache
         with:
-          version: 1.10.0
-          github-cache-mode: objects
+          workspaces: |
+            rust
+            conformance/runner/rust
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install cargo-deny
         uses: taiki-e/install-action@c3ec0de9ae7f1019cea21aa96aa0a895b9552063 # v2.87.9
@@ -77,13 +74,12 @@ jobs:
 
       # fmt, clippy, tests and docs with all features, then clippy and the tests again
       # with the shipped HTTP client off, cargo deny over both workspaces, and the crate
-      # packaged and built from its tarball. The same target a developer runs, with every
-      # cargo invocation going through mbx.
+      # packaged and built from its tarball. The same target a developer runs.
       - name: Format, lint and test
-        run: make rs-check CARGO=mbx
+        run: make rs-check
 
       - name: Check generated code is up to date
-        run: make rs-check-drift CARGO=mbx
+        run: make rs-check-drift
 
   msrv-rust:
     name: Rust MSRV

--- a/rust/Makefile
+++ b/rust/Makefile
@@ -1,9 +1,6 @@
 # HEY Rust SDK Makefile
 
 CARGO := cargo
-# make exports a command-line variable to every recipe, and mbx resolves the real cargo from
-# CARGO when it is set, so `make CARGO=mbx` would otherwise have mbx call itself.
-unexport CARGO
 
 .PHONY: all
 all: check


### PR DESCRIPTION
Reverts #182: `Rust Tests` goes back to `Swatinem/rust-cache` (now with #181's `save-if`, so the step matches the other Rust jobs whichever lands first) and `make rs-check` runs plain cargo. #182 set its own bar — "if it does not beat the baseline … revert" — and after one afternoon on main the numbers are in, and they are not close.

**What #182 was for.** With a rust-cache hit, ~140 s of the job is compiling the workspace crate and its ~55 test binaries twice; 19 of the last 40 merged PRs did not touch `rust/`, and the hope was that mbx's content-keyed objects would restore that compile on those PRs.

**What happened.** Every run of the job got slower, on both sides of the merge:

| | rust-cache hit (six runs, 10 Sep) | mbx `objects` |
|---|---|---|
| PR, `rust/` untouched | 193–201 s | **394 s** (#183), **430 s** (#184) |
| push to main | 194–204 s | **455–468 s** (3189771, 9aef17b, 2388759) — cold build 264–323 s + a 122–183 s post step saving a **2.5 GB** entry |
| cache entry | 416 MB | 2.5 GB per push to main; three pushes took the repository from 9.8 GB / ~60 entries to 12.3 GB / 38, evicting every other job's entries |

The PRs did restore main's entry — exact key hit, 2.66 GB downloaded and imported in ~80 s — and then mbx looked up nothing: every session reported `0 hits … not looked up` for the workspace crate. Two causes, and the second is the one that decides it:

1. mbx's store sweep runs at 5% of the runner's disk, below the 10.5 GiB the import had just written, so it evicted half the objects on the job's first cargo command. #185 turns the sweep off. That fix is necessary but not sufficient, because of:
2. The exported bundle does not carry what mbx needs to *look up* a compilation before running it. Reproduced on thelio in CI's exact shape — export the closure from a build, import it into an empty store, fresh clone at the same path, same command, no GC in play: `restored Cargo workspace state (757 referenced files, 9.7 GiB)` followed by **69 hits, 0 misses, 388 not looked up**, 24 s against a 27–30 s cold build. `MBX_SUMMARY=full` says why: "could not look up 388 compilations: no usable dep-info from an earlier build and no prediction to derive an action key from". A second clone against a *local* store does hit (478 hits, 8.7 s), because that store learned the predictions in its first build; the bundle transports objects and results but not that. The 69 that hit are build scripts and proc-macros. So on mbx 1.10.0 the GHA objects payload cannot restore the workspace crate on a fresh checkout, which was the entire point. #185 ran the same experiment on the runner itself, sweep off ([34515135292](https://github.com/basecamp/hey-sdk/actions/runs/34515135292)): no eviction, the same exact-key restore, and still `654 not looked up` on the first clippy pass and `605 not looked up` on the test build; 411 s.

`target` mode is not a way out: it transports the target tree and registry without the object store, so freshness is cargo's mtime check on a fresh checkout — the same recompile rust-cache does, plus mbx in the loop.

**What this costs.** One cold `Rust Tests` job on the first push to main after merging, ~130 s over the warm 194–204 s, because main's `test-rust` rust-cache entry has been evicted by the 2.5 GB bundles; every run after that is warm. The three `linux-x64-mbx-…` entries expire on their own after seven days idle, or can be deleted from the repository's cache list now.

**What to keep from the trial.** #184 (conformance jobs no longer wait on the unit tests, ~60 s off every run's wall time) and #186 (line-tables-only debuginfo, which cuts every Rust job's cache entry and link time) are independent of the cache backend and stand on their own. Local mbx on thelio is untouched by this; it works there because the store learns.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the mr-boxington build-cache trial for Rust tests. The trial made every `Rust Tests` run slower (394-468 s vs 193-204 s with rust-cache), so the job goes back to `Swatinem/rust-cache` and `make rs-check` runs plain cargo.

- mbx's `objects` bundle can't look up workspace crate compilations on a fresh checkout (388 not looked up), so the crate rebuilt cold anyway.
- Each push to main saved a 2.5 GB cache entry, evicting other jobs' entries and growing the repository cache from 9.8 GB to 12.3 GB.
- The revert keeps `save-if`, so the rust-cache entry is only written on main.

**Rollout**
- One cold `Rust Tests` run after merging, ~130 s over the warm baseline; warm runs resume after that.
- The `linux-x64-mbx-…` entries expire after seven days idle, or can be deleted from the repository's cache list now.
- The #184 and #186 improvements are independent of the cache backend and remain in place.

<sup>Written for commit 25247450af4974504d92672055fee0d327874256. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-sdk/pull/187?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

