### PR TITLE
Try mr-boxington objects mode again, with mbx pinned to a fix on its main

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,6 +56,12 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    env:
+      MBX_REV: 68e48f140664c04682a7b33a1c7782b86484d21a
+      # mbx's store sweep is sized to 5% of the runner's disk, below the bundle the action
+      # imports, so on the job's first cargo command it evicted half of what was just
+      # restored. Nothing else writes to this store during the job.
+      MBX_GC_AUTO: "0"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -66,13 +72,35 @@ jobs:
       - name: Set up Rust
         run: rustup toolchain install && rustup show
 
-      - name: Cache cargo
-        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2 # zizmor: ignore[cache-poisoning] -- cache is branch-isolated; fork PRs cannot write to this cache
+      # mbx from upstream main rather than a release: 1.10.0's export keeps only the last
+      # command's lookup predictions (jdx/mr-boxington#422), so a job that runs clippy, tests,
+      # docs and examples in turn ships a bundle the next job cannot look anything up in.
+      # 68e48f1 carries the fix (#424). Built once per commit with cargo install and kept in
+      # the Actions cache under that commit; a bump here is a new key, and the build below
+      # runs only when the key is absent.
+      - name: Restore mbx
+        id: mbx
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          workspaces: |
-            rust
-            conformance/runner/rust
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+          path: ~/.cargo/bin/mbx
+          key: mbx-${{ env.MBX_REV }}-${{ runner.os }}-${{ runner.arch }}
+
+      - name: Build mbx
+        if: steps.mbx.outputs.cache-hit != 'true'
+        run: cargo install --locked --git https://github.com/jdx/mr-boxington --rev "$MBX_REV" mbx
+
+      # With `version` omitted the action uses the mbx on PATH instead of installing a
+      # release. mbx keys each compilation on the content it reads, with checkout paths mapped
+      # to placeholders, so the workspace crate restores on a pull request that leaves rust/
+      # untouched; a warm target tree cannot do that on a fresh checkout's mtimes. `objects`
+      # transports that content-addressed closure rather than the target tree. Entries are
+      # saved on pushes to main only; pull requests, forks included, restore. The generation
+      # follows the mbx commit so a bump never restores a bundle written by another build.
+      - name: Cache cargo
+        uses: jdx/mr-boxington-action@7234d3dd1a6ca8f6c381eea8e4dfb03f18fcf777 # v1.3.0
+        with:
+          github-cache-mode: objects
+          cache-generation: ${{ env.MBX_REV }}
 
       - name: Install cargo-deny
         uses: taiki-e/install-action@c3ec0de9ae7f1019cea21aa96aa0a895b9552063 # v2.87.9
@@ -81,12 +109,13 @@ jobs:
 
       # fmt, clippy, tests and docs with all features, then clippy and the tests again
       # with the shipped HTTP client off, cargo deny over both workspaces, and the crate
-      # packaged and built from its tarball. The same target a developer runs.
+      # packaged and built from its tarball. The same target a developer runs, with every
+      # cargo invocation going through mbx.
       - name: Format, lint and test
-        run: make rs-check
+        run: make rs-check CARGO=mbx
 
       - name: Check generated code is up to date
-        run: make rs-check-drift
+        run: make rs-check-drift CARGO=mbx
 
   msrv-rust:
     name: Rust MSRV

--- a/rust/Makefile
+++ b/rust/Makefile
@@ -1,6 +1,9 @@
 # HEY Rust SDK Makefile
 
 CARGO := cargo
+# make exports a command-line variable to every recipe, and mbx resolves the real cargo from
+# CARGO when it is set, so `make CARGO=mbx` would otherwise have mbx call itself.
+unexport CARGO
 
 .PHONY: all
 all: check


### PR DESCRIPTION
Second run of the #182 experiment, reverted in #187. Same shape as #182: the `Rust Tests` job swaps `Swatinem/rust-cache` for [`jdx/mr-boxington-action`](https://github.com/jdx/mr-boxington-action) (pinned to v1.3.0's commit) in `objects` mode, and `make rs-check` / `rs-check-drift` run cargo through `mbx` via the Makefile's `CARGO` variable, with `unexport CARGO` back in `rust/Makefile` so mbx does not call itself. The MSRV, docs.rs and conformance jobs keep rust-cache and are untouched. One thing is different, and it is the thing #187 found decisive.

**What #187 found.** The bundle a job exported carried objects and action results for every command it ran, but the lookup predictions of the *last* command only, so a pull request that restored main's entry looked nothing up (`654 not looked up`) and compiled the workspace cold, on top of an 80 s restore. Reported as [jdx/mr-boxington#422](https://github.com/jdx/mr-boxington/discussions/422); fixed upstream the same day by [#424](https://github.com/jdx/mr-boxington/pull/424) (export unions every command's predictions per task). That fix is on mr-boxington's `main` at `68e48f1` and in no release yet; the action installs releases only.

**How mbx gets to the runner.** The action's `version` input accepts a release number or `latest`, nothing else, but when `version` is omitted it uses the `mbx` it finds on `PATH` and installs nothing (v1.2.0's behaviour, checked in v1.3.0's `setupMbx`). So the job builds mbx itself: `cargo install --locked --git https://github.com/jdx/mr-boxington --rev 68e48f1… mbx`, into `~/.cargo/bin`, which is on `PATH`, kept in the Actions cache under a key that is the commit plus runner OS/arch. The build runs only when that key is absent: once on this PR, once on main after merge, and once per future bump of `MBX_REV`. The action's `cache-generation` is set to the same commit, so a bump never restores a bundle written by a different mbx build (the README's own advice for an mbx upgrade). Two other things: `MBX_GC_AUTO=0` at job level, because mbx's store sweep is sized to 5% of the runner's disk, below the bundle the action had just imported, and evicted half of it on the first cargo command (#185 measured this; the action's [#37](https://github.com/jdx/mr-boxington-action/pull/37) makes it the default on hosted runners, merged today, unreleased). The action's `mbx-version` output will read `1.10.0`, which is the crate version on main; the binary is the pinned commit.

**Reproduced locally first, in CI's shape.** Linux workstation, mbx built from `68e48f1`, hey-sdk at `08045bc` (this PR's base), `CARGO_PROFILE_DEV_DEBUG=line-tables-only` as in CI, `MBX_GC_AUTO=0`, an export group set as the action sets it. Populate an empty store from a fresh clone at path P with `clippy --workspace --all-targets --all-features` then `test --workspace --all-features --no-run`; `mbx cache export --group`; import the tar into a second, empty store; delete and re-clone at P; run both commands again:

| | 1.10.0 (#187, same experiment) | `68e48f1` |
|---|---|---|
| task manifest in the bundle | 1 task, **424** predictions (the last command's) | 1 task, **907** predictions (909 actions, 3880 objects, 2.6 GiB) |
| `clippy` after import, fresh clone | 55 hits, **404 not looked up** | **274 hits**, 2 misses, 184 not looked up, **5.9 s** (cold plain cargo 18.5 s) |
| `test --no-run` after import | 273 hits (it was the last command) | **273 hits**, 2 misses, 184 not looked up, **6.5 s** (cold plain cargo 27.1 s) |

The 184 not looked up are `aws-lc-sys`'s C compilations (`cc-unportable-output` in `MBX_BYPASS_LOG`: the object path is under `target/`, which the key normalizes away), the same class both before and after, and the only compile work left on a warm job; the two misses are the same in every run. So the bundle now carries what a fresh checkout needs to look up every rustc compilation from every command in the job, which is what #182 assumed and 1.10.0 did not deliver.

**What to compare.** The same numbers as #182 and #187, on the same job:

| | rust-cache hit (main today) | #182 as merged (1.10.0) | expected here |
|---|---|---|---|
| PR `Rust Tests`, `rust/` untouched | 191–204 s | 394–430 s | below the baseline: restore of a ~1 GB entry (~30–40 s) plus the C compilations, the test runs themselves, `cargo deny` and `cargo publish --dry-run` |
| push to main | 194–204 s | 455–468 s (cold + 122–183 s saving 2.5 GB) | cold build + one save; entry ~0.9 GB now that #186's line tables apply (hill-log: 3.9 GiB raw closure → 0.93 GB zstd, against 2.5 GB before) |
| first run on this PR, and the first push to main after merge | | | + one `cargo install` of mbx from source on a 4-vCPU runner (a few minutes; cached under the commit afterwards), and a cold build with no entry to restore |

The bar is #182's: if PR runs that leave `rust/` untouched do not beat the rust-cache baseline after a few of them, revert. This PR's own runs are cold by construction (no entry exists under the new generation until main saves one); the measurement is the PRs that follow the merge.

**Kill switch.** Revert this commit; it touches one job and one Makefile line. Cost of a revert after a week: main's `test-rust` rust-cache entry will have expired and the first push to main after it pays one cold job (~130 s over warm), as with #187.

**Security.** Save policy unchanged: the action saves only on pushes to `main`; pull requests, forks included, are restore-only, enforced by the action; `save-on-workflow-dispatch` stays at its default and the workflow has no `workflow_dispatch`. The mbx binary is built from a full commit hash over HTTPS from the upstream repository with `--locked`, and its cache entry lives under GitHub's usual branch scoping (a PR's build is visible to that PR only; main's to everything). The action's `github-token` is the job's default `GITHUB_TOKEN` with `contents: read`, and with `version` omitted it is not used to resolve a release at all. The trust decision is the same as #182's, a single-maintainer build tool driving cargo in this job, now at a commit rather than a signed release. actionlint and zizmor pass locally.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retries mr-boxington objects mode for the Rust Tests job, replacing `Swatinem/rust-cache` with `jdx/mr-boxington-action` and a pinned `mbx` build that includes the upstream export fix. Unlike the previous attempt, bundles retain lookup predictions from every cargo command, allowing fresh checkouts to reuse restored objects instead of recompiling the workspace.

**Details**

- Builds `mbx` from the pinned commit once per runner platform and reuses it through the Actions cache.
- Matches the action’s cache generation to the `mbx` revision and disables automatic store GC to protect restored bundles.
- Runs `make rs-check` and `rs-check-drift` with `CARGO=mbx` while preventing recursive `mbx` invocation in `rust/Makefile`.
- Keeps save-on-main and restore-only pull request behavior; MSRV, docs.rs, and conformance jobs are unchanged.
- The first run and first post-merge main run pay for the `mbx` build and a cold cache.

<sup>Written for commit e2e9093f3d98e987cbff33d884d7ac9f1167d116. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-sdk/pull/188?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

