### PR TITLE
Rewrap the linked-accounts paragraph in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,10 +91,11 @@ _ = work.Messages().Create(ctx, "Subject", "Body", []string{"someone@example.com
 `ForAccount` verifies that the account is accessible to the authenticated identity when the
 scoped client is derived, then adds HEY's `filtered_account_id` to same-origin API requests,
 including pagination and retries. Long-lived applications can derive a fresh scoped client
-after observing identity or account-membership changes. It never adds the filter to signed external upload or download URLs.
-Account-scoped message sends resolve a sender from that account, and account-scoped contact
-creation resolves the identity's user in that account. Both operations return an error when
-the account has no matching sender or user rather than falling back to another account.
+after observing identity or account-membership changes. It never adds the filter to signed
+external upload or download URLs. Account-scoped message sends resolve a sender from that
+account, and account-scoped contact creation resolves the identity's user in that account.
+Both operations return an error when the account has no matching sender or user rather than
+falling back to another account.
 
 Account scope follows HEY's mail-filter semantics; it is not an authorization boundary.
 Identity-owned services such as Calendar and Journal remain identity-wide. Use a client


### PR DESCRIPTION
One sentence in the linked-accounts paragraph ran to 124 columns where the file wraps at 96; rewrapped, no words changed.

Docs-only on purpose: this is the first pull request that leaves `rust/` untouched since #188, so its `Rust Tests` job is the measurement #188 asked for — restore of main's objects entry, mbx's hits / misses / not-looked-up on the workspace crate, and the job's wall time against the 191–204 s rust-cache baseline. The numbers land on #188's thread.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rewraps the linked-accounts paragraph in the README to follow the file's 96-column wrap; no words changed.

<sup>Written for commit 2f1b25a1816fde1e34fa70f973670d91295be96f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-sdk/pull/189?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

