### PR TITLE
Install mbx from its 1.10.1 release instead of building it from git

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,7 +57,6 @@ jobs:
     permissions:
       contents: read
     env:
-      MBX_REV: 68e48f140664c04682a7b33a1c7782b86484d21a
       # mbx's store sweep is sized to 5% of the runner's disk, below the bundle the action
       # imports, so on the job's first cargo command it evicted half of what was just
       # restored. Nothing else writes to this store during the job.
@@ -72,35 +71,24 @@ jobs:
       - name: Set up Rust
         run: rustup toolchain install && rustup show
 
-      # mbx from upstream main rather than a release: 1.10.0's export keeps only the last
-      # command's lookup predictions (jdx/mr-boxington#422), so a job that runs clippy, tests,
-      # docs and examples in turn ships a bundle the next job cannot look anything up in.
-      # 68e48f1 carries the fix (#424). Built once per commit with cargo install and kept in
-      # the Actions cache under that commit; a bump here is a new key, and the build below
-      # runs only when the key is absent.
-      - name: Restore mbx
-        id: mbx
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/.cargo/bin/mbx
-          key: mbx-${{ env.MBX_REV }}-${{ runner.os }}-${{ runner.arch }}
-
-      - name: Build mbx
-        if: steps.mbx.outputs.cache-hit != 'true'
-        run: cargo install --locked --git https://github.com/jdx/mr-boxington --rev "$MBX_REV" mbx
-
-      # With `version` omitted the action uses the mbx on PATH instead of installing a
-      # release. mbx keys each compilation on the content it reads, with checkout paths mapped
-      # to placeholders, so the workspace crate restores on a pull request that leaves rust/
+      # The action installs the release named here, checking the archive against the digest
+      # GitHub reports for the immutable release. 1.10.1 is the first release with the export
+      # fix (jdx/mr-boxington#424) that main had been building from upstream to get.
+      # mbx keys each compilation on the content it reads, with checkout paths mapped to
+      # placeholders, so the workspace crate restores on a pull request that leaves rust/
       # untouched; a warm target tree cannot do that on a fresh checkout's mtimes. `objects`
       # transports that content-addressed closure rather than the target tree. Entries are
       # saved on pushes to main only; pull requests, forks included, restore. The generation
-      # follows the mbx commit so a bump never restores a bundle written by another build.
+      # is the mbx commit main's bundle was written under: 1.10.1 stores the same objects
+      # under the same keys (only the cc adapter's predictions moved to a new namespace, and
+      # those are relearned on the first run), so the entry carries over. Bump it when a
+      # release changes what the store holds.
       - name: Cache cargo
         uses: jdx/mr-boxington-action@7234d3dd1a6ca8f6c381eea8e4dfb03f18fcf777 # v1.3.0
         with:
+          version: 1.10.1
           github-cache-mode: objects
-          cache-generation: ${{ env.MBX_REV }}
+          cache-generation: 68e48f140664c04682a7b33a1c7782b86484d21a
 
       - name: Install cargo-deny
         uses: taiki-e/install-action@c3ec0de9ae7f1019cea21aa96aa0a895b9552063 # v2.87.9


### PR DESCRIPTION
Upstream released mr-boxington v1.10.1 at 20:51Z, and 68e48f1 (the commit the Rust Tests job has been building with `cargo install --git`) is an ancestor of the tag: `compare/68e48f1...v1.10.1` is 2 commits ahead, 0 behind (jdx/mr-boxington#423 and the release commit).

## Change

- `jdx/mr-boxington-action` gets `version: 1.10.1`. The action resolves the release through the GitHub API, accepts it only when GitHub reports the release as immutable and supplies an asset digest, then downloads the archive and rejects it on a sha256 mismatch (`src/index.ts` `resolveRelease` / `installMbx`). v1.10.1 is immutable and the Linux x86_64 asset's digest is `sha256:3aac91bf…2776`.
- The `Restore mbx` / `Build mbx` steps and the `MBX_REV` job env go away, along with the `actions/cache` entry they kept.
- `cache-generation` **stays** at `68e48f14…d21a`, the generation main's current 1221 MB bundle was written under. The diff between 68e48f1 and v1.10.1 touches only the cc adapter (#423): it adds a `path_specific` flag to cc predictions (serde default, absent from older payloads) and moves cc prediction lookups to a `cc-path-binding-v1` namespace. `mbx-cache-store` and `mbx-cache-core` are version bumps only, and portable cc actions "keep their existing keys". So 1.10.1 reads main's objects unchanged; the cc predictions are relearned on the first run and exported with the next main entry. Bumping the generation would have forced one fully cold main push for nothing.
- `MBX_GC_AUTO=0` and `make … CARGO=mbx` are unchanged.

actionlint and zizmor are clean.

## Effect

The per-run cost is unchanged (a 5 MB cache restore becomes a 5.9 MB verified release download). What disappears is the ~213 s `cargo install --git` build that ran on the first job after every pin move, and would run again whenever the 5 MB `mbx-<rev>` entry was evicted.

Timing from this PR's own Rust Tests run, against the docs-only probe (#189, run 34527697019: 148 s = restore 32 s + rs-check 96 s):

| | probe #189 (68e48f1 git build, cached) | this PR (1.10.1 release) |
| --- | --- | --- |
| Rust Tests wall | 148 s | **134 s** (run 34532188007) |
| mbx install | 1 s (5 MB `actions/cache` restore) | 1 s (release download + sha256 check, into the runner tool cache) |
| Cache cargo (restore + import) | 32 s | 33 s (download 5 s at 261 MB/s, unpack 11 s, import 17 s; same 1082 actions / 4860 objects) |
| `make rs-check` | 96 s | 87 s |
| clippy | 485 hits / 1 miss / 184 not looked up, 36.8 s | 281 hits / 0 miss / 389 not looked up, 26.1 s |
| test | 426 / 1 / 184, 37.7 s | 222 / 0 / 389, 41.3 s |
| doc, clippy nd, test nd, examples, publish | 21 / 58 / 60 / 6 / 15 hits | 21 / 58 / 60 / 6 / 15 hits |

The hit counts drop by 204 on clippy and test: those are the cc compilations (ring, aws-lc-sys) whose predictions 1.10.1 now looks up under the new namespace and main's bundle carries under the old one, so the C objects were built (11.9 MiB + 5.4 MiB stored locally) rather than restored. They cost little wall time and the first main push on this branch exports them, after which pull requests restore them again. Every rustc hit carried over. The 14 s wall difference is runner variance, not the change.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Installs mbx from its pinned 1.10.1 release instead of building it from git, removing the per-pin `cargo install` build and its cache entry.

- The `jdx/mr-boxington-action` now downloads the release archive, rejecting it on a sha256 mismatch against the digest GitHub reports for the immutable release.
- The `Restore mbx`/`Build mbx` steps, the `MBX_REV` job env, and the `actions/cache` entry they used are gone.
- `cache-generation` stays at 68e48f1 because 1.10.1 writes the same objects under the same keys; only cc prediction lookups moved to a new namespace and are relearned on the first run.
- Per-run cost is unchanged (a 5.9 MB verified download instead of a 5 MB cache restore), but the ~213 s build no longer runs after every pin move or cache eviction.

<sup>Written for commit 4ab8d972f2b8d900d2b9e8ec4309429579dec095. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/hey-sdk/pull/190?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


